### PR TITLE
Refactor the group button spacing

### DIFF
--- a/inc/css/blocks/class-button-group-css.php
+++ b/inc/css/blocks/class-button-group-css.php
@@ -40,13 +40,12 @@ class Button_Group_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'selector'   => ' .wp-block-themeisle-blocks-button',
 				'properties' => array(
 					array(
-						'property' => 'margin-right',
+						'property' => 'column-gap',
 						'value'    => 'spacing',
-						'unit'     => 'px',
 						'default'  => 20,
+						'unit'     => 'px',
 					),
 				),
 			)

--- a/src/blocks/blocks/button-group/button/edit.js
+++ b/src/blocks/blocks/button-group/button/edit.js
@@ -78,9 +78,6 @@ const Edit = ({
 	}
 
 	if ( hasParent ) {
-		buttonStyleParent = {
-			marginRight: ! isLastChild && `${ parentAttributes.spacing }px`
-		};
 
 		buttonStyle = {
 			paddingTop: `${ parentAttributes.paddingTopBottom }px`,

--- a/src/blocks/blocks/button-group/editor.scss
+++ b/src/blocks/blocks/button-group/editor.scss
@@ -24,6 +24,10 @@
 		vertical-align: middle;
 	}
 
+	.block-editor-block-list__layout {
+		display: flex;
+	}
+
 	.wp-block.block-editor-block-list__block[data-type="themeisle-blocks/button"] {
 		display: inline-block;
 		width: auto;

--- a/src/blocks/blocks/button-group/group/edit.js
+++ b/src/blocks/blocks/button-group/group/edit.js
@@ -1,8 +1,15 @@
+/** @jsx jsx */
+
 /**
  * External dependencies
  */
 import classnames from 'classnames';
 import GoogleFontLoader from 'react-google-font-loader';
+
+import {
+	css,
+	jsx
+} from '@emotion/react';
 
 /**
  * WordPress dependencies.
@@ -102,6 +109,13 @@ const Edit = ({
 						'collapse': ( 'collapse-desktop' === attributes.collapse && ( isDesktop || isTablet || isMobile ) ) || ( 'collapse-tablet' === attributes.collapse && ( isTablet || isMobile ) ) || ( 'collapse-mobile' === attributes.collapse && isMobile )
 					}
 				) }
+				css={
+					css`
+						.block-editor-block-list__layout {
+							column-gap: ${ attributes.spacing }px;
+						}
+					`
+				}
 			>
 				<InnerBlocks
 					allowedBlocks={ [ 'themeisle-blocks/button' ] }


### PR DESCRIPTION
Fix #544

This PR will only change the styling in PHP and Editor.

Testing: No breaking changes should arise. Put a group with buttons of different sizes, go to mobile mode and reduce the window width until the buttons are vertical. They should be centered; if not, the problem is still present.


| Wrong |![image](https://user-images.githubusercontent.com/17597852/141483000-dc1f5d2d-d3d6-42e8-b9a9-b3f55f3303d2.png) | 
| ---- | --- |
| Correct | ![image](https://user-images.githubusercontent.com/17597852/141482844-83c0a46e-6d87-4ce8-a0d9-5ffafa736420.png)|
