### PR TITLE
Add additional checks on core/editor loading

### DIFF
--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -376,7 +376,7 @@ class Main {
 
 		wp_set_script_translations( 'themeisle-gutenberg-blocks', 'otter-blocks' );
 
-		global $wp_roles;
+		global $wp_roles, $current_screen;
 
 		$default_fields = array();
 
@@ -418,6 +418,7 @@ class Main {
 					'isBoosterActive' => 'valid' === apply_filters( 'product_neve_license_status', false ) && true === apply_filters( 'neve_has_block_editor_module', false ),
 					'wooComparison'   => class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Comparison_Table\Options' ) ? \Neve_Pro\Modules\Woocommerce_Booster\Comparison_Table\Options::is_module_activated() : false,
 				),
+				'isBlockEditor'       => 'post' === $current_screen->base,
 			)
 		);
 

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -376,7 +376,7 @@ class Main {
 
 		wp_set_script_translations( 'themeisle-gutenberg-blocks', 'otter-blocks' );
 
-		global $wp_roles, $current_screen;
+		global $wp_roles;
 
 		$default_fields = array();
 
@@ -418,7 +418,7 @@ class Main {
 					'isBoosterActive' => 'valid' === apply_filters( 'product_neve_license_status', false ) && true === apply_filters( 'neve_has_block_editor_module', false ),
 					'wooComparison'   => class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Comparison_Table\Options' ) ? \Neve_Pro\Modules\Woocommerce_Booster\Comparison_Table\Options::is_module_activated() : false,
 				),
-				'isBlockEditor'       => 'post' === $current_screen->base,
+				'isBlockEditor'  => 'post' === $current_screen->base,
 			)
 		);
 

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -103,7 +103,7 @@ const Edit = ({
 	useEffect( () => {
 		if ( attributes.id && select( 'core/edit-widgets' ) ) {
 			setAttributes({ optionName: `widget_${ attributes.id.slice( -8 ) }` });
-		} else if ( attributes.id && window.themeisleGutenberg.isBlockEditor && select( 'core/editor' )?.getCurrentPostId() ) {
+		} else if ( attributes.id && Boolean( window.themeisleGutenberg.isBlockEditor ) && select( 'core/editor' )?.getCurrentPostId() ) {
 			setAttributes({ optionName: `${ select( 'core/editor' ).getCurrentPostId() }_${ attributes.id.slice( -8 ) }` });
 		}
 	}, [ attributes.id ]);

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -103,7 +103,7 @@ const Edit = ({
 	useEffect( () => {
 		if ( attributes.id && select( 'core/edit-widgets' ) ) {
 			setAttributes({ optionName: `widget_${ attributes.id.slice( -8 ) }` });
-		} else if ( attributes.id && select( 'core/editor' )?.getCurrentPostId() ) {
+		} else if ( attributes.id && window.themeisleGutenberg.isBlockEditor && select( 'core/editor' )?.getCurrentPostId() ) {
 			setAttributes({ optionName: `${ select( 'core/editor' ).getCurrentPostId() }_${ attributes.id.slice( -8 ) }` });
 		}
 	}, [ attributes.id ]);

--- a/src/blocks/plugins/css-handler/index.js
+++ b/src/blocks/plugins/css-handler/index.js
@@ -79,7 +79,7 @@ subscribe( () => {
 		}
 	}
 
-	if ( window.themeisleGutenberg.isBlockEditor && select( 'core/editor' ) ) {
+	if ( Boolean( window.themeisleGutenberg.isBlockEditor ) && select( 'core/editor' ) ) {
 		const {
 			isCurrentPostPublished,
 			getEditedPostAttribute,

--- a/src/blocks/plugins/css-handler/index.js
+++ b/src/blocks/plugins/css-handler/index.js
@@ -79,7 +79,7 @@ subscribe( () => {
 		}
 	}
 
-	if ( select( 'core/editor' ) ) {
+	if ( window.themeisleGutenberg.isBlockEditor && select( 'core/editor' ) ) {
 		const {
 			isCurrentPostPublished,
 			getEditedPostAttribute,

--- a/src/blocks/plugins/data-logging/index.js
+++ b/src/blocks/plugins/data-logging/index.js
@@ -10,7 +10,7 @@ import {
 
 window.themeisleGutenberg.dataLogging = {};
 
-if ( window.themeisleGutenberg.isBlockEditor && select( 'core/editor' ) ) {
+if ( Boolean( window.themeisleGutenberg.isBlockEditor ) && select( 'core/editor' ) ) {
 	let hasEditorLoaded = false;
 	let hasSaved = false;
 

--- a/src/blocks/plugins/data-logging/index.js
+++ b/src/blocks/plugins/data-logging/index.js
@@ -10,7 +10,7 @@ import {
 
 window.themeisleGutenberg.dataLogging = {};
 
-if ( select( 'core/editor' ) ) {
+if ( window.themeisleGutenberg.isBlockEditor && select( 'core/editor' ) ) {
 	let hasEditorLoaded = false;
 	let hasSaved = false;
 

--- a/src/blocks/plugins/registerPlugin.js
+++ b/src/blocks/plugins/registerPlugin.js
@@ -25,7 +25,7 @@ import './menu-icons/index.js';
 
 const icon = <Icon icon={ otterIcon } />;
 
-if ( window.themeisleGutenberg.isBlockEditor && select( 'core/editor' ) ) {
+if ( Boolean( window.themeisleGutenberg.isBlockEditor ) && select( 'core/editor' ) ) {
 	registerPlugin( 'themeisle-blocks', {
 		icon,
 		render: Options

--- a/src/blocks/plugins/registerPlugin.js
+++ b/src/blocks/plugins/registerPlugin.js
@@ -25,7 +25,7 @@ import './menu-icons/index.js';
 
 const icon = <Icon icon={ otterIcon } />;
 
-if ( select( 'core/editor' ) ) {
+if ( window.themeisleGutenberg.isBlockEditor && select( 'core/editor' ) ) {
 	registerPlugin( 'themeisle-blocks', {
 		icon,
 		render: Options


### PR DESCRIPTION
Make sure core/editor package doesn't cause any issues on the widgets screen.

@irinelenache Can you make sure of two things:

- Blocks load properly in Post Editor.
- Blocks load properly in Widget screen while this plugin is installed: https://wordpress.org/plugins/download-monitor/

Closes #605