### PR TITLE
Fix Blocks CSS not working

### DIFF
--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -52,7 +52,7 @@ class Blocks_Animation {
 
 		wp_enqueue_script(
 			'otter-animation',
-			BLOCKS_ANIMATION_URL . '/build/animation/index.js',
+			BLOCKS_ANIMATION_URL . 'build/animation/index.js',
 			$asset_file['dependencies'],
 			$asset_file['version'],
 			true
@@ -81,14 +81,14 @@ class Blocks_Animation {
 
 		wp_enqueue_style(
 			'animate-css',
-			BLOCKS_ANIMATION_URL . '/assets/animate/animate.min.css',
+			BLOCKS_ANIMATION_URL . 'assets/animate/animate.min.css',
 			array(),
 			$asset_file['version']
 		);
 
 		wp_enqueue_style(
 			'otter-animation',
-			BLOCKS_ANIMATION_URL . '/build/animation/index.css',
+			BLOCKS_ANIMATION_URL . 'build/animation/index.css',
 			array(),
 			$asset_file['version']
 		);
@@ -99,7 +99,7 @@ class Blocks_Animation {
 
 		wp_enqueue_script(
 			'otter-animation-frontend',
-			BLOCKS_ANIMATION_URL . '/build/animation/frontend.js',
+			BLOCKS_ANIMATION_URL . 'build/animation/frontend.js',
 			$asset_file['dependencies'],
 			$asset_file['version'],
 			true

--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -52,7 +52,7 @@ class Blocks_CSS {
 
 		wp_enqueue_script(
 			'otter-css',
-			BLOCKS_CSS_URL . '/build/css/index.js',
+			BLOCKS_CSS_URL . 'build/css/index.js',
 			array_merge( $asset_file['dependencies'], array( 'code-editor', 'csslint' ) ),
 			$asset_file['version'],
 			true
@@ -62,7 +62,7 @@ class Blocks_CSS {
 
 		wp_enqueue_style(
 			'otter-css',
-			BLOCKS_CSS_URL . '/build/css/index.css',
+			BLOCKS_CSS_URL . 'build/css/index.css',
 			array( 'code-editor' ),
 			$asset_file['version']
 		);

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -142,7 +142,7 @@ class Main {
 
 		add_action( 'init', array( $this, 'autoload_classes' ), 11 );
 		add_action( 'init', array( $this, 'register_blocks' ), 11 );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 1 );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) ); // Don't change the priority or else Blocks CSS will stop working.
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_frontend_assets' ) );
 		add_filter( 'script_loader_tag', array( $this, 'filter_script_loader_tag' ), 10, 2 );
 


### PR DESCRIPTION
This fixes Blocks CSS not working. Closes https://github.com/Codeinwp/otter-blocks/issues/631

To test, make sure:

- Blocks CSS work properly on Otter & non-Otter blocks.
- Make sure this change doesn't break Block Conditions and they keep working.

Can you do the testing @irinelenache?