### PR TITLE
Stop the infinit loop for Resuable Blocks on the ID hook.

### DIFF
--- a/src/blocks/blocks/leaflet-map/edit.js
+++ b/src/blocks/blocks/leaflet-map/edit.js
@@ -56,7 +56,7 @@ const Edit = ({
 	toggleSelection
 }) => {
 	useEffect( () => {
-		const unsubscribe = blockInit( clientId, defaultAttributes )
+		const unsubscribe = blockInit( clientId, defaultAttributes );
 		return () => unsubscribe( attributes.id );
 	}, [ attributes.id ]);
 
@@ -336,6 +336,7 @@ const Edit = ({
 
 	useEffect( () => {
 		if ( markersStore ) {
+
 			// setAttributes({ markers: markersStore.map( ({ markerProps }) => markerProps ) });
 
 			markersStore.forEach( marker => {
@@ -359,7 +360,7 @@ const Edit = ({
 			});
 
 
-			if( attributes.markers.length !== markersStore.length && map ) {
+			if ( attributes.markers.length !== markersStore.length && map ) {
 				setAttributes({ markers: markersStore.map( ({ markerProps }) => markerProps ) });
 			}
 		}

--- a/src/blocks/blocks/leaflet-map/edit.js
+++ b/src/blocks/blocks/leaflet-map/edit.js
@@ -336,9 +336,6 @@ const Edit = ({
 
 	useEffect( () => {
 		if ( markersStore ) {
-
-			// setAttributes({ markers: markersStore.map( ({ markerProps }) => markerProps ) });
-
 			markersStore.forEach( marker => {
 				if ( ! map.hasLayer( marker ) ) {
 					map.addLayer( marker );

--- a/src/blocks/blocks/leaflet-map/edit.js
+++ b/src/blocks/blocks/leaflet-map/edit.js
@@ -56,7 +56,7 @@ const Edit = ({
 	toggleSelection
 }) => {
 	useEffect( () => {
-		const unsubscribe = blockInit( clientId, defaultAttributes );
+		const unsubscribe = blockInit( clientId, defaultAttributes )
 		return () => unsubscribe( attributes.id );
 	}, [ attributes.id ]);
 
@@ -161,7 +161,7 @@ const Edit = ({
 	 * To avoid this, we will use a dispatch function that doesn't need to know the updated state;
 	 * he will send the data and let the reducer manipulate it using the current states.
 	 */
-	const [ markersStore, dispatch ] = useReducer( markerReducer, []);
+	const [ markersStore, dispatch ] = useReducer( markerReducer, [], () => []);
 	const createMap = () => {
 		if ( ! mapRef.current && ! window.L ) {
 			return;
@@ -336,7 +336,7 @@ const Edit = ({
 
 	useEffect( () => {
 		if ( markersStore ) {
-			setAttributes({ markers: markersStore.map( ({ markerProps }) => markerProps ) });
+			// setAttributes({ markers: markersStore.map( ({ markerProps }) => markerProps ) });
 
 			markersStore.forEach( marker => {
 				if ( ! map.hasLayer( marker ) ) {
@@ -357,8 +357,13 @@ const Edit = ({
 				marker.unbindPopup();
 				marker.bindPopup( createPopupContent( markerProps, dispatch ) );
 			});
+
+
+			if( attributes.markers.length !== markersStore.length && map ) {
+				setAttributes({ markers: markersStore.map( ({ markerProps }) => markerProps ) });
+			}
 		}
-	}, [ markersStore ]);
+	}, [ markersStore, map, attributes.markers ]);
 
 	const blockProps = useBlockProps();
 

--- a/src/blocks/frontend/leaflet-map/index.js
+++ b/src/blocks/frontend/leaflet-map/index.js
@@ -41,11 +41,10 @@ const createMarker = ( markerProps ) => {
 	return markerMap;
 };
 
-const createLeafletMap = ( containerId, attributes ) => {
-	const container = document.querySelector( `#${ containerId }` );
+const createLeafletMap = ( container, attributes ) => {
 
 	if ( ! container ) {
-		console.warn( `The placeholder for the leaflet map block with id: ${ containerId } does not exist!` );
+		console.warn( `The placeholder for the leaflet map block with id: ${ container } does not exist!` );
 		return;
 	}
 
@@ -92,11 +91,20 @@ domReady( () => {
 				return;
 			}
 
-			window.themeisleLeafletMaps.forEach( block => {
-				createLeafletMap( block.container, block.attributes );
-			});
-
 			clearInterval( checker );
+
+			const idAttrMapping = Array.from( window.themeisleLeafletMaps )
+				.reduce( ( acc, x ) => {
+					acc[x.container] = x.attributes;
+					return acc;
+				}, {});
+
+			document.querySelectorAll( '.wp-block-themeisle-blocks-leaflet-map' )
+				.forEach( mapElem => {
+					if ( idAttrMapping[mapElem.id] !== undefined ) {
+						createLeafletMap( mapElem, idAttrMapping[mapElem.id]);
+					}
+				});
 		},
 		2_000
 	);

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -92,9 +92,9 @@ const localIDs = {};
  * @returns {boolean}
  */
 const isInReusableBlock = ( clientId ) => {
-	return getBlockParents(clientId)
-		?.map( id => getBlock(id))
-		?.some( block => block?.attributes?.ref )
+	return getBlockParents( clientId )
+		?.map( id => getBlock( id ) )
+		?.some( block => block?.attributes?.ref );
 };
 
 /**
@@ -266,7 +266,7 @@ export const blockInit = ( clientId, defaultAttributes ) => {
 	return addBlockId({
 		clientId,
 		defaultAttributes,
-		setAttributes: ! isInReusableBlock(clientId) ? updateAttrs( clientId ) : () => null,
+		setAttributes: ! isInReusableBlock( clientId ) ? updateAttrs( clientId ) : () => null,
 		...extractBlockData( clientId )
 	});
 };

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -88,13 +88,12 @@ const localIDs = {};
 
 /**
  * Check if the ID is inside a reusable block.
- * @param {string} id
+ * @param {string} clientId
  * @returns {boolean}
  */
 const isInReusableBlock = ( clientId ) => {
 	return getBlockParents( clientId )
-		?.map( id => getBlock( id ) )
-		?.some( block => block?.attributes?.ref );
+		?.some( id => getBlock( id )?.attributes?.ref );
 };
 
 /**
@@ -169,7 +168,7 @@ export const addBlockId = ( args ) => {
 	}
 
 	// Initialize with an empty array the id list for the given block
-	localIDs[name] ??= new Set();
+	localIDs[name] ??= new Set()
 
 	// Check if the ID is already used. EXCLUDE the one that come from reusable blocks.
 	const idIsAlreadyUsed = attributes.id && localIDs[name].has( attributes.id );

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -100,7 +100,7 @@ const isInReusableBlock = ( clientId ) => {
  * Generate an Id based on the client id of the block. If the new id is also already used, create a new one using the `uuid`.
  * This might problem of duplicated new ids can be observed in the `Template Library` of the `Section` block when using Neve
  * Reference: https://github.com/Codeinwp/neve/blob/master/gutenberg/blocks/blog/template.json
- * The created block will share the same client Id at the beggining, after refresh a new will be generated and thus the problem will fix itself
+ * The created block will share the same client Id at the beginning, after refresh a new will be generated and thus the problem will fix itself
  * by creating new id based on the new uniq `clientId`
  *
  * @param {string}       idPrefix The prefix used for generating the block id
@@ -213,6 +213,7 @@ export const addBlockId = ( args ) => {
 const getBlock = select( 'core/block-editor' ).getBlock;
 const getBlockParents = select( 'core/block-editor' ).getBlockParents;
 const updateBlockAttributes = dispatch( 'core/block-editor' ).updateBlockAttributes;
+const getSelectedBlockClientId = select( 'core/block-editor' ).getSelectedBlockClientId;
 
 /**
  * Create the function that behaves like `setAttributes` using the client id
@@ -265,7 +266,7 @@ export const blockInit = ( clientId, defaultAttributes ) => {
 	return addBlockId({
 		clientId,
 		defaultAttributes,
-		setAttributes: ! isInReusableBlock( clientId ) ? updateAttrs( clientId ) : () => null,
+		setAttributes: (! isInReusableBlock( clientId ) || getSelectedBlockClientId() === clientId ) ? updateAttrs( clientId ) : () => null,
 		...extractBlockData( clientId )
 	});
 };

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -168,7 +168,7 @@ export const addBlockId = ( args ) => {
 	}
 
 	// Initialize with an empty array the id list for the given block
-	localIDs[name] ??= new Set()
+	localIDs[name] ??= new Set();
 
 	// Check if the ID is already used. EXCLUDE the one that come from reusable blocks.
 	const idIsAlreadyUsed = attributes.id && localIDs[name].has( attributes.id );
@@ -266,7 +266,7 @@ export const blockInit = ( clientId, defaultAttributes ) => {
 	return addBlockId({
 		clientId,
 		defaultAttributes,
-		setAttributes: (! isInReusableBlock( clientId ) || getSelectedBlockClientId() === clientId ) ? updateAttrs( clientId ) : () => null,
+		setAttributes: ( ! isInReusableBlock( clientId ) || getSelectedBlockClientId() === clientId ) ? updateAttrs( clientId ) : () => null,
 		...extractBlockData( clientId )
 	});
 };

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -171,7 +171,7 @@ export const addBlockId = ( args ) => {
 	localIDs[name] ??= new Set();
 
 	// Check if the ID is already used. EXCLUDE the one that come from reusable blocks.
-	const idIsAlreadyUsed = attributes.id && localIDs[name].has( attributes.id );
+	const idIsAlreadyUsed = Boolean( attributes.id && localIDs[name].has( attributes.id ) );
 
 	if ( attributes.id === undefined || idIsAlreadyUsed ) {
 
@@ -185,15 +185,16 @@ export const addBlockId = ( args ) => {
 			addGlobalDefaults( attributes, setAttributes, name, defaultAttributes );
 
 			// Save the id in all methods
-			setAttributes({ id: instanceId });
 			localIDs[name].add( instanceId );
 			blockIDs.push( instanceId );
+			setAttributes({ id: instanceId });
+
 		} else if ( idIsAlreadyUsed ) {
 
 			// The block must be a copy and its is already used
 			// Generate a new one and save it to `localIDs` to keep track of it in local mode.
-			setAttributes({ id: instanceId });
 			localIDs[name].add( instanceId );
+			setAttributes({ id: instanceId });
 		}
 		return ( savedId ) => {
 			localIDs[name].delete( instanceId || savedId );
@@ -266,7 +267,7 @@ export const blockInit = ( clientId, defaultAttributes ) => {
 	return addBlockId({
 		clientId,
 		defaultAttributes,
-		setAttributes: ( ! isInReusableBlock( clientId ) || getSelectedBlockClientId() === clientId ) ? updateAttrs( clientId ) : () => null,
+		setAttributes: ( ! isInReusableBlock( clientId ) || getSelectedBlockClientId() === clientId ) ? updateAttrs( clientId ) : undefined,
 		...extractBlockData( clientId )
 	});
 };


### PR DESCRIPTION
fix #869 

@HardeepAsrani, my method for detecting reusable blocks is pretty brute. I did not find a more reliable way to check if the block from the page is a reusable block. So, for now, I am checking if the block ID is in one of the reusable blocks provided by 
```javascript
select( 'core/block-editor' )
			?.getSettings()
			?.__experimentalReusableBlocks.
```
----

#### Testing

Create a simple Lottie block, make it a reusable block, then insert the reusable block on the page a few times, and check if the animation is still showing. Also, the page must not freeze.

Also, try to add a new Otter block to it while is duplicated. For duplicated reusable blocks, the changes are reflected. If we add a new block inside it, change the colors then *publish* the page, the colors need to work in the frontend.

https://user-images.githubusercontent.com/17597852/162975660-085049aa-861c-4743-8851-6ee344a6ab12.mp4


