### PR TITLE
Fix: animations on print

### DIFF
--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -1,7 +1,3 @@
-.hidden-animated {
-	visibility: hidden;
-}
-
 .animated.delay-100ms {
 	-webkit-animation-delay: 100ms;
 	animation-delay: 100ms;
@@ -103,6 +99,12 @@
 
 .otter-animations-count-image {
    width: 100%;
+}
+
+@media screen {
+	.hidden-animated {
+		visibility: hidden;
+	}
 }
 
 @media ( max-width: 782px ) {


### PR DESCRIPTION
Makes animated blocks show when the page is printed.