### PR TITLE
Fix Flip block sizing issues

### DIFF
--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -15,12 +15,14 @@
 	--frontMediaHeight: 150px;
 
 	--flip-anim: unset;
+
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	width: max-content;
 	margin-left: auto;
 	margin-right: auto;
+	width: var(--width);
+	height: var(--height);
 
 	perspective: 1000px; /* Remove this if you don't want the 3D effect */
 
@@ -46,8 +48,8 @@
 
 	.o-flip-inner {
 		position: relative;
-		width:var( --width );
-		height: var( --height );
+		width: 100%;
+		height: 100%;
 		text-align: center;
 		transition: transform 0.8s;
 		transform-style: preserve-3d;
@@ -71,6 +73,7 @@
 		background-size: inherit;
 		border: var( --borderWidth ) solid var( --borderColor );
 		border-radius: var( --borderRadius );
+		box-sizing: border-box;
 	}
 
 	.o-flip-front {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1022 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Small CSS tweaks

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Flip block
2. Add some content
3. Check on the frontend.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

