### PR TITLE
refactor: compatibility added for neve pro modules that support singl…

### DIFF
--- a/inc/render/class-woo-comparison-block.php
+++ b/inc/render/class-woo-comparison-block.php
@@ -52,10 +52,33 @@ class Woo_Comparison_Block extends Base_Block {
 			}
 		}
 
-		if ( is_admin() && class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Module' ) ) {
-			$module = new \Neve_Pro\Modules\Woocommerce_Booster\Module();
-			add_action( 'admin_enqueue_scripts', array( $module, 'enqueue_scripts' ) );
+		$this->load_woocommerce_booster_assets();
+	}
+
+	/**
+	 * Load Scripts and Styles of the WooCommerce Booster
+	 *
+	 * @return bool
+	 */
+	protected function load_woocommerce_booster_assets() {
+		if( ! is_admin() ) {
+			return false;
 		}
+
+		if( defined( 'NEVE_PRO_COMPATIBILITY_FEATURES' ) && isset( NEVE_PRO_COMPATIBILITY_FEATURES[ 'singleton_pattern_on_pro_modules' ] )  ) {
+			$module = neve_pro()->module('woocommerce_booster');
+		}else if( class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Module' ) ) {
+			$module = new \Neve_Pro\Modules\Woocommerce_Booster\Module();
+		}else{
+			return false;
+		}
+
+		if( ! method_exists( $module, 'enqueue_scripts' ) ) {
+			return false;
+		}
+
+		add_action( 'admin_enqueue_scripts', array( $module, 'enqueue_scripts' ) );
+		return true;
 	}
 
 	/**

--- a/inc/render/class-woo-comparison-block.php
+++ b/inc/render/class-woo-comparison-block.php
@@ -61,19 +61,19 @@ class Woo_Comparison_Block extends Base_Block {
 	 * @return bool
 	 */
 	protected function load_woocommerce_booster_assets() {
-		if( ! is_admin() ) {
+		if ( ! is_admin() ) {
 			return false;
 		}
 
-		if( defined( 'NEVE_PRO_COMPATIBILITY_FEATURES' ) && isset( NEVE_PRO_COMPATIBILITY_FEATURES[ 'singleton_pattern_on_pro_modules' ] )  ) {
-			$module = neve_pro()->module('woocommerce_booster');
-		}else if( class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Module' ) ) {
+		if ( defined( 'NEVE_PRO_COMPATIBILITY_FEATURES' ) && isset( NEVE_PRO_COMPATIBILITY_FEATURES['singleton_pattern_on_pro_modules'] ) ) {
+			$module = neve_pro()->module( 'woocommerce_booster' );
+		} elseif ( class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Module' ) ) {
 			$module = new \Neve_Pro\Modules\Woocommerce_Booster\Module();
-		}else{
+		} else {
 			return false;
 		}
 
-		if( ! method_exists( $module, 'enqueue_scripts' ) ) {
+		if ( ! method_exists( $module, 'enqueue_scripts' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
We've made refactor on the modules of the Neve Pro: [singleton pattern on neve pro modules](https://github.com/Codeinwp/neve-pro-addon/issues/1820) as part of the [Automatic Module Configurations](https://github.com/Codeinwp/neve-pro-addon/issues/1573). With the next release that has [Automatic Module Configurations PR](https://github.com/Codeinwp/neve-pro-addon/pull/1856), current modules will be legacy.

I've added compatibility support for the new module structure with this PR.

Now, Otter supports both of them ( old Neve Pro versions (doesn't support singleton pattern ones) and next Neve Pro versions (does support singleton pattern ones) )

-------

**These change only will affect the users that has the condition in the following:**
We have a removal plan for legacy module structure from Neve Pro (estimated 3 major version later - mid of the x month of month 2022)

So, if the user doesn't update the Otter and just update Neve Pro:

**- Deprecated notice will be shown until the legacy module removal (estimated mid of the x month of 2022)**

      **Notice will be something like that:**
      _Deprecated: Neve_Pro\Modules\Woocommerce_Booster\Module is deprecated since 2.1.6, please use Neve_Pro\Modules\Woocommerce_Booster\Main instead. in /disagreenation/wordpress/wp-content/plugins/neve-pro-addon/includes/core/legacy_abstract_module.php on line 43_

**- Compatibility support will be broken after the legacy module removal (estimated mid of the x month of 2022)**

    In this case, woocommerce booster of the Neve Pro styles will not be loaded.
    
 
 note: we'll tackle removal of the legacy part on the [here](https://github.com/Codeinwp/neve-pro-addon/issues/1857)

------

### Test Cases for QA
* This PR + Neve Pro stable version(any neve pro version released before the x month of  2022) should work well with there should no any error&notice.
* This PR + [Singleton Pattern PR of the Neve Pro](https://github.com/Codeinwp/neve-pro-addon/pull/1821) should work well with there should no deprecated error.
* Otter stable version + [Singleton Pattern PR of Neve Pro](https://github.com/Codeinwp/neve-pro-addon/pull/1821) should throws deprecated error. (We did this consciously.)

Closes #730 
