### PR TITLE
fix: comparison table editor style

### DIFF
--- a/inc/render/class-woo-comparison-block.php
+++ b/inc/render/class-woo-comparison-block.php
@@ -47,7 +47,7 @@ class Woo_Comparison_Block extends Base_Block {
 
 			$table = new \Neve_Pro\Modules\Woocommerce_Booster\Comparison_Table\Main();
 
-			if( method_exists( $table, 'enqueue_assets' ) ) {
+			if ( method_exists( $table, 'enqueue_assets' ) ) {
 				$table->enqueue_assets();
 			}
 		}

--- a/inc/render/class-woo-comparison-block.php
+++ b/inc/render/class-woo-comparison-block.php
@@ -46,7 +46,7 @@ class Woo_Comparison_Block extends Base_Block {
 			wp_enqueue_style( 'neve-woocommerce', NEVE_ASSETS_URL . 'css/woocommerce' . ( ( NEVE_DEBUG ) ? '' : '.min' ) . '.css', array( 'woocommerce-general' ), apply_filters( 'neve_version_filter', NEVE_VERSION ) );
 
 			$table = new \Neve_Pro\Modules\Woocommerce_Booster\Comparison_Table\Main();
-			$table->register_assets();
+			$table->enqueue_assets();
 		}
 
 		if ( is_admin() && class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Module' ) ) {

--- a/inc/render/class-woo-comparison-block.php
+++ b/inc/render/class-woo-comparison-block.php
@@ -46,7 +46,10 @@ class Woo_Comparison_Block extends Base_Block {
 			wp_enqueue_style( 'neve-woocommerce', NEVE_ASSETS_URL . 'css/woocommerce' . ( ( NEVE_DEBUG ) ? '' : '.min' ) . '.css', array( 'woocommerce-general' ), apply_filters( 'neve_version_filter', NEVE_VERSION ) );
 
 			$table = new \Neve_Pro\Modules\Woocommerce_Booster\Comparison_Table\Main();
-			$table->enqueue_assets();
+
+			if( method_exists( $table, 'enqueue_assets' ) ) {
+				$table->enqueue_assets();
+			}
 		}
 
 		if ( is_admin() && class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Module' ) ) {


### PR DESCRIPTION
### Description
Comparison table block styles wasn't working on the editor side (ref: https://github.com/Codeinwp/otter-blocks/issues/657#issuecomment-1022141070 reported by @irinelenache)

Now, comparison table block styles works well frontend+editor side.

Note: To able fix the issue; this PR needs a dependent PR on Neve Pro repo: https://github.com/Codeinwp/neve-pro-addon/pull/1834

### Test instructions
1. Install Otter from this PR: https://github.com/Codeinwp/otter-blocks/pull/691
2. Install Neve Pro from this PR: https://github.com/Codeinwp/neve-pro-addon/pull/1834
3. Comparison Table block should be worked well on frontend+editor side.

cc: @Soare-Robert-Daniel 