### PR TITLE
Fix Adv Heading Span alignment

### DIFF
--- a/src/blocks/blocks/advanced-heading/editor.scss
+++ b/src/blocks/blocks/advanced-heading/editor.scss
@@ -1,3 +1,5 @@
+@import "style";
+
 .o-heading-header-panel {
 	&.is-opened {
 		padding: 0;

--- a/src/blocks/blocks/advanced-heading/style.scss
+++ b/src/blocks/blocks/advanced-heading/style.scss
@@ -1,8 +1,5 @@
-span {
-	&.wp-block-themeisle-blocks-advanced-heading {
-		display: block;
-	}
-
+span.wp-block-themeisle-blocks-advanced-heading {
+	display: block;
 	&.highlight {
 		background-color: yellow;
 		color: black;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1003.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Add missing import of the `style.scss`.

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/17597852/176608271-48546197-550d-4952-b9b0-67261e0d7049.png)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert an Adv Heading.
2. Set tag to Span.
3. Play with the alignment.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

