### PR TITLE
Fix multiple tabs not working on same page

### DIFF
--- a/src/blocks/frontend/tabs/index.js
+++ b/src/blocks/frontend/tabs/index.js
@@ -6,14 +6,14 @@ import { domReady } from '../../helpers/frontend-helper-functions.js';
 domReady( () => {
 	const tabs = document.querySelectorAll( '.wp-block-themeisle-blocks-tabs' );
 
-	let openedTab = false;
-	const closedTabs = [];
-
 	tabs.forEach( tab => {
 		const items = Array.from( tab.querySelectorAll( ':scope > .wp-block-themeisle-blocks-tabs__content > .wp-block-themeisle-blocks-tabs-item' ) );
 		const header = document.createElement( 'div' );
 		header.classList.add( 'wp-block-themeisle-blocks-tabs__header' );
 		tab.prepend( header );
+
+		let openedTab = false;
+		const closedTabs = [];
 
 		items.forEach( ( item, index ) => {
 			const headerItem = document.createElement( 'div' );
@@ -28,7 +28,7 @@ domReady( () => {
 				closedTabs.push({headerItem, content});
 			}
 
-			headerItem.innerHTML = item.dataset.title || 'Untitled Tab';
+			headerItem.innerHTML = item.dataset.title || `Tab ${ index + 1 }`;
 			headerItem.tabIndex = 0;
 
 			const headerMobile = item.querySelector( '.wp-block-themeisle-blocks-tabs-item__header' );
@@ -69,13 +69,13 @@ domReady( () => {
 
 			header.appendChild( headerItem );
 		});
-	});
 
-	/**
-	 * If no tab is set to open, open the first closed tab.
-	 */
-	if ( ! openedTab ) {
-		closedTabs?.[0]?.headerItem.classList.add( 'active' );
-		closedTabs?.[0]?.content.classList.add( 'active' );
-	}
+		/**
+		 * If no tab is set to open, open the first closed tab.
+		 */
+		if ( ! openedTab ) {
+			closedTabs?.[0]?.headerItem.classList.add( 'active' );
+			closedTabs?.[0]?.content.classList.add( 'active' );
+		}
+	});
 });


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #991.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
Fixes the issue where if a page had multiple tabs, only the first tab worked properly. Also, change the Untitled title to Tab `n`

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add a multiple Tabs block to a page and make sure all of them work properly.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

