### PR TITLE
Load Otter CSS inline

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -55,6 +55,13 @@ class Registration {
 	);
 
 	/**
+	 * Flag to mark that Otter CSS has loaded.
+	 *
+	 * @var bool
+	 */
+	public static $inline_css_loaded = false;
+
+	/**
 	 * Flag to mark that the styles which have loaded.
 	 *
 	 * @var array
@@ -267,6 +274,31 @@ class Registration {
 	}
 
 	/**
+	 * Get inline Otter Styles.
+	 *
+	 * @since   2.0.7
+	 * @access  public
+	 */
+	public static function get_inline_block_styles() {
+		self::$inline_css_loaded = true;
+		$css = file_get_contents( OTTER_BLOCKS_PATH . '/build/blocks/blocks.css' );
+		return $css;
+	}
+
+	/**
+	 * Enqueue Otter Styles.
+	 *
+	 * @since   2.0.7
+	 * @access  public
+	 */
+	public static function enqueue_otter_style() {
+		if ( ! self::$inline_css_loaded ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
+			wp_enqueue_style( 'otter-blocks', OTTER_BLOCKS_URL . 'build/blocks/blocks.css', [], $asset_file['version'] );
+		}
+	}
+
+	/**
 	 * Load frontend assets for our blocks.
 	 *
 	 * @since   2.0.0
@@ -278,9 +310,6 @@ class Registration {
 		if ( is_admin() ) {
 			return;
 		}
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
-		wp_enqueue_style( 'otter-blocks', OTTER_BLOCKS_URL . 'build/blocks/blocks.css', [], $asset_file['version'] );
 
 		if ( is_singular() ) {
 			$this->enqueue_dependencies();

--- a/inc/css/class-block-frontend.php
+++ b/inc/css/class-block-frontend.php
@@ -300,6 +300,13 @@ class Block_Frontend extends Base_CSS {
 			return;
 		}
 
+		add_action(
+			'enqueue_block_assets',
+			function() {
+				Registration::enqueue_otter_style();
+			}
+		);
+
 		if ( $footer ) {
 			add_action(
 				'wp_footer',
@@ -355,6 +362,10 @@ class Block_Frontend extends Base_CSS {
 
 			if ( empty( $css ) || is_preview() ) {
 				$css = $this->get_page_css_inline( $post_id );
+			}
+
+			if ( ! Registration::$inline_css_loaded ) {
+				$css .= Registration::get_inline_block_styles();
 			}
 
 			if ( empty( $css ) ) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #922.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
@irinelenache This is for testing the above issue. I wanted to do more with this but first want to make sure this method doesn't have a major problem, nothing found so far in my testing.

Here's what you have to test:

- Instead of loading the `otter-blocks/build/blocks/blocks.css` we load the CSS inline. So can you make sure that it loads the inline styles. You can simply search `.otter-masonry .blocks-gallery-grid .blocks-gallery-item` to find the styles.
- Also make sure that the styles are only loaded once and they're always loaded when needed.
- Also in some circumstances, specially if the page is too big, we will not load the inline styles and in such cases the stylesheet is being loaded properly.
- And to make sure that the styles are always being loaded like they used to, just inline.
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

