### PR TITLE
Add reset button for section width range control

### DIFF
--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -539,6 +539,7 @@ const Inspector = ({
 							<RangeControl
 								label={ __( 'Maximum Content Width', 'otter-blocks' ) }
 								value={ attributes.columnsWidth || '' }
+								allowReset
 								onChange={ changeColumnsWidth }
 								min={ 0 }
 								max={ 2400 }


### PR DESCRIPTION
Added a reset button for the range that controls the maximal content width on sections.

When clicked it sets the value to the default value which is `undefined`.