### PR TITLE
fix: wrong word-break was not working for text without spaces

### DIFF
--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -2,6 +2,12 @@
 @import './components/onboarding/editor';
 @import './components/separators/editor';
 
+html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[lang="zh-Hant"] {
+	.wp-block-themeisle-blocks-advanced-columns .innerblocks-wrap {
+		word-break: normal;
+	}
+}
+
 .wp-block-themeisle-blocks-advanced-columns {
 	--columnsWidth: initial;
 	display: flex;

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -1,5 +1,11 @@
 @import './components/separators/style';
 
+html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[lang="zh-Hant"] {
+	.wp-block-themeisle-blocks-advanced-columns .innerblocks-wrap {
+		word-break: normal;
+	}
+}
+
 .wp-block-themeisle-blocks-advanced-columns {
 	--columnsWidth: initial;
 	--horizontalAlign: unset;


### PR DESCRIPTION
When `word-break: keep-all` is used it doesn't respect breaks in the flow of text for languages such as Chinese and Japanese.

This causes the text to "overflow" off the page:

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/10324144/165585398-f39c2377-1ab0-4b16-9453-f85b6f5f349e.png">

As per MDN for `keep-all` value:

> Word breaks should not be used for Chinese/Japanese/Korean (CJK) text. Non-CJK text behavior is the same as for normal.

https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

Expected behavior introduced by this pull:

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/10324144/165585824-a5b270e6-ee74-46e5-9505-f7367baf2281.png">

This was reported in Neve but this block is by Otter https://github.com/Codeinwp/neve-pro-addon/issues/1933