### PR TITLE
Hover space on Flip Card

### DIFF
--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -18,8 +18,15 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	width: max-content;
+	margin-left: auto;
+	margin-right: auto;
 
 	perspective: 1000px; /* Remove this if you don't want the 3D effect */
+
+	&[class^="block-editor"] {
+		width: auto;
+	}
 
 	&.flipX {
 		--flip-anim: rotateX(180deg);


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #883 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
The container of the Flip Card had full width regardless of the width of the card thus creating a bigger hover space than necessary.

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Place a Flip Card block in a container larger than the card
- The hover space should be exactly the size of the card

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

