### PR TITLE
Refactor spacing in Icon List Block

### DIFF
--- a/inc/css/blocks/class-icon-list-css.php
+++ b/inc/css/blocks/class-icon-list-css.php
@@ -51,32 +51,11 @@ class Icon_List_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'selector'   => ' .wp-block-themeisle-blocks-icon-list-item',
 				'properties' => array(
 					array(
-						'property' => 'margin-bottom',
+						'property' => 'gap',
 						'value'    => 'gap',
 						'unit'     => 'px',
-						'default'  => 5,
-					),
-				),
-			)
-		);
-
-		$css->add_item(
-			array(
-				'selector'   => '.is-style-horizontal .wp-block-themeisle-blocks-icon-list-item',
-				'properties' => array(
-					array(
-						'property' => 'margin-right',
-						'value'    => 'gap',
-						'unit'     => 'px',
-						'default'  => 5,
-					),
-					array(
-						'property' => 'margin-bottom',
-						'unit'     => 'px',
-						'default'  => 0,
 					),
 				),
 			)
@@ -94,7 +73,6 @@ class Icon_List_CSS extends Base_CSS {
 						'property' => 'font-size',
 						'value'    => 'defaultSize',
 						'unit'     => 'px',
-						'default'  => 20,
 					),
 				),
 			)

--- a/src/blocks/blocks/icon-list/edit.js
+++ b/src/blocks/blocks/icon-list/edit.js
@@ -54,6 +54,7 @@ const Edit = ({
 						.block-editor-block-list__layout {
 							align-items: ${ attributes.horizontalAlign || 'unset' } !important;
 							justify-content: ${ attributes.horizontalAlign || 'unset' } !important;
+							gap: ${ attributes.gap }px;
 						}
 					`
 				}

--- a/src/blocks/blocks/icon-list/inspector.js
+++ b/src/blocks/blocks/icon-list/inspector.js
@@ -87,6 +87,7 @@ const Inspector = ({
 					onChange={ onDefaultSizeChange }
 					min={ 0 }
 					max={ 60 }
+					allowReset={true}
 				/>
 
 				<RangeControl
@@ -96,6 +97,7 @@ const Inspector = ({
 					onChange={ onGapChange }
 					min={ 0 }
 					max={ 60 }
+					allowReset={ true }
 				/>
 
 				<ColorGradientControl

--- a/src/blocks/blocks/icon-list/item/edit.js
+++ b/src/blocks/blocks/icon-list/item/edit.js
@@ -73,9 +73,6 @@ const Edit = ({
 		fill: attributes.iconColor || parentAttributes.defaultIconColor,
 		fontSize: parentAttributes.defaultSize + 'px'
 	};
-	const itemStyle = {
-		marginRight: parentClass.includes( 'is-style-horizontal' ) ? parentAttributes.gap + 'px' : parentAttributes.gap + 'px'
-	};
 
 	/**
 	 * Add the missing components from parent's attributes
@@ -101,7 +98,6 @@ const Edit = ({
 
 			<div
 				className={ className }
-				style={ itemStyle }
 			>
 				{ 'themeisle-icons' === attributes.library && attributes.icon && Icon !== undefined ? (
 					<Icon

--- a/src/blocks/blocks/icon-list/style.scss
+++ b/src/blocks/blocks/icon-list/style.scss
@@ -1,6 +1,7 @@
 .wp-block-themeisle-blocks-icon-list {
 	display: flex;
 	flex-direction: column;
+	gap: 5px;
 
 	&.is-style-horizontal {
 		flex-wrap: wrap;
@@ -19,6 +20,7 @@
 		}
 
 		p {
+			font-size: 20px;
 			margin-bottom: 0px;
 		}
 	}


### PR DESCRIPTION
Fix #621

Changelog:
- Use `gap` instead of `margin` for spacing
- Add reset button to `font-size` and `gap`
- Move defaults value to CSS instead of PHP

Like in #611, this is just styling and no breaking change should be present.