### PR TITLE
Fix deprecated code

### DIFF
--- a/src/animation/components/animation-popover.js
+++ b/src/animation/components/animation-popover.js
@@ -77,7 +77,7 @@ function AnimationPopover({
 				position="bottom center"
 				renderToggle={ ({ isOpen, onToggle }) => (
 					<Button
-						isLarge
+
 						className="themeisle-animations-control__button"
 						id={ id }
 						onClick={ onToggle }

--- a/src/blocks/blocks/advanced-heading/controls.js
+++ b/src/blocks/blocks/advanced-heading/controls.js
@@ -9,7 +9,7 @@ import {
 	DropdownMenu,
 	RangeControl,
 	SVG,
-	Toolbar
+	ToolbarGroup
 } from '@wordpress/components';
 
 import { BlockControls } from '@wordpress/block-editor';
@@ -126,7 +126,7 @@ const Controls = ({
 				] }
 			/>
 
-			<Toolbar>
+			<ToolbarGroup>
 				<Dropdown
 					contentClassName="wp-themesiel-blocks-advanced-heading-popover-content"
 					position="bottom center"
@@ -177,7 +177,7 @@ const Controls = ({
 						</Fragment>
 					) }
 				/>
-			</Toolbar>
+			</ToolbarGroup>
 		</BlockControls>
 	);
 };

--- a/src/blocks/blocks/advanced-heading/edit.js
+++ b/src/blocks/blocks/advanced-heading/edit.js
@@ -196,7 +196,7 @@ const Edit = ({
 				formattingControls={ [ 'bold', 'italic', 'link', 'strikethrough', 'highlight' ] }
 				allowedFormats={ [ 'core/bold', 'core/italic', 'core/link', 'core/strikethrough', 'themeisle-blocks/highlight' ] }
 				onMerge={ mergeBlocks }
-				unstableOnSplit={
+				onSplit={
 					insertBlocksAfter ?
 						( before, after, ...blocks ) => {
 							setAttributes({ content: before });

--- a/src/blocks/blocks/button-group/button/inspector.js
+++ b/src/blocks/blocks/button-group/button/inspector.js
@@ -61,8 +61,7 @@ const Inspector = ({
 			<ButtonGroup>
 				<Button
 					isSmall
-					isSecondary={ hover }
-					isPrimary={ ! hover }
+					variant={ hover ? 'primary' : 'secondary' }
 					onClick={ () => setHover( false ) }
 				>
 					{ __( 'Normal', 'otter-blocks' ) }
@@ -70,8 +69,7 @@ const Inspector = ({
 
 				<Button
 					isSmall
-					isSecondary={ ! hover }
-					isPrimary={ hover }
+					variant={ hover ? 'primary' : 'secondary' }
 					onClick={ () => setHover( true ) }
 				>
 					{ __( 'Hover', 'otter-blocks' ) }

--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -198,7 +198,7 @@ const Inspector = ({
 						<>
 							<Button
 								onClick={ onToggle }
-								isSecondary
+								 variant="secondary"
 								aria-expanded={ isOpen }
 							>
 								{ attributes.date ? format( settings.formats.datetime, attributes.date ) : __( 'Select Date', 'otter-blocks' ) }

--- a/src/blocks/blocks/countdown/save.js
+++ b/src/blocks/blocks/countdown/save.js
@@ -19,12 +19,11 @@ import {
 const DisplayTimeComponent = ({
 	name,
 	value,
-	tag,
-	key
+	tag
 }) => {
 	return (
 		<div
-			key={ key }
+			key={ name }
 			name={ tag }
 			className={ classnames(
 				'otter-countdown__display-area',
@@ -45,7 +44,7 @@ const DisplayTime = ({
 }) => {
 	const elemToDisplay = hasSeparators ? insertBetweenItems( time, { name: 'sep', value: ':', tag: 'separator' }) : time;
 
-	const renderElem = elemToDisplay?.map( ( elem, key ) => <DisplayTimeComponent { ...elem } key={ key } /> );
+	const renderElem = elemToDisplay?.map( ( elem ) => <DisplayTimeComponent { ...elem } /> );
 
 	return time !== undefined ? (
 		<div className="otter-countdown__container">

--- a/src/blocks/blocks/font-awesome-icons/inspector.js
+++ b/src/blocks/blocks/font-awesome-icons/inspector.js
@@ -112,8 +112,7 @@ const Inspector = ({
 				<ButtonGroup>
 					<Button
 						isSmall
-						isSecondary={ hover }
-						isPrimary={ ! hover }
+						variant={ ! hover ? 'primary' : 'secondary' }
 						onClick={ () => setHover( false ) }
 					>
 						{ __( 'Normal', 'otter-blocks' ) }
@@ -121,8 +120,7 @@ const Inspector = ({
 
 					<Button
 						isSmall
-						isSecondary={ ! hover }
-						isPrimary={ hover }
+						variant={ hover ? 'primary' : 'secondary' }
 						onClick={ () => setHover( true ) }
 					>
 						{ __( 'Hover', 'otter-blocks' ) }

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -166,7 +166,7 @@ const Inspector = ({
 				/>
 
 				<Button
-					isPrimary
+					variant="primary"
 					onClick={ saveEmail }
 					disabled={ email === savedEmail }
 				>

--- a/src/blocks/blocks/form/placeholder.js
+++ b/src/blocks/blocks/form/placeholder.js
@@ -64,7 +64,7 @@ const BlockPlaceholder = ({
 					/>
 
 					<Button
-						isLarge
+
 						variant="primary"
 						type="submit"
 						onClick={ saveAPIKey }

--- a/src/blocks/blocks/form/placeholder.js
+++ b/src/blocks/blocks/form/placeholder.js
@@ -65,7 +65,7 @@ const BlockPlaceholder = ({
 
 					<Button
 						isLarge
-						isPrimary
+						variant="primary"
 						type="submit"
 						onClick={ saveAPIKey }
 						isBusy={ isSaving }

--- a/src/blocks/blocks/google-maps/components/marker-modal.js
+++ b/src/blocks/blocks/google-maps/components/marker-modal.js
@@ -144,7 +144,7 @@ const MarkerModal = ({
 
 			<ButtonGroup>
 				<Button
-					isLarge
+
 					variant="primary"
 					onClick={ () => addMarker( location, title, icon, description, latitude, longitude ) }
 				>
@@ -152,8 +152,8 @@ const MarkerModal = ({
 				</Button>
 
 				<Button
-					isLarge
-					isSecondary
+
+					 variant="secondary"
 					onClick={ close }
 				>
 					{ __( 'Cancel', 'otter-blocks' ) }

--- a/src/blocks/blocks/google-maps/components/marker-modal.js
+++ b/src/blocks/blocks/google-maps/components/marker-modal.js
@@ -145,7 +145,7 @@ const MarkerModal = ({
 			<ButtonGroup>
 				<Button
 					isLarge
-					isPrimary
+					variant="primary"
 					onClick={ () => addMarker( location, title, icon, description, latitude, longitude ) }
 				>
 					{ __( 'Add', 'otter-blocks' ) }

--- a/src/blocks/blocks/google-maps/components/marker-wrapper.js
+++ b/src/blocks/blocks/google-maps/components/marker-wrapper.js
@@ -59,8 +59,8 @@ const MarkerWrapper = ({
 			</div>
 
 			<Button
-				isSecondary
-				isLarge
+				 variant="secondary"
+
 				className="wp-block-themeisle-blocks-google-map-marker-add"
 				onClick={ addMarker }
 			>

--- a/src/blocks/blocks/google-maps/inspector.js
+++ b/src/blocks/blocks/google-maps/inspector.js
@@ -316,8 +316,8 @@ const Inspector = ({
 				/>
 
 				<Button
-					isLarge
-					isSecondary
+
+					 variant="secondary"
 					type="submit"
 					onClick={ saveAPIKey }
 					isBusy={ isSaving }

--- a/src/blocks/blocks/google-maps/placeholder.js
+++ b/src/blocks/blocks/google-maps/placeholder.js
@@ -48,7 +48,7 @@ const BlockPlaceholder = ({
 
 					<Button
 						isLarge
-						isPrimary
+						variant="primary"
 						type="submit"
 						onClick={ saveAPIKey }
 						isBusy={ isSaving }

--- a/src/blocks/blocks/google-maps/placeholder.js
+++ b/src/blocks/blocks/google-maps/placeholder.js
@@ -47,7 +47,7 @@ const BlockPlaceholder = ({
 					/>
 
 					<Button
-						isLarge
+
 						variant="primary"
 						type="submit"
 						onClick={ saveAPIKey }

--- a/src/blocks/blocks/icon-list/item/edit.js
+++ b/src/blocks/blocks/icon-list/item/edit.js
@@ -145,7 +145,6 @@ const Edit = ({
 					onMerge={ mergeBlocks }
 					onReplace={ onReplace }
 					onRemove={ onRemove }
-					keepPlaceholderOnFocus={ true }
 				/>
 			</div>
 		</Fragment>

--- a/src/blocks/blocks/leaflet-map/components/marker-wrapper.js
+++ b/src/blocks/blocks/leaflet-map/components/marker-wrapper.js
@@ -43,8 +43,8 @@ const MarkerWrapper = ({
 			</div>
 
 			<Button
-				isSecondary
-				isLarge
+				 variant="secondary"
+
 				className="wp-block-themeisle-blocks-leaflet-map-marker-add"
 				onClick={ () => {
 					dispatch({

--- a/src/blocks/blocks/lottie/controls.js
+++ b/src/blocks/blocks/lottie/controls.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	Dashicon,
 	Button,
-	Toolbar,
+	ToolbarGroup,
 	Tooltip
 } from '@wordpress/components';
 
@@ -18,7 +18,7 @@ const Controls = ({
 }) => {
 	return (
 		<BlockControls>
-			<Toolbar>
+			<ToolbarGroup>
 				<Tooltip text={ isEditing ? __( 'Save', 'otter-blocks' ) : __( 'Edit', 'otter-blocks' ) }>
 					<Button
 						onClick={ () => setEditing( ! isEditing ) }
@@ -26,7 +26,7 @@ const Controls = ({
 						<Dashicon icon={ isEditing ? 'yes' : 'edit' } />
 					</Button>
 				</Tooltip>
-			</Toolbar>
+			</ToolbarGroup>
 		</BlockControls>
 	);
 };

--- a/src/blocks/blocks/lottie/placeholder.js
+++ b/src/blocks/blocks/lottie/placeholder.js
@@ -78,7 +78,7 @@ const BlockPlaceholder = ({
 					/>
 
 					<Button
-						isPrimary
+						variant="primary"
 						disabled={ ! url }
 						type="submit"
 					>

--- a/src/blocks/blocks/lottie/placeholder.js
+++ b/src/blocks/blocks/lottie/placeholder.js
@@ -87,7 +87,7 @@ const BlockPlaceholder = ({
 
 					{ ! Boolean( window.themeisleGutenberg.isWPVIP ) && (
 						<Button
-							isSecondary
+							 variant="secondary"
 							onClick={ () => setOpen( true ) }
 						>
 							{ __( 'Upload', 'otter-blocks' ) }

--- a/src/blocks/blocks/plugin-card/controls.js
+++ b/src/blocks/blocks/plugin-card/controls.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	Dashicon,
 	Button,
-	Toolbar,
+	ToolbarGroup,
 	Tooltip
 } from '@wordpress/components';
 
@@ -15,7 +15,7 @@ import { BlockControls } from '@wordpress/block-editor';
 const Controls = ({ setAttributes }) => {
 	return (
 		<BlockControls>
-			<Toolbar>
+			<ToolbarGroup>
 				<Tooltip text={ __( 'Edit', 'otter-blocks' ) }>
 					<Button
 						className="components-icon-button components-toolbar__control wp-block-themeisle-blocks-plugin-cards-edit-plugin-card"
@@ -24,7 +24,7 @@ const Controls = ({ setAttributes }) => {
 						<Dashicon icon="edit" />
 					</Button>
 				</Tooltip>
-			</Toolbar>
+			</ToolbarGroup>
 		</BlockControls>
 	);
 };

--- a/src/blocks/blocks/popup/edit.js
+++ b/src/blocks/blocks/popup/edit.js
@@ -67,7 +67,7 @@ const Edit = ({
 				className={ className }
 			>
 				<Button
-					isPrimary
+					variant="primary"
 					icon={ external }
 					onClick={ () => setEditing( true ) }
 				>

--- a/src/blocks/blocks/review-comparison/placeholder.js
+++ b/src/blocks/blocks/review-comparison/placeholder.js
@@ -132,7 +132,7 @@ const BlockPlaceholder = ({
 					</MenuGroup>
 
 					<Button
-						isPrimary
+						variant="primary"
 						onClick={ onComplete }
 					>
 						{ __( 'Done', 'otter-blocks' ) }

--- a/src/blocks/blocks/review/inspector.js
+++ b/src/blocks/blocks/review/inspector.js
@@ -227,7 +227,7 @@ const Inspector = ({
 						/>
 
 						<Button
-							isSecondary
+							 variant="secondary"
 							onClick={ () => setAttributes({ image: undefined }) }
 							disabled={ attributes.product }
 						>
@@ -265,8 +265,8 @@ const Inspector = ({
 				) ) }
 
 				<Button
-					isSecondary
-					isLarge
+					 variant="secondary"
+
 					className="wp-block-themeisle-blocks-review__inspector_add"
 					onClick={ addFeature }
 				>
@@ -294,8 +294,8 @@ const Inspector = ({
 				) ) }
 
 				<Button
-					isSecondary
-					isLarge
+					 variant="secondary"
+
 					className="wp-block-themeisle-blocks-review__inspector_add"
 					onClick={ addPro }
 				>
@@ -323,8 +323,8 @@ const Inspector = ({
 				) ) }
 
 				<Button
-					isSecondary
-					isLarge
+					 variant="secondary"
+
 					className="wp-block-themeisle-blocks-review__inspector_add"
 					onClick={ addCon }
 				>
@@ -410,8 +410,8 @@ const Inspector = ({
 							) ) }
 
 							<Button
-								isSecondary
-								isLarge
+								 variant="secondary"
+
 								className="wp-block-themeisle-blocks-review__inspector_add"
 								onClick={ addLinks }
 							>

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -651,7 +651,7 @@ const Inspector = ({
 									</div>
 
 									<Button
-										isSecondary
+										 variant="secondary"
 										className="wp-block-themeisle-image-container-delete-button"
 										onClick={ removeBackgroundImage }
 									>

--- a/src/blocks/blocks/section/columns/controls.js
+++ b/src/blocks/blocks/section/columns/controls.js
@@ -6,6 +6,8 @@ import {
 	BlockVerticalAlignmentToolbar
 } from '@wordpress/block-editor';
 
+import { ToolbarItem } from '@wordpress/components';
+
 const Controls = ({
 	attributes,
 	setAttributes
@@ -32,10 +34,12 @@ const Controls = ({
 
 	return (
 		<BlockControls>
-			<BlockVerticalAlignmentToolbar
-				onChange={ changeVerticalAlign }
-				value={ getVerticalAlignValue() }
-			/>
+			<ToolbarItem>
+				<BlockVerticalAlignmentToolbar
+					onChange={ changeVerticalAlign }
+					value={ getVerticalAlignValue() }
+				/>
+			</ToolbarItem>
 		</BlockControls>
 	);
 };

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -384,7 +384,6 @@ const Edit = ({
 				<Tooltip text={ __( 'Open Template Library', 'otter-blocks' ) } >
 					<Button
 						variant="primary"
-						isLarge={ true }
 						className="wp-block-themeisle-template-library"
 						onClick={ () => setIsLibraryOpen( true ) }
 					>

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -383,8 +383,8 @@ const Edit = ({
 				/>
 				<Tooltip text={ __( 'Open Template Library', 'otter-blocks' ) } >
 					<Button
-						isPrimary
-						isLarge
+						variant="primary"
+						isLarge={ true }
 						className="wp-block-themeisle-template-library"
 						onClick={ () => setIsLibraryOpen( true ) }
 					>

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -962,8 +962,7 @@ const Inspector = ({
 											icon="editor-alignleft"
 											label={ __( 'Left', 'otter-blocks' ) }
 											showTooltip={ true }
-											isLarge
-											isPrimary={ 'flex-start' === attributes.horizontalAlign }
+											variant={ 'flex-start' === attributes.horizontalAlign ? 'primary' : 'secondary' }
 											onClick={ () => changeHorizontalAlign( 'flex-start' ) }
 										/>
 
@@ -971,8 +970,7 @@ const Inspector = ({
 											icon="editor-aligncenter"
 											label={ __( 'Center', 'otter-blocks' ) }
 											showTooltip={ true }
-											isLarge
-											isPrimary={ 'center' === attributes.horizontalAlign }
+											variant={ 'center' === attributes.horizontalAlign ? 'primary' : 'secondary' }
 											onClick={ () => changeHorizontalAlign( 'center' ) }
 										/>
 
@@ -980,8 +978,7 @@ const Inspector = ({
 											icon="editor-alignright"
 											label={ __( 'Right', 'otter-blocks' ) }
 											showTooltip={ true }
-											isLarge
-											isPrimary={ 'flex-end' === attributes.horizontalAlign }
+											variant={ 'flex-end' === attributes.horizontalAlign ? 'primary' : 'secondary' }
 											onClick={ () => changeHorizontalAlign( 'flex-end' ) }
 										/>
 									</ButtonGroup>
@@ -1064,7 +1061,7 @@ const Inspector = ({
 										</div>
 
 										<Button
-											isSecondary
+											 variant="secondary"
 											className="wp-block-themeisle-image-container-delete-button"
 											onClick={ removeBackgroundImage }
 										>
@@ -1207,7 +1204,7 @@ const Inspector = ({
 										</div>
 
 										<Button
-											isSecondary
+											 variant="secondary"
 											className="wp-block-themeisle-image-container-delete-button"
 											onClick={ removeBackgroundOverlayImage }
 										>
@@ -1523,8 +1520,7 @@ const Inspector = ({
 							<ButtonGroup>
 								<Button
 									isSmall
-									isSecondary={ 'top' !== dividerViewType }
-									isPrimary={ 'top' === dividerViewType }
+									variant={ 'top' === dividerViewType ? 'primary' : 'secondary' }
 									onClick={ () => setDividerViewType( 'top' ) }
 								>
 									{ __( 'Top', 'otter-blocks' ) }
@@ -1532,8 +1528,7 @@ const Inspector = ({
 
 								<Button
 									isSmall
-									isSecondary={ 'bottom' !== dividerViewType }
-									isPrimary={ 'bottom' === dividerViewType }
+									variant={ 'bottom' === dividerViewType ? 'primary' : 'secondary' }
 									onClick={ () => setDividerViewType( 'bottom' ) }
 								>
 									{ __( 'Bottom', 'otter-blocks' ) }

--- a/src/blocks/blocks/section/components/background-control/index.js
+++ b/src/blocks/blocks/section/components/background-control/index.js
@@ -37,7 +37,7 @@ const BackgroundControl = ({
 							icon={ 'admin-customizer' }
 							label={ __( 'Color', 'otter-blocks' ) }
 							showTootlip={ true }
-							isPrimary={ 'color' === backgroundType }
+							variant={ 'color' === backgroundType ? 'primary' : undefined }
 							onClick={ () => changeBackgroundType( 'color' ) }
 						/>
 
@@ -45,7 +45,7 @@ const BackgroundControl = ({
 							icon={ 'format-image' }
 							label={ __( 'Image', 'otter-blocks' ) }
 							showTootlip={ true }
-							isPrimary={ 'image' === backgroundType }
+							variant={ 'image' === backgroundType ? 'primary' : undefined }
 							onClick={ () => changeBackgroundType( 'image' ) }
 						/>
 
@@ -53,7 +53,7 @@ const BackgroundControl = ({
 							icon={ () => <Icon icon={ barcodeIcon } /> }
 							label={ __( 'Gradient', 'otter-blocks' ) }
 							showTootlip={ true }
-							isPrimary={ 'gradient' === backgroundType }
+							variant={ 'gradient' === backgroundType ? 'primary' : undefined }
 							onClick={ () => changeBackgroundType( 'gradient' ) }
 						/>
 					</ButtonGroup>

--- a/src/blocks/blocks/section/components/onboarding/index.js
+++ b/src/blocks/blocks/section/components/onboarding/index.js
@@ -47,7 +47,7 @@ const Onboarding = ({
 			<div className="wp-block-themeisle-layout-picker">
 				<Tooltip text={ __( 'Equal', 'otter-blocks' ) } >
 					<Button
-						isLarge
+
 						className="wp-block-themeisle-blocks-advanced-column-layout"
 						onClick={ () => setupColumns( 2, 'equal' ) }
 					>
@@ -60,7 +60,7 @@ const Onboarding = ({
 
 				<Tooltip text={ __( '1:2', 'otter-blocks' ) } >
 					<Button
-						isLarge
+
 						className="wp-block-themeisle-blocks-advanced-column-layout"
 						onClick={ () => setupColumns( 2, 'oneTwo' ) }
 					>
@@ -73,7 +73,7 @@ const Onboarding = ({
 
 				<Tooltip text={ __( '2:1', 'otter-blocks' ) } >
 					<Button
-						isLarge
+
 						className="wp-block-themeisle-blocks-advanced-column-layout"
 						onClick={ () => setupColumns( 2, 'twoOne' ) }
 					>
@@ -86,7 +86,7 @@ const Onboarding = ({
 
 				<Tooltip text={ __( 'Equal', 'otter-blocks' ) } >
 					<Button
-						isLarge
+
 						className="wp-block-themeisle-blocks-advanced-column-layout"
 						onClick={ () => setupColumns( 3, 'equal' ) }
 					>
@@ -100,7 +100,7 @@ const Onboarding = ({
 
 				<Tooltip text={ __( '1:1:2', 'otter-blocks' ) } >
 					<Button
-						isLarge
+
 						className="wp-block-themeisle-blocks-advanced-column-layout"
 						onClick={ () => setupColumns( 3, 'oneOneTwo' ) }
 					>
@@ -114,7 +114,7 @@ const Onboarding = ({
 
 				<Tooltip text={ __( '2:1:1', 'otter-blocks' ) } >
 					<Button
-						isLarge
+
 						className="wp-block-themeisle-blocks-advanced-column-layout"
 						onClick={ () => setupColumns( 3, 'twoOneOne' ) }
 					>
@@ -128,7 +128,7 @@ const Onboarding = ({
 
 				<Tooltip text={ __( 'Equal', 'otter-blocks' ) } >
 					<Button
-						isLarge
+
 						className="wp-block-themeisle-blocks-advanced-column-layout"
 						onClick={ () => setupColumns( 4, 'equal' ) }
 					>
@@ -145,7 +145,7 @@ const Onboarding = ({
 			<Tooltip text={ __( 'Open Template Library', 'otter-blocks' ) } >
 				<Button
 					variant="primary"
-					isLarge
+
 					className="wp-block-themeisle-template-library"
 					onClick={ () => setIsLibraryOpen( true ) }
 				>
@@ -163,7 +163,7 @@ const Onboarding = ({
 
 			<div className="wp-block-themeisle-layout-skipper">
 				<Button
-					isLink
+					 variant="link"
 					onClick={ () => setupColumns( 1, 'equal' ) }
 				>
 					{ __( 'Skip', 'otter-blocks' ) }

--- a/src/blocks/blocks/section/components/onboarding/index.js
+++ b/src/blocks/blocks/section/components/onboarding/index.js
@@ -145,7 +145,6 @@ const Onboarding = ({
 			<Tooltip text={ __( 'Open Template Library', 'otter-blocks' ) } >
 				<Button
 					variant="primary"
-
 					className="wp-block-themeisle-template-library"
 					onClick={ () => setIsLibraryOpen( true ) }
 				>

--- a/src/blocks/blocks/section/components/onboarding/index.js
+++ b/src/blocks/blocks/section/components/onboarding/index.js
@@ -144,7 +144,7 @@ const Onboarding = ({
 
 			<Tooltip text={ __( 'Open Template Library', 'otter-blocks' ) } >
 				<Button
-					isPrimary
+					variant="primary"
 					isLarge
 					className="wp-block-themeisle-template-library"
 					onClick={ () => setIsLibraryOpen( true ) }

--- a/src/blocks/blocks/sharing-icons/controls.js
+++ b/src/blocks/blocks/sharing-icons/controls.js
@@ -14,7 +14,7 @@ import {
 import { BlockControls } from '@wordpress/block-editor';
 
 import {
-	Toolbar,
+	ToolbarGroup,
 	Button,
 	Tooltip
 } from '@wordpress/components';
@@ -32,7 +32,7 @@ const Controls = ({ attributes, setAttributes }) => {
 
 	return (
 		<BlockControls>
-			<Toolbar>
+			<ToolbarGroup>
 				{ Object.keys( socialList ).map( ( item ) => {
 					const prop = attributes[ item ];
 
@@ -56,7 +56,7 @@ const Controls = ({ attributes, setAttributes }) => {
 						</Tooltip>
 					);
 				}) }
-			</Toolbar>
+			</ToolbarGroup>
 		</BlockControls>
 	);
 };

--- a/src/blocks/blocks/tabs/group/inspector.js
+++ b/src/blocks/blocks/tabs/group/inspector.js
@@ -91,8 +91,8 @@ const Inspector = ({
 				) }
 
 				<Button
-					isSecondary
-					isLarge
+					 variant="secondary"
+
 					className="wp-block-themeisle-blocks-tabs-inspector-add-tab"
 					onClick={ addTab }
 				>

--- a/src/blocks/blocks/tabs/item/inspector.js
+++ b/src/blocks/blocks/tabs/item/inspector.js
@@ -29,7 +29,7 @@ const Inspector = ({
 				title={ __( 'Settings', 'otter-blocks' ) }
 			>
 				<Button
-					isSecondary
+					 variant="secondary"
 					onClick={ () => selectParent() }
 				>
 					{ __( 'Back to the Tabs', 'otter-blocks' ) }

--- a/src/blocks/blocks/woo-comparison/placeholder.js
+++ b/src/blocks/blocks/woo-comparison/placeholder.js
@@ -165,7 +165,7 @@ const BlockPlaceholder = ({
 					</MenuGroup>
 
 					<Button
-						isPrimary
+						variant="primary"
 						onClick={ onComplete }
 					>
 						{ __( 'Done', 'otter-blocks' ) }

--- a/src/blocks/components/block-navigator-control/index.js
+++ b/src/blocks/components/block-navigator-control/index.js
@@ -12,7 +12,7 @@ import {
 import {
 	Button,
 	Modal,
-	Toolbar
+	ToolbarGroup
 } from '@wordpress/components';
 
 import {
@@ -55,7 +55,7 @@ const BlockNavigatorControl = ({ clientId }) => {
 	return (
 		<Fragment>
 			<BlockControls>
-				<Toolbar>
+				<ToolbarGroup>
 					<Button
 						className="components-toolbar__control"
 						label={ __( 'Open block navigator', 'otter-blocks' ) }
@@ -63,7 +63,7 @@ const BlockNavigatorControl = ({ clientId }) => {
 						onClick={ () => setOpen( true ) }
 						icon={ navigatorIcon }
 					/>
-				</Toolbar>
+				</ToolbarGroup>
 			</BlockControls>
 
 			{ isOpen && (

--- a/src/blocks/components/clear-button/index.js
+++ b/src/blocks/components/clear-button/index.js
@@ -44,7 +44,7 @@ const ClearButton = ({
 		<div className="otter-clear-button">
 			<Button
 				isSmall
-				isSecondary
+				 variant="secondary"
 				onClick={ clearValues }
 			>
 				{ __( 'Clear', 'otter-blocks' ) }

--- a/src/blocks/components/google-fonts-control/index.js
+++ b/src/blocks/components/google-fonts-control/index.js
@@ -142,7 +142,7 @@ const GoogleFontsControl = ({
 							position="bottom center"
 							renderToggle={ ({ isOpen, onToggle }) => (
 								<Button
-									isLarge
+
 									className="otter-gfont-button"
 									id={ id }
 									onClick={ onToggle }

--- a/src/blocks/components/icon-picker-control/index.js
+++ b/src/blocks/components/icon-picker-control/index.js
@@ -176,7 +176,7 @@ const IconPickerControl = ({
 							label={ label }
 						>
 							<Button
-								isLarge
+
 								className="otter-icon-picker-button"
 								onClick={ onToggle }
 								aria-expanded={ isOpen }

--- a/src/blocks/components/image-grid/SortableList.js
+++ b/src/blocks/components/image-grid/SortableList.js
@@ -55,7 +55,7 @@ const SortableList = SortableContainer( ({
 			<Button
 				label={ __( 'Add Images', 'otter-blocks' ) }
 				icon={ <Icon icon={ plus } /> }
-				isPrimary
+				variant="primary"
 				onClick={ open }
 			/>
 		</div>

--- a/src/blocks/components/style-switcher-control/index.js
+++ b/src/blocks/components/style-switcher-control/index.js
@@ -10,7 +10,7 @@ import {
 	BaseControl,
 	Button,
 	Dropdown,
-	Toolbar
+	ToolbarGroup
 } from '@wordpress/components';
 
 import { useInstanceId } from '@wordpress/compose';
@@ -78,7 +78,7 @@ export const StyleSwitcherBlockControl = ({
 
 	return (
 		<BlockControls>
-			<Toolbar>
+			<ToolbarGroup>
 				<Dropdown
 					contentClassName="otter-styles-popover-content"
 					position="bottom center"
@@ -122,7 +122,7 @@ export const StyleSwitcherBlockControl = ({
 						</Fragment>
 					) }
 				/>
-			</Toolbar>
+			</ToolbarGroup>
 		</BlockControls>
 	);
 };

--- a/src/blocks/components/template-library/components/template.js
+++ b/src/blocks/components/template-library/components/template.js
@@ -42,8 +42,8 @@ const Template = ({
 
 				<div className="library-modal-content__footer_actions">
 					<Button
-						isSecondary
-						isLarge
+						 variant="secondary"
+
 						className="library-modal-overlay__actions"
 						onClick={ () => importPreview( template ) }
 						tabindex="0"
@@ -53,7 +53,7 @@ const Template = ({
 
 					<Button
 						variant="primary"
-						isLarge
+
 						className="library-modal-overlay__actions"
 						onClick={ () => importTemplate( template.template_url ) }
 						tabindex="0"

--- a/src/blocks/components/template-library/components/template.js
+++ b/src/blocks/components/template-library/components/template.js
@@ -52,7 +52,7 @@ const Template = ({
 					</Button>
 
 					<Button
-						isPrimary
+						variant="primary"
 						isLarge
 						className="library-modal-overlay__actions"
 						onClick={ () => importTemplate( template.template_url ) }

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -298,7 +298,7 @@ const Edit = ({
 							<Button
 								id={ id }
 								onClick={ onToggle }
-								isSecondary
+								 variant="secondary"
 								aria-expanded={ isOpen }
 							>
 								{ value ? format( settings.formats.datetime, value ) : __( 'Select Date', 'otter-blocks' ) }
@@ -526,7 +526,7 @@ const Edit = ({
 														/>
 
 														<Button
-															isSecondary
+															 variant="secondary"
 															isSmall
 															disabled={ ! i.start_time }
 															onClick={ () => {
@@ -593,7 +593,7 @@ const Edit = ({
 														/>
 
 														<Button
-															isSecondary
+															 variant="secondary"
 															isSmall
 															disabled={ ! i.end_time }
 															onClick={ () => {
@@ -628,7 +628,7 @@ const Edit = ({
 										) }
 
 										<Button
-											isLarge
+
 											isDestructive
 											className="otter-blocks-conditions__add"
 											onClick={ () => removeCondition( index, n ) }
@@ -643,8 +643,8 @@ const Edit = ({
 								) ) }
 
 								<Button
-									isSecondary
-									isLarge
+									 variant="secondary"
+
 									className="otter-blocks-conditions__add"
 									onClick={ () => addNewCondition( index ) }
 								>
@@ -660,8 +660,8 @@ const Edit = ({
 				}) }
 
 				<Button
-					isSecondary
-					isLarge
+					 variant="secondary"
+
 					className="otter-blocks-conditions__add"
 					onClick={ addGroup }
 				>

--- a/src/blocks/plugins/options/global-defaults/block-item.js
+++ b/src/blocks/plugins/options/global-defaults/block-item.js
@@ -59,7 +59,7 @@ const BlockItem = ({
 
 					<div className="wp-block-themeisle-blocks-options-global-defaults-actions">
 						<Button
-							isLink
+							 variant="link"
 							isDestructive
 							onClick={ () => resetConfig( blockName ) }
 						>
@@ -68,8 +68,8 @@ const BlockItem = ({
 
 						<div className="wp-block-themeisle-blocks-options-global-defaults-actions-primary">
 							<Button
-								isSecondary
-								isLarge
+								 variant="secondary"
+
 								onClick={ () => setOpen( false ) }
 							>
 								{ __( 'Close', 'otter-blocks' ) }
@@ -77,7 +77,7 @@ const BlockItem = ({
 
 							<Button
 								variant="primary"
-								isLarge
+
 								isBusy={ isLoading }
 								onClick={ async() => {
 									setLoading( true );

--- a/src/blocks/plugins/options/global-defaults/block-item.js
+++ b/src/blocks/plugins/options/global-defaults/block-item.js
@@ -76,7 +76,7 @@ const BlockItem = ({
 							</Button>
 
 							<Button
-								isPrimary
+								variant="primary"
 								isLarge
 								isBusy={ isLoading }
 								onClick={ async() => {

--- a/src/blocks/plugins/options/global-defaults/controls/button.js
+++ b/src/blocks/plugins/options/global-defaults/controls/button.js
@@ -29,8 +29,7 @@ const ButtonBlock = ({
 			<ButtonGroup>
 				<Button
 					isSmall
-					isSecondary={ hover }
-					isPrimary={ ! hover }
+					variant={ ! hover ? 'primary' : 'secondary' }
 					onClick={ () => setHover( false ) }
 				>
 					{ __( 'Normal', 'otter-blocks' ) }
@@ -38,8 +37,7 @@ const ButtonBlock = ({
 
 				<Button
 					isSmall
-					isSecondary={ ! hover }
-					isPrimary={ hover }
+					variant={ hover ? 'primary' : 'secondary' }
 					onClick={ () => setHover( true ) }
 				>
 					{ __( 'Hover', 'otter-blocks' ) }

--- a/src/blocks/plugins/options/global-defaults/controls/font-awesome-icons.js
+++ b/src/blocks/plugins/options/global-defaults/controls/font-awesome-icons.js
@@ -76,8 +76,7 @@ const ButtonGroupBlock = ({
 				<ButtonGroup>
 					<Button
 						isSmall
-						isSecondary={ hover }
-						isPrimary={ ! hover }
+						variant={ ! hover ? 'primary' : 'secondary' }
 						onClick={ () => setHover( false ) }
 					>
 						{ __( 'Normal', 'otter-blocks' ) }
@@ -85,8 +84,7 @@ const ButtonGroupBlock = ({
 
 					<Button
 						isSmall
-						isSecondary={ ! hover }
-						isPrimary={ hover }
+						variant={ hover ? 'primary' : 'secondary' }
 						onClick={ () => setHover( true ) }
 					>
 						{ __( 'Hover', 'otter-blocks' ) }

--- a/src/blocks/plugins/options/global-defaults/controls/section-columns.js
+++ b/src/blocks/plugins/options/global-defaults/controls/section-columns.js
@@ -519,8 +519,8 @@ const SectionColumns = ({
 									icon="editor-alignleft"
 									label={ __( 'Left', 'otter-blocks' ) }
 									showTooltip={ true }
-									isLarge
-									isPrimary={ 'flex-start' === defaults.horizontalAlign }
+
+									variant={ 'flex-start' === defaults.horizontalAlign ? 'primary' : undefined}
 									onClick={ () => changeHorizontalAlign( 'flex-start' ) }
 								/>
 
@@ -528,8 +528,8 @@ const SectionColumns = ({
 									icon="editor-aligncenter"
 									label={ __( 'Center', 'otter-blocks' ) }
 									showTooltip={ true }
-									isLarge
-									isPrimary={ 'center' === defaults.horizontalAlign }
+
+									variant={ 'center' === defaults.horizontalAlign ? 'primary' : undefined }
 									onClick={ () => changeHorizontalAlign( 'center' ) }
 								/>
 
@@ -537,8 +537,8 @@ const SectionColumns = ({
 									icon="editor-alignright"
 									label={ __( 'Right', 'otter-blocks' ) }
 									showTooltip={ true }
-									isLarge
-									isPrimary={ 'flex-end' === defaults.horizontalAlign }
+
+									variant={ 'flex-end' === defaults.horizontalAlign ? 'primary' : undefined }
 									onClick={ () => changeHorizontalAlign( 'flex-end' ) }
 								/>
 							</ButtonGroup>
@@ -589,8 +589,8 @@ const SectionColumns = ({
 							/> }
 							label={ __( 'Top', 'otter-blocks' ) }
 							showTooltip={ true }
-							isLarge
-							isPrimary={ 'flex-start' === defaults.verticalAlign }
+
+							variant={ 'flex-start' === defaults.verticalAlign ? 'primary' : undefined }
 							onClick={ () => changeVerticalAlign( 'flex-start' ) }
 						/>
 
@@ -601,8 +601,8 @@ const SectionColumns = ({
 							/> }
 							label={ __( 'Middle', 'otter-blocks' ) }
 							showTooltip={ true }
-							isLarge
-							isPrimary={ 'center' === defaults.verticalAlign }
+
+							variant={ 'center' === defaults.verticalAlign ? 'primary' : undefined }
 							onClick={ () => changeVerticalAlign( 'center' ) }
 						/>
 
@@ -613,8 +613,8 @@ const SectionColumns = ({
 							/> }
 							label={ __( 'Bottom', 'otter-blocks' ) }
 							showTooltip={ true }
-							isLarge
-							isPrimary={ 'flex-end' === defaults.verticalAlign }
+
+							variant={ 'flex-end' === defaults.verticalAlign ? 'primary' : undefined }
 							onClick={ () => changeVerticalAlign( 'flex-end' ) }
 						/>
 					</ButtonGroup>

--- a/src/dashboard/Components/ButtonControl.js
+++ b/src/dashboard/Components/ButtonControl.js
@@ -31,7 +31,7 @@ const ButtonControl = ({
 
 			<div className="otter-button-control-group">
 				<Button
-					isPrimary
+					variant="primary"
 					isLarge
 					disabled={ disabled }
 					onClick={ action }

--- a/src/dashboard/Components/ButtonControl.js
+++ b/src/dashboard/Components/ButtonControl.js
@@ -32,7 +32,7 @@ const ButtonControl = ({
 			<div className="otter-button-control-group">
 				<Button
 					variant="primary"
-					isLarge
+
 					disabled={ disabled }
 					onClick={ action }
 				>

--- a/src/dashboard/Components/Main.js
+++ b/src/dashboard/Components/Main.js
@@ -254,7 +254,7 @@ const Main = () => {
 								<div className="otter-button-group">
 									<Button
 										variant="primary"
-										isLarge
+
 										disabled={ isAPISaving }
 										onClick={ () => changeOptions( 'themeisle_google_map_block_api_key', 'googleMapsAPI', googleMapsAPI ) }
 									>
@@ -299,7 +299,7 @@ const Main = () => {
 								<div className="otter-button-group">
 									<Button
 										variant="primary"
-										isLarge
+
 										disabled={ isAPISaving }
 										onClick={ () => {
 											changeOptions( 'themeisle_google_captcha_api_site_key', 'googleCaptchaAPISiteKey', googleCaptchaAPISiteKey );
@@ -373,8 +373,8 @@ const Main = () => {
 
 						<div className="otter-info-button-group">
 							<Button
-								isSecondary
-								isLarge
+								 variant="secondary"
+
 								target="_blank"
 								href="https://wordpress.org/support/plugin/otter-blocks"
 								className="otter-step-seven"
@@ -383,8 +383,8 @@ const Main = () => {
 							</Button>
 
 							<Button
-								isSecondary
-								isLarge
+								 variant="secondary"
+
 								target="_blank"
 								href="https://wordpress.org/support/plugin/otter-blocks/reviews/#new-post"
 								className="otter-step-eight"
@@ -406,8 +406,8 @@ const Main = () => {
 
 					<div className="otter-modal-actions">
 						<Button
-							isSecondary
-							isLarge
+							 variant="secondary"
+
 							onClick={ () => setOpen( false ) }
 						>
 							{ __( 'Cancel', 'otter-blocks' ) }
@@ -415,7 +415,7 @@ const Main = () => {
 
 						<Button
 							variant="primary"
-							isLarge
+
 							disabled={ isAPISaving }
 							isBusy={ isAPISaving }
 							onClick={ regenerateStyles }

--- a/src/dashboard/Components/Main.js
+++ b/src/dashboard/Components/Main.js
@@ -253,7 +253,7 @@ const Main = () => {
 
 								<div className="otter-button-group">
 									<Button
-										isPrimary
+										variant="primary"
 										isLarge
 										disabled={ isAPISaving }
 										onClick={ () => changeOptions( 'themeisle_google_map_block_api_key', 'googleMapsAPI', googleMapsAPI ) }
@@ -298,7 +298,7 @@ const Main = () => {
 
 								<div className="otter-button-group">
 									<Button
-										isPrimary
+										variant="primary"
 										isLarge
 										disabled={ isAPISaving }
 										onClick={ () => {
@@ -414,7 +414,7 @@ const Main = () => {
 						</Button>
 
 						<Button
-							isPrimary
+							variant="primary"
 							isLarge
 							disabled={ isAPISaving }
 							isBusy={ isAPISaving }

--- a/src/dashboard/Components/Onboarding.js
+++ b/src/dashboard/Components/Onboarding.js
@@ -115,7 +115,7 @@ const Onboarding = () => {
 
 					<div className="otter-onboarding-modal-action">
 						<Button
-							isPrimary
+							variant="primary"
 							isLarge
 							onClick={ () => {
 								setOpen( false );

--- a/src/dashboard/Components/Onboarding.js
+++ b/src/dashboard/Components/Onboarding.js
@@ -116,7 +116,7 @@ const Onboarding = () => {
 					<div className="otter-onboarding-modal-action">
 						<Button
 							variant="primary"
-							isLarge
+
 							onClick={ () => {
 								setOpen( false );
 								setRunTour( true );
@@ -126,8 +126,8 @@ const Onboarding = () => {
 						</Button>
 
 						<Button
-							isSecondary
-							isLarge
+							 variant="secondary"
+
 							onClick={ () => skipTour( 'skipped' ) }
 						>
 							{ __( 'Skip', 'otter-blocks' ) }

--- a/src/export-import/importer.js
+++ b/src/export-import/importer.js
@@ -142,7 +142,7 @@ const BlocksImporter = ({
 			<FormFileUpload
 				accept="text/json"
 				onChange={ ( e ) => uploadImport( e.target.files ) }
-				isSecondary
+				 variant="secondary"
 			>
 				{ __( 'Upload' ) }
 			</FormFileUpload>


### PR DESCRIPTION
Changelog
- [x] Refactor `Button`. `isPrimary`, `isSecondary`, 'isLink` changed to `variant`. `isLarge` has been removed.
- [x] Refactor `RichText`.  `unstableOnSplit` is now `onSplit`
- [x] `Toolbar` changed to `ToolbarGroup`