### PR TITLE
Add loading condition for blocks.css

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -281,9 +281,6 @@ class Registration {
 			return;
 		}
 
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
-		wp_enqueue_style( 'otter-blocks', OTTER_BLOCKS_URL . 'build/blocks/blocks.css', [], $asset_file['version'] );
-
 		if ( is_singular() ) {
 			$this->enqueue_dependencies();
 		} else {
@@ -549,6 +546,8 @@ class Registration {
 	 * @access  public
 	 */
 	public function enqueue_block_styles( $post ) {
+		$otter_block_found = false;
+
 		foreach ( self::$blocks as $block ) {
 			if ( in_array( $block, self::$styles_loaded ) || ! has_block( 'themeisle-blocks/' . $block, $post ) ) {
 				continue;
@@ -580,6 +579,7 @@ class Registration {
 			}
 
 			if ( file_exists( $style_path ) && ! empty( $metadata['style'] ) ) {
+				$otter_block_found = true;
 				wp_register_style(
 					$metadata['style'],
 					$style,
@@ -589,6 +589,11 @@ class Registration {
 			}
 
 			array_push( self::$styles_loaded, $block );
+		}
+
+		if ( $otter_block_found ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
+			wp_enqueue_style( 'otter-blocks', OTTER_BLOCKS_URL . 'build/blocks/blocks.css', [], $asset_file['version'] );
 		}
 	}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1040 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- [x] Load `blocks.css` for Otter when is needed
- [ ] Load `blocks.css` for Otter Pro when is needed

@HardeepAsrani we need to replicate the same mechanism in Otter pro for loading the blocks. But first, we need a refine the functions because the current state is a mess in my opinion ( I have a hard time jumping through the code when fixing FSE ).

I will try to make a new mechanism, hoping to be more robust and easy to add features.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make an empty page.
2. Go to the frontend and make sure that no `blocks.css` is loaded.
3. Go back, and add an Otter block.
4. Go to the frontend and make that that a `blocks.css` is loaded.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

