### PR TITLE
 Allow option to disable Block Conditions module

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -273,6 +273,9 @@ class Registration {
 				'useOldMacyContainer' => version_compare( get_bloginfo( 'version' ), '5.8.10', '<=' ),
 				'postTypes'           => get_post_types( [ 'public' => true ] ),
 				'rootUrl'             => get_site_url(),
+				'hasModule'           => array(
+					'blockConditions' => get_option( 'themeisle_blocks_settings_block_conditions', true ),
+				),
 			)
 		);
 

--- a/inc/plugins/class-block-conditions.php
+++ b/inc/plugins/class-block-conditions.php
@@ -23,8 +23,10 @@ class Block_Conditions {
 	 * Initialize the class
 	 */
 	public function init() {
-		add_action( 'render_block', array( $this, 'render_blocks' ), 999, 2 );
-		add_action( 'wp_loaded', array( $this, 'add_attributes_to_blocks' ), 999 );
+		if ( get_option( 'themeisle_blocks_settings_block_conditions', true ) ) {
+			add_action( 'render_block', array( $this, 'render_blocks' ), 999, 2 );
+			add_action( 'wp_loaded', array( $this, 'add_attributes_to_blocks' ), 999 );
+		}
 	}
 
 	/**

--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -88,6 +88,17 @@ class Options_Settings {
 
 		register_setting(
 			'themeisle_blocks_settings',
+			'themeisle_blocks_settings_block_conditions',
+			array(
+				'type'         => 'boolean',
+				'description'  => __( 'Blocks Conditions module allows to hide/display blocks to your users based on selected conditions.', 'otter-blocks' ),
+				'show_in_rest' => true,
+				'default'      => true,
+			)
+		);
+
+		register_setting(
+			'themeisle_blocks_settings',
 			'otter_blocks_logger_flag',
 			array(
 				'type'         => 'string',

--- a/src/blocks/plugins/conditions/index.js
+++ b/src/blocks/plugins/conditions/index.js
@@ -57,6 +57,8 @@ const withConditionsIndicator = createHigherOrderComponent( BlockListBlock => {
 	};
 }, 'withMasonryExtension' );
 
-addFilter( 'blocks.registerBlockType', 'themeisle-gutenberg/conditions-register', addAttribute );
-addFilter( 'editor.BlockEdit', 'themeisle-gutenberg/conditions-inspector', withConditions );
-addFilter( 'editor.BlockListBlock', 'block-visibility/contextual-indicators', withConditionsIndicator );
+if ( Boolean( window.themeisleGutenberg.hasModule.blockConditions ) ) {
+	addFilter( 'blocks.registerBlockType', 'themeisle-gutenberg/conditions-register', addAttribute );
+	addFilter( 'editor.BlockEdit', 'themeisle-gutenberg/conditions-inspector', withConditions );
+	addFilter( 'editor.BlockListBlock', 'block-visibility/contextual-indicators', withConditionsIndicator );
+}

--- a/src/dashboard/Components/Main.js
+++ b/src/dashboard/Components/Main.js
@@ -47,6 +47,7 @@ const Main = () => {
 				settingsRef.current.fetch().then( response => {
 					setCSSModule( Boolean( response.themeisle_blocks_settings_css_module ) );
 					setBlocksAnimation( Boolean( response.themeisle_blocks_settings_blocks_animation ) );
+					setBlockConditions( Boolean( response.themeisle_blocks_settings_block_conditions ) );
 					setDefaultSection( Boolean( response.themeisle_blocks_settings_default_block ) );
 					setGoogleMapsAPI( response.themeisle_google_map_block_api_key );
 					setLoggingData( response.otter_blocks_logger_flag );
@@ -68,6 +69,7 @@ const Main = () => {
 	const [ notification, setNotification ] = useState( null );
 	const [ cssModule, setCSSModule ] = useState( false );
 	const [ blocksAnimation, setBlocksAnimation ] = useState( false );
+	const [ blockConditions, setBlockConditions ] = useState( false );
 	const [ isDefaultSection, setDefaultSection ] = useState( true );
 	const [ googleMapsAPI, setGoogleMapsAPI ] = useState( '' );
 	const [ isLoggingData, setLoggingData ] = useState( 'no' );
@@ -130,6 +132,9 @@ const Main = () => {
 			break;
 		case 'blocksAnimation':
 			setBlocksAnimation( value );
+			break;
+		case 'blockConditions':
+			setBlockConditions( value );
 			break;
 		case 'isDefaultSection':
 			setDefaultSection( value );
@@ -211,6 +216,15 @@ const Main = () => {
 								help={ __( 'Blocks Animation module allows to add CSS animations to each block in Block Editor.', 'otter-blocks' ) }
 								checked={ blocksAnimation }
 								onChange={ () => changeOptions( 'themeisle_blocks_settings_blocks_animation', 'blocksAnimation', ! blocksAnimation ) }
+							/>
+						</PanelRow>
+
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Enable Block Condition Module', 'otter-blocks' ) }
+								help={ __( 'Blocks Conditions module allows to hide/display blocks to your users based on selected conditions.', 'otter-blocks' ) }
+								checked={ blockConditions }
+								onChange={ () => changeOptions( 'themeisle_blocks_settings_block_conditions', 'blockConditions', ! blockConditions ) }
 							/>
 						</PanelRow>
 					</PanelBody>


### PR DESCRIPTION
fixes: https://github.com/Codeinwp/otter-blocks/issues/838

There should be an option to disable the module in Dashboard.