### PR TITLE
Fix pop not working with WP 5.9

### DIFF
--- a/src/blocks/blocks/popup/save.js
+++ b/src/blocks/blocks/popup/save.js
@@ -10,8 +10,6 @@ import classnames from 'classnames';
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-import { Button } from '@wordpress/components';
-
 const Save = ({
 	attributes,
 	className
@@ -40,7 +38,7 @@ const Save = ({
 				<div className="otter-popup__modal_content">
 					{ attributes.showClose && (
 						<div className="otter-popup__modal_header">
-							<Button icon={ closeSmall } />
+							<button type="button" class="components-button has-icon"><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg></button>
 						</div>
 					) }
 


### PR DESCRIPTION
This should fix it: https://github.com/Codeinwp/otter-blocks/issues/657