### PR TITLE
Fix column remove via Toolbar

### DIFF
--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -152,8 +152,6 @@ const Edit = ({
 				updateColumnsWidth( 1, 'equal' );
 			}
 
-			console.count( 'Update' );
-
 			setAttributes({
 				columns: children.length
 			});

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -143,6 +143,17 @@ const Edit = ({
 
 	useEffect( () => {
 		if ( attributes.columns !== children.length ) {
+
+			if ( 6 >= children.length ) {
+				updateColumnsWidth( children.length, 'equal' );
+			} else if ( 6 < children.length ) {
+				updateColumnsWidth( 6, 'equal' );
+			} else if ( 1 >= children.length ) {
+				updateColumnsWidth( 1, 'equal' );
+			}
+
+			console.count( 'Update' );
+
 			setAttributes({
 				columns: children.length
 			});

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -70,8 +70,6 @@ const Inspector = ({
 
 	const [ tab, setTab ] = useState( 'layout' );
 
-	const [ hasColumnsChanged, setColumnsChanged ] = useState( false );
-
 	const changeColumns = value => {
 		if ( 6 >= value ) {
 			setAttributes({
@@ -98,24 +96,7 @@ const Inspector = ({
 		}
 
 		changeColumnsNumbers( value );
-		setColumnsChanged( true );
 	};
-
-	useEffect( () => {
-		if ( ! hasColumnsChanged ) {
-			return;
-		}
-
-		if ( 6 >= attributes.columns ) {
-			updateColumnsWidth( attributes.columns, 'equal' );
-		} else if ( 6 < attributes.columns ) {
-			updateColumnsWidth( 6, 'equal' );
-		} else if ( 1 >= attributes.columns ) {
-			updateColumnsWidth( 1, 'equal' );
-		}
-
-		setColumnsChanged( false );
-	}, [ attributes.columns ]);
 
 	const changeLayout = value => {
 		switch ( getView ) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #980.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Removing columns with Toolbar will have the same behavior as removing them with the Inspector.

### Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/17597852/174963343-418206b3-1c92-4398-90cc-3629bb834fe8.mp4


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Section block.
2. Add/Remove block via Toolbar.
3. Check their width value.

You can see the clip on how it should look.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

