### PR TITLE
Fix: Google maps invalid key

### DIFF
--- a/src/blocks/blocks/google-map/edit.js
+++ b/src/blocks/blocks/google-map/edit.js
@@ -454,6 +454,7 @@ const Edit = ({
 					error={ errorState }
 					isAPILoaded={ isAPILoaded }
 					isAPISaved={ isAPISaved }
+					isSaving={ isSaving }
 					changeAPI={ ( key ) => {
 						setAPI( key );
 						setErrorState( false );

--- a/src/blocks/blocks/google-map/edit.js
+++ b/src/blocks/blocks/google-map/edit.js
@@ -81,6 +81,10 @@ const Edit = ({
 
 		window.isMapLoaded = window.isMapLoaded || false;
 		window[ `removeMarker_${ clientId.substr( 0, 8 ) }` ] = removeMarker;
+		// eslint-disable-next-line camelcase
+		window.gm_authFailure = function() {
+			setAPISaved( false );
+		};
 
 		linkRef.current = document.createElement( 'script' );
 		linkRef.current.type = 'text/javascript';

--- a/src/blocks/blocks/google-map/edit.js
+++ b/src/blocks/blocks/google-map/edit.js
@@ -84,6 +84,7 @@ const Edit = ({
 		// eslint-disable-next-line camelcase
 		window.gm_authFailure = function() {
 			setAPISaved( false );
+			setErrorState( true );
 		};
 
 		linkRef.current = document.createElement( 'script' );
@@ -127,6 +128,7 @@ const Edit = ({
 	const [ isModalOpen, setModalOpen ] = useState( false );
 	const [ isAdvanced, setAdvanced ] = useState( false );
 	const [ selectedMarker, setSelectedMarker ] = useState({});
+	const [ errorState, setErrorState ] = useState( false );
 
 	const enqueueScript = api => {
 		if ( ! window.isMapLoaded ) {
@@ -449,9 +451,13 @@ const Edit = ({
 			<div { ...blockProps }>
 				<Placeholder
 					api={ api }
+					error={ errorState }
 					isAPILoaded={ isAPILoaded }
 					isAPISaved={ isAPISaved }
-					changeAPI={ setAPI }
+					changeAPI={ ( key ) => {
+						setAPI( key );
+						setErrorState( false );
+					} }
 					saveAPIKey={ saveAPIKey }
 				/>
 			</div>

--- a/src/blocks/blocks/google-map/editor.scss
+++ b/src/blocks/blocks/google-map/editor.scss
@@ -25,18 +25,21 @@
 			min-height: 36px;
 		}
 
-		#inspector-text-control-1__help {
-			font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;
-			font-size: 13px;
-			font-style: italic;
-			margin-bottom: 15px;
-		}
-
 		&.is-invalid {
 			input[type="text"] {
 				border-color: var(--wp--preset--color--vivid-red);
 				box-shadow: 0 0 0 1px var(--wp--preset--color--vivid-red);
 				outline: 2px solid transparent;
+			}
+		}
+	}
+
+	.components-placeholder__fieldset {
+		.components-placeholder__learn-more {
+			p {
+				font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;
+				font-size: 13px;
+				margin-bottom: 5px;
 			}
 		}
 	}

--- a/src/blocks/blocks/google-map/editor.scss
+++ b/src/blocks/blocks/google-map/editor.scss
@@ -24,6 +24,21 @@
 		input[type="text"] {
 			min-height: 36px;
 		}
+
+		#inspector-text-control-1__help {
+			font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;
+			font-size: 13px;
+			font-style: italic;
+			margin-bottom: 15px;
+		}
+
+		&.is-invalid {
+			input[type="text"] {
+				border-color: var(--wp--preset--color--vivid-red);
+				box-shadow: 0 0 0 1px var(--wp--preset--color--vivid-red);
+				outline: 2px solid transparent;
+			}
+		}
 	}
 
 	.gmnoprint {

--- a/src/blocks/blocks/google-map/placeholder.js
+++ b/src/blocks/blocks/google-map/placeholder.js
@@ -47,7 +47,6 @@ const BlockPlaceholder = ({
 						placeholder={ __( 'Google Maps API Key', 'otter-blocks' ) }
 						value={ api }
 						className={ classnames( 'components-placeholder__input', { 'is-invalid': error }) }
-						help={ error && __( 'The API key could not be validated.', 'otter-blocks' ) }
 						onChange={ changeAPI }
 					/>
 
@@ -63,7 +62,9 @@ const BlockPlaceholder = ({
 				</div>
 
 				<div className="components-placeholder__learn-more">
-					{ __( 'You need to activate Maps and Places API.', 'otter-blocks' ) } <ExternalLink href="https://developers.google.com/maps/documentation/javascript/get-api-key">{ __( 'Need an API key? Get one here.', 'otter-blocks' ) }</ExternalLink>
+					{ error && <p>{ __( 'The API key could not be validated.', 'otter-blocks' ) }</p> }
+
+					<p>{ __( 'You need to activate Maps and Places API.', 'otter-blocks' ) } <ExternalLink href="https://developers.google.com/maps/documentation/javascript/get-api-key">{ __( 'Need an API key? Get one here.', 'otter-blocks' ) }</ExternalLink></p>
 				</div>
 			</Placeholder>
 		);

--- a/src/blocks/blocks/google-map/placeholder.js
+++ b/src/blocks/blocks/google-map/placeholder.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -13,6 +18,7 @@ import {
 
 const BlockPlaceholder = ({
 	api,
+	error,
 	isAPILoaded,
 	isAPISaved,
 	isSaving,
@@ -40,7 +46,8 @@ const BlockPlaceholder = ({
 						type="text"
 						placeholder={ __( 'Google Maps API Key', 'otter-blocks' ) }
 						value={ api }
-						className="components-placeholder__input"
+						className={ classnames( 'components-placeholder__input', { 'is-invalid': error }) }
+						help={ error && __( 'The API key could not be validated!', 'otter-blocks' ) }
 						onChange={ changeAPI }
 					/>
 
@@ -49,7 +56,7 @@ const BlockPlaceholder = ({
 						type="submit"
 						onClick={ saveAPIKey }
 						isBusy={ isSaving }
-						disabled={ '' === api }
+						disabled={ '' === api || error }
 					>
 						{ __( 'Save', 'otter-blocks' ) }
 					</Button>

--- a/src/blocks/blocks/google-map/placeholder.js
+++ b/src/blocks/blocks/google-map/placeholder.js
@@ -47,7 +47,7 @@ const BlockPlaceholder = ({
 						placeholder={ __( 'Google Maps API Key', 'otter-blocks' ) }
 						value={ api }
 						className={ classnames( 'components-placeholder__input', { 'is-invalid': error }) }
-						help={ error && __( 'The API key could not be validated!', 'otter-blocks' ) }
+						help={ error && __( 'The API key could not be validated.', 'otter-blocks' ) }
 						onChange={ changeAPI }
 					/>
 


### PR DESCRIPTION
When the saved API key is invalid, the placeholder should appear instead of the blank map.

If the user enters again an invalid key the issue is still there, but after a refresh, the placeholder should appear again.
So, the issue is partially solved.