### PR TITLE
Made desktop the default style for Section block

### DIFF
--- a/inc/css/blocks/class-advanced-column-css.php
+++ b/inc/css/blocks/class-advanced-column-css.php
@@ -451,7 +451,7 @@ class Advanced_Column_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'query'      => '@media ( min-width: 600px ) and ( max-width: 960px )',
+				'query'      => '@media ( max-width: 960px )',
 				'properties' => array(
 					array(
 						'property'  => 'padding-top',

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -718,7 +718,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'query'      => '@media ( min-width: 600px ) and ( max-width: 960px )',
+				'query'      => '@media ( max-width: 960px )',
 				'properties' => array(
 					array(
 						'property'  => 'padding-top',
@@ -800,7 +800,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'query'      => '@media ( min-width: 600px ) and ( max-width: 960px )',
+				'query'      => '@media ( max-width: 960px )',
 				'selector'   => ' .wp-block-themeisle-blocks-advanced-columns-separators.top svg',
 				'properties' => array(
 					array(
@@ -829,7 +829,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'query'      => '@media ( min-width: 600px ) and ( max-width: 960px )',
+				'query'      => '@media ( max-width: 960px )',
 				'selector'   => ' .wp-block-themeisle-blocks-advanced-columns-separators.bottom svg',
 				'properties' => array(
 					array(

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -172,7 +172,7 @@ const Edit = ({
 	};
 
 
-	if ( isTablet ) {
+	if ( isTablet || isMobile ) {
 		const tabletStyle = pickBy({
 			paddingTop: getValue( 'paddingTablet' )?.top,
 			paddingRight: getValue( 'paddingTablet' )?.right,
@@ -197,6 +197,7 @@ const Edit = ({
 			marginBottom: getValue( 'marginMobile' )?.bottom,
 			marginLeft: getValue( 'marginMobile' )?.left
 		}, ( value ) => value );
+
 		stylesheet = merge( stylesheet, mobileStyle );
 	}
 

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -6,7 +6,7 @@ import hexToRgba from 'hex-rgba';
 /**
  * WordPress dependencies
  */
-import { isEmpty } from 'lodash';
+import { isEmpty, merge, pickBy } from 'lodash';
 
 import {
 	InnerBlocks,
@@ -157,23 +157,23 @@ const Edit = ({
 
 	const Tag = attributes.columnsHTMLTag;
 
-	let stylesheet, background, borderStyle, borderRadiusStyle, boxShadowStyle;
+	let background, borderStyle, borderRadiusStyle, boxShadowStyle;
 
-	if ( isDesktop ) {
-		stylesheet = {
-			paddingTop: getValue( 'padding' )?.top,
-			paddingRight: getValue( 'padding' )?.right,
-			paddingBottom: getValue( 'padding' )?.bottom,
-			paddingLeft: getValue( 'padding' )?.left,
-			marginTop: getValue( 'margin' )?.top,
-			marginRight: getValue( 'margin' )?.right,
-			marginBottom: getValue( 'margin' )?.bottom,
-			marginLeft: getValue( 'margin' )?.left
-		};
-	}
+
+	let	stylesheet = {
+		paddingTop: getValue( 'padding' )?.top,
+		paddingRight: getValue( 'padding' )?.right,
+		paddingBottom: getValue( 'padding' )?.bottom,
+		paddingLeft: getValue( 'padding' )?.left,
+		marginTop: getValue( 'margin' )?.top,
+		marginRight: getValue( 'margin' )?.right,
+		marginBottom: getValue( 'margin' )?.bottom,
+		marginLeft: getValue( 'margin' )?.left
+	};
+
 
 	if ( isTablet ) {
-		stylesheet = {
+		const tabletStyle = pickBy({
 			paddingTop: getValue( 'paddingTablet' )?.top,
 			paddingRight: getValue( 'paddingTablet' )?.right,
 			paddingBottom: getValue( 'paddingTablet' )?.bottom,
@@ -182,11 +182,12 @@ const Edit = ({
 			marginRight: getValue( 'marginTablet' )?.right,
 			marginBottom: getValue( 'marginTablet' )?.bottom,
 			marginLeft: getValue( 'marginTablet' )?.left
-		};
+		}, ( value ) => value );
+		stylesheet = merge( stylesheet, tabletStyle );
 	}
 
 	if ( isMobile ) {
-		stylesheet = {
+		const mobileStyle = pickBy({
 			paddingTop: getValue( 'paddingMobile' )?.top,
 			paddingRight: getValue( 'paddingMobile' )?.right,
 			paddingBottom: getValue( 'paddingMobile' )?.bottom,
@@ -195,7 +196,8 @@ const Edit = ({
 			marginRight: getValue( 'marginMobile' )?.right,
 			marginBottom: getValue( 'marginMobile' )?.bottom,
 			marginLeft: getValue( 'marginMobile' )?.left
-		};
+		}, ( value ) => value );
+		stylesheet = merge( stylesheet, mobileStyle );
 	}
 
 	if ( 'color' === attributes.backgroundType ) {

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -94,9 +94,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'padding' );
 		case 'Tablet':
-			return getValue( 'paddingTablet' );
+			return getValue( 'paddingTablet' ) ?? getValue( 'padding' );
 		case 'Mobile':
-			return getValue( 'paddingMobile' );
+			return getValue( 'paddingMobile' ) ?? getValue( 'padding' );
 		default:
 			return undefined;
 		}
@@ -137,9 +137,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'margin' );
 		case 'Tablet':
-			return getValue( 'marginTablet' );
+			return getValue( 'marginTablet' ) ?? getValue( 'margin' );
 		case 'Mobile':
-			return getValue( 'marginMobile' );
+			return getValue( 'marginMobile' ) ?? getValue( 'margin' );
 		default:
 			return undefined;
 		}

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 
-import { pick } from 'lodash';
+import { merge, pick } from 'lodash';
 
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
@@ -94,9 +94,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'padding' );
 		case 'Tablet':
-			return getValue( 'paddingTablet' ) ?? getValue( 'padding' );
+			return merge( getValue( 'padding' ), getValue( 'paddingTablet' ) );
 		case 'Mobile':
-			return getValue( 'paddingMobile' ) ?? getValue( 'paddingTablet' ) ?? getValue( 'padding' );
+			return merge( getValue( 'padding' ), getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) );
 		default:
 			return undefined;
 		}
@@ -137,9 +137,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'margin' );
 		case 'Tablet':
-			return getValue( 'marginTablet' ) ?? getValue( 'margin' );
+			return merge( getValue( 'margin' ), getValue( 'marginTablet' ) );
 		case 'Mobile':
-			return getValue( 'marginMobile' ) ?? getValue( 'marginTablet' ) ?? getValue( 'margin' );
+			return merge( getValue( 'margin' ), getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
 		default:
 			return undefined;
 		}

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -96,7 +96,7 @@ const Inspector = ({
 		case 'Tablet':
 			return getValue( 'paddingTablet' ) ?? getValue( 'padding' );
 		case 'Mobile':
-			return getValue( 'paddingMobile' ) ?? getValue( 'padding' );
+			return getValue( 'paddingMobile' ) ?? getValue( 'paddingTablet' ) ?? getValue( 'padding' );
 		default:
 			return undefined;
 		}
@@ -139,7 +139,7 @@ const Inspector = ({
 		case 'Tablet':
 			return getValue( 'marginTablet' ) ?? getValue( 'margin' );
 		case 'Mobile':
-			return getValue( 'marginMobile' ) ?? getValue( 'margin' );
+			return getValue( 'marginMobile' ) ?? getValue( 'marginTablet' ) ?? getValue( 'margin' );
 		default:
 			return undefined;
 		}

--- a/src/blocks/blocks/section/columns/block.json
+++ b/src/blocks/blocks/section/columns/block.json
@@ -204,28 +204,22 @@
 			"default": "#000000"
 		},
 		"dividerTopWidth": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerTopWidthTablet": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerTopWidthMobile": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerTopHeight": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerTopHeightTablet": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerTopHeightMobile": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerTopInvert": {
 			"type": "boolean",
@@ -240,28 +234,22 @@
 			"default": "#000000"
 		},
 		"dividerBottomWidth": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerBottomWidthTablet": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerBottomWidthMobile": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerBottomHeight": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerBottomHeightTablet": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerBottomHeightMobile": {
-			"type": "number",
-			"default": 100
+			"type": "number"
 		},
 		"dividerBottomInvert": {
 			"type": "boolean",

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -226,7 +226,7 @@ const Edit = ({
 	};
 
 
-	if ( isTablet ) {
+	if ( isTablet || isMobile ) {
 		const tabletStyle = pickBy({
 			paddingTop: getValue( 'paddingTablet' )?.top,
 			paddingRight: getValue( 'paddingTablet' )?.right,

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -181,7 +181,7 @@ const Edit = ({
 	const [ dividerViewType, setDividerViewType ] = useState( 'top' );
 
 	const getValueBasedOnScreenSize = ({ mobile, tablet, desktop }) => {
-		return ( isMobile && mobile ) || ( isTablet && tablet ) || ( isDesktop && desktop ) || undefined;
+		return (( isMobile && mobile ) || ( isTablet && tablet ) || desktop ) ?? desktop ?? 100;
 	};
 
 	const getDividerTopWidth = getValueBasedOnScreenSize({

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -181,7 +181,7 @@ const Edit = ({
 	const [ dividerViewType, setDividerViewType ] = useState( 'top' );
 
 	const getValueBasedOnScreenSize = ({ mobile, tablet, desktop }) => {
-		return (( isMobile && mobile ) || ( isTablet && tablet ) || desktop ) ?? desktop ?? 100;
+		return ( ( isMobile && mobile ) || ( isTablet && tablet ) || desktop ) ?? desktop ?? 100;
 	};
 
 	const getDividerTopWidth = getValueBasedOnScreenSize({

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -11,7 +11,9 @@ import { __ } from '@wordpress/i18n';
 
 import {
 	times,
-	isEmpty
+	isEmpty,
+	pickBy,
+	merge
 } from 'lodash';
 
 import {
@@ -210,22 +212,22 @@ const Edit = ({
 
 	const Tag = attributes.columnsHTMLTag;
 
-	let stylesheet, background, overlayBackground, borderStyle, borderRadiusStyle, boxShadowStyle;
+	let  background, overlayBackground, borderStyle, borderRadiusStyle, boxShadowStyle;
 
-	if ( isDesktop ) {
-		stylesheet = {
-			paddingTop: getValue( 'padding' ) && getValue( 'padding' ).top,
-			paddingRight: getValue( 'padding' ) && getValue( 'padding' ).right,
-			paddingBottom: getValue( 'padding' ) && getValue( 'padding' ).bottom,
-			paddingLeft: getValue( 'padding' ) && getValue( 'padding' ).left,
-			marginTop: getValue( 'margin' ) && getValue( 'margin' ).top,
-			marginBottom: getValue( 'margin' ) && getValue( 'margin' ).bottom,
-			minHeight: 'custom' === attributes.columnsHeight ? `${ attributes.columnsHeightCustom }px` : attributes.columnsHeight
-		};
-	}
+
+	let	stylesheet = {
+		paddingTop: getValue( 'padding' ) && getValue( 'padding' ).top,
+		paddingRight: getValue( 'padding' ) && getValue( 'padding' ).right,
+		paddingBottom: getValue( 'padding' ) && getValue( 'padding' ).bottom,
+		paddingLeft: getValue( 'padding' ) && getValue( 'padding' ).left,
+		marginTop: getValue( 'margin' ) && getValue( 'margin' ).top,
+		marginBottom: getValue( 'margin' ) && getValue( 'margin' ).bottom,
+		minHeight: 'custom' === attributes.columnsHeight ? `${ attributes.columnsHeightCustom }px` : attributes.columnsHeight
+	};
+
 
 	if ( isTablet ) {
-		stylesheet = {
+		const tabletStyle = pickBy({
 			paddingTop: getValue( 'paddingTablet' )?.top,
 			paddingRight: getValue( 'paddingTablet' )?.right,
 			paddingBottom: getValue( 'paddingTablet' )?.bottom,
@@ -233,11 +235,12 @@ const Edit = ({
 			marginTop: getValue( 'marginTablet' )?.top,
 			marginBottom: getValue( 'marginTablet' )?.bottom,
 			minHeight: 'custom' === attributes.columnsHeight ? `${ attributes.columnsHeightCustomTablet }px` : attributes.columnsHeight
-		};
+		}, ( value ) => value );
+		stylesheet = merge( stylesheet, tabletStyle );
 	}
 
 	if ( isMobile ) {
-		stylesheet = {
+		const mobileStyle = pickBy({
 			paddingTop: getValue( 'paddingMobile' )?.top,
 			paddingRight: getValue( 'paddingMobile' )?.right,
 			paddingBottom: getValue( 'paddingMobile' )?.bottom,
@@ -245,7 +248,8 @@ const Edit = ({
 			marginTop: getValue( 'marginMobile' )?.top,
 			marginBottom: getValue( 'marginMobile' )?.bottom,
 			minHeight: 'custom' === attributes.columnsHeight ? `${ attributes.columnsHeightCustomMobile }px` : attributes.columnsHeight
-		};
+		}, ( value ) => value );
+		stylesheet = merge( stylesheet, mobileStyle );
 	}
 
 	if ( 'color' === attributes.backgroundType ) {

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -304,20 +304,20 @@ const Inspector = ({
 		if ( 'top' == dividerViewType ) {
 			switch ( getView ) {
 			case 'Desktop':
-				return attributes.dividerTopWidth;
+				return attributes.dividerTopWidth ?? 100;
 			case 'Tablet':
-				return attributes.dividerTopWidthTablet;
+				return attributes.dividerTopWidthTablet ?? 100;
 			case 'Mobile':
-				return attributes.dividerTopWidthMobile;
+				return attributes.dividerTopWidthMobile ?? 100;
 			}
 		} else if ( 'bottom' == dividerViewType ) {
 			switch ( getView ) {
 			case 'Desktop':
-				return attributes.dividerBottomWidth;
+				return attributes.dividerBottomWidth ?? 100;
 			case 'Tablet':
-				return attributes.dividerBottomWidthTablet;
+				return attributes.dividerBottomWidthTablet ?? 100;
 			case 'Mobile':
-				return attributes.dividerBottomWidthMobile;
+				return attributes.dividerBottomWidthMobile ?? 100;
 			}
 		}
 

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -131,9 +131,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'padding' );
 		case 'Tablet':
-			return getValue( 'paddingTablet' );
+			return getValue( 'paddingTablet' ) ?? getValue( 'padding' );
 		case 'Mobile':
-			return getValue( 'paddingMobile' );
+			return getValue( 'paddingMobile' ) ?? getValue( 'padding' );
 		default:
 			return undefined;
 		}
@@ -174,9 +174,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'margin' );
 		case 'Tablet':
-			return getValue( 'marginTablet' );
+			return getValue( 'marginTablet' ) ?? getValue( 'margin' );
 		case 'Mobile':
-			return getValue( 'marginMobile' );
+			return getValue( 'marginMobile' ) ?? getValue( 'margin' );
 		default:
 			return undefined;
 		}
@@ -222,9 +222,9 @@ const Inspector = ({
 		case 'Desktop':
 			return attributes.columnsHeightCustom;
 		case 'Tablet':
-			return attributes.columnsHeightCustomTablet;
+			return attributes.columnsHeightCustomTablet ?? attributes.columnsHeightCustom;
 		case 'Mobile':
-			return attributes.columnsHeightCustomMobile;
+			return attributes.columnsHeightCustomMobile ?? attributes.columnsHeightCustom;
 		default:
 			return undefined;
 		}
@@ -306,18 +306,18 @@ const Inspector = ({
 			case 'Desktop':
 				return attributes.dividerTopWidth ?? 100;
 			case 'Tablet':
-				return attributes.dividerTopWidthTablet ?? 100;
+				return attributes.dividerTopWidthTablet ?? attributes.dividerTopWidth ?? 100;
 			case 'Mobile':
-				return attributes.dividerTopWidthMobile ?? 100;
+				return attributes.dividerTopWidthMobile ?? attributes.dividerTopWidth ?? 100;
 			}
 		} else if ( 'bottom' == dividerViewType ) {
 			switch ( getView ) {
 			case 'Desktop':
 				return attributes.dividerBottomWidth ?? 100;
 			case 'Tablet':
-				return attributes.dividerBottomWidthTablet ?? 100;
+				return attributes.dividerBottomWidthTablet ?? attributes.dividerBottomWidth ?? 100;
 			case 'Mobile':
-				return attributes.dividerBottomWidthMobile ?? 100;
+				return attributes.dividerBottomWidthMobile ?? attributes.dividerBottomWidth ?? 100;
 			}
 		}
 

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -133,7 +133,7 @@ const Inspector = ({
 		case 'Tablet':
 			return getValue( 'paddingTablet' ) ?? getValue( 'padding' );
 		case 'Mobile':
-			return getValue( 'paddingMobile' ) ?? getValue( 'padding' );
+			return getValue( 'paddingMobile' ) ?? getValue( 'paddingTablet' ) ?? getValue( 'padding' );
 		default:
 			return undefined;
 		}
@@ -176,7 +176,7 @@ const Inspector = ({
 		case 'Tablet':
 			return getValue( 'marginTablet' ) ?? getValue( 'margin' );
 		case 'Mobile':
-			return getValue( 'marginMobile' ) ?? getValue( 'margin' );
+			return getValue( 'marginMobile' ) ?? getValue( 'marginTablet' ) ?? getValue( 'margin' );
 		default:
 			return undefined;
 		}
@@ -224,7 +224,7 @@ const Inspector = ({
 		case 'Tablet':
 			return attributes.columnsHeightCustomTablet ?? attributes.columnsHeightCustom;
 		case 'Mobile':
-			return attributes.columnsHeightCustomMobile ?? attributes.columnsHeightCustom;
+			return attributes.columnsHeightCustomMobile ?? attributes.columnsHeightCustomTablet ?? attributes.columnsHeightCustom;
 		default:
 			return undefined;
 		}
@@ -308,7 +308,7 @@ const Inspector = ({
 			case 'Tablet':
 				return attributes.dividerTopWidthTablet ?? attributes.dividerTopWidth ?? 100;
 			case 'Mobile':
-				return attributes.dividerTopWidthMobile ?? attributes.dividerTopWidth ?? 100;
+				return attributes.dividerTopWidthMobile ?? attributes.dividerTopWidthTablet ?? attributes.dividerTopWidth ?? 100;
 			}
 		} else if ( 'bottom' == dividerViewType ) {
 			switch ( getView ) {
@@ -317,7 +317,7 @@ const Inspector = ({
 			case 'Tablet':
 				return attributes.dividerBottomWidthTablet ?? attributes.dividerBottomWidth ?? 100;
 			case 'Mobile':
-				return attributes.dividerBottomWidthMobile ?? attributes.dividerBottomWidth ?? 100;
+				return attributes.dividerBottomWidthMobile ?? attributes.dividerBottomWidthTablet ?? attributes.dividerBottomWidth ?? 100;
 			}
 		}
 

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 
-import { pick } from 'lodash';
+import { merge, pick } from 'lodash';
 
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
@@ -131,9 +131,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'padding' );
 		case 'Tablet':
-			return getValue( 'paddingTablet' ) ?? getValue( 'padding' );
+			return merge( getValue( 'padding' ), getValue( 'paddingTablet' ) );
 		case 'Mobile':
-			return getValue( 'paddingMobile' ) ?? getValue( 'paddingTablet' ) ?? getValue( 'padding' );
+			return merge( getValue( 'padding' ), getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) ) ;
 		default:
 			return undefined;
 		}
@@ -174,9 +174,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'margin' );
 		case 'Tablet':
-			return getValue( 'marginTablet' ) ?? getValue( 'margin' );
+			return merge( getValue( 'margin' ), getValue( 'marginTablet' ) );
 		case 'Mobile':
-			return getValue( 'marginMobile' ) ?? getValue( 'marginTablet' ) ?? getValue( 'margin' );
+			return merge( getValue( 'margin' ), getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
 		default:
 			return undefined;
 		}
@@ -186,6 +186,8 @@ const Inspector = ({
 		if ( isNullObject( value ) ) {
 			value = undefined;
 		}
+
+		console.log( value );
 
 		if ( 'object' === typeof value ) {
 			value = Object.fromEntries( Object.entries( value ).filter( ([ _, v ]) => null !== v ) );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1030 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Remove the strict scoping for some CSS props.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Section block
2. Customize on desktop
3. Check on the Mobile/Tablet preview to see if the CSS is kept.
4. Tablet/Mobile should inherit from Desktop. If Tablet is set, the Mobile will inherit them instead of the Desktop.


#### Query
```javascript
new QueryQA().select('blocks').where({ has: { blocks: ['section'] }}).run()
```


---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

