### PR TITLE
Add static background until map is loaded (for leaflet)

### DIFF
--- a/inc/render/class-leaflet-map-block.php
+++ b/inc/render/class-leaflet-map-block.php
@@ -50,7 +50,7 @@ class Leaflet_Map_Block {
 				'id'    => $id,
 				'class' => $class,
 				'style' => $style,
-			) 
+			)
 		);
 
 		// Load the attributes in the page and make a placeholder to render the map.

--- a/src/blocks/frontend/leaflet-map/index.js
+++ b/src/blocks/frontend/leaflet-map/index.js
@@ -82,6 +82,12 @@ domReady( () => {
 		return;
 	}
 
+	document.querySelectorAll( '.wp-block-themeisle-blocks-leaflet-map' )
+		.forEach( mapElem => {
+			mapElem.style.margin = '20px 0';
+			mapElem.style.backgroundColor = '#ccc';
+		});
+
 	const checker = setInterval(
 		() => {
 			if ( ! window.L ) {
@@ -101,6 +107,8 @@ domReady( () => {
 				.forEach( mapElem => {
 					if ( idAttrMapping[mapElem.id] !== undefined ) {
 						createLeafletMap( mapElem, idAttrMapping[mapElem.id]);
+						mapElem.style.removeProperty( 'margin' );
+						mapElem.style.removeProperty( 'background-color' );
 					}
 				});
 		},


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #785.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- Adds a gray background for the block until the map is loaded.
- The Google map already had this, so no need to modify anything there.
- It also fixes a jumping the page had when the map was loading because of the margin that appeared only when the map loaded (the block CSS doesn't load until the map loads).

### Test instructions
<!-- Describe how this pull request can be tested. -->
Add a map block, and until the map loads, in the frontend should appear a gray placeholder.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

