### PR TITLE
Fix typing slowness

### DIFF
--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -172,18 +172,14 @@ const defaultConditionsKeys = Object.keys( defaultConditions );
 
 const getPostData = () => {
 	const { getUsers, getEntityRecords } = select( 'core' );
-	const authors = getUsers({ who: 'authors' });
+	const authors = getUsers({ 'who': 'authors' });
 	const categories = getEntityRecords( 'taxonomy', 'category', { 'per_page': 100 });
-
-	console.count( 'Get Post data.' ); // TODO: remove after final review
 
 	return {
 		postAuthors: authors && Boolean( authors.length ) ? authors.map( author => author.username ) : [],
 		postCategories: categories && Boolean( categories.length ) ? categories.map( category => category.slug ) : []
 	};
 };
-
-const { postAuthors, postCategories} = getPostData();
 
 const Separator = ({ label }) => {
 	return (
@@ -204,6 +200,12 @@ const Edit = ({
 	const [ conditions, setConditions ] = useState({});
 	const [ flatConditions, setFlatConditions ] = useState([]);
 	const [ toggleVisibility, setToggleVisibility ] = useState([]);
+	const [ postData, setPostData ] = useState({});
+
+	useEffect( () => {
+		setPostData( getPostData() );
+		console.count( 'Get Post Data' ); // TODO: remove after final review
+	}, []);
 
 	useEffect( () => {
 		if ( ! Boolean( attributes?.otterConditions?.length ) ) {
@@ -373,10 +375,10 @@ const Edit = ({
 											<FormTokenField
 												label={ __( 'Post Authors', 'otter-blocks' ) }
 												value={ i.authors }
-												suggestions={ postAuthors }
+												suggestions={ postData?.postAuthors }
 												onChange={ authors => changeArrayValue( authors, index, n, 'authors' ) }
 												__experimentalExpandOnFocus={ true }
-												__experimentalValidateInput={ newValue => postAuthors.includes( newValue ) }
+												__experimentalValidateInput={ newValue => postData?.postAuthors.includes( newValue ) }
 											/>
 										) }
 
@@ -384,10 +386,10 @@ const Edit = ({
 											<FormTokenField
 												label={ __( 'Post Category', 'otter-blocks' ) }
 												value={ i.categories }
-												suggestions={ postCategories }
+												suggestions={ postData?.postCategories }
 												onChange={ categories => changeArrayValue( categories, index, n, 'categories' ) }
 												__experimentalExpandOnFocus={ true }
-												__experimentalValidateInput={ newValue => postCategories.includes( newValue ) }
+												__experimentalValidateInput={ newValue => postData?.postCategories.includes( newValue ) }
 											/>
 										) }
 

--- a/src/pro/plugins/conditions/edit.js
+++ b/src/pro/plugins/conditions/edit.js
@@ -128,6 +128,181 @@ const Multiselect = ({
 	);
 };
 
+const ProductsMultiselect = ( props ) => {
+	const {
+		products,
+		productsStatus
+	} = useSelect( select => {
+		if ( ! Boolean( window.otterPro.hasWooCommerce ) ) {
+			return {
+				products: [],
+				productsStatus: 'loading'
+			};
+		}
+
+		const { COLLECTIONS_STORE_KEY } = window?.wc?.wcBlocksData;
+
+		// eslint-disable-next-line camelcase
+		const productsError = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products', { per_page: 100 });
+
+		const products = productsError ? [] : ( select( COLLECTIONS_STORE_KEY )?.getCollection( '/wc/store', 'products', { 'per_page': 100 }) ?? [])?.map( result => ({
+			value: result.id,
+			label: decodeEntities( result.name )
+		}) );
+
+		return {
+			products,
+			productsStatus: ( productsError && 'error' ) || ( ! isEmpty( products ) && 'loaded' ) || 'loading'
+		};
+	}, []);
+
+	return 'loading' === productsStatus ? (
+		<Placeholder><Spinner /></Placeholder>
+	) : (
+		<Multiselect
+			{...props}
+			items={ products }
+		/>
+	);
+};
+
+const CategoriesMultiselect = ( props ) => {
+	const {
+		categories,
+		categoriesStatus
+	} = useSelect( select => {
+		if ( ! Boolean( window.otterPro.hasWooCommerce ) ) {
+			return {
+				categories: [],
+				categoriesStatus: 'loading'
+			};
+		}
+
+		const { COLLECTIONS_STORE_KEY } = window?.wc?.wcBlocksData;
+
+		// eslint-disable-next-line camelcase
+		const categoriesError = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products/categories' );
+
+		const categories = categoriesError ? [] : ( select( COLLECTIONS_STORE_KEY ).getCollection( '/wc/store', 'products/categories' ) ?? [])?.map( result => ({
+			value: result.id,
+			label: decodeEntities( result.name )
+		}) );
+
+		return {
+			categories,
+			categoriesStatus: ( categoriesError && 'error' ) || ( ! isEmpty( categories ) && 'loaded' ) || 'loading'
+		};
+	}, []);
+
+	return 'loading' === categoriesStatus ? (
+		<Placeholder><Spinner /></Placeholder>
+	) : (
+		<Multiselect
+			{...props}
+			items={ categories }
+		/>
+	);
+};
+
+const CoursesMultiselect = ( props ) => {
+	const {
+		courses,
+		coursesStatus
+	} = useSelect( select => {
+		if ( ! Boolean( window.otterPro.hasLearnDash ) ) {
+			return {
+				courses: [],
+				cursesStatus: 'loading'
+			};
+		}
+
+		const courses = select( 'otter-pro' )?.getLearnDashCourses() ?? [];
+		return {
+			courses,
+			coursesStatus: ! isEmpty( courses ) ? 'loaded' : 'loading'
+		};
+	}, []);
+
+	return 'loading' === coursesStatus ? (
+		<Placeholder><Spinner /></Placeholder>
+	) : (
+		<Multiselect
+			{...props}
+			items={ courses }
+		/>
+	);
+};
+
+const CoursesSelect = ( props ) => {
+	const {
+		courses,
+		coursesStatus
+	} = useSelect( select => {
+		if ( ! Boolean( window.otterPro.hasLearnDash ) ) {
+			return {
+				courses: [],
+				cursesStatus: 'loading'
+			};
+		}
+
+		const courses = select( 'otter-pro' )?.getLearnDashCourses() ?? [];
+		return {
+			courses,
+			coursesStatus: ! isEmpty( courses ) ? 'loaded' : 'loading'
+		};
+	}, []);
+
+	return (
+		<Fragment>
+			{ 'loaded' === coursesStatus && (
+				<Fragment>
+					{ Boolean( courses.length ) ? (
+						<SelectControl
+							{ ...props }
+							options={ courses }
+						/>
+					) : (
+						<p>{ __( 'No courses available.', 'otter-blocks' ) }</p>
+					) }
+
+					{ props.children }
+				</Fragment>
+			) }
+
+			{ 'loading' === coursesStatus && <Placeholder><Spinner /></Placeholder> }
+		</Fragment>
+	);
+};
+
+const GroupsMultiselect = ( props ) => {
+	const {
+		groups,
+		groupsStatus
+	} = useSelect( select => {
+		if ( ! Boolean( window.otterPro.hasLearnDash ) ) {
+			return {
+				groups: [],
+				groupsStatus: 'loading'
+			};
+		}
+
+		const groups = select( 'otter-pro' )?.getLearnDashGroups()() ?? [];
+		return {
+			groups,
+			groupsStatus: ! isEmpty( groups ) ? 'loaded' : 'loading'
+		};
+	}, []);
+
+	return 'loading' === groupsStatus ? (
+		<Placeholder><Spinner /></Placeholder>
+	) : (
+		<Multiselect
+			{...props}
+			items={ groups }
+		/>
+	);
+};
+
 const Edit = ({
 	groupIndex,
 	itemIndex,
@@ -136,90 +311,6 @@ const Edit = ({
 	setAttributes,
 	changeValue
 }) => {
-	const {
-		products,
-		categories,
-		productsStatus,
-		categoriesStatus,
-		courses,
-		coursesStatus,
-		courseGroups,
-		courseGroupsStatus
-	} = useSelect( select => {
-		let products = [];
-		let categories = [];
-		let productsStatus = 'loading';
-		let categoriesStatus = 'loading';
-		let courses = [];
-		let courseGroups = [];
-		let coursesStatus = 'loading';
-		let courseGroupsStatus = 'loading';
-
-		if ( Boolean( window.otterPro.hasWooCommerce ) ) {
-			const { COLLECTIONS_STORE_KEY } = window.wc.wcBlocksData;
-
-			// eslint-disable-next-line camelcase
-			const productsError = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products', { per_page: 100 });
-
-			if ( productsError ) {
-				productsStatus = 'error';
-			} else {
-				// eslint-disable-next-line camelcase
-				products = select( COLLECTIONS_STORE_KEY ).getCollection( '/wc/store', 'products', { per_page: 100 });
-
-				if ( ! isEmpty( products ) ) {
-					productsStatus = 'loaded';
-
-					products = products.map( result => ({
-						value: result.id,
-						label: decodeEntities( result.name )
-					}) );
-				}
-			}
-
-			const categoriesError = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products/categories' );
-
-			if ( categoriesError ) {
-				categoriesStatus = 'error';
-			} else {
-				categories = select( COLLECTIONS_STORE_KEY ).getCollection( '/wc/store', 'products/categories' );
-
-				if ( ! isEmpty( categories ) ) {
-					categoriesStatus = 'loaded';
-
-					categories = categories.map( result => ({
-						value: result.id,
-						label: decodeEntities( result.name )
-					}) );
-				}
-			}
-		}
-
-		if ( Boolean( window.otterPro.hasLearnDash ) ) {
-			courses = select( 'otter-pro' ).getLearnDashCourses();
-
-			if ( ! isEmpty( courses ) ) {
-				coursesStatus = 'loaded';
-			}
-
-			courseGroups = select( 'otter-pro' ).getLearnDashGroups();
-
-			if ( ! isEmpty( courseGroups ) ) {
-				courseGroupsStatus = 'loaded';
-			}
-		}
-
-		return {
-			products,
-			categories,
-			productsStatus,
-			categoriesStatus,
-			courses,
-			coursesStatus,
-			courseGroups,
-			courseGroupsStatus
-		};
-	}, []);
 
 	const changeDays = ( value, groupIndex, key ) => {
 		const otterConditions = [ ...conditions ];
@@ -562,31 +653,21 @@ const Edit = ({
 
 					{ 'products' === item.on && (
 						<Fragment>
-							{ 'loaded' === productsStatus && (
-								<Multiselect
-									label={ __( 'Products', 'otter-blocks' ) }
-									items={ products }
-									values={ item.products }
-									onChange={ values => changeProducts( values, groupIndex, itemIndex ) }
-								/>
-							) }
-
-							{ 'loading' === productsStatus && <Placeholder><Spinner /></Placeholder> }
+							<ProductsMultiselect
+								label={ __( 'Products', 'otter-blocks' ) }
+								values={ item.products }
+								onChange={ values => changeProducts( values, groupIndex, itemIndex ) }
+							/>
 						</Fragment>
 					) }
 
 					{ 'categories' === item.on && (
 						<Fragment>
-							{ 'loaded' === categoriesStatus && (
-								<Multiselect
-									label={ __( 'Categories', 'otter-blocks' ) }
-									items={ categories }
-									values={ item.categories }
-									onChange={ values => changeCategories( values, groupIndex, itemIndex ) }
-								/>
-							) }
-
-							{ 'loading' === categoriesStatus && <Placeholder><Spinner /></Placeholder> }
+							<CategoriesMultiselect
+								label={ __( 'Categories', 'otter-blocks' ) }
+								values={ item.categories }
+								onChange={ values => changeCategories( values, groupIndex, itemIndex ) }
+							/>
 						</Fragment>
 					) }
 				</Fragment>
@@ -632,16 +713,11 @@ const Edit = ({
 
 			{ 'wooPurchaseHistory' === item.type && (
 				<Fragment>
-					{ 'loaded' === productsStatus && (
-						<Multiselect
-							label={ __( 'Products', 'otter-blocks' ) }
-							items={ products }
-							values={ item.products }
-							onChange={ values => changeProducts( values, groupIndex, itemIndex ) }
-						/>
-					) }
-
-					{ 'loading' === productsStatus && <Placeholder><Spinner /></Placeholder> }
+					<ProductsMultiselect
+						label={ __( 'Products', 'otter-blocks' ) }
+						values={ item.products }
+						onChange={ values => changeProducts( values, groupIndex, itemIndex ) }
+					/>
 				</Fragment>
 			) }
 
@@ -665,31 +741,21 @@ const Edit = ({
 
 					{ 'courses' === item.on && (
 						<Fragment>
-							{ 'loaded' === coursesStatus && (
-								<Multiselect
-									label={ __( 'Courses', 'otter-blocks' ) }
-									items={ courses }
-									values={ item.courses }
-									onChange={ values => changeCourses( values, groupIndex, itemIndex ) }
-								/>
-							) }
-
-							{ 'loading' === coursesStatus && <Placeholder><Spinner /></Placeholder> }
+							<CoursesMultiselect
+								label={ __( 'Courses', 'otter-blocks' ) }
+								values={ item.courses }
+								onChange={ values => changeCourses( values, groupIndex, itemIndex ) }
+							/>
 						</Fragment>
 					) }
 
 					{ 'groups' === item.on && (
 						<Fragment>
-							{ 'loaded' === courseGroupsStatus && (
-								<Multiselect
-									label={ __( 'Groups', 'otter-blocks' ) }
-									items={ courseGroups }
-									values={ item.groups }
-									onChange={ values => changeGroups( values, groupIndex, itemIndex ) }
-								/>
-							) }
-
-							{ 'loading' === courseGroupsStatus && <Placeholder><Spinner /></Placeholder> }
+							<GroupsMultiselect
+								label={ __( 'Groups', 'otter-blocks' ) }
+								values={ item.groups }
+								onChange={ values => changeGroups( values, groupIndex, itemIndex ) }
+							/>
 						</Fragment>
 					) }
 				</Fragment>
@@ -697,42 +763,31 @@ const Edit = ({
 
 			{ 'learnDashCourseStatus' === item.type && (
 				<Fragment>
-					{ 'loaded' === coursesStatus && (
-						<Fragment>
-							{ Boolean( courses.length ) ? (
-								<SelectControl
-									label={ __( 'Course', 'otter-blocks' ) }
-									options={ courses }
-									value={ item.course }
-									onChange={ e => changeValue( Number( e ), groupIndex, itemIndex, 'course' ) }
-								/>
-							) : (
-								<p>{ __( 'No courses available.', 'otter-blocks' ) }</p>
-							) }
-
-							<SelectControl
-								label={ __( 'Status', 'otter-blocks' ) }
-								options={ [
-									{
-										value: 'not_started',
-										label: __( 'Not Started', 'otter-blocks' )
-									},
-									{
-										value: 'in_progress',
-										label: __( 'In Progress', 'otter-blocks' )
-									},
-									{
-										value: 'completed',
-										label: __( 'Completed', 'otter-blocks' )
-									}
-								] }
-								value={ item.status }
-								onChange={ e => changeValue( e, groupIndex, itemIndex, 'status' ) }
-							/>
-						</Fragment>
-					) }
-
-					{ 'loading' === coursesStatus && <Placeholder><Spinner /></Placeholder> }
+					<CoursesSelect
+						label={ __( 'Course', 'otter-blocks' ) }
+						value={ item.course }
+						onChange={ e => changeValue( Number( e ), groupIndex, itemIndex, 'course' ) }
+					>
+						<SelectControl
+							label={ __( 'Status', 'otter-blocks' ) }
+							options={ [
+								{
+									value: 'not_started',
+									label: __( 'Not Started', 'otter-blocks' )
+								},
+								{
+									value: 'in_progress',
+									label: __( 'In Progress', 'otter-blocks' )
+								},
+								{
+									value: 'completed',
+									label: __( 'Completed', 'otter-blocks' )
+								}
+							] }
+							value={ item.status }
+							onChange={ e => changeValue( e, groupIndex, itemIndex, 'status' ) }
+						/>
+					</CoursesSelect>
 				</Fragment>
 			) }
 		</Fragment>

--- a/src/pro/plugins/conditions/edit.js
+++ b/src/pro/plugins/conditions/edit.js
@@ -131,32 +131,37 @@ const Multiselect = ({
 const ProductsMultiselect = ( props ) => {
 	const {
 		products,
-		productsStatus
+		isLoading
 	} = useSelect( select => {
 		if ( ! Boolean( window.otterPro.hasWooCommerce ) ) {
 			return {
 				products: [],
-				productsStatus: 'loading'
+				isLoading: false
 			};
 		}
 
 		const { COLLECTIONS_STORE_KEY } = window?.wc?.wcBlocksData;
+		const {
+			getCollection,
+			getCollectionError,
+			isResolving
+		} = select( COLLECTIONS_STORE_KEY );
 
 		// eslint-disable-next-line camelcase
-		const productsError = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products', { per_page: 100 });
+		const productsError = getCollectionError?.( '/wc/store', 'products', { per_page: 100 });
 
-		const products = productsError ? [] : ( select( COLLECTIONS_STORE_KEY )?.getCollection( '/wc/store', 'products', { 'per_page': 100 }) ?? [])?.map( result => ({
+		const products = productsError ? [] : ( getCollection?.( '/wc/store', 'products', { 'per_page': 100 }) ?? [])?.map( result => ({
 			value: result.id,
 			label: decodeEntities( result.name )
 		}) );
 
 		return {
 			products,
-			productsStatus: ( productsError && 'error' ) || ( ! isEmpty( products ) && 'loaded' ) || 'loading'
+			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products', { 'per_page': 100 } ])
 		};
 	}, []);
 
-	return 'loading' === productsStatus ? (
+	return isLoading ? (
 		<Placeholder><Spinner /></Placeholder>
 	) : (
 		<Multiselect
@@ -169,32 +174,37 @@ const ProductsMultiselect = ( props ) => {
 const CategoriesMultiselect = ( props ) => {
 	const {
 		categories,
-		categoriesStatus
+		isLoading
 	} = useSelect( select => {
 		if ( ! Boolean( window.otterPro.hasWooCommerce ) ) {
 			return {
 				categories: [],
-				categoriesStatus: 'loading'
+				isLoading: false
 			};
 		}
 
 		const { COLLECTIONS_STORE_KEY } = window?.wc?.wcBlocksData;
+		const {
+			getCollection,
+			getCollectionError,
+			isResolving
+		} = select( COLLECTIONS_STORE_KEY );
 
 		// eslint-disable-next-line camelcase
-		const categoriesError = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products/categories' );
+		const categoriesError = getCollectionError( '/wc/store', 'products/categories' );
 
-		const categories = categoriesError ? [] : ( select( COLLECTIONS_STORE_KEY ).getCollection( '/wc/store', 'products/categories' ) ?? [])?.map( result => ({
+		const categories = categoriesError ? [] : ( getCollection( '/wc/store', 'products/categories' ) ?? [])?.map( result => ({
 			value: result.id,
 			label: decodeEntities( result.name )
 		}) );
 
 		return {
 			categories,
-			categoriesStatus: ( categoriesError && 'error' ) || ( ! isEmpty( categories ) && 'loaded' ) || 'loading'
+			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products/categories' ])
 		};
 	}, []);
 
-	return 'loading' === categoriesStatus ? (
+	return isLoading ? (
 		<Placeholder><Spinner /></Placeholder>
 	) : (
 		<Multiselect
@@ -207,23 +217,23 @@ const CategoriesMultiselect = ( props ) => {
 const CoursesMultiselect = ( props ) => {
 	const {
 		courses,
-		coursesStatus
+		isLoading
 	} = useSelect( select => {
 		if ( ! Boolean( window.otterPro.hasLearnDash ) ) {
 			return {
 				courses: [],
-				cursesStatus: 'loading'
+				cursesStatus: false
 			};
 		}
 
 		const courses = select( 'otter-pro' )?.getLearnDashCourses() ?? [];
 		return {
 			courses,
-			coursesStatus: ! isEmpty( courses ) ? 'loaded' : 'loading'
+			isLoading: ! select( 'otter-pro' )?.isLearnDashCoursesLoaded()
 		};
 	}, []);
 
-	return 'loading' === coursesStatus ? (
+	return isLoading ? (
 		<Placeholder><Spinner /></Placeholder>
 	) : (
 		<Multiselect
@@ -236,25 +246,25 @@ const CoursesMultiselect = ( props ) => {
 const CoursesSelect = ( props ) => {
 	const {
 		courses,
-		coursesStatus
+		isLoading
 	} = useSelect( select => {
 		if ( ! Boolean( window.otterPro.hasLearnDash ) ) {
 			return {
 				courses: [],
-				cursesStatus: 'loading'
+				cursesStatus: false
 			};
 		}
 
 		const courses = select( 'otter-pro' )?.getLearnDashCourses() ?? [];
 		return {
 			courses,
-			coursesStatus: ! isEmpty( courses ) ? 'loaded' : 'loading'
+			isLoading: ! select( 'otter-pro' )?.isLearnDashCoursesLoaded()
 		};
 	}, []);
 
 	return (
 		<Fragment>
-			{ 'loaded' === coursesStatus && (
+			{ ! isLoading && (
 				<Fragment>
 					{ Boolean( courses.length ) ? (
 						<SelectControl
@@ -269,7 +279,7 @@ const CoursesSelect = ( props ) => {
 				</Fragment>
 			) }
 
-			{ 'loading' === coursesStatus && <Placeholder><Spinner /></Placeholder> }
+			{ isLoading && <Placeholder><Spinner /></Placeholder> }
 		</Fragment>
 	);
 };
@@ -286,14 +296,14 @@ const GroupsMultiselect = ( props ) => {
 			};
 		}
 
-		const groups = select( 'otter-pro' )?.getLearnDashGroups()() ?? [];
+		const groups = select( 'otter-pro' )?.getLearnDashGroups() ?? [];
 		return {
 			groups,
-			groupsStatus: ! isEmpty( groups ) ? 'loaded' : 'loading'
+			groupsStatus: ! select( 'otter-pro' )?.isLearnDashGroupsLoaded()
 		};
 	}, []);
 
-	return 'loading' === groupsStatus ? (
+	return groupsStatus ? (
 		<Placeholder><Spinner /></Placeholder>
 	) : (
 		<Multiselect

--- a/src/pro/plugins/data/index.js
+++ b/src/pro/plugins/data/index.js
@@ -107,9 +107,8 @@ registerStore( 'otter-pro', {
 			if ( ! Boolean( window.otterPro.hasLearnDash ) ) {
 				return;
 			}
-			console.log( 'Get Course' );
+
 			const data = yield actions.fetchFromAPI( 'ldlms/v2/sfwd-courses' );
-			console.log( 'Got the course' );
 
 			const courses = data.map( datum => ({
 				value: datum.id,

--- a/src/pro/plugins/data/index.js
+++ b/src/pro/plugins/data/index.js
@@ -11,20 +11,24 @@ const DEFAULT_STATE = {
 	acfGroups: [],
 	acfFields: {},
 	learndDashCourses: [],
-	learndDashGroups: []
+	learndDashGroups: [],
+	haveLoadedCourses: false,
+	haveLoadedGroups: false
 };
 
 const actions = {
 	setCourses( courses ) {
 		return {
 			type: 'SET_LEARNDASH_COURSES',
-			courses
+			courses,
+			haveLoadedCourses: true
 		};
 	},
 	setGroups( groups ) {
 		return {
 			type: 'SET_LEARNDASH_GROUPS',
-			groups
+			groups,
+			haveLoadedGroups: true
 		};
 	},
 	setACFData( groups, fields ) {
@@ -47,14 +51,16 @@ registerStore( 'otter-pro', {
 		if ( 'SET_LEARNDASH_COURSES' === action.type ) {
 			return {
 				...state,
-				learndDashCourses: action.courses
+				learndDashCourses: action.courses,
+				haveLoadedCourses: action.haveLoadedCourses
 			};
 		}
 
 		if ( 'SET_LEARNDASH_GROUPS' === action.type ) {
 			return {
 				...state,
-				learndDashGroups: action.groups
+				learndDashGroups: action.groups,
+				haveLoadedGroups: action.haveLoadedGroups
 			};
 		}
 
@@ -81,6 +87,12 @@ registerStore( 'otter-pro', {
 				groups: state.acfGroups,
 				fields: state.acfFields
 			};
+		},
+		isLearnDashCoursesLoaded( state ) {
+			return state.haveLoadedCourses;
+		},
+		isLearnDashGroupsLoaded( state ) {
+			return state.haveLoadedGroups;
 		}
 	},
 
@@ -95,8 +107,9 @@ registerStore( 'otter-pro', {
 			if ( ! Boolean( window.otterPro.hasLearnDash ) ) {
 				return;
 			}
-
+			console.log( 'Get Course' );
 			const data = yield actions.fetchFromAPI( 'ldlms/v2/sfwd-courses' );
+			console.log( 'Got the course' );
 
 			const courses = data.map( datum => ({
 				value: datum.id,


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #799 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The Condition Inspector is triggering for every block, thus any computation becomes expensive. This update will make sure that the data is done only when needed. Also, I suspect that the useSelect was doing synchronization with the global store, thus the _indirect_ overhead in the Profiler for `onStoreChange`.

@HardeepAsrani @selul @Skystream96 @preda-bogdan @abaicus feel free to take a look.

### Screenshots <!-- if applicable -->

The site was tested with the following query: `new QueryQA().select('blocks').run()` which puts all the block template available (more than 70 blocks in total).

**Performance result**

Current version:
<img width="1878" alt="Screenshot 2022-07-06 at 13 50 31" src="https://user-images.githubusercontent.com/17597852/177534097-a7c29372-337f-446a-8834-14dbd1dfdbaa.png">

As you can see, a lot of red dots indicated a huge load with like a 100ms computation time per typing.


Updated: 

No more red dots. 30 ms computation time per typing. _So 3x increase in performance._

<img width="1831" alt="Screenshot 2022-07-06 at 13 49 52" src="https://user-images.githubusercontent.com/17597852/177534082-a328064e-7578-422e-a5c3-554a070f6425.png">


----

### Test instructions
<!-- Describe how this pull request can be tested. -->


#### Query
```javascript
new QueryQA().select('blocks').run()
```


---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

