### PR TITLE
Fix: About author block on dark mode

### DIFF
--- a/inc/render/class-about-author-block.php
+++ b/inc/render/class-about-author-block.php
@@ -33,14 +33,17 @@ class About_Author_Block {
 			esc_html( get_the_author_meta( 'display_name' ) )
 		);
 
-		$content_markup = sprintf(
-			'<p>%1$s</p>',
-			esc_html( wp_strip_all_tags( get_the_author_meta( 'description' ) ) )
-		);
+		$content_markup = '';
+		if ( ! empty( get_the_author_meta( 'description' ) ) ) {
+			$content_markup = sprintf(
+				'<p>%1$s</p>',
+				esc_html( wp_strip_all_tags( get_the_author_meta( 'description' ) ) )
+			);
+		}
 
 		return sprintf(
 			'<section %1$s><div class="o-author-image">%2$s</div><div class="o-author-data">%3$s%4$s</div></section>',
-			$wrapper_attributes = get_block_wrapper_attributes(),
+			get_block_wrapper_attributes(),
 			$img_markup,
 			$title_markup,
 			$content_markup

--- a/src/blocks/blocks/about-author/style.scss
+++ b/src/blocks/blocks/about-author/style.scss
@@ -3,7 +3,6 @@ section {
 		border: 0;
 		margin-bottom: 30px;
 		border-radius: 6px;
-		color: rgba(0,0,0,.87);
 		width: 100%;
 		position: relative;
 		display: flex;
@@ -21,20 +20,26 @@ section {
 				height: auto;
 				box-shadow: 0 16px 38px -12px rgba(0, 0, 0, 0.56), 0 4px 25px 0 rgba(0, 0, 0, 0.12), 0 8px 10px -5px rgba(0, 0, 0, 0.2);
 				border-radius: 50%;
-	
+
 				&:hover {
 					opacity: 0.8;
 				}
 			}
 		}
-	
+
 		.o-author-data {
 			width: 83.33333333%;
 			float: left;
 			margin: 0 15px;
-	
+			align-self: center;
+
+			h4 {
+				margin: 0;
+			}
+
 			p {
 				font-size: 14px;
+				margin: 15px 0;
 			}
 		}
 


### PR DESCRIPTION
Improvements on the About Author block:
- fixed text color on Neve dark mode
- author's name is centered when the description is empty