### PR TITLE
Icon visual fix

### DIFF
--- a/src/blocks/blocks/font-awesome-icons/editor.scss
+++ b/src/blocks/blocks/font-awesome-icons/editor.scss
@@ -5,4 +5,8 @@
 		display: inline-flex;
 		justify-content: center;
 	}
+
+	i {
+		width: 100%;
+	}
 }

--- a/src/blocks/blocks/font-awesome-icons/style.scss
+++ b/src/blocks/blocks/font-awesome-icons/style.scss
@@ -8,5 +8,9 @@
 		svg {
 			width: 16px;
 		}
+
+		i {
+			width: 100%;
+		}
 	}
 }


### PR DESCRIPTION
Fix #618 

Use this for testing:
```html
<!-- wp:group -->
<div class="wp-block-group"><!-- wp:themeisle-blocks/font-awesome-icons {"id":"wp-block-themeisle-blocks-font-awesome-icons-2fc2eb9d","align":"left","icon":"accusoft","fontSize":31,"padding":0,"margin":0} -->
<p class="wp-block-themeisle-blocks-font-awesome-icons" id="wp-block-themeisle-blocks-font-awesome-icons-2fc2eb9d"><span class="wp-block-themeisle-blocks-font-awesome-icons-container"><i class="fab fa-accusoft"></i></span></p>
<!-- /wp:themeisle-blocks/font-awesome-icons -->

<!-- wp:heading {"level":3} -->
<h3 id="professional">PROFESSIONAL</h3>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Butcher austin biodiesel aesthetic cray palo santo la croix gastropub forage. Seitan lo-fi minim, poke duis kale chips</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
Use the `development` branch, create a new post and paste the code above. Preview it; the icon should be a little to the left, like in the issue. 

After switching to this, the icon will respect the container, and there should be no breaking changes.
