### PR TITLE
Fix ignored `max-width` for sections with one column

### DIFF
--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -15,6 +15,10 @@
 		left: 0;
 	}
 
+	.wp-block-themeisle-blocks-advanced-column:only-child {
+		max-width: var( --columnsWidth );
+	}
+
 	.wp-block-themeisle-blocks-advanced-column {
 		.wp-block-themeisle-blocks-slider {
 			display: grid;
@@ -77,7 +81,7 @@
 			.innerblocks-wrap {
 				align-items: center;
 			}
-		}	
+		}
 
 		&.has-vertical-flex-end,
 		&.has-vertical-bottom {
@@ -101,11 +105,11 @@
 
 			.wp-block-themeisle-blocks-advanced-column {
 				position: relative;
-	
+
 				&:first-child {
 					margin-left: 0;
 				}
-		
+
 				&:last-child {
 					margin-right: 0;
 				}
@@ -144,7 +148,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex-basis: 33.34%;
-	
+
 						&:last-child {
 							flex-basis: 66.66%;
 						}
@@ -157,7 +161,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex-basis: 33.34%;
-			
+
 						&:first-child {
 							flex-basis: 66.66%;
 						}
@@ -182,7 +186,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex-basis: 25%;
-			
+
 						&:last-child {
 							flex-basis: 50%;
 						}
@@ -195,7 +199,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex-basis: 25%;
-			
+
 						&:first-child {
 							flex-basis: 50%;
 						}
@@ -208,7 +212,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex-basis: 50%;
-			
+
 						&:first-child {
 							flex-basis: 25%;
 						}
@@ -225,11 +229,11 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex-basis: 60%;
-		
+
 						&:first-child {
 							flex-basis: 20%;
 						}
-		
+
 						&:last-child {
 							flex-basis: 20%;
 						}
@@ -315,7 +319,7 @@
 
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
-			
+
 						&:first-child {
 							flex: 2;
 						}
@@ -330,7 +334,7 @@
 
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
-			
+
 						&:last-child {
 							flex: 2;
 						}
@@ -342,7 +346,7 @@
 
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
-			
+
 						&:first-child {
 							flex: 2;
 						}
@@ -355,7 +359,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex: 2;
-			
+
 						&:first-child {
 							flex: 1;
 						}
@@ -372,7 +376,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex: 3;
-			
+
 						&:first-child {
 							flex: 1;
 						}
@@ -459,7 +463,7 @@
 
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
-			
+
 						&:first-child {
 							flex: 2;
 						}
@@ -474,7 +478,7 @@
 
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
-			
+
 						&:last-child {
 							flex: 2;
 						}
@@ -486,7 +490,7 @@
 
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
-			
+
 						&:first-child {
 							flex: 2;
 						}
@@ -499,7 +503,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex: 2;
-			
+
 						&:first-child {
 							flex: 1;
 						}
@@ -516,7 +520,7 @@
 				> .innerblocks-wrap {
 					> .wp-block-themeisle-blocks-advanced-column {
 						flex: 3;
-			
+
 						&:first-child {
 							flex: 1;
 						}


### PR DESCRIPTION
Fixes #878

----

### Testing

Query

```javascript
new QueryQA().select('blocks').where({ names: ['one-column-section'] }).run()
```