### PR TITLE
Fix speed class name for Typing

### DIFF
--- a/src/animation/frontend/typing/index.js
+++ b/src/animation/frontend/typing/index.js
@@ -14,7 +14,7 @@ const speedConfig = {
 	'o-typing-slower': 0.4,
 	'o-typing-slow': 0.25,
 	'o-typing-fast': 0.05,
-	'o-typing-fastest': 0.01
+	'o-typing-faster': 0.01
 };
 
 /**


### PR DESCRIPTION
Fix #845

---- 

#### Test Query

```javascript
new QueryQA().select('blocks').where({ has: { plugins: ['typing'] }}).run()
```

[Query Engine](https://github.com/Codeinwp/otter-query-engine)  
[Browser Extension](https://github.com/Soare-Robert-Daniel/otter-blocks-qa-templates/tree/main/chrome-extension)