### PR TITLE
Disable custom CSS for Site Editor

### DIFF
--- a/src/animation/editor.js
+++ b/src/animation/editor.js
@@ -46,9 +46,7 @@ function AnimationControls({ attributes, clientId, setAttributes }) {
 	const [ animation, setAnimation ] = useState( 'none' );
 	const [ delay, setDelay ] = useState( 'default' );
 	const [ speed, setSpeed ] = useState( 'default' );
-	const [ currentAnimationLabel, setCurrentAnimationLabel ] = useState(
-		'none'
-	);
+	const [ currentAnimationLabel, setCurrentAnimationLabel ] = useState( 'none' );
 
 	const updateAnimation = ( e ) => {
 		let classes;
@@ -95,7 +93,7 @@ function AnimationControls({ attributes, clientId, setAttributes }) {
 		setAnimation( e );
 		setAttributes({ className: classes });
 
-		let block = document.querySelector( `#block-${ clientId } .animated` );
+		let block = document.querySelector( `#block-${ clientId } .animated` ) || document.querySelector( `#block-${ clientId }.animated` );
 
 		if ( block ) {
 			outAnimation.forEach( ( i ) => {
@@ -172,6 +170,7 @@ function AnimationControls({ attributes, clientId, setAttributes }) {
 				currentAnimationLabel={ currentAnimationLabel }
 				setCurrentAnimationLabel={ setCurrentAnimationLabel }
 			/>
+
 			{ 'none' !== animation && (
 				<Fragment>
 					<SelectControl

--- a/src/css/index.js
+++ b/src/css/index.js
@@ -7,11 +7,13 @@ import { __ } from '@wordpress/i18n';
 
 import { hasBlockSupport } from '@wordpress/blocks';
 
+import { InspectorControls } from '@wordpress/block-editor';
+
 import { PanelBody } from '@wordpress/components';
 
 import { createHigherOrderComponent } from '@wordpress/compose';
 
-import { InspectorControls } from '@wordpress/block-editor';
+import { select } from '@wordpress/data';
 
 import { Fragment } from '@wordpress/element';
 
@@ -70,5 +72,7 @@ const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
 	};
 }, 'withInspectorControl' );
 
-addFilter( 'blocks.registerBlockType', 'themeisle-custom-css/attribute', addAttribute );
-addFilter( 'editor.BlockEdit', 'themeisle-custom-css/with-inspector-controls', withInspectorControls );
+if ( ! select( 'core/edit-site' ) ) {
+	addFilter( 'blocks.registerBlockType', 'themeisle-custom-css/attribute', addAttribute );
+	addFilter( 'editor.BlockEdit', 'themeisle-custom-css/with-inspector-controls', withInspectorControls );
+}


### PR DESCRIPTION
Disable custom CSS editor for Site Editor: https://github.com/Codeinwp/otter-blocks/issues/671

Animations work just fine but without the animations being previewed.