### PR TITLE
Fix image duplication for Masonry Plugin

### DIFF
--- a/src/blocks/plugins/masonry-extension/edit.js
+++ b/src/blocks/plugins/masonry-extension/edit.js
@@ -99,13 +99,7 @@ const Edit = ({
 				</PanelBody>
 			</InspectorControls>
 
-			{ props.attributes.isMasonry ? (
-				<div className="otter-masonry">
-					{children}
-				</div>
-			) : (
-				children
-			) }
+			{ props.attributes.isMasonry ? <div className="otter-masonry">{ children }</div> : children }
 		</Fragment>
 	);
 };

--- a/src/blocks/plugins/masonry-extension/edit.js
+++ b/src/blocks/plugins/masonry-extension/edit.js
@@ -18,8 +18,8 @@ import {
 } from '@wordpress/element';
 
 const Edit = ({
-	BlockEdit,
-	props
+	props,
+	children
 }) => {
 	useEffect( () => {
 		initMasonry();
@@ -101,10 +101,10 @@ const Edit = ({
 
 			{ props.attributes.isMasonry ? (
 				<div className="otter-masonry">
-					<BlockEdit { ...props } />
+					{children}
 				</div>
 			) : (
-				<BlockEdit { ...props } />
+				children
 			) }
 		</Fragment>
 	);

--- a/src/blocks/plugins/masonry-extension/index.js
+++ b/src/blocks/plugins/masonry-extension/index.js
@@ -34,12 +34,19 @@ const addAttribute = ( props ) => {
 
 const withMasonryExtension = createHigherOrderComponent( BlockEdit => {
 	return ( props ) => {
-		if ( 'core/gallery' === props.name && !! props.attributes.images.length ) {
+
+		// We need to omit the uploading state of the images, because it can result in duplicated images
+		const imagesUploading = props.attributes?.images?.some(
+			( img ) => ! img.id && 0 === img.url?.indexOf( 'blob:' )
+		);
+
+		if ( 'core/gallery' === props.name && !! props.attributes.images?.length && ! imagesUploading ) {
 			return (
 				<Edit
-					BlockEdit={ BlockEdit }
 					props={ props }
-				/>
+				>
+					<BlockEdit { ...props } />
+				</Edit>
 			);
 		}
 


### PR DESCRIPTION
#### Changelog
- Add a new condition such as not adding Masonry when images are loading.
- Make `Edit` be more like a wrapper.