### PR TITLE
Change Icon block semantic

### DIFF
--- a/src/blocks/blocks/font-awesome-icons/deprecated.js
+++ b/src/blocks/blocks/font-awesome-icons/deprecated.js
@@ -1,3 +1,7 @@
+import themeIsleIcons from '../../helpers/themeisle-icons';
+import {useBlockProps} from '@wordpress/block-editor';
+
+
 const attributes = {
 	prefix: {
 		type: 'string',
@@ -38,204 +42,311 @@ const attributes = {
 	}
 };
 
-const deprecated = [ {
-	attributes,
-
-	supports: {
-		align: [ 'left', 'center', 'right' ]
-	},
-
-	migrate: oldAttributes => {
-		let align = 'center';
-
-		if ( oldAttributes.className.includes( 'alignleft' ) ) {
-			align = 'left';
-		}
-
-		if ( oldAttributes.className.includes( 'aligncenter' ) ) {
-			align = 'center';
-		}
-
-		if ( oldAttributes.className.includes( 'alignright' ) ) {
-			align = 'right';
-		}
-
-		return {
-			...oldAttributes,
-			align,
-			className: ''
-		};
-	},
-
-	save: ({
-		attributes,
-		className
-	}) => {
-		const iconStyle = {
-			borderRadius: attributes.borderRadius + '%',
-			fontSize: attributes.fontSize + 'px',
-			padding: attributes.padding + 'px'
-		};
-
-		const containerStyle = {
-			color: attributes.textColor,
-			backgroundColor: attributes.backgroundColor,
-			borderColor: attributes.borderColor,
-			borderRadius: attributes.borderRadius + '%',
-			borderStyle: 'solid',
-			borderWidth: attributes.borderSize + 'px',
-			display: 'inline-block',
-			margin: attributes.margin + 'px'
-		};
-
-		return (
-			<p
-				className={ className }
-				style={ { textAlign: attributes.align } }
-			>
-				<span
-					className={ `${ className }-container` }
-					style={ containerStyle }
-				>
-					<i
-						className={ `${ attributes.prefix } fa-${ attributes.icon }` }
-						style={ iconStyle }
-					>
-					</i>
-				</span>
-			</p>
-		);
-	}
-}, {
-	attributes: {
-		...attributes,
-		align: {
-			type: 'string'
-		}
-	},
-
-	save: ({
-		attributes,
-		className
-	}) => {
-		const iconStyle = {
-			borderRadius: attributes.borderRadius + '%',
-			fontSize: attributes.fontSize + 'px',
-			padding: attributes.padding + 'px'
-		};
-
-		const containerStyle = {
-			color: attributes.textColor,
-			backgroundColor: attributes.backgroundColor,
-			borderColor: attributes.borderColor,
-			borderRadius: attributes.borderRadius + '%',
-			borderStyle: 'solid',
-			borderWidth: attributes.borderSize + 'px',
-			display: 'inline-block',
-			margin: attributes.margin + 'px'
-		};
-
-		return (
-			<p
-				className={ className }
-				style={ { textAlign: attributes.align } }
-			>
-				<span
-					className="undefined-container"
-					style={ containerStyle }
-				>
-					<i
-						className={ `${ attributes.prefix } fa-${ attributes.icon }` }
-						style={ iconStyle }
-					>
-					</i>
-				</span>
-			</p>
-		);
-	}
-}, {
-	attributes: {
-		...attributes,
-		id: {
-			type: 'string'
+const deprecated = [
+	{
+		attributes: {
+			'id': {
+				'type': 'string'
+			},
+			'align': {
+				'type': 'string'
+			},
+			'library': {
+				'type': 'string',
+				'default': 'fontawesome'
+			},
+			'prefix': {
+				'type': 'string',
+				'default': 'fab'
+			},
+			'icon': {
+				'type': 'string',
+				'default': 'themeisle'
+			},
+			'link': {
+				'type': 'string'
+			},
+			'newTab': {
+				'type': 'boolean',
+				'default': false
+			},
+			'fontSize': {
+				'type': 'number',
+				'default': 16
+			},
+			'padding': {
+				'type': 'number',
+				'default': 5
+			},
+			'margin': {
+				'type': 'number',
+				'default': 5
+			},
+			'backgroundColor': {
+				'type': 'string'
+			},
+			'textColor': {
+				'type': 'string'
+			},
+			'borderColor': {
+				'type': 'string'
+			},
+			'backgroundColorHover': {
+				'type': 'string'
+			},
+			'textColorHover': {
+				'type': 'string'
+			},
+			'borderColorHover': {
+				'type': 'string'
+			},
+			'borderSize': {
+				'type': 'number',
+				'default': 0
+			},
+			'borderRadius': {
+				'type': 'number',
+				'default': 0
+			},
+			'isSynced': {
+				'type': 'array'
+			}
 		},
-		align: {
-			type: 'string'
-		},
-		link: {
-			type: 'string'
-		},
-		newTab: {
-			type: 'boolean',
-			default: false
-		},
-		backgroundColorHover: {
-			type: 'string'
-		},
-		textColorHover: {
-			type: 'string'
-		},
-		borderColorHover: {
-			type: 'string'
-		}
-	},
 
-	save: ({
-		attributes,
-		className
-	}) => {
-		const containerStyle = {
-			borderRadius: attributes.borderRadius + '%',
-			borderStyle: 'solid',
-			borderWidth: attributes.borderSize + 'px',
-			display: 'inline-block',
-			margin: attributes.margin + 'px'
-		};
+		supports: {
+			align: [ 'left', 'center', 'right' ]
+		},
 
-		const iconStyle = {
-			borderRadius: attributes.borderRadius + '%',
-			fontSize: attributes.fontSize + 'px',
-			padding: attributes.padding + 'px'
-		};
+		save: ({
+			attributes
+		}) => {
+			const Icon = themeIsleIcons.icons[ attributes.icon ];
 
-		const IconElement = () => {
+			const blockProps = useBlockProps.save({
+				id: attributes.id
+			});
+
 			return (
-				<i
-					className={ `${ attributes.prefix } fa-${ attributes.icon }` }
-					style={ iconStyle }
-				>
-				</i>
+				<p { ...blockProps }>
+					<span className="wp-block-themeisle-blocks-font-awesome-icons-container">
+						{ ( attributes.link ) ? (
+							<a
+								href={ attributes.link }
+								target={ attributes.newTab ? '_blank' : '_self' }
+								rel="noopener noreferrer"
+							>
+								{ 'themeisle-icons' === attributes.library ?
+									<Icon/> :
+									<i className={ `${ attributes.prefix } fa-${ attributes.icon }` }></i>
+								}
+							</a>
+						) : (
+							'themeisle-icons' === attributes.library ?
+								<Icon/> :
+								<i className={ `${ attributes.prefix } fa-${ attributes.icon }` }></i>
+						) }
+					</span>
+				</p>
 			);
-		};
+		}
+	}, {
+		attributes,
 
-		return (
-			<p
-				className={ className }
-				id={ attributes.id }
-				style={ { textAlign: attributes.align } }
-			>
-				<span
-					className="wp-block-themeisle-blocks-font-awesome-icons-container"
-					style={ containerStyle }
+		supports: {
+			align: [ 'left', 'center', 'right' ]
+		},
+
+		migrate: oldAttributes => {
+			let align = 'center';
+
+			if ( oldAttributes.className.includes( 'alignleft' ) ) {
+				align = 'left';
+			}
+
+			if ( oldAttributes.className.includes( 'aligncenter' ) ) {
+				align = 'center';
+			}
+
+			if ( oldAttributes.className.includes( 'alignright' ) ) {
+				align = 'right';
+			}
+
+			return {
+				...oldAttributes,
+				align,
+				className: ''
+			};
+		},
+
+		save: ({
+			attributes,
+			className
+		}) => {
+			const iconStyle = {
+				borderRadius: attributes.borderRadius + '%',
+				fontSize: attributes.fontSize + 'px',
+				padding: attributes.padding + 'px'
+			};
+
+			const containerStyle = {
+				color: attributes.textColor,
+				backgroundColor: attributes.backgroundColor,
+				borderColor: attributes.borderColor,
+				borderRadius: attributes.borderRadius + '%',
+				borderStyle: 'solid',
+				borderWidth: attributes.borderSize + 'px',
+				display: 'inline-block',
+				margin: attributes.margin + 'px'
+			};
+
+			return (
+				<p
+					className={ className }
+					style={ { textAlign: attributes.align } }
 				>
-					{ ( attributes.link ) ? (
-						<a
-							href={ attributes.link }
-							target={ attributes.newTab ? '_blank' : '_self' }
-							style={ {
-								color: attributes.textColor
-							} }
-							rel="noopener noreferrer"
+					<span
+						className={ `${ className }-container` }
+						style={ containerStyle }
+					>
+						<i
+							className={ `${ attributes.prefix } fa-${ attributes.icon }` }
+							style={ iconStyle }
 						>
+						</i>
+					</span>
+				</p>
+			);
+		}
+	}, {
+		attributes: {
+			...attributes,
+			align: {
+				type: 'string'
+			}
+		},
+
+		save: ({
+			attributes,
+			className
+		}) => {
+			const iconStyle = {
+				borderRadius: attributes.borderRadius + '%',
+				fontSize: attributes.fontSize + 'px',
+				padding: attributes.padding + 'px'
+			};
+
+			const containerStyle = {
+				color: attributes.textColor,
+				backgroundColor: attributes.backgroundColor,
+				borderColor: attributes.borderColor,
+				borderRadius: attributes.borderRadius + '%',
+				borderStyle: 'solid',
+				borderWidth: attributes.borderSize + 'px',
+				display: 'inline-block',
+				margin: attributes.margin + 'px'
+			};
+
+			return (
+				<p
+					className={ className }
+					style={ { textAlign: attributes.align } }
+				>
+					<span
+						className="undefined-container"
+						style={ containerStyle }
+					>
+						<i
+							className={ `${ attributes.prefix } fa-${ attributes.icon }` }
+							style={ iconStyle }
+						>
+						</i>
+					</span>
+				</p>
+			);
+		}
+	}, {
+		attributes: {
+			...attributes,
+			id: {
+				type: 'string'
+			},
+			align: {
+				type: 'string'
+			},
+			link: {
+				type: 'string'
+			},
+			newTab: {
+				type: 'boolean',
+				default: false
+			},
+			backgroundColorHover: {
+				type: 'string'
+			},
+			textColorHover: {
+				type: 'string'
+			},
+			borderColorHover: {
+				type: 'string'
+			}
+		},
+
+		save: ({
+			attributes,
+			className
+		}) => {
+			const containerStyle = {
+				borderRadius: attributes.borderRadius + '%',
+				borderStyle: 'solid',
+				borderWidth: attributes.borderSize + 'px',
+				display: 'inline-block',
+				margin: attributes.margin + 'px'
+			};
+
+			const iconStyle = {
+				borderRadius: attributes.borderRadius + '%',
+				fontSize: attributes.fontSize + 'px',
+				padding: attributes.padding + 'px'
+			};
+
+			const IconElement = () => {
+				return (
+					<i
+						className={ `${ attributes.prefix } fa-${ attributes.icon }` }
+						style={ iconStyle }
+					>
+					</i>
+				);
+			};
+
+			return (
+				<p
+					className={ className }
+					id={ attributes.id }
+					style={ { textAlign: attributes.align } }
+				>
+					<span
+						className="wp-block-themeisle-blocks-font-awesome-icons-container"
+						style={ containerStyle }
+					>
+						{ ( attributes.link ) ? (
+							<a
+								href={ attributes.link }
+								target={ attributes.newTab ? '_blank' : '_self' }
+								style={ {
+									color: attributes.textColor
+								} }
+								rel="noopener noreferrer"
+							>
+								<IconElement />
+							</a>
+						) : (
 							<IconElement />
-						</a>
-					) : (
-						<IconElement />
-					) }
-				</span>
-			</p>
-		);
-	}
-} ];
+						) }
+					</span>
+				</p>
+			);
+		}
+	} ];
 
 export default deprecated;

--- a/src/blocks/blocks/font-awesome-icons/save.js
+++ b/src/blocks/blocks/font-awesome-icons/save.js
@@ -18,7 +18,7 @@ const Save = ({
 	});
 
 	return (
-		<p { ...blockProps }>
+		<div { ...blockProps }>
 			<span className="wp-block-themeisle-blocks-font-awesome-icons-container">
 				{ ( attributes.link ) ? (
 					<a
@@ -37,7 +37,7 @@ const Save = ({
 						<i className={ `${ attributes.prefix } fa-${ attributes.icon }` }></i>
 				) }
 			</span>
-		</p>
+		</div>
 	);
 };
 


### PR DESCRIPTION
Use `div` instead of `p` tag to avoid weird settings from WP.

----

### Testing

This is a breaking change. Create an Icon block using the version from WP.org. Switch to this version and see if the block has not crashed.