### PR TITLE
Allow SVG for Icons

### DIFF
--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -28,10 +28,16 @@ class Options_Settings {
 		add_action( 'init', array( $this, 'register_meta' ), 19 );
 
 		$allow_json = get_option( 'themeisle_allow_json_upload' );
+		$allow_svg = get_option( 'themeisle_allow_svg_upload' );
 
 		if ( isset( $allow_json ) && true === (bool) $allow_json && ! function_exists( 'is_wpcom_vip' ) ) {
 			add_filter( 'upload_mimes', array( $this, 'allow_json' ) ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
 			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_json' ), 75, 4 );
+		}
+
+		if ( isset( $allow_svg ) && true === (bool) $allow_svg && ! function_exists( 'is_wpcom_vip' ) ) {
+			add_filter( 'upload_mimes', array( $this, 'allow_svg' ) ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
+			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_svg' ), 75, 4 );
 		}
 	}
 
@@ -218,6 +224,18 @@ class Options_Settings {
 
 		register_setting(
 			'themeisle_blocks_settings',
+			'themeisle_allow_svg_upload',
+			array(
+				'type'              => 'boolean',
+				'description'       => __( 'Allow SVG Upload to Media Library.', 'otter-blocks' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'show_in_rest'      => true,
+				'default'           => false,
+			)
+		);
+
+		register_setting(
+			'themeisle_blocks_settings',
 			'themeisle_blocks_form_emails',
 			array(
 				'type'              => 'array',
@@ -355,6 +373,20 @@ class Options_Settings {
 	}
 
 	/**
+	 * Allow SVG uploads
+	 *
+	 * @param array $mimes Supported mimes.
+	 *
+	 * @return array
+	 * @since  2.0.0
+	 * @access public
+	 */
+	public function allow_svg( $mimes ) {
+		$mimes['svg'] = 'image/svg+xml';
+		return $mimes;
+	}
+
+	/**
 	 * Allow JSON uploads
 	 *
 	 * @param null $data File data.
@@ -375,6 +407,31 @@ class Options_Settings {
 		if ( 'json' === $ext ) {
 			$data['type'] = 'application/json';
 			$data['ext']  = 'json';
+		}
+		return $data;
+	}
+
+	/**
+	 * Allow SVG uploads
+	 *
+	 * @param null $data File data.
+	 * @param null $file File object.
+	 * @param null $filename File name.
+	 * @param null $mimes Supported mimes.
+	 *
+	 * @return array
+	 * @since  2.0.0
+	 * @access public
+	 */
+	public function fix_mime_type_svg( $data = null, $file = null, $filename = null, $mimes = null ) {
+		$ext = isset( $data['ext'] ) ? $data['ext'] : '';
+		if ( 1 > strlen( $ext ) ) {
+			$exploded = explode( '.', $filename );
+			$ext      = strtolower( end( $exploded ) );
+		}
+		if ( 'svg' === $ext ) {
+			$data['type'] = 'image/svg+xml';
+			$data['ext']  = 'svg';
 		}
 		return $data;
 	}

--- a/src/dashboard/Components/Main.js
+++ b/src/dashboard/Components/Main.js
@@ -51,6 +51,7 @@ const Main = () => {
 					setGoogleMapsAPI( response.themeisle_google_map_block_api_key );
 					setLoggingData( response.otter_blocks_logger_flag );
 					setJSONUploads( Boolean( response.themeisle_allow_json_upload ) );
+					setSVGUploads( Boolean( response.themeisle_allow_svg_upload ) );
 					setAPILoaded( true );
 					setGoogleCaptchaAPISiteKey( response.themeisle_google_captcha_api_site_key );
 					setGoogleCaptchaAPISecretKey( response.themeisle_google_captcha_api_secret_key );
@@ -72,6 +73,7 @@ const Main = () => {
 	const [ googleMapsAPI, setGoogleMapsAPI ] = useState( '' );
 	const [ isLoggingData, setLoggingData ] = useState( 'no' );
 	const [ allowJSONUploads, setJSONUploads ] = useState( false );
+	const [ allowSVGUploads, setSVGUploads ] = useState( false );
 	const [ isOpen, setOpen ] = useState( false );
 	const [ isRegeneratedDisabled, setRegeneratedDisabled ] = useState( false );
 	const [ googleCaptchaAPISiteKey, setGoogleCaptchaAPISiteKey ] = useState( '' );
@@ -338,6 +340,15 @@ const Main = () => {
 								help={ __( 'This option allows JSON files to be uploaded to the media library to use in Lottie Block. Only enable this option if you want to use custom JSON uploads in Lottie Block.', 'otter-blocks' ) }
 								checked={ allowJSONUploads }
 								onChange={ () => changeOptions( 'themeisle_allow_json_upload', 'allowJSONUploads', ! allowJSONUploads ) }
+							/>
+						</PanelRow>
+
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Allow SVG Uploads.', 'otter-blocks' ) }
+								help={ __( 'This option allows SVG files to be uploaded to the media library to use in Lottie Block. Only enable this option if you want to use custom SVG uploads in Lottie Block.', 'otter-blocks' ) }
+								checked={ allowSVGUploads }
+								onChange={ () => changeOptions( 'themeisle_allow_svg_upload', 'allowSVGUploads', ! allowSVGUploads ) }
 							/>
 						</PanelRow>
 


### PR DESCRIPTION
Close #539 

@HardeepAsrani, I got a problem with SVG manipulation. So, the media placeholder gives us a link with the SVG. We can insert the link via `img` tag. The problem is that we can not manipulate the SVG color in this way.

One idea is to download the content of the link is saved to `library` or `icon` attr, then save the media id in the `library` or `icon`. I am not sure about the approach.
