### PR TITLE
Make CSS vars to snake case.

### DIFF
--- a/inc/css/blocks/class-accordion-css.php
+++ b/inc/css/blocks/class-accordion-css.php
@@ -38,22 +38,22 @@ class Accordion_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--titleColor',
+						'property' => '--title-color',
 						'value'    => 'titleColor',
 						'hasSync'  => 'accordionTitleColor',
 					),
 					array(
-						'property' => '--titleBackground',
+						'property' => '--title-background',
 						'value'    => 'titleBackground',
 						'hasSync'  => 'accordionTitleBackground',
 					),
 					array(
-						'property' => '--borderColor',
+						'property' => '--border-color',
 						'value'    => 'borderColor',
 						'hasSync'  => 'accordionBorderColor',
 					),
 					array(
-						'property' => '--contentBackground',
+						'property' => '--content-background',
 						'value'    => 'contentBackground',
 						'hasSync'  => 'accordionContentBackground',
 					),

--- a/inc/css/blocks/class-accordion-css.php
+++ b/inc/css/blocks/class-accordion-css.php
@@ -40,22 +40,22 @@ class Accordion_CSS extends Base_CSS {
 					array(
 						'property' => '--title-color',
 						'value'    => 'titleColor',
-						'hasSync'  => 'accordionTitleColor',
+						'hasSync'  => 'accordion-title-color',
 					),
 					array(
 						'property' => '--title-background',
 						'value'    => 'titleBackground',
-						'hasSync'  => 'accordionTitleBackground',
+						'hasSync'  => 'accordion-title-background',
 					),
 					array(
 						'property' => '--border-color',
 						'value'    => 'borderColor',
-						'hasSync'  => 'accordionBorderColor',
+						'hasSync'  => 'accordion-border-color',
 					),
 					array(
 						'property' => '--content-background',
 						'value'    => 'contentBackground',
-						'hasSync'  => 'accordionContentBackground',
+						'hasSync'  => 'accordion-content-background',
 					),
 				),
 			)
@@ -98,19 +98,19 @@ class Accordion_CSS extends Base_CSS {
 				'selector'   => '.wp-block-themeisle-blocks-accordion',
 				'properties' => array(
 					array(
-						'property' => '--accordionTitleColor',
+						'property' => '--accordion-title-color',
 						'value'    => 'titleColor',
 					),
 					array(
-						'property' => '--accordionTitleBackground',
+						'property' => '--accordion-title-background',
 						'value'    => 'titleBackground',
 					),
 					array(
-						'property' => '--accordionBorderColor',
+						'property' => '--accordion-border-color',
 						'value'    => 'borderColor',
 					),
 					array(
-						'property' => '--accordionContentBackground',
+						'property' => '--accordion-content-background',
 						'value'    => 'contentBackground',
 					),
 				),

--- a/inc/css/blocks/class-advanced-column-css.php
+++ b/inc/css/blocks/class-advanced-column-css.php
@@ -103,7 +103,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['top'] );
 						},
-						'hasSync'   => 'columnPaddingTop',
+						'hasSync'   => 'column-padding-top',
 					),
 					array(
 						'property'  => 'padding-bottom',
@@ -114,7 +114,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['bottom'] );
 						},
-						'hasSync'   => 'columnPaddingBottom',
+						'hasSync'   => 'column-padding-bottom',
 					),
 					array(
 						'property'  => 'padding-left',
@@ -125,7 +125,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['left'] );
 						},
-						'hasSync'   => 'columnPaddingLeft',
+						'hasSync'   => 'column-padding-left',
 					),
 					array(
 						'property'  => 'padding-right',
@@ -136,7 +136,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['right'] );
 						},
-						'hasSync'   => 'columnPaddingRight',
+						'hasSync'   => 'column-padding-right',
 					),
 					array(
 						'property'  => 'margin-top',
@@ -147,7 +147,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['top'] );
 						},
-						'hasSync'   => 'columnMarginTop',
+						'hasSync'   => 'column-margin-top',
 					),
 					array(
 						'property'  => 'margin-bottom',
@@ -158,7 +158,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['bottom'] );
 						},
-						'hasSync'   => 'columnMarginBottom',
+						'hasSync'   => 'column-margin-bottom',
 					),
 					array(
 						'property'  => 'margin-left',
@@ -169,7 +169,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['left'] );
 						},
-						'hasSync'   => 'columnMarginLeft',
+						'hasSync'   => 'column-margin-left',
 					),
 					array(
 						'property'  => 'margin-right',
@@ -180,7 +180,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['right'] );
 						},
-						'hasSync'   => 'columnMarginRight',
+						'hasSync'   => 'column-margin-right',
 					),
 					array(
 						'property'  => 'background',
@@ -462,7 +462,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['top'] );
 						},
-						'hasSync'   => 'columnPaddingTopTablet',
+						'hasSync'   => 'column-padding-top-tablet',
 					),
 					array(
 						'property'  => 'padding-bottom',
@@ -473,7 +473,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['bottom'] );
 						},
-						'hasSync'   => 'columnPaddingBottomTablet',
+						'hasSync'   => 'column-padding-bottom-tablet',
 					),
 					array(
 						'property'  => 'padding-left',
@@ -484,7 +484,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['left'] );
 						},
-						'hasSync'   => 'columnPaddingLeftTablet',
+						'hasSync'   => 'column-padding-left-tablet',
 					),
 					array(
 						'property'  => 'padding-right',
@@ -495,7 +495,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['right'] );
 						},
-						'hasSync'   => 'columnPaddingRightTablet',
+						'hasSync'   => 'column-padding-right-tablet',
 					),
 					array(
 						'property'  => 'margin-top',
@@ -506,7 +506,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['top'] );
 						},
-						'hasSync'   => 'columnMarginTopTablet',
+						'hasSync'   => 'column-margin-top-tablet',
 					),
 					array(
 						'property'  => 'margin-bottom',
@@ -517,7 +517,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['bottom'] );
 						},
-						'hasSync'   => 'columnMarginBottomTablet',
+						'hasSync'   => 'column-margin-bottom-tablet',
 					),
 					array(
 						'property'  => 'margin-left',
@@ -528,7 +528,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['left'] );
 						},
-						'hasSync'   => 'columnMarginLeftTablet',
+						'hasSync'   => 'column-margin-left-tablet',
 					),
 					array(
 						'property'  => 'margin-right',
@@ -539,7 +539,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['right'] );
 						},
-						'hasSync'   => 'columnMarginRightTablet',
+						'hasSync'   => 'column-margin-right-tablet',
 					),
 				),
 			)
@@ -558,7 +558,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['top'] );
 						},
-						'hasSync'   => 'columnPaddingTopMobile',
+						'hasSync'   => 'column-padding-top-mobile',
 					),
 					array(
 						'property'  => 'padding-bottom',
@@ -569,7 +569,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['bottom'] );
 						},
-						'hasSync'   => 'columnPaddingBottomMobile',
+						'hasSync'   => 'column-padding-bottom-mobile',
 					),
 					array(
 						'property'  => 'padding-left',
@@ -580,7 +580,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['left'] );
 						},
-						'hasSync'   => 'columnPaddingLeftMobile',
+						'hasSync'   => 'column-padding-left-mobile',
 					),
 					array(
 						'property'  => 'padding-right',
@@ -591,7 +591,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['right'] );
 						},
-						'hasSync'   => 'columnPaddingRightMobile',
+						'hasSync'   => 'column-padding-right-mobile',
 					),
 					array(
 						'property'  => 'margin-top',
@@ -602,7 +602,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['top'] );
 						},
-						'hasSync'   => 'columnMarginTopMobile',
+						'hasSync'   => 'column-margin-top-mobile',
 					),
 					array(
 						'property'  => 'margin-bottom',
@@ -613,7 +613,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['bottom'] );
 						},
-						'hasSync'   => 'columnMarginBottomMobile',
+						'hasSync'   => 'column-margin-bottom-mobile',
 					),
 					array(
 						'property'  => 'margin-left',
@@ -624,7 +624,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['left'] );
 						},
-						'hasSync'   => 'columnMarginLeftMobile',
+						'hasSync'   => 'column-margin-left-mobile',
 					),
 					array(
 						'property'  => 'margin-right',
@@ -635,7 +635,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['right'] );
 						},
-						'hasSync'   => 'columnMarginRightMobile',
+						'hasSync'   => 'column-margin-right-mobile',
 					),
 				),
 			)
@@ -963,7 +963,7 @@ class Advanced_Column_CSS extends Base_CSS {
 				'selector'   => '.wp-block-themeisle-blocks-advanced-column',
 				'properties' => array(
 					array(
-						'property'  => '--columnPaddingTop',
+						'property'  => '--column-padding-top',
 						'value'     => 'padding',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -973,7 +973,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingBottom',
+						'property'  => '--column-padding-bottom',
 						'value'     => 'padding',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -983,7 +983,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingLeft',
+						'property'  => '--column-padding-left',
 						'value'     => 'padding',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -993,7 +993,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingRight',
+						'property'  => '--column-padding-right',
 						'value'     => 'padding',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];
@@ -1003,7 +1003,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginTop',
+						'property'  => '--column-margin-top',
 						'value'     => 'margin',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1013,7 +1013,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginBottom',
+						'property'  => '--column-margin-bottom',
 						'value'     => 'margin',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1023,7 +1023,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginLeft',
+						'property'  => '--column-margin-left',
 						'value'     => 'margin',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -1033,7 +1033,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginRight',
+						'property'  => '--column-margin-right',
 						'value'     => 'margin',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];
@@ -1043,7 +1043,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingTopTablet',
+						'property'  => '--column-padding-top-tablet',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1053,7 +1053,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingBottomTablet',
+						'property'  => '--column-padding-bottom-tablet',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1063,7 +1063,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingLeftTablet',
+						'property'  => '--column-padding-left-tablet',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -1073,7 +1073,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingRightTablet',
+						'property'  => '--column-padding-right-tablet',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];
@@ -1083,7 +1083,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginTopTablet',
+						'property'  => '--column-margin-top-tablet',
 						'value'     => 'marginTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1093,7 +1093,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginBottomTablet',
+						'property'  => '--column-margin-bottom-tablet',
 						'value'     => 'marginTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1103,7 +1103,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginLeftTablet',
+						'property'  => '--column-margin-left-tablet',
 						'value'     => 'marginTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -1113,7 +1113,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginRightTablet',
+						'property'  => '--column-margin-right-tablet',
 						'value'     => 'marginTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];
@@ -1123,7 +1123,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingTopMobile',
+						'property'  => '--column-padding-top-mobile',
 						'value'     => 'paddingMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1133,7 +1133,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingBottomMobile',
+						'property'  => '--column-padding-bottom-mobile',
 						'value'     => 'paddingMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1143,7 +1143,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingLeftMobile',
+						'property'  => '--column-padding-left-mobile',
 						'value'     => 'paddingMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -1153,7 +1153,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnPaddingRightMobile',
+						'property'  => '--column-padding-right-mobile',
 						'value'     => 'paddingMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];
@@ -1163,7 +1163,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginTopMobile',
+						'property'  => '--column-margin-top-mobile',
 						'value'     => 'marginMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1173,7 +1173,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginBottomMobile',
+						'property'  => '--column-margin-bottom-mobile',
 						'value'     => 'marginMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1183,7 +1183,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginLeftMobile',
+						'property'  => '--column-margin-left-mobile',
 						'value'     => 'marginMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -1193,7 +1193,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--columnMarginRightMobile',
+						'property'  => '--column-margin-right-mobile',
 						'value'     => 'marginMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -154,7 +154,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'hasSync'   => 'sectionMarginBottom',
 					),
 					array(
-						'property' => '--columnsWidth',
+						'property' => '--columns-width',
 						'value'    => 'columnsWidth',
 						'unit'     => 'px',
 						'hasSync'  => 'sectionColumnsWidth',

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -107,7 +107,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['bottom'] );
 						},
-						'hasSync'   => 'sectionPaddingBottom',
+						'hasSync'   => 'section-padding-bottom',
 					),
 					array(
 						'property'  => 'padding-left',
@@ -118,7 +118,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['left'] );
 						},
-						'hasSync'   => 'sectionPaddingLeft',
+						'hasSync'   => 'section-padding-left',
 					),
 					array(
 						'property'  => 'padding-right',
@@ -129,7 +129,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['right'] );
 						},
-						'hasSync'   => 'sectionPaddingRight',
+						'hasSync'   => 'section-padding-right',
 					),
 					array(
 						'property'  => 'margin-top',
@@ -140,7 +140,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['top'] );
 						},
-						'hasSync'   => 'sectionMarginTop',
+						'hasSync'   => 'section-margin-top',
 					),
 					array(
 						'property'  => 'margin-bottom',
@@ -151,18 +151,18 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['bottom'] );
 						},
-						'hasSync'   => 'sectionMarginBottom',
+						'hasSync'   => 'section-margin-bottom',
 					),
 					array(
 						'property' => '--columns-width',
 						'value'    => 'columnsWidth',
 						'unit'     => 'px',
-						'hasSync'  => 'sectionColumnsWidth',
+						'hasSync'  => 'section-columns-width',
 					),
 					array(
 						'property' => 'justify-content',
 						'value'    => 'horizontalAlign',
-						'hasSync'  => 'sectionHorizontalAlign',
+						'hasSync'  => 'section-horizontal-align',
 					),
 					array(
 						'property'  => 'min-height',
@@ -729,7 +729,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['top'] );
 						},
-						'hasSync'   => 'sectionPaddingTopTablet',
+						'hasSync'   => 'section-padding-top-tablet',
 					),
 					array(
 						'property'  => 'padding-bottom',
@@ -740,7 +740,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['bottom'] );
 						},
-						'hasSync'   => 'sectionPaddingBottomTablet',
+						'hasSync'   => 'section-padding-bottom-tablet',
 					),
 					array(
 						'property'  => 'padding-left',
@@ -751,7 +751,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['left'] );
 						},
-						'hasSync'   => 'sectionPaddingLeftTablet',
+						'hasSync'   => 'section-padding-left-tablet',
 					),
 					array(
 						'property'  => 'padding-right',
@@ -762,7 +762,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['right'] );
 						},
-						'hasSync'   => 'sectionPaddingRightTablet',
+						'hasSync'   => 'section-padding-right-tablet',
 					),
 					array(
 						'property'  => 'margin-top',
@@ -773,7 +773,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['top'] );
 						},
-						'hasSync'   => 'sectionMarginTopTablet',
+						'hasSync'   => 'section-margin-top-tablet',
 					),
 					array(
 						'property'  => 'margin-bottom',
@@ -784,7 +784,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['bottom'] );
 						},
-						'hasSync'   => 'sectionMarginBottomTablet',
+						'hasSync'   => 'section-margin-bottom-tablet',
 					),
 					array(
 						'property'  => 'min-height',
@@ -869,7 +869,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['top'] );
 						},
-						'hasSync'   => 'sectionPaddingTopMobile',
+						'hasSync'   => 'section-padding-top-mobile',
 					),
 					array(
 						'property'  => 'padding-bottom',
@@ -880,7 +880,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['bottom'] );
 						},
-						'hasSync'   => 'sectionPaddingBottomMobile',
+						'hasSync'   => 'section-padding-bottom-mobile',
 					),
 					array(
 						'property'  => 'padding-left',
@@ -891,7 +891,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['left'] );
 						},
-						'hasSync'   => 'sectionPaddingLeftMobile',
+						'hasSync'   => 'section-padding-left-mobile',
 					),
 					array(
 						'property'  => 'padding-right',
@@ -902,7 +902,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['right'] );
 						},
-						'hasSync'   => 'sectionPaddingRightMobile',
+						'hasSync'   => 'section-padding-right-mobile',
 					),
 					array(
 						'property'  => 'margin-top',
@@ -913,7 +913,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['top'] );
 						},
-						'hasSync'   => 'sectionMarginTopMobile',
+						'hasSync'   => 'section-margin-top-mobile',
 					),
 					array(
 						'property'  => 'margin-bottom',
@@ -924,7 +924,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['bottom'] );
 						},
-						'hasSync'   => 'sectionMarginBottomMobile',
+						'hasSync'   => 'section-margin-bottom-mobile',
 					),
 					array(
 						'property'  => 'min-height',
@@ -1293,7 +1293,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingBottom',
+						'property'  => '--section-padding-bottom',
 						'value'     => 'padding',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1303,7 +1303,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingLeft',
+						'property'  => '--section-padding-left',
 						'value'     => 'padding',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -1313,7 +1313,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingRight',
+						'property'  => '--section-padding-right',
 						'value'     => 'padding',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];
@@ -1323,7 +1323,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionMarginTop',
+						'property'  => '--section-margin-top',
 						'value'     => 'margin',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1333,7 +1333,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionMarginBottom',
+						'property'  => '--section-margin-bottom',
 						'value'     => 'margin',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1343,7 +1343,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingTopTablet',
+						'property'  => '--section-padding-top-tablet',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1353,7 +1353,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingBottomTablet',
+						'property'  => '--section-padding-bottom-tablet',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1363,7 +1363,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingLeftTablet',
+						'property'  => '--section-padding-left-tablet',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -1373,7 +1373,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingRightTablet',
+						'property'  => '--section-padding-right-tablet',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];
@@ -1383,7 +1383,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionMarginTopTablet',
+						'property'  => '--section-margin-top-tablet',
 						'value'     => 'marginTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1393,7 +1393,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionMarginBottomTablet',
+						'property'  => '--section-margin-bottom-tablet',
 						'value'     => 'marginTablet',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1403,7 +1403,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingTopMobile',
+						'property'  => '--section-padding-top-mobile',
 						'value'     => 'paddingMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1413,7 +1413,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingBottomMobile',
+						'property'  => '--section-padding-bottom-mobile',
 						'value'     => 'paddingMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1423,7 +1423,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingLeftMobile',
+						'property'  => '--section-padding-left-mobile',
 						'value'     => 'paddingMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['left'];
@@ -1433,7 +1433,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionPaddingRightMobile',
+						'property'  => '--section-padding-right-mobile',
 						'value'     => 'paddingMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['right'];
@@ -1443,7 +1443,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionMarginTopMobile',
+						'property'  => '--section-margin-top-mobile',
 						'value'     => 'marginMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];
@@ -1453,7 +1453,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'  => '--sectionMarginBottomMobile',
+						'property'  => '--section-margin-bottom-mobile',
 						'value'     => 'marginMobile',
 						'format'    => function( $value, $attrs ) {
 							return $value['bottom'];
@@ -1463,12 +1463,12 @@ class Advanced_Columns_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property' => '--sectionColumnsWidth',
+						'property' => '--section-columns-width',
 						'value'    => 'columnsWidth',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--sectionHorizontalAlign',
+						'property' => '--section-horizontal-align',
 						'value'    => 'horizontalAlign',
 					),
 				),

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -96,7 +96,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['top'] );
 						},
-						'hasSync'   => 'sectionPaddingTop',
+						'hasSync'   => 'section-padding-top',
 					),
 					array(
 						'property'  => 'padding-bottom',
@@ -1283,7 +1283,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 				'selector'   => '.wp-block-themeisle-blocks-advanced-columns',
 				'properties' => array(
 					array(
-						'property'  => '--sectionPaddingTop',
+						'property'  => '--section-padding-top',
 						'value'     => 'padding',
 						'format'    => function( $value, $attrs ) {
 							return $value['top'];

--- a/inc/css/blocks/class-circle-counter-css.php
+++ b/inc/css/blocks/class-circle-counter-css.php
@@ -51,7 +51,7 @@ class Circle_Counter_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--fontSizeTitle',
+						'property' => '--font-size-title',
 						'value'    => 'fontSizeTitle',
 						'unit'     => 'px',
 					),
@@ -61,7 +61,7 @@ class Circle_Counter_CSS extends Base_CSS {
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--backgroundColor',
+						'property' => '--background-color',
 						'value'    => 'backgroundColor',
 						'format'   => function( $value, $attrs ) {
 							$percentage = isset( $attrs['percentage'] ) ? $attrs['percentage'] : 50;

--- a/inc/css/blocks/class-circle-counter-css.php
+++ b/inc/css/blocks/class-circle-counter-css.php
@@ -74,7 +74,7 @@ class Circle_Counter_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property' => '--progressColor',
+						'property' => '--progress-color',
 						'value'    => 'progressColor',
 						'format'   => function( $value, $attrs ) {
 							$percentage = isset( $attrs['percentage'] ) ? $attrs['percentage'] : 50;
@@ -98,7 +98,7 @@ class Circle_Counter_CSS extends Base_CSS {
 						),
 					),
 					array(
-						'property' => '--percentageStart',
+						'property' => '--percentage-start',
 						'value'    => 'percentage',
 						'default'  => 50,
 						'format'   => function( $value, $attrs ) {
@@ -110,7 +110,7 @@ class Circle_Counter_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property' => '--percentageEnd',
+						'property' => '--percentage-end',
 						'value'    => 'percentage',
 						'default'  => 50,
 						'format'   => function( $value, $attrs ) {

--- a/inc/css/blocks/class-countdown-css.php
+++ b/inc/css/blocks/class-countdown-css.php
@@ -38,15 +38,15 @@ class Countdown_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--backgroundColor',
+						'property' => '--background-color',
 						'value'    => 'backgroundColor',
 					),
 					array(
-						'property' => '--borderColor',
+						'property' => '--border-color',
 						'value'    => 'borderColor',
 					),
 					array(
-						'property'  => '--borderRadius',
+						'property'  => '--border-radius',
 						'value'     => 'borderRadius',
 						'unit'      => 'px',
 						'default'   => 0,
@@ -55,7 +55,7 @@ class Countdown_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property'       => '--borderRadius',
+						'property'       => '--border-radius',
 						'pattern'        => 'top-left top-right bottom-right bottom-left',
 						'pattern_values' => array(
 							'top-left'     => array(
@@ -89,12 +89,12 @@ class Countdown_CSS extends Base_CSS {
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--widthTablet',
+						'property' => '--width-tablet',
 						'value'    => 'widthTablet',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--widthMobile',
+						'property' => '--width-mobile',
 						'value'    => 'widthMobile',
 						'unit'     => 'px',
 					),
@@ -104,27 +104,27 @@ class Countdown_CSS extends Base_CSS {
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--heightTablet',
+						'property' => '--height-tablet',
 						'value'    => 'heightTablet',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--heightMobile',
+						'property' => '--height-mobile',
 						'value'    => 'heightMobile',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderWidth',
+						'property' => '--border-width',
 						'value'    => 'borderWidth',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderWidthTablet',
+						'property' => '--border-widthTablet',
 						'value'    => 'borderWidthTablet',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderWidthMobile',
+						'property' => '--border-widthMobile',
 						'value'    => 'borderWidthMobile',
 						'unit'     => 'px',
 					),
@@ -134,42 +134,42 @@ class Countdown_CSS extends Base_CSS {
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--gapTablet',
+						'property' => '--gap-tablet',
 						'value'    => 'gapTablet',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--gapMobile',
+						'property' => '--gap-mobile',
 						'value'    => 'gapMobile',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--valueFontSize',
+						'property' => '--value-font-size',
 						'value'    => 'valueFontSize',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--valueFontSizeTablet',
+						'property' => '--value-font-size-tablet',
 						'value'    => 'valueFontSizeTablet',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--valueFontSizeMobile',
+						'property' => '--value-font-size-mobile',
 						'value'    => 'valueFontSizeMobile',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--labelFontSize',
+						'property' => '--label-font-size',
 						'value'    => 'labelFontSize',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--labelFontSizeTablet',
+						'property' => '--label-font-size-tablet',
 						'value'    => 'labelFontSizeTablet',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--labelFontSizeMobile',
+						'property' => '--label-font-size-mobile',
 						'value'    => 'labelFontSizeMobile',
 						'unit'     => 'px',
 					),

--- a/inc/css/blocks/class-flip-css.php
+++ b/inc/css/blocks/class-flip-css.php
@@ -48,35 +48,35 @@ class Flip_CSS extends Base_CSS {
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderColor',
+						'property' => '--border-color',
 						'value'    => 'borderColor',
 					),
 					array(
-						'property' => '--borderWidth',
+						'property' => '--border-width',
 						'value'    => 'borderWidth',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderRadius',
+						'property' => '--border-radius',
 						'value'    => 'borderRadius',
 						'unit'     => 'px',
 					),
 					array(
-						'property'  => '--frontBackground',
+						'property'  => '--front-background',
 						'value'     => 'frontBackgroundColor',
 						'condition' => function( $attrs ) {
 							return ! isset( $attrs['frontBackgroundType'] );
 						},
 					),
 					array(
-						'property'  => '--frontBackground',
+						'property'  => '--front-background',
 						'value'     => 'frontBackgroundGradient',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['frontBackgroundType'] ) && 'gradient' === $attrs['frontBackgroundType'];
 						},
 					),
 					array(
-						'property'       => '--frontBackground',
+						'property'       => '--front-background',
 						'pattern'        => 'url( imageURL ) repeat attachment position/size',
 						'pattern_values' => array(
 							'imageURL'   => array(
@@ -116,29 +116,29 @@ class Flip_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property' => '--frontVerticalAlign',
+						'property' => '--front-vertical-align',
 						'value'    => 'frontVerticalAlign',
 					),
 					array(
-						'property' => '--frontHorizontalAlign',
+						'property' => '--front-horizontal-align',
 						'value'    => 'frontHorizontalAlign',
 					),
 					array(
-						'property'  => '--backBackground',
+						'property'  => '--back-background',
 						'value'     => 'backBackgroundColor',
 						'condition' => function( $attrs ) {
 							return ! isset( $attrs['backBackgroundType'] );
 						},
 					),
 					array(
-						'property'  => '--backBackground',
+						'property'  => '--back-background',
 						'value'     => 'backBackgroundGradient',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['backBackgroundType'] ) && 'gradient' === $attrs['backBackgroundType'];
 						},
 					),
 					array(
-						'property'       => '--backBackground',
+						'property'       => '--back-background',
 						'pattern'        => 'url( imageURL ) repeat attachment position/size',
 						'pattern_values' => array(
 							'imageURL'   => array(
@@ -178,7 +178,7 @@ class Flip_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property' => '--backVerticalAlign',
+						'property' => '--back-vertical-align',
 						'value'    => 'backVerticalAlign',
 					),
 					array(
@@ -187,7 +187,7 @@ class Flip_CSS extends Base_CSS {
 						'unit'     => 'px',
 					),
 					array(
-						'property'       => '--boxShadow',
+						'property'       => '--box-shadow',
 						'pattern'        => 'horizontal vertical blur color',
 						'pattern_values' => array(
 							'horizontal' => array(
@@ -219,12 +219,12 @@ class Flip_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property' => '--frontMediaWidth',
+						'property' => '--front-media-width',
 						'value'    => 'frontMediaWidth',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--frontMediaHeight',
+						'property' => '--front-media-height',
 						'value'    => 'frontMediaHeight',
 						'unit'     => 'px',
 					),

--- a/inc/css/blocks/class-font-awesome-icons-css.php
+++ b/inc/css/blocks/class-font-awesome-icons-css.php
@@ -59,20 +59,20 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						'property' => '--margin',
 						'value'    => 'margin',
 						'unit'     => 'px',
-						'hasSync'  => 'iconMargin',
+						'hasSync'  => 'icon-margin',
 					),
 					array(
 						'property' => '--padding',
 						'value'    => 'padding',
 						'default'  => 5,
 						'unit'     => 'px',
-						'hasSync'  => 'iconPadding',
+						'hasSync'  => 'icon-padding',
 					),
 					array(
 						'property' => '--font-size',
 						'value'    => 'fontSize',
 						'unit'     => 'px',
-						'hasSync'  => 'iconFontSize',
+						'hasSync'  => 'icon-font-size',
 					),
 				),
 			)
@@ -88,7 +88,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					'value'    => 'padding',
 					'default'  => 5,
 					'unit'     => 'px',
-					'hasSync'  => 'iconPadding',
+					'hasSync'  => 'icon-padding',
 				),
 			);
 		}
@@ -101,12 +101,12 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						array(
 							'property' => 'color',
 							'value'    => 'textColor',
-							'hasSync'  => 'iconTextColor',
+							'hasSync'  => 'icon-text-color',
 						),
 						array(
 							'property' => 'background',
 							'value'    => 'backgroundColor',
-							'hasSync'  => 'iconBackgroundColor',
+							'hasSync'  => 'icon-background-color',
 						),
 					),
 					$padding
@@ -124,12 +124,12 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return ! ( isset( $attrs['library'] ) && 'themeisle-icons' === $this->get_attr_value( $attrs['library'], 'fontawesome' ) );
 						},
-						'hasSync'   => 'iconTextColorHover',
+						'hasSync'   => 'icon-text-color-hover',
 					),
 					array(
 						'property' => 'background',
 						'value'    => 'backgroundColorHover',
-						'hasSync'  => 'iconBackgroundColorHover',
+						'hasSync'  => 'icon-background-color-hover',
 					),
 					array(
 						'property' => 'border-color',
@@ -150,7 +150,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return ! ( isset( $attrs['library'] ) && 'themeisle-icons' === $this->get_attr_value( $attrs['library'], 'fontawesome' ) );
 						},
-						'hasSync'   => 'iconTextColor',
+						'hasSync'   => 'icon-text-color',
 					),
 				),
 			)
@@ -164,7 +164,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						'property' => 'font-size',
 						'value'    => 'fontSize',
 						'unit'     => 'px',
-						'hasSync'  => 'iconFontSize',
+						'hasSync'  => 'icon-font-size',
 					),
 				),
 			)
@@ -180,7 +180,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['library'] ) && 'themeisle-icons' === $this->get_attr_value( $attrs['library'], 'fontawesome' );
 						},
-						'hasSync'   => 'iconTextColor',
+						'hasSync'   => 'icon-text-color',
 					),
 				),
 			)
@@ -196,7 +196,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						'condition' => function( $attrs ) {
 							return isset( $attrs['library'] ) && 'themeisle-icons' === $this->get_attr_value( $attrs['library'], 'fontawesome' );
 						},
-						'hasSync'   => 'iconTextColorHover',
+						'hasSync'   => 'icon-text-color-hover',
 					),
 				),
 			)
@@ -239,34 +239,34 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 				'selector'   => '.wp-block-themeisle-blocks-font-awesome-icons',
 				'properties' => array(
 					array(
-						'property' => '--iconFontSize',
+						'property' => '--icon-font-size',
 						'value'    => 'fontSize',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--iconMargin',
+						'property' => '--icon-margin',
 						'value'    => 'margin',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--iconPadding',
+						'property' => '--icon-padding',
 						'value'    => 'padding',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--iconTextColorHover',
+						'property' => '--icon-text-color-hover',
 						'value'    => 'textColorHover',
 					),
 					array(
-						'property' => '--iconBackgroundColorHover',
+						'property' => '--icon-background-color-hover',
 						'value'    => 'backgroundColorHover',
 					),
 					array(
-						'property' => '--iconTextColor',
+						'property' => '--icon-text-color',
 						'value'    => 'textColor',
 					),
 					array(
-						'property' => '--iconBackgroundColor',
+						'property' => '--icon-background-color',
 						'value'    => 'backgroundColor',
 					),
 				),

--- a/inc/css/blocks/class-font-awesome-icons-css.php
+++ b/inc/css/blocks/class-font-awesome-icons-css.php
@@ -42,16 +42,16 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						'value'    => 'align',
 					),
 					array(
-						'property' => '--borderColor',
+						'property' => '--border-color',
 						'value'    => 'borderColor',
 					),
 					array(
-						'property' => '--borderSize',
+						'property' => '--border-size',
 						'value'    => 'borderSize',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderRadius',
+						'property' => '--border-radius',
 						'value'    => 'borderRadius',
 						'unit'     => '%',
 					),
@@ -69,7 +69,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 						'hasSync'  => 'iconPadding',
 					),
 					array(
-						'property' => '--fontSize',
+						'property' => '--font-size',
 						'value'    => 'fontSize',
 						'unit'     => 'px',
 						'hasSync'  => 'iconFontSize',

--- a/inc/css/blocks/class-form-css.php
+++ b/inc/css/blocks/class-form-css.php
@@ -37,20 +37,20 @@ class Form_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--labelColor',
+						'property' => '--label-color',
 						'value'    => 'labelColor',
 					),
 					array(
-						'property' => '--borderRadius',
+						'property' => '--border-radius',
 						'value'    => 'inputBorderRadius',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderColor',
+						'property' => '--border-color',
 						'value'    => 'inputBorderColor',
 					),
 					array(
-						'property' => '--borderWidth',
+						'property' => '--border-width',
 						'value'    => 'inputBorderWidth',
 						'unit'     => 'px',
 					),
@@ -68,7 +68,7 @@ class Form_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property' => '--inputWidth',
+						'property' => '--input-width',
 						'value'    => 'inputWidth',
 						'unit'     => '%',
 					),
@@ -81,53 +81,53 @@ class Form_CSS extends Base_CSS {
 						'value'    => 'submitBackgroundColorHover',
 					),
 					array(
-						'property' => '--submitColor',
+						'property' => '--submit-color',
 						'value'    => 'submitColor',
 					),
 					array(
-						'property' => '--helpLabelColor',
+						'property' => '--help-label-color',
 						'value'    => 'helpLabelColor',
 					),
 					array(
-						'property' => '--submitMsgColor',
+						'property' => '--submit-msg-color',
 						'value'    => 'submitMessageColor',
 					),
 					array(
-						'property' => '--submitErrorColor',
+						'property' => '--submit-error-color',
 						'value'    => 'submitMessageErrorColor',
 					),
 					array(
-						'property' => '--inputsGap',
+						'property' => '--inputs-gap',
 						'value'    => 'inputsGap',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--inputGap',
+						'property' => '--input-gap',
 						'value'    => 'inputGap',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--labelFontSize',
+						'property' => '--label-font-size',
 						'value'    => 'labelFontSize',
 					),
 					array(
-						'property' => '--submitFontSize',
+						'property' => '--submit-font-size',
 						'value'    => 'submitFontSize',
 					),
 					array(
-						'property' => '--messageFontSize',
+						'property' => '--message-font-size',
 						'value'    => 'messageFontSize',
 					),
 					array(
-						'property' => '--inputFontSize',
+						'property' => '--input-font-size',
 						'value'    => 'inputFontSize',
 					),
 					array(
-						'property' => '--helpFontSize',
+						'property' => '--help-font-size',
 						'value'    => 'helpFontSize',
 					),
 					array(
-						'property' => '--inputColor',
+						'property' => '--input-color',
 						'value'    => 'inputColor',
 					),
 				),

--- a/inc/css/blocks/class-form-css.php
+++ b/inc/css/blocks/class-form-css.php
@@ -73,14 +73,6 @@ class Form_CSS extends Base_CSS {
 						'unit'     => '%',
 					),
 					array(
-						'property' => '--submitBackground',
-						'value'    => 'submitBackgroundColor',
-					),
-					array(
-						'property' => '--submitBackgroundHover',
-						'value'    => 'submitBackgroundColorHover',
-					),
-					array(
 						'property' => '--submit-color',
 						'value'    => 'submitColor',
 					),

--- a/inc/css/blocks/class-form-input-css.php
+++ b/inc/css/blocks/class-form-input-css.php
@@ -37,11 +37,11 @@ class Form_Input_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--labelColor',
+						'property' => '--label-color',
 						'value'    => 'labelColor',
 					),
 					array(
-						'property' => '--inputWidth',
+						'property' => '--input-width',
 						'value'    => 'inputWidth',
 						'unit'     => '%',
 					),

--- a/inc/css/blocks/class-form-textarea-css.php
+++ b/inc/css/blocks/class-form-textarea-css.php
@@ -37,11 +37,11 @@ class Form_Textarea_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--labelColor',
+						'property' => '--label-color',
 						'value'    => 'labelColor',
 					),
 					array(
-						'property' => '--inputWidth',
+						'property' => '--input-width',
 						'value'    => 'inputWidth',
 					),
 				),

--- a/inc/css/blocks/class-icon-list-css.php
+++ b/inc/css/blocks/class-icon-list-css.php
@@ -38,7 +38,7 @@ class Icon_List_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--horizontalAlign',
+						'property' => '--horizontal-align',
 						'value'    => 'horizontalAlign',
 					),
 					array(
@@ -47,15 +47,15 @@ class Icon_List_CSS extends Base_CSS {
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--contentColor',
+						'property' => '--content-color',
 						'value'    => 'defaultContentColor',
 					),
 					array(
-						'property' => '--iconColor',
+						'property' => '--icon-color',
 						'value'    => 'defaultIconColor',
 					),
 					array(
-						'property' => '--fontSize',
+						'property' => '--font-size',
 						'value'    => 'defaultSize',
 						'unit'     => 'px',
 						'default'  => 20,

--- a/inc/css/blocks/class-icon-list-item-css.php
+++ b/inc/css/blocks/class-icon-list-item-css.php
@@ -38,11 +38,11 @@ class Icon_List_Item_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--contentColor',
+						'property' => '--content-color',
 						'value'    => 'contentColor',
 					),
 					array(
-						'property' => '--iconColor',
+						'property' => '--icon-color',
 						'value'    => 'iconColor',
 					),
 				),

--- a/inc/css/blocks/class-popup-css.php
+++ b/inc/css/blocks/class-popup-css.php
@@ -38,29 +38,29 @@ class Popup_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--minWidth',
+						'property' => '--min-width',
 						'value'    => 'minWidth',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--maxWidth',
+						'property' => '--max-width',
 						'value'    => 'maxWidth',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--backgroundColor',
+						'property' => '--background-color',
 						'value'    => 'backgroundColor',
 					),
 					array(
-						'property' => '--closeColor',
+						'property' => '--close-color',
 						'value'    => 'closeColor',
 					),
 					array(
-						'property' => '--overlayColor',
+						'property' => '--overlay-color',
 						'value'    => 'overlayColor',
 					),
 					array(
-						'property' => '--overlayOpacity',
+						'property' => '--overlay-opacity',
 						'value'    => 'overlayOpacity',
 						'format'   => function( $value ) {
 							return $value / 100;

--- a/inc/css/blocks/class-posts-css.php
+++ b/inc/css/blocks/class-posts-css.php
@@ -44,23 +44,23 @@ class Posts_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--textAlign',
+						'property' => '--text-align',
 						'value'    => 'textAlign',
 					),
 					array(
-						'property' => '--vertAlign',
+						'property' => '--vert-align',
 						'value'    => 'verticalAlign',
 						'format'   => function( $value, $attrs ) use ( $vertical_value_mapping ) {
 							return $vertical_value_mapping[ $value ];
 						},
 					),
 					array(
-						'property' => '--imgWidth',
+						'property' => '--img-width',
 						'value'    => 'imageWidth',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--imgBorderRadius',
+						'property' => '--img-border-radius',
 						'value'    => 'borderRadius',
 						'unit'     => 'px',
 					),
@@ -73,12 +73,12 @@ class Posts_CSS extends Base_CSS {
 				'query'      => '@media ( min-width: 960px )',
 				'properties' => array(
 					array(
-						'property' => '--titleTextSize',
+						'property' => '--title-text-size',
 						'value'    => 'customTitleFontSize',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--descriptionTextSize',
+						'property' => '--description-text-size',
 						'value'    => 'customDescriptionFontSize',
 						'unit'     => 'px',
 					),
@@ -91,12 +91,12 @@ class Posts_CSS extends Base_CSS {
 				'query'      => '@media ( min-width: 600px ) and ( max-width: 960px )',
 				'properties' => array(
 					array(
-						'property' => '--titleTextSize',
+						'property' => '--title-text-size',
 						'value'    => 'customTitleFontSizeTablet',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--descriptionTextSize',
+						'property' => '--description-text-size',
 						'value'    => 'customDescriptionFontSizeTablet',
 						'unit'     => 'px',
 					),
@@ -109,12 +109,12 @@ class Posts_CSS extends Base_CSS {
 				'query'      => '@media ( max-width: 600px )',
 				'properties' => array(
 					array(
-						'property' => '--titleTextSize',
+						'property' => '--title-text-size',
 						'value'    => 'customTitleFontSizeMobile',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--descriptionTextSize',
+						'property' => '--description-text-size',
 						'value'    => 'customDescriptionFontSizeMobile',
 						'unit'     => 'px',
 					),

--- a/inc/css/blocks/class-progress-bar-css.php
+++ b/inc/css/blocks/class-progress-bar-css.php
@@ -45,43 +45,43 @@ class Progress_Bar_CSS extends Base_CSS {
 						'unit'     => '%',
 					),
 					array(
-						'property' => '--titleColor',
+						'property' => '--title-color',
 						'value'    => 'titleColor',
 					),
 					array(
-						'property'  => '--percentageColor',
+						'property'  => '--percentage-color',
 						'value'     => 'percentageColor',
 						'condition' => function( $attrs ) {
 							return ! isset( $attrs['percentagePosition'] );
 						},
 					),
 					array(
-						'property'  => '--percentageColorOuter',
+						'property'  => '--percentage-color-outer',
 						'value'     => 'percentageColor',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['percentagePosition'] ) && 'outer' === $attrs['percentagePosition'];
 						},
 					),
 					array(
-						'property'  => '--percentageColorTooltip',
+						'property'  => '--percentage-color-tooltip',
 						'value'     => 'percentageColor',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['percentagePosition'] ) && 'tooltip' === $attrs['percentagePosition'];
 						},
 					),
 					array(
-						'property'  => '--percentageColorAppend',
+						'property'  => '--percentage-color-append',
 						'value'     => 'percentageColor',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['percentagePosition'] ) && 'append' === $attrs['percentagePosition'];
 						},
 					),
 					array(
-						'property' => '--backgroundColor',
+						'property' => '--background-color',
 						'value'    => 'backgroundColor',
 					),
 					array(
-						'property' => '--borderRadius',
+						'property' => '--border-radius',
 						'value'    => 'borderRadius',
 						'unit'     => 'px',
 					),
@@ -91,7 +91,7 @@ class Progress_Bar_CSS extends Base_CSS {
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--barBackground',
+						'property' => '--bar-background',
 						'value'    => 'barBackgroundColor',
 					),
 				),

--- a/inc/css/blocks/class-review-css.php
+++ b/inc/css/blocks/class-review-css.php
@@ -38,22 +38,22 @@ class Review_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--backgroundColor',
+						'property' => '--background-color',
 						'value'    => 'backgroundColor',
 						'hasSync'  => 'reviewBackgroundColor',
 					),
 					array(
-						'property' => '--primaryColor',
+						'property' => '--primary-color',
 						'value'    => 'primaryColor',
 						'hasSync'  => 'reviewPrimaryColor',
 					),
 					array(
-						'property' => '--textColor',
+						'property' => '--text-color',
 						'value'    => 'textColor',
 						'hasSync'  => 'reviewTextColor',
 					),
 					array(
-						'property' => '--buttonTextColor',
+						'property' => '--button-text-color',
 						'value'    => 'buttonTextColor',
 						'hasSync'  => 'reviewButtonTextColor',
 					),

--- a/inc/css/blocks/class-review-css.php
+++ b/inc/css/blocks/class-review-css.php
@@ -40,22 +40,22 @@ class Review_CSS extends Base_CSS {
 					array(
 						'property' => '--background-color',
 						'value'    => 'backgroundColor',
-						'hasSync'  => 'reviewBackgroundColor',
+						'hasSync'  => 'review-background-color',
 					),
 					array(
 						'property' => '--primary-color',
 						'value'    => 'primaryColor',
-						'hasSync'  => 'reviewPrimaryColor',
+						'hasSync'  => 'review-primary-color',
 					),
 					array(
 						'property' => '--text-color',
 						'value'    => 'textColor',
-						'hasSync'  => 'reviewTextColor',
+						'hasSync'  => 'review-text-color',
 					),
 					array(
 						'property' => '--button-text-color',
 						'value'    => 'buttonTextColor',
-						'hasSync'  => 'reviewButtonTextColor',
+						'hasSync'  => 'review-button-text-color',
 					),
 				),
 			)
@@ -98,19 +98,19 @@ class Review_CSS extends Base_CSS {
 				'selector'   => '.wp-block-themeisle-blocks-review',
 				'properties' => array(
 					array(
-						'property' => '--reviewBackgroundColor',
+						'property' => '--review-background-color',
 						'value'    => 'backgroundColor',
 					),
 					array(
-						'property' => '--reviewPrimaryColor',
+						'property' => '--review-primary-color',
 						'value'    => 'primaryColor',
 					),
 					array(
-						'property' => '--reviewTextColor',
+						'property' => '--review-text-color',
 						'value'    => 'textColor',
 					),
 					array(
-						'property' => '--reviewButtonTextColor',
+						'property' => '--review-button-text-color',
 						'value'    => 'buttonTextColor',
 					),
 				),

--- a/inc/css/blocks/class-sharing-icons-css.php
+++ b/inc/css/blocks/class-sharing-icons-css.php
@@ -40,7 +40,7 @@ class Sharing_Icons_CSS extends Base_CSS {
 					'selector'   => ' .is-' . $icon,
 					'properties' => array(
 						array(
-							'property'  => '--iconBgColor',
+							'property'  => '--icon-bg-color',
 							'value'     => $icon,
 							'format'    => function( $value, $attrs ) {
 								return $value['backgroundColor'];
@@ -50,7 +50,7 @@ class Sharing_Icons_CSS extends Base_CSS {
 							},
 						),
 						array(
-							'property'  => '--textColor',
+							'property'  => '--text-color',
 							'value'     => $icon,
 							'format'    => function( $value, $attrs ) {
 								return $value['textColor'];
@@ -68,12 +68,12 @@ class Sharing_Icons_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--iconsGap',
+						'property' => '--icons-gap',
 						'value'    => 'gap',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderRadius',
+						'property' => '--border-radius',
 						'value'    => 'borderRadius',
 						'unit'     => 'px',
 					),

--- a/inc/css/blocks/class-tabs-css.php
+++ b/inc/css/blocks/class-tabs-css.php
@@ -38,20 +38,20 @@ class Tabs_CSS extends Base_CSS {
 			array(
 				'properties' => array(
 					array(
-						'property' => '--borderWidth',
+						'property' => '--border-width',
 						'value'    => 'borderWidth',
 						'unit'     => 'px',
 					),
 					array(
-						'property' => '--borderColor',
+						'property' => '--border-color',
 						'value'    => 'borderColor',
 					),
 					array(
-						'property' => '--activeTitleColor',
+						'property' => '--active-title-color',
 						'value'    => 'activeTitleColor',
 					),
 					array(
-						'property' => '--tabColor',
+						'property' => '--tab-color',
 						'value'    => 'tabColor',
 					),
 				),

--- a/plugins/otter-pro/inc/css/blocks/class-woo-comparison-css.php
+++ b/plugins/otter-pro/inc/css/blocks/class-woo-comparison-css.php
@@ -43,7 +43,7 @@ class Woo_Comparison_CSS extends Base_CSS {
 						'value'    => 'rowColor',
 					),
 					array(
-						'property' => '--headerColor',
+						'property' => '--header-color',
 						'value'    => 'headerColor',
 					),
 					array(
@@ -51,7 +51,7 @@ class Woo_Comparison_CSS extends Base_CSS {
 						'value'    => 'textColor',
 					),
 					array(
-						'property' => '--borderColor',
+						'property' => '--border-color',
 						'value'    => 'borderColor',
 					),
 					array(

--- a/plugins/otter-pro/inc/css/blocks/class-woo-comparison-css.php
+++ b/plugins/otter-pro/inc/css/blocks/class-woo-comparison-css.php
@@ -43,7 +43,7 @@ class Woo_Comparison_CSS extends Base_CSS {
 						'value'    => 'rowColor',
 					),
 					array(
-						'property' => '--header-color',
+						'property' => '--headerColor',
 						'value'    => 'headerColor',
 					),
 					array(
@@ -51,7 +51,7 @@ class Woo_Comparison_CSS extends Base_CSS {
 						'value'    => 'textColor',
 					),
 					array(
-						'property' => '--border-color',
+						'property' => '--borderColor',
 						'value'    => 'borderColor',
 					),
 					array(

--- a/src/blocks/blocks/accordion/editor.scss
+++ b/src/blocks/blocks/accordion/editor.scss
@@ -1,8 +1,8 @@
 .wp-block-themeisle-blocks-accordion {
-	--titleColor: #1e1e1e;
-	--titleBackground: #ffffff;
-	--borderColor: #d5dadf;
-	--contentBackground: #ffffff;
+	--title-color: #1e1e1e;
+	--title-background: #ffffff;
+	--border-color: #d5dadf;
+	--content-background: #ffffff;
 
 	margin: 20px auto;
 
@@ -11,9 +11,9 @@
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
-			color: var( --titleColor );
-			background: var( --titleBackground );
-			border: 1px solid var( --borderColor );
+			color: var( --title-color );
+			background: var( --title-background );
+			border: 1px solid var( --border-color );
 			padding: 18px 24px;
 			cursor: pointer;
 
@@ -22,7 +22,7 @@
 			}
 
 			svg {
-				fill: var( --titleColor );
+				fill: var( --title-color );
 				width: 24px;
 				height: 24px;
 			}
@@ -33,8 +33,8 @@
 		}
 
 		.wp-block-themeisle-blocks-accordion-item__content {
-			background: var( --contentBackground );
-			border: 1px solid var( --borderColor );
+			background: var( --content-background );
+			border: 1px solid var( --border-color );
 			border-top: none;
 			padding: 18px 24px;
 		}

--- a/src/blocks/blocks/accordion/group/edit.js
+++ b/src/blocks/blocks/accordion/group/edit.js
@@ -48,10 +48,10 @@ const Edit = ({
 	const getValue = field => getDefaultValueByField({ name, field, defaultAttributes, attributes });
 
 	const inlineStyles = {
-		'--titleColor': getValue( 'titleColor' ),
-		'--titleBackground': getValue( 'titleBackground' ),
-		'--borderColor': getValue( 'borderColor' ),
-		'--contentBackground': getValue( 'contentBackground' )
+		'--title-color': getValue( 'titleColor' ),
+		'--title-background': getValue( 'titleBackground' ),
+		'--border-color': getValue( 'borderColor' ),
+		'--content-background': getValue( 'contentBackground' )
 	};
 
 	const blockProps = useBlockProps({

--- a/src/blocks/blocks/accordion/style.scss
+++ b/src/blocks/blocks/accordion/style.scss
@@ -1,16 +1,16 @@
 .wp-block-themeisle-blocks-accordion {
-	--titleColor: #1e1e1e;
-	--titleBackground: #ffffff;
-	--borderColor: #d5dadf;
-	--contentBackground: #ffffff;
+	--title-color: #1e1e1e;
+	--title-background: #ffffff;
+	--border-color: #d5dadf;
+	--content-background: #ffffff;
 
 	margin: 20px auto;
 
 	.wp-block-themeisle-blocks-accordion-item {
 		.wp-block-themeisle-blocks-accordion-item__title {
-			color: var( --titleColor );
-			background: var( --titleBackground );
-			border: 1px solid var( --borderColor );
+			color: var( --title-color );
+			background: var( --title-background );
+			border: 1px solid var( --border-color );
 			list-style: none;
 			cursor: pointer;
 			user-select: none;
@@ -42,8 +42,8 @@
 				content: '';
 				justify-self: end;
 				align-self: center;
-				border-right: 2px solid var( --borderColor );
-				border-bottom: 2px solid var( --borderColor );
+				border-right: 2px solid var( --border-color );
+				border-bottom: 2px solid var( --border-color );
 				width: 8px;
 				height: 8px;
 				transform: rotate(45deg) translate(-25%, 0%);
@@ -51,8 +51,8 @@
 		}
 
 		.wp-block-themeisle-blocks-accordion-item__content {
-			background: var( --contentBackground );
-			border: 1px solid var( --borderColor );
+			background: var( --content-background );
+			border: 1px solid var( --border-color );
 			border-top: none;
 			padding: 18px 24px;
 		}

--- a/src/blocks/blocks/circle-counter/edit.js
+++ b/src/blocks/blocks/circle-counter/edit.js
@@ -132,7 +132,7 @@ const CircularProgressBarBlock = ({
 
 
 	const inlineStyles = {
-		'--fontSizeTitle': px( attributes.fontSizeTitle )
+		'--font-size-title': px( attributes.fontSizeTitle )
 	};
 
 	const blockProps = useBlockProps({

--- a/src/blocks/blocks/circle-counter/style.scss
+++ b/src/blocks/blocks/circle-counter/style.scss
@@ -60,10 +60,10 @@ html {
 	&[amp] {
 		.wp-block-themeisle-blocks-circle-counter {
 			--background-color: #e3ecf4;
-			--progressColor: #3878ff;
+			--progress-color: #3878ff;
 			--border-radius: 100px 0px 0px 100px;
-			--percentageStart: rotate( 180deg );
-			--percentageEnd: rotate( 300deg );
+			--percentage-start: rotate( 180deg );
+			--percentage-end: rotate( 300deg );
 
 			.wp-block-themeisle-blocks-circle-counter-container {
 				width: var( --height );
@@ -97,15 +97,15 @@ html {
 				position: absolute;
 				top: 0;
 				left: 0;
-				border: 11px solid var( --progressColor );
+				border: 11px solid var( --progress-color );
 				border-radius: var( --border-radius );
 				border-right: 0;
 				transform-origin: right;
 				z-index: 100;
-				transform: var( --percentageStart );
+				transform: var( --percentage-start );
 
 				&:last-of-type {
-					transform: var( --percentageEnd );
+					transform: var( --percentage-end );
 				}
 			}
 

--- a/src/blocks/blocks/circle-counter/style.scss
+++ b/src/blocks/blocks/circle-counter/style.scss
@@ -1,5 +1,5 @@
 .wp-block-themeisle-blocks-circle-counter {
-	--fontSizeTitle: 15px;
+	--font-size-title: 15px;
 	--height: 100px;
 
 	display: flex;
@@ -21,7 +21,7 @@
 	.wp-block-themeisle-blocks-circle-counter-title__value {
 		font-weight: bold;
 		text-align: center;
-		font-size: var( --fontSizeTitle );
+		font-size: var( --font-size-title );
 	}
 	
 	.wp-block-themeisle-blocks-circle-counter__bar {
@@ -59,9 +59,9 @@
 html {
 	&[amp] {
 		.wp-block-themeisle-blocks-circle-counter {
-			--backgroundColor: #e3ecf4;
+			--background-color: #e3ecf4;
 			--progressColor: #3878ff;
-			--borderRadius: 100px 0px 0px 100px;
+			--border-radius: 100px 0px 0px 100px;
 			--percentageStart: rotate( 180deg );
 			--percentageEnd: rotate( 300deg );
 
@@ -82,7 +82,7 @@ html {
 				transform: rotate( 0);
 				width: 100%;
 				height: 100%;
-				border: 10px solid var( --backgroundColor );
+				border: 10px solid var( --background-color );
 				border-radius: 100%;
 				margin: 0;
 				position: relative;
@@ -98,7 +98,7 @@ html {
 				top: 0;
 				left: 0;
 				border: 11px solid var( --progressColor );
-				border-radius: var( --borderRadius );
+				border-radius: var( --border-radius );
 				border-right: 0;
 				transform-origin: right;
 				z-index: 100;

--- a/src/blocks/blocks/countdown/edit.js
+++ b/src/blocks/blocks/countdown/edit.js
@@ -175,9 +175,9 @@ const Edit = ({
 	const borderRadius = 'linked' === attributes.borderRadiusType ? attributes.borderRadius + '%' : `${ attributes.borderRadiusTopLeft }% ${ attributes.borderRadiusTopRight }% ${ attributes.borderRadiusBottomRight }% ${ attributes.borderRadiusBottomLeft }%`;
 
 	const inlineStyles = {
-		'--backgroundColor': attributes.backgroundColor,
-		'--borderColor': attributes.borderColor,
-		'--borderRadius': borderRadius
+		'--background-color': attributes.backgroundColor,
+		'--border-color': attributes.borderColor,
+		'--border-radius': borderRadius
 	};
 
 	const [ cssNodeName, setCSS ] = useCSSNode();

--- a/src/blocks/blocks/countdown/style.scss
+++ b/src/blocks/blocks/countdown/style.scss
@@ -1,25 +1,25 @@
 .wp-block-themeisle-blocks-countdown {
-	--backgroundColor: transparent;
-	--borderColor: #000;
-	--borderRadius: 0;
+	--background-color: transparent;
+	--border-color: #000;
+	--border-radius: 0;
 	--width: 70px;
-	--widthTablet: 70px;
-	--widthMobile: 70px;
+	--width-tablet: 70px;
+	--width-mobile: 70px;
 	--height: 70px;
-	--heightTablet: 70px;
-	--heightMobile: 70px;
-	--borderWidth: 2px;
-	--borderWidthTablet: 2px;
-	--borderWidthMobile: 2px;
+	--height-tablet: 70px;
+	--height-mobile: 70px;
+	--border-width: 2px;
+	--border-widthTablet: 2px;
+	--border-widthMobile: 2px;
 	--gap: 6px;
-	--gapTablet: 6px;
-	--gapMobile: 6px;
-	--valueFontSize: 1.5rem;
-	--valueFontSizeTablet: 1.5rem;
-	--valueFontSizeMobile: 1.5rem;
-	--labelFontSize: 0.6rem;
-	--labelFontSizeTablet: 0.6rem;
-	--labelFontSizeMobile: 0.6rem;
+	--gap-tablet: 6px;
+	--gap-mobile: 6px;
+	--value-font-size: 1.5rem;
+	--value-font-size-tablet: 1.5rem;
+	--value-font-size-mobile: 1.5rem;
+	--label-font-size: 0.6rem;
+	--label-font-size-tablet: 0.6rem;
+	--label-font-size-mobile: 0.6rem;
 
 	.otter-countdown__container {
 		display: flex;
@@ -33,11 +33,11 @@
 		gap: var( --gap );
 
 		@media ( min-width: 600px ) and ( max-width: 960px ) {
-			gap: var( --gapTablet );
+			gap: var( --gap-tablet );
 		}
 
 		@media ( max-width: 600px ) {
-			gap: var( --gapMobile );
+			gap: var( --gap-mobile );
 		}
 	}
 
@@ -46,23 +46,23 @@
 		justify-content: center;
 		align-items: center;
 		flex-direction: column;
-		background: var( --backgroundColor );
-		border: var( --borderWidth ) solid var( --borderColor );
+		background: var( --background-color );
+		border: var( --border-width ) solid var( --border-color );
 		width: max-content;
-		border-radius: var( --borderRadius );
+		border-radius: var( --border-radius );
 		width: var( --width );
 		height: var( --height );
 
 		@media ( min-width: 600px ) and ( max-width: 960px ) {
-			width: var( --widthTablet );
-			height: var( --heightTablet );
-			border: var( --borderWidthTablet ) solid var( --borderColor );
+			width: var( --width-tablet );
+			height: var( --height-tablet );
+			border: var( --border-widthTablet ) solid var( --border-color );
 		}
 
 		@media ( max-width: 600px ) {
-			width: var( --widthMobile );
-			height: var( --heightMobile );
-			border: var( --borderWidthMobile ) solid var( --borderColor );
+			width: var( --width-mobile );
+			height: var( --height-mobile );
+			border: var( --border-widthMobile ) solid var( --border-color );
 		}
 
 		&[name="separator"] {
@@ -77,32 +77,32 @@
 	}
 
 	.otter-countdown__value {
-		font-size: var( --valueFontSize );
+		font-size: var( --value-font-size );
 		line-height: 1.2;
 		text-align: center;
 		width: 100%;
 
 		@media ( min-width: 600px ) and ( max-width: 960px ) {
-			font-size: var( --valueFontSizeTablet );
+			font-size: var( --value-font-size-tablet );
 		}
 
 		@media ( max-width: 600px ) {
-			font-size: var( --valueFontSizeMobile );
+			font-size: var( --value-font-size-mobile );
 		}
 	}
 
 	.otter-countdown__label {
-		font-size: var( --labelFontSize );
+		font-size: var( --label-font-size );
 		min-height: 1rem;
 		text-align: center;
 		width: 100%;
 
 		@media ( min-width: 600px ) and ( max-width: 960px ) {
-			font-size: var( --labelFontSizeTablet );
+			font-size: var( --label-font-size-tablet );
 		}
 
 		@media ( max-width: 600px ) {
-			font-size: var( --labelFontSizeMobile );
+			font-size: var( --label-font-size-mobile );
 		}
 	}
 }

--- a/src/blocks/blocks/flip/edit.js
+++ b/src/blocks/blocks/flip/edit.js
@@ -68,26 +68,26 @@ const Edit = ({
 	const inlineStyles = {
 		'--width': attributes.width !== undefined && `${ attributes.width }px`,
 		'--height': attributes.height !== undefined && `${ attributes.height }px`,
-		'--borderWidth': attributes.borderWidth !== undefined && `${ attributes.borderWidth }px`,
-		'--borderColor': attributes.borderColor,
-		'--borderRadius': attributes.borderRadius !== undefined && `${ attributes.borderRadius }px`,
-		'--frontBackground': getChoice([
+		'--border-width': attributes.borderWidth !== undefined && `${ attributes.borderWidth }px`,
+		'--border-color': attributes.borderColor,
+		'--border-radius': attributes.borderRadius !== undefined && `${ attributes.borderRadius }px`,
+		'--front-background': getChoice([
 			[ ( 'gradient' === attributes.frontBackgroundType && attributes.frontBackgroundGradient ), attributes.frontBackgroundGradient ],
 			[ ( 'image' === attributes.frontBackgroundType && attributes.frontBackgroundImage?.url ), `url( ${ attributes.frontBackgroundImage?.url } ) ${ attributes.frontBackgroundRepeat || 'repeat' } ${ attributes.frontBackgroundAttachment || 'scroll' } ${ Math.round( attributes.frontBackgroundPosition?.x * 100 ) || 50 }% ${ Math.round( attributes.frontBackgroundPosition?.y * 100 ) || 50 }%/${ attributes.frontBackgroundSize || 'auto' }` ],
 			[ attributes.frontBackgroundColor ]
 		]),
-		'--backBackground': getChoice([
+		'--back-background': getChoice([
 			[ ( 'gradient' === attributes.backBackgroundType && attributes.backBackgroundGradient ), attributes.backBackgroundGradient ],
 			[ ( 'image' === attributes.backBackgroundType && attributes.backBackgroundImage?.url ), `url( ${ attributes.backBackgroundImage?.url } ) ${ attributes.backBackgroundRepeat || 'repeat' } ${ attributes.backBackgroundAttachment || 'scroll' } ${ Math.round( attributes.backBackgroundPosition?.x * 100 ) || 50 }% ${ Math.round( attributes.backBackgroundPosition?.y * 100 ) || 50 }%/${ attributes.backBackgroundSize || 'auto' }` ],
 			[ attributes.backBackgroundColor ]
 		]),
 		'--padding': attributes.padding !== undefined && `${ attributes.padding }px`,
-		'--boxShadow': attributes.boxShadow && `${ attributes.boxShadowHorizontal }px ${ attributes.boxShadowVertical }px ${ attributes.boxShadowBlur }px ${ getShadowColor() }`,
-		'--frontVerticalAlign': attributes.frontVerticalAlign,
-		'--frontHorizontalAlign': attributes.frontHorizontalAlign,
-		'--backVerticalAlign': attributes.backVerticalAlign,
-		'--frontMediaWidth': attributes.frontMediaWidth !== undefined && `${ attributes.frontMediaWidth }px`,
-		'--frontMediaHeight': attributes.frontMediaHeight !== undefined && `${ attributes.frontMediaHeight }px`
+		'--box-shadow': attributes.boxShadow && `${ attributes.boxShadowHorizontal }px ${ attributes.boxShadowVertical }px ${ attributes.boxShadowBlur }px ${ getShadowColor() }`,
+		'--front-vertical-align': attributes.frontVerticalAlign,
+		'--front-horizontal-align': attributes.frontHorizontalAlign,
+		'--back-vertical-align': attributes.backVerticalAlign,
+		'--front-media-width': attributes.frontMediaWidth !== undefined && `${ attributes.frontMediaWidth }px`,
+		'--front-media-height': attributes.frontMediaHeight !== undefined && `${ attributes.frontMediaHeight }px`
 	};
 
 	const [ cssNodeName, setNodeCSS ] = useCSSNode();

--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -1,18 +1,18 @@
 .wp-block-themeisle-blocks-flip {
 	--width: 100%;
 	--height: 300px;
-	--borderWidth: 3px;
-	--borderColor: #aaa;
-	--borderRadius: 10px;
-	--frontBackground: transparent;
-	--backBackground: transparent;
+	--border-width: 3px;
+	--border-color: #aaa;
+	--border-radius: 10px;
+	--front-background: transparent;
+	--back-background: transparent;
 	--padding: 20px;
-	--boxShadow: none;
-	--frontVerticalAlign: center;
-	--frontHorizontalAlign: center;
-	--backVerticalAlign: flex-start;
-	--frontMediaWidth: 150px;
-	--frontMediaHeight: 150px;
+	--box-shadow: none;
+	--front-vertical-align: center;
+	--front-horizontal-align: center;
+	--back-vertical-align: flex-start;
+	--front-media-width: 150px;
+	--front-media-height: 150px;
 
 	--flip-anim: unset;
 
@@ -71,24 +71,24 @@
 		overflow-x: hidden;
 		overflow-y: auto;
 		background-size: inherit;
-		border: var( --borderWidth ) solid var( --borderColor );
-		border-radius: var( --borderRadius );
+		border: var( --border-width ) solid var( --border-color );
+		border-radius: var( --border-radius );
 		box-sizing: border-box;
 	}
 
 	.o-flip-front {
-		background: var( --frontBackground );
+		background: var( --front-background );
 
 		&:hover {
-			box-shadow: var( --boxShadow );
+			box-shadow: var( --box-shadow );
 		}
 	}
 
 	.o-flip-content {
 		display: flex;
 		flex-direction: column;
-		justify-content: var( --frontVerticalAlign );
-		align-items: var( --frontHorizontalAlign );
+		justify-content: var( --front-vertical-align );
+		align-items: var( --front-horizontal-align );
 
 		padding: var( --padding );
 		width: 100%;
@@ -99,30 +99,30 @@
 		}
 
 		.o-img {
-			width: var( --frontMediaWidth );
-			height: var( --frontMediaHeight );
+			width: var( --front-media-width );
+			height: var( --front-media-height );
 		}
 	}
 
 	.o-flip-back {
-		background: var( --backBackground );
+		background: var( --back-background );
 		padding: var( --padding );
-		box-shadow: var( --boxShadow );
+		box-shadow: var( --box-shadow );
 		transform: var( --flip-anim );
-		justify-content: var( --backVerticalAlign );
+		justify-content: var( --back-vertical-align );
 	}
 
 	.invert {
 		.o-flip-front {
 			transform: var( --flip-anim );
-			box-shadow: var( --boxShadow );
+			box-shadow: var( --box-shadow );
 		}
 
 		.o-flip-back {
 			transform: unset;
 			box-shadow: unset;
 			&:hover {
-				box-shadow: var( --boxShadow );
+				box-shadow: var( --box-shadow );
 			}
 		}
 	}

--- a/src/blocks/blocks/font-awesome-icons/edit.js
+++ b/src/blocks/blocks/font-awesome-icons/edit.js
@@ -49,12 +49,12 @@ const Edit = ({
 
 	const inlineStyles = {
 		'--align': attributes.align,
-		'--borderColor': attributes.borderColor,
-		'--borderSize': attributes.borderSize !== undefined && `${attributes.borderSize }px`,
-		'--borderRadius': attributes.borderRadius !== undefined && `${ attributes.borderRadius }%`,
+		'--border-color': attributes.borderColor,
+		'--border-size': attributes.borderSize !== undefined && `${attributes.borderSize }px`,
+		'--border-radius': attributes.borderRadius !== undefined && `${ attributes.borderRadius }%`,
 		'--margin':	attributes.margin !== undefined && `${ getValue( 'margin' ) }px`,
 		'--padding': attributes.padding !== undefined && `${ getValue( 'padding' ) }px`,
-		'--fontSize': attributes.fontSize !== undefined && `${ getValue( 'fontSize' ) }px`
+		'--font-size': attributes.fontSize !== undefined && `${ getValue( 'fontSize' ) }px`
 	};
 
 	const [ cssNodeName, setNodeCSS ] = useCSSNode();

--- a/src/blocks/blocks/font-awesome-icons/style.scss
+++ b/src/blocks/blocks/font-awesome-icons/style.scss
@@ -1,30 +1,30 @@
 .wp-block-themeisle-blocks-font-awesome-icons {
 	--align: center;
-	--borderColor: #000;
-	--borderSize: unset;
-	--borderRadius: 0%;
+	--border-color: #000;
+	--border-size: unset;
+	--border-radius: 0%;
 	--margin: 0px;
 	--padding: 0px;
-	--fontSize: 16px;
+	--font-size: 16px;
 
 	text-align: var( --align );
 
 	.wp-block-themeisle-blocks-font-awesome-icons-container {
 		display: inline-flex;
 		justify-content: center;
-		border: var( --borderSize ) solid var( --borderColor );
-		border-radius: var( --borderRadius );
+		border: var( --border-size ) solid var( --border-color );
+		border-radius: var( --border-radius );
 		margin: var( --margin );
 
 		text-align: center;
 		align-items: center;
 
-		width: calc( var(--fontSize) * 1.5 + var( --padding ));
-		height: calc( var(--fontSize) * 1.5 + var( --padding ));
+		width: calc( var(--font-size) * 1.5 + var( --padding ));
+		height: calc( var(--font-size) * 1.5 + var( --padding ));
 
 		svg {
-			width: var( --fontSize );
-			height: var( --fontSize );
+			width: var( --font-size );
+			height: var( --font-size );
 		}
 
 		i {

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -713,23 +713,23 @@ const Edit = ({
 	};
 
 	const inlineStyles = {
-		'--messageFontSize': attributes.messageFontSize !== undefined && attributes.messageFontSize,
-		'--inputFontSize': attributes.inputFontSize !== undefined && attributes.inputFontSize,
-		'--helpFontSize': attributes.helpFontSize !== undefined && attributes.helpFontSize,
-		'--inputColor': attributes.inputColor,
+		'--message-font-size': attributes.messageFontSize !== undefined && attributes.messageFontSize,
+		'--input-font-size': attributes.inputFontSize !== undefined && attributes.inputFontSize,
+		'--help-font-size': attributes.helpFontSize !== undefined && attributes.helpFontSize,
+		'--input-color': attributes.inputColor,
 		'--padding': padding( attributes.inputPadding ),
-		'--borderRadius': attributes.inputBorderRadius !== undefined && ( attributes.inputBorderRadius + 'px' ),
-		'--borderWidth': attributes.inputBorderWidth !== undefined && ( attributes.inputBorderWidth + 'px' ),
-		'--borderColor': attributes.inputBorderColor,
-		'--labelColor': attributes.labelColor,
-		'--inputWidth': attributes.inputWidth !== undefined && ( attributes.inputWidth + '%' ),
-		'--submitColor': attributes.submitColor,
-		'--requiredColor': attributes.inputRequiredColor,
-		'--inputGap': attributes.inputGap !== undefined && ( attributes.inputGap + 'px' ),
-		'--inputsGap': attributes.inputsGap !== undefined && ( attributes.inputsGap + 'px' ),
-		'--labelFontSize': attributes.labelFontSize !== undefined && ( attributes.labelFontSize + 'px' ),
-		'--submitFontSize': attributes.submitFontSize !== undefined && ( attributes.submitFontSize + 'px' ),
-		'--helpLabelColor': attributes.helpLabelColor
+		'--border-radius': attributes.inputBorderRadius !== undefined && ( attributes.inputBorderRadius + 'px' ),
+		'--border-width': attributes.inputBorderWidth !== undefined && ( attributes.inputBorderWidth + 'px' ),
+		'--border-color': attributes.inputBorderColor,
+		'--label-color': attributes.labelColor,
+		'--input-width': attributes.inputWidth !== undefined && ( attributes.inputWidth + '%' ),
+		'--submit-color': attributes.submitColor,
+		'--required-color': attributes.inputRequiredColor,
+		'--input-gap': attributes.inputGap !== undefined && ( attributes.inputGap + 'px' ),
+		'--inputs-gap': attributes.inputsGap !== undefined && ( attributes.inputsGap + 'px' ),
+		'--label-font-size': attributes.labelFontSize !== undefined && ( attributes.labelFontSize + 'px' ),
+		'--submit-font-size': attributes.submitFontSize !== undefined && ( attributes.submitFontSize + 'px' ),
+		'--help-label-color': attributes.helpLabelColor
 	};
 
 	const [ cssNodeName, setCSS ] = useCSSNode();

--- a/src/blocks/blocks/form/editor.scss
+++ b/src/blocks/blocks/form/editor.scss
@@ -19,7 +19,7 @@
 	.otter-form__container > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
 		flex-direction: column;
-		gap: var(--inputsGap);
+		gap: var(--inputs-gap);
 
 		&> div {
 			width: 100%;

--- a/src/blocks/blocks/form/input/edit.js
+++ b/src/blocks/blocks/form/input/edit.js
@@ -53,13 +53,13 @@ const Edit = ({
 		 */
 
 		if ( inputRef.current ) {
-			inputRef.current?.style?.setProperty( '--inputWidth', per( attributes.inputWidth ) );
+			inputRef.current?.style?.setProperty( '--input-width', per( attributes.inputWidth ) );
 		}
 		if ( labelRef.current ) {
-			labelRef.current?.style?.setProperty( '--labelColor', attributes.labelColor || null );
+			labelRef.current?.style?.setProperty( '--label-color', attributes.labelColor || null );
 		}
 		if ( helpRef.current ) {
-			helpRef.current?.style?.setProperty( '--labelColor', attributes.labelColor || null );
+			helpRef.current?.style?.setProperty( '--label-color', attributes.labelColor || null );
 		}
 	}, [ inputRef.current, labelRef.current, helpRef.current, attributes.labelColor, attributes.inputWidth ]);
 

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -1,28 +1,28 @@
 .wp-block-themeisle-blocks-form {
 	--padding: 8px;
-	--borderRadius: 4px;
-	--borderColor: inherit;
-	--borderWidth: 1px;
-	--labelColor: inherit;
-	--helpLabelColor: inherit;
-	--inputWidth: 100%;
-	--requiredColor: red;
-	--submitColor: white;
-	--submitMsgColor: green;
-	--submitErrorColor: red;
-	--inputsGap: 10px;
-	--inputGap: 16px;
-	--labelFontSize: var(--bodyFontSize, inherit);
-	--messageFontSize: var(--bodyFontSize, inherit);
-	--submitFontSize: var(--btnFs, var(--bodyFontSize, inherit));
-	--inputColor: initial;
-	--inputFontSize: 1em;
-	--helpFontSize: 13px;
+	--border-radius: 4px;
+	--border-color: inherit;
+	--border-width: 1px;
+	--label-color: inherit;
+	--help-label-color: inherit;
+	--input-width: 100%;
+	--required-color: red;
+	--submit-color: white;
+	--submit-msg-color: green;
+	--submit-error-color: red;
+	--inputs-gap: 10px;
+	--input-gap: 16px;
+	--label-font-size: var(--bodyFontSize, inherit);
+	--message-font-size: var(--bodyFontSize, inherit);
+	--submit-font-size: var(--btnFs, var(--bodyFontSize, inherit));
+	--input-color: initial;
+	--input-font-size: 1em;
+	--help-font-size: 13px;
 
 	.otter-form__container {
 		display: flex;
 		flex-direction: column;
-		gap: var(--inputsGap);
+		gap: var(--inputs-gap);
 
 		p {
 			margin-bottom: 10px;
@@ -34,11 +34,11 @@
 			flex-direction: row;
 
 			.wp-block-button__link {
-				font-size: var(--submitFontSize);
+				font-size: var(--submit-font-size);
 				text-align: center;
 				height: auto;
 				padding: 10px 20px;
-				color: var(--submitColor);
+				color: var(--submit-color);
 				border: 0px;
 				transition: background-color 0.15s linear;
 			}
@@ -67,35 +67,35 @@
 		display: flex;
 		flex-direction: column;
 		width: 100%;
-		gap: var(--inputGap);
+		gap: var(--input-gap);
 		margin: 0px;
 
 		.otter-form-input-label, .otter-form-textarea-label {
 			width: 100%;
-			color: var(--labelColor);
-			font-size: var(--labelFontSize);
+			color: var(--label-color);
+			font-size: var(--label-font-size);
 
 			.required {
-				color: var(--requiredColor);
+				color: var(--required-color);
 			}
 		}
 
 		.otter-form-input,.otter-form-textarea-input {
-			color: var(--inputColor);
-			width: var(--inputWidth);
+			color: var(--input-color);
+			width: var(--input-width);
 			padding: var(--padding);
-			border-radius: var(--borderRadius);
-			border-width: var(--borderWidth);
-			border-color: var(--borderColor);
+			border-radius: var(--border-radius);
+			border-width: var(--border-width);
+			border-color: var(--border-color);
 			border-style: solid;
-			font-size: var(--inputFontSize);
+			font-size: var(--input-font-size);
 		}
 
 		.o-form-help {
 			opacity: 0.8;
-			color: var(--helpLabelColor);
+			color: var(--help-label-color);
 			margin-bottom: 12px;
-			font-size: var(--helpFontSize);
+			font-size: var(--help-font-size);
 		}
 	}
 
@@ -121,16 +121,16 @@
 	.o-form-server-response {
 		text-align: left;
 		padding: 1rem;
-		font-size: var(--messageFontSize);
+		font-size: var(--message-font-size);
 		border-radius: 10%;
 		margin-left: 10px;
 
 		&.o-success {
-			color: var(--submitMsgColor);
+			color: var(--submit-msg-color);
 		}
 
 		&.o-error {
-			color: var(--submitErrorColor);
+			color: var(--submit-error-color);
 		}
 
 		&.o-info {
@@ -162,7 +162,7 @@
 			margin-top: -10px;
 			margin-left: -10px;
 			border-radius: 50%;
-			border-top: 2px solid var(--submitColor);
+			border-top: 2px solid var(--submit-color);
 			border-right: 2px solid transparent;
 			animation: spinner 0.6s linear infinite;
 		}

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -12,9 +12,9 @@
 	--submit-error-color: red;
 	--inputs-gap: 10px;
 	--input-gap: 16px;
-	--label-font-size: var(--bodyFontSize, inherit);
-	--message-font-size: var(--bodyFontSize, inherit);
-	--submit-font-size: var(--btnFs, var(--bodyFontSize, inherit));
+	--label-font-size: var(--bodyfontsize, inherit);
+	--message-font-size: var(--bodyfontsize, inherit);
+	--submit-font-size: var(--btnFs, var(--bodyfontsize, inherit));
 	--input-color: initial;
 	--input-font-size: 1em;
 	--help-font-size: 13px;

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -14,7 +14,7 @@
 	--input-gap: 16px;
 	--label-font-size: var(--bodyfontsize, inherit);
 	--message-font-size: var(--bodyfontsize, inherit);
-	--submit-font-size: var(--btnFs, var(--bodyfontsize, inherit));
+	--submit-font-size: var(--btnfs, var(--bodyfontsize, inherit));
 	--input-color: initial;
 	--input-font-size: 1em;
 	--help-font-size: 13px;

--- a/src/blocks/blocks/form/textarea/edit.js
+++ b/src/blocks/blocks/form/textarea/edit.js
@@ -53,13 +53,13 @@ const Edit = ({
 		 */
 
 		if ( inputRef.current ) {
-			inputRef.current?.style?.setProperty( '--inputWidth', per( attributes.inputWidth ) );
+			inputRef.current?.style?.setProperty( '--input-width', per( attributes.inputWidth ) );
 		}
 		if ( labelRef.current ) {
-			labelRef.current?.style?.setProperty( '--labelColor',  attributes.labelColor || null );
+			labelRef.current?.style?.setProperty( '--label-color',  attributes.labelColor || null );
 		}
 		if ( helpRef.current ) {
-			helpRef.current?.style?.setProperty( '--labelColor', attributes.labelColor || null );
+			helpRef.current?.style?.setProperty( '--label-color', attributes.labelColor || null );
 		}
 	}, [ inputRef.current, labelRef.current, attributes ]);
 

--- a/src/blocks/blocks/icon-list/edit.js
+++ b/src/blocks/blocks/icon-list/edit.js
@@ -37,9 +37,9 @@ const Edit = ({
 	}, [ attributes.id ]);
 
 	const inlineStyles = {
-		'--horizontalAlign': attributes.horizontalAlign,
+		'--horizontal-align': attributes.horizontalAlign,
 		'--gap': attributes.gap && `${ attributes.gap }px`,
-		'--fontSize': attributes.defaultSize && `${ attributes.defaultSize }px`
+		'--font-size': attributes.defaultSize && `${ attributes.defaultSize }px`
 	};
 
 	const blockProps = useBlockProps({

--- a/src/blocks/blocks/icon-list/editor.scss
+++ b/src/blocks/blocks/icon-list/editor.scss
@@ -1,9 +1,9 @@
 .wp-block-themeisle-blocks-icon-list {
-	--horizontalAlign: unset;
+	--horizontal-align: unset;
 	--gap: 5px;
-	--fontSize: 20px;
-	--contentColor: inherit;
-	--iconColor: inherit;
+	--font-size: 20px;
+	--content-color: inherit;
+	--icon-color: inherit;
 
 	display: flex;
 	flex-direction: column;
@@ -26,8 +26,8 @@
 		display: flex;
 		flex-direction: inherit;
 		flex-wrap: wrap;
-		align-items: var( --horizontalAlign );
-		justify-content: var( --horizontalAlign );
+		align-items: var( --horizontal-align );
+		justify-content: var( --horizontal-align );
 		gap: var( --gap );
 		width: 100%;
 	}
@@ -40,16 +40,16 @@
 		margin: 0;
 
 		i {
-			font-size: var( --fontSize );
+			font-size: var( --font-size );
 		}
 
 		svg {
-			min-width: var( --fontSize );
-			width: var( --fontSize );
+			min-width: var( --font-size );
+			width: var( --font-size );
 		}
 
 		img {
-			width: var( --fontSize );
+			width: var( --font-size );
 		}
 
 		p {
@@ -59,15 +59,15 @@
 
 	.wp-block-themeisle-blocks-icon-list-item-content,
 	.wp-block-themeisle-blocks-icon-list-item-content-custom {
-		color: var( --contentColor );
-		font-size: var( --fontSize );
+		color: var( --content-color );
+		font-size: var( --font-size );
 		flex-grow: 1;
 		margin: 0 10px;
 	}
 
 	.wp-block-themeisle-blocks-icon-list-item-icon,
 	.wp-block-themeisle-blocks-icon-list-item-icon-custom {
-		fill: var( --iconColor );
-		color: var( --iconColor );
+		fill: var( --icon-color );
+		color: var( --icon-color );
 	}
 }

--- a/src/blocks/blocks/icon-list/item/edit.js
+++ b/src/blocks/blocks/icon-list/item/edit.js
@@ -104,8 +104,8 @@ const Edit = ({
 	};
 
 	const inlineStyles = {
-		'--contentColor': attributes.contentColor ?? parentAttributes.defaultContentColor,
-		'--iconColor': attributes.iconColor ?? parentAttributes.defaultIconColor
+		'--content-color': attributes.contentColor ?? parentAttributes.defaultContentColor,
+		'--icon-color': attributes.iconColor ?? parentAttributes.defaultIconColor
 	};
 
 	const blockProps = useBlockProps({

--- a/src/blocks/blocks/icon-list/style.scss
+++ b/src/blocks/blocks/icon-list/style.scss
@@ -1,14 +1,14 @@
 .wp-block-themeisle-blocks-icon-list {
-	--horizontalAlign: unset;
+	--horizontal-align: unset;
 	--gap: 5px;
-	--fontSize: 20px;
-	--contentColor: inherit;
-	--iconColor: inherit;
+	--font-size: 20px;
+	--content-color: inherit;
+	--icon-color: inherit;
 
 	display: flex;
 	flex-direction: column;
-	align-items: var( --horizontalAlign );
-	justify-content: var( --horizontalAlign );
+	align-items: var( --horizontal-align );
+	justify-content: var( --horizontal-align );
 	gap: var( --gap );
 
 	&.is-style-horizontal {
@@ -23,16 +23,16 @@
 		transition: margin 0.10s linear;
 
 		i {
-			font-size: var( --fontSize );
+			font-size: var( --font-size );
 		}
 
 		svg {
-			min-width: var( --fontSize );
-			width: var( --fontSize );
+			min-width: var( --font-size );
+			width: var( --font-size );
 		}
 
 		img {
-			width: var( --fontSize );
+			width: var( --font-size );
 		}
 
 		p {
@@ -42,14 +42,14 @@
 
 	.wp-block-themeisle-blocks-icon-list-item-content,
 	.wp-block-themeisle-blocks-icon-list-item-content-custom {
-		color: var( --contentColor );
-		font-size: var( --fontSize );
+		color: var( --content-color );
+		font-size: var( --font-size );
 		margin: 0 10px;
 	}
 
 	.wp-block-themeisle-blocks-icon-list-item-icon,
 	.wp-block-themeisle-blocks-icon-list-item-icon-custom {
-		fill: var( --iconColor );
-		color: var( --iconColor );
+		fill: var( --icon-color );
+		color: var( --icon-color );
 	}
 }

--- a/src/blocks/blocks/popup/edit.js
+++ b/src/blocks/blocks/popup/edit.js
@@ -52,12 +52,12 @@ const Edit = ({
 	const [ isEditing, setEditing ] = useState( false );
 
 	const inlineStyles = {
-		'--minWidth': attributes.minWidth ? attributes.minWidth + 'px' : '400px',
-		'--maxWidth': attributes.maxWidth ? attributes.maxWidth + 'px' : undefined,
-		'--backgroundColor': attributes.backgroundColor,
-		'--closeColor': attributes.closeColor,
-		'--overlayColor': attributes.overlayColor,
-		'--overlayOpacity': attributes.overlayOpacity ? attributes.overlayOpacity / 100 : 1
+		'--min-width': attributes.minWidth ? attributes.minWidth + 'px' : '400px',
+		'--max-width': attributes.maxWidth ? attributes.maxWidth + 'px' : undefined,
+		'--background-color': attributes.backgroundColor,
+		'--close-color': attributes.closeColor,
+		'--overlay-color': attributes.overlayColor,
+		'--overlay-opacity': attributes.overlayOpacity ? attributes.overlayOpacity / 100 : 1
 	};
 
 	const blockProps = useBlockProps({

--- a/src/blocks/blocks/popup/style.scss
+++ b/src/blocks/blocks/popup/style.scss
@@ -1,11 +1,11 @@
 $base-index: 9999 !default;
 
 .wp-block-themeisle-blocks-popup {
-	--minWidth: 400px;
-	--backgroundColor: #fff;
-	--closeColor: #000;
-	--overlayColor: rgba(0, 0, 0, 0.5);
-	--overlayOpacity: 1;
+	--min-width: 400px;
+	--background-color: #fff;
+	--close-color: #000;
+	--overlay-color: rgba(0, 0, 0, 0.5);
+	--overlay-opacity: 1;
 
 	&.is-front {
 		display: none;
@@ -16,8 +16,8 @@ $base-index: 9999 !default;
 	}
 
 	.otter-popup__modal_wrap_overlay {
-		background-color: var( --overlayColor );
-		opacity: var( --overlayOpacity );
+		background-color: var( --overlay-color );
+		opacity: var( --overlay-opacity );
 		left: 0;
 		right: 0;
 		top: 0;
@@ -45,9 +45,9 @@ $base-index: 9999 !default;
 	.otter-popup__modal_content {
 		position: relative;
 		z-index: $base-index + 1;
-		background-color: var( --backgroundColor );
-		min-width: var( --minWidth );
-		max-width: var( --maxWidth );
+		background-color: var( --background-color );
+		min-width: var( --min-width );
+		max-width: var( --max-width );
 		padding: 20px;
 
 		@media ( max-width: 600px ) {
@@ -77,7 +77,7 @@ $base-index: 9999 !default;
 
 		button {
 			background-color: transparent !important;
-			color: var( --closeColor );
+			color: var( --close-color );
 			height: auto !important;
 			display: flex;
 			align-items: center;

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -110,26 +110,26 @@ const Edit = ({
 	}, [ slugs ]);
 
 	const inlineStyles = {
-		'--imgWidth': `${ attributes.imageWidth }px`,
-		'--imgBorderRadius': attributes.borderRadius && `${ attributes.borderRadius }px;`,
-		'--vertAlign': _align( attributes.verticalAlign ),
-		'--textAlign': attributes.textAlign
+		'--img-width': `${ attributes.imageWidth }px`,
+		'--img-border-radius': attributes.borderRadius && `${ attributes.borderRadius }px;`,
+		'--vert-align': _align( attributes.verticalAlign ),
+		'--text-align': attributes.textAlign
 	};
 
 	const [ cssNodeName, setNodeCSS ] = useCSSNode();
 	useEffect( () => {
 		setNodeCSS([
 			`{
-				${ attributes.customTitleFontSize && `--titleTextSize: ${ attributes.customTitleFontSize }px;` }
-				${ attributes.customDescriptionFontSize && `--descriptionTextSize: ${ attributes.customDescriptionFontSize }px;` }
+				${ attributes.customTitleFontSize && `--title-text-size: ${ attributes.customTitleFontSize }px;` }
+				${ attributes.customDescriptionFontSize && `--description-text-size: ${ attributes.customDescriptionFontSize }px;` }
 			}`,
 			`{
-				${ attributes.customTitleFontSizeTablet && `--titleTextSize: ${ attributes.customTitleFontSizeTablet }px;` }
-				${ attributes.customDescriptionFontSizeTablet && `--descriptionTextSize: ${ attributes.customDescriptionFontSizeTablet }px;` }
+				${ attributes.customTitleFontSizeTablet && `--title-text-size: ${ attributes.customTitleFontSizeTablet }px;` }
+				${ attributes.customDescriptionFontSizeTablet && `--description-text-size: ${ attributes.customDescriptionFontSizeTablet }px;` }
 			}`,
 			`{
-				${ attributes.customTitleFontSizeMobile && `--titleTextSize: ${ attributes.customTitleFontSizeMobile }px;` }
-				${ attributes.customDescriptionFontSizeMobile && `--descriptionTextSize: ${ attributes.customDescriptionFontSizeMobile }px;` }
+				${ attributes.customTitleFontSizeMobile && `--title-text-size: ${ attributes.customTitleFontSizeMobile }px;` }
+				${ attributes.customDescriptionFontSizeMobile && `--description-text-size: ${ attributes.customDescriptionFontSizeMobile }px;` }
 			}`
 		], [
 			'@media ( min-width: 960px )',

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -1,10 +1,10 @@
 .wp-block-themeisle-blocks-posts-grid {
-	--textAlign: initial;
-	--vertAlign: initial;
-	--imgBorderRadius: 5px;
-	--imgWidth: initial;
-	--titleTextSize: initial;
-	--descriptionTextSize: initial;
+	--text-align: initial;
+	--vert-align: initial;
+	--img-border-radius: 5px;
+	--img-width: initial;
+	--title-text-size: initial;
+	--description-text-size: initial;
 
 	.has-shadow {
 		img {
@@ -71,7 +71,7 @@
 						width: 150px;
 						height: 150px;
 						object-fit: cover;
-						border-radius: var(--imgBorderRadius);
+						border-radius: var(--img-border-radius);
 					}
 				}
 			}
@@ -101,18 +101,18 @@
 		align-items: center;
 
 		img {
-			width: var(--imgWidth);
+			width: var(--img-width);
 			border-radius: 5px;
-			border-radius: var(--imgBorderRadius);
+			border-radius: var(--img-border-radius);
 		}
 	}
 
 	.o-posts-grid-post-body {
 		display: flex;
 		flex-direction: column;
-		justify-content: var(--vertAlign);
+		justify-content: var(--vert-align);
 		padding-bottom: 15px;
-		text-align: var(--textAlign);
+		text-align: var(--text-align);
 
 
 		&.is-full {
@@ -132,7 +132,7 @@
 			a {
 				text-decoration: none;
 				transition: all .15s ease 0s;
-				font-size: var(--titleTextSize);
+				font-size: var(--title-text-size);
 
 				&:hover {
 					text-decoration: underline;
@@ -150,11 +150,11 @@
 
 			p {
 				margin-bottom: 0px;
-				font-size: var(--descriptionTextSize);
+				font-size: var(--description-text-size);
 			}
 
 			.read-more {
-				font-size: var(--descriptionTextSize);
+				font-size: var(--description-text-size);
 				display: block;
 				margin-bottom: 5px;
 			}
@@ -181,7 +181,7 @@
 
 @media ( max-width: 960px ) {
 	.o-posts-grid-post-image img {
-		width: min(var(--imgWidth), 100%);
+		width: min(var(--img-width), 100%);
 	}
 }
 

--- a/src/blocks/blocks/progress-bar/edit.js
+++ b/src/blocks/blocks/progress-bar/edit.js
@@ -87,15 +87,15 @@ const ProgressBar = ({
 	}, [ attributes.percentage, attributes.duration ]);
 
 	const inlineStyles = {
-		'--titleColor': attributes.titleColor,
-		'--percentageColor': attributes.percentageColor,
-		'--percentageColorOuter': attributes.percentageColor,
-		'--percentageColorTooltip': attributes.percentageColor,
-		'--percentageColorAppend': attributes.percentageColor,
-		'--backgroundColor': attributes.backgroundColor,
-		'--borderRadius': attributes.borderRadius !== undefined && ( attributes.borderRadius + 'px' ),
+		'--title-color': attributes.titleColor,
+		'--percentage-color': attributes.percentageColor,
+		'--percentage-color-outer': attributes.percentageColor,
+		'--percentage-color-tooltip': attributes.percentageColor,
+		'--percentage-color-append': attributes.percentageColor,
+		'--background-color': attributes.backgroundColor,
+		'--border-radius': attributes.borderRadius !== undefined && ( attributes.borderRadius + 'px' ),
 		'--height': attributes.height !== undefined && ( attributes.height + 'px' ),
-		'--barBackground': attributes.barBackgroundColor
+		'--bar-background': attributes.barBackgroundColor
 	};
 
 	const onHeightChange = value => {

--- a/src/blocks/blocks/progress-bar/style.scss
+++ b/src/blocks/blocks/progress-bar/style.scss
@@ -1,15 +1,15 @@
 .wp-block-themeisle-blocks-progress-bar {
 	--percentage: 50%;
-	--titleColor: inherit;
-	--percentageColor: rgba(0, 0, 0, 0.4);
-	--percentageColorOuter: inherit;
-	--percentageColorTooltip: #FFF;
-	--percentageColorAppend: #FFF;
-	--backgroundColor: #EEE;
-	--borderRadius: 5px;
+	--title-color: inherit;
+	--percentage-color: rgba(0, 0, 0, 0.4);
+	--percentage-color-outer: inherit;
+	--percentage-color-tooltip: #FFF;
+	--percentage-color-append: #FFF;
+	--background-color: #EEE;
+	--border-radius: 5px;
 	--height: 30px;
-	--fontSize: calc( var( --height ) * 0.65 );
-	--barBackground: #6adcfa;
+	--font-size: calc( var( --height ) * 0.65 );
+	--bar-background: #6adcfa;
 
 	display: flex;
 	flex-direction: column;
@@ -26,14 +26,14 @@
 	}
 
 	.wp-block-themeisle-blocks-progress-bar__outer__title {
-		color: var( --titleColor );
+		color: var( --title-color );
 		margin: 0px;
 		display: grid;
 		align-items: center;
 	}
 
 	.wp-block-themeisle-blocks-progress-bar__outer__value {
-		color: var( --percentageColorOuter );
+		color: var( --percentage-color-outer );
 		margin-left: auto;
 		display: grid;
 		align-items: center;
@@ -45,9 +45,9 @@
 		display: block;
 		margin-bottom: 15px;
 		width: 100%;
-		background: var( --backgroundColor );
+		background: var( --background-color );
 		height: var( --height );
-		border-radius: var( --borderRadius );
+		border-radius: var( --border-radius );
 		transition: 0.4s linear;
 		transition-property: width, background-color;
 	}
@@ -58,17 +58,17 @@
 		position: absolute;
 		right: 10px;
 		top: 0;
-		font-size: var( --fontSize );
+		font-size: var( --font-size );
 		height: var( --height );
 		line-height: 30px;
-		color: var( --percentageColor );
+		color: var( --percentage-color );
 	}
 
 	.wp-block-themeisle-blocks-progress-bar__area__bar {
 		height: var( --height );
 		width: 0px;
-		background: var( --barBackground);
-		border-radius: var( --borderRadius );
+		background: var( --bar-background);
+		border-radius: var( --border-radius );
 		opacity: 0;
 
 		&.show {
@@ -84,11 +84,11 @@
 		right: 10px;
 		left: 0px;
 		top: 0;
-		font-size: var( --fontSize );
+		font-size: var( --font-size );
 		margin-right: 5px;
 		height: var( --height );
 		line-height: 30px;
-		color: var( --percentageColorAppend );
+		color: var( --percentage-color-append );
 		opacity: 0;
 
 		&.show {
@@ -102,7 +102,7 @@
 		float: right;
 		bottom: 40px;
 		left: 20px;
-		color: var( --percentageColorTooltip );
+		color: var( --percentage-color-tooltip );
 		transition: all 1s;
 		position: relative;
 		padding: 4px 10px 7px 10px;
@@ -137,26 +137,26 @@
 		left: 0;
 		width: auto;
 		font-weight: bold;
-		font-size: var( --fontSize );
+		font-size: var( --font-size );
 		height: var( --height );
 		color: #ffffff;
 		background: transparent;
-		border-radius: var( --borderRadius ) 0px 0px var( --borderRadius );
+		border-radius: var( --border-radius ) 0px 0px var( --border-radius );
 
 		&.highlight {
-			background: var( --barBackground );
+			background: var( --bar-background );
 
 			span {
-				color: var( --titleColor );
+				color: var( --title-color );
 				background: rgba(0, 0, 0, 0.1);
 			}
 		}
 
 		span {
-			color: var( --titleColor );
+			color: var( --title-color );
 			display: flex;
 			align-items: center;
-			border-radius: var( --borderRadius ) 0px 0px var( --borderRadius );
+			border-radius: var( --border-radius ) 0px 0px var( --border-radius );
 			width: 100%;
 			background: transparent;
 			padding: 0 20px;

--- a/src/blocks/blocks/review/edit.js
+++ b/src/blocks/blocks/review/edit.js
@@ -117,10 +117,10 @@ const Edit = ({
 	};
 
 	const inlineStyles = {
-		'--backgroundColor': getValue( 'backgroundColor' ),
-		'--primaryColor': getValue( 'primaryColor' ),
-		'--textColor': getValue( 'textColor' ),
-		'--buttonTextColor': getValue( 'buttonTextColor' )
+		'--background-color': getValue( 'backgroundColor' ),
+		'--primary-color': getValue( 'primaryColor' ),
+		'--text-color': getValue( 'textColor' ),
+		'--button-text-color': getValue( 'buttonTextColor' )
 	};
 
 	const isPlaceholder = ( 'object' === typeof status && null !== status && status.isError ) || 'isLoading' === status;

--- a/src/blocks/blocks/review/style.scss
+++ b/src/blocks/blocks/review/style.scss
@@ -1,10 +1,10 @@
 .wp-block-themeisle-blocks-review {
-	--backgroundColor: transparent;
-	--primaryColor: #1357BD;
-	--textColor: inherit;
-	--buttonTextColor: #FFF;
+	--background-color: transparent;
+	--primary-color: #1357BD;
+	--text-color: inherit;
+	--button-text-color: #FFF;
 
-	background: var( --backgroundColor );
+	background: var( --background-color );
 	border: 1px #eaeaea solid;
 	display: grid;
 	grid-template-columns: 1fr 1fr 1fr;
@@ -14,12 +14,12 @@
 
 	.o-review__header {
 		padding: 20px 30px;
-		border-left: 10px solid var( --primaryColor );
+		border-left: 10px solid var( --primary-color );
 		grid-area: header;
 		overflow: hidden;
 
 		h3 {
-			color: var( --textColor );
+			color: var( --text-color );
 			font-size: 28px;
 			font-style: normal;
 			font-weight: 700;
@@ -61,7 +61,7 @@
 		}
 
 		span {
-			color: var( --textColor );
+			color: var( --text-color );
 			padding-left: 10px;
 			font-size: 13px;
 			min-width: 50px;
@@ -69,7 +69,7 @@
 	}
 
 	.o-review__header_price {
-		color: var( --textColor );
+		color: var( --text-color );
 
 		del {
 			color: #A2A2A2;
@@ -93,7 +93,7 @@
 		align-items: center;
 
 		p {
-			color: var( --textColor );
+			color: var( --text-color );
 		}
 
 		img {
@@ -132,7 +132,7 @@
 	}
 
 	.o-review__left_feature_title {
-		color: var( --textColor );
+		color: var( --text-color );
 		font-weight: 600;
 	}
 
@@ -159,7 +159,7 @@
 		}
 
 		span {
-			color: var( --textColor );
+			color: var( --text-color );
 			padding-left: 10px;
 			font-size: 13px;
 			word-break: keep-all;
@@ -177,7 +177,7 @@
 	.o-review__right_pros,
 	.o-review__right_cons {
 		h4 {
-			color: var( --textColor );
+			color: var( --text-color );
 		}
 	}
 
@@ -199,7 +199,7 @@
 		}
 
 		p {
-			color: var( --textColor );
+			color: var( --text-color );
 			margin: 0;
 		}
 	}
@@ -215,7 +215,7 @@
 	}
 
 	.o-review__footer_label {
-		color: var( --textColor );
+		color: var( --text-color );
 		font-weight: 600;
 	}
 
@@ -225,8 +225,8 @@
 
 		a,
 		span {
-			background: var( --primaryColor );
-			color: var( --buttonTextColor );
+			background: var( --primary-color );
+			color: var( --button-text-color );
 			padding: 12px 50px;
 			margin: 10px;
 			cursor: pointer;

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -8,14 +8,14 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 }
 
 .wp-block-themeisle-blocks-advanced-columns {
-	--columnsWidth: initial;
+	--columns-width: initial;
 	display: flex;
 
 	> .innerblocks-wrap {
 		flex-basis: 100%;
 		width: 100%;
 		word-break: keep-all;
-		max-width: var( --columnsWidth );
+		max-width: var( --columns-width );
 
 		> .block-editor-inner-blocks > .block-editor-block-list__layout {
 			display: flex;

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -7,10 +7,10 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 }
 
 .wp-block-themeisle-blocks-advanced-columns {
-	--columnsWidth: initial;
-	--horizontalAlign: unset;
+	--columns-width: initial;
+	--horizontal-align: unset;
 
-	justify-content: var( --horizontalAlign );
+	justify-content: var( --horizontal-align );
 
 	.wp-themeisle-block-overlay,
 	.wp-block-themeisle-blocks-advanced-columns-overlay {
@@ -22,7 +22,7 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	}
 
 	.wp-block-themeisle-blocks-advanced-column:only-child {
-		max-width: var( --columnsWidth );
+		max-width: var( --columns-width );
 	}
 
 	.wp-block-themeisle-blocks-advanced-column {
@@ -107,7 +107,7 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 			display: flex;
 			flex-basis: 100%;
 			word-break: keep-all;
-			max-width: var( --columnsWidth );
+			max-width: var( --columns-width );
 
 			.wp-block-themeisle-blocks-advanced-column {
 				position: relative;
@@ -295,7 +295,7 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 			display: flex;
 			flex-basis: 100%;
 			word-break: keep-all;
-			max-width: var( --columnsWidth );
+			max-width: var( --columns-width );
 
 			.wp-block-themeisle-blocks-advanced-column {
 				position: relative;

--- a/src/blocks/blocks/sharing-icons/style.scss
+++ b/src/blocks/blocks/sharing-icons/style.scss
@@ -17,14 +17,14 @@
 
 	.social-icons-wrap {
 		display: flex;
-		column-gap: var(--iconsGap, 5px);
+		column-gap: var(--icons-gap, 5px);
 		flex-wrap: wrap;
 	}
 
 	.social-icon {
 		font-size: 14px;
 		padding: 12px;
-		border-radius: var(--borderRadius, 3px);
+		border-radius: var(--border-radius, 3px);
 		white-space: nowrap;
 		display: inline-block;
 		text-align: center;
@@ -34,33 +34,33 @@
 		text-decoration: none;
 
 		&.is-facebook {
-			background-color: var(--iconBgColor, #3b5998);
-			color: var(--textColor, #fff);
+			background-color: var(--icon-bg-color, #3b5998);
+			color: var(--text-color, #fff);
 		}
 
 		&.is-twitter {
-			background-color: var(--iconBgColor, #55acee);
-			color: var(--textColor, #fff);
+			background-color: var(--icon-bg-color, #55acee);
+			color: var(--text-color, #fff);
 		}
 
 		&.is-linkedin {
-			background-color: var(--iconBgColor, #0976b4);
-			color: var(--textColor, #fff);
+			background-color: var(--icon-bg-color, #0976b4);
+			color: var(--text-color, #fff);
 		}
 
 		&.is-pinterest {
-			background-color: var(--iconBgColor, #cc2127);
-			color: var(--textColor, #fff);
+			background-color: var(--icon-bg-color, #cc2127);
+			color: var(--text-color, #fff);
 		}
 
 		&.is-tumblr {
-			background-color: var(--iconBgColor, #35465c);
-			color: var(--textColor, #fff);
+			background-color: var(--icon-bg-color, #35465c);
+			color: var(--text-color, #fff);
 		}
 
 		&.is-reddit {
-			background-color: var(--iconBgColor, #ff4500);
-			color: var(--textColor, #fff);
+			background-color: var(--icon-bg-color, #ff4500);
+			color: var(--text-color, #fff);
 		}
 
 		&:hover {
@@ -70,7 +70,7 @@
 		i {
 			min-width: 20px;
 			font-size: 16px;
-			color: var(--textColor, #fff);
+			color: var(--text-color, #fff);
 		}
 	}
 
@@ -78,7 +78,7 @@
 		.v-line {
 			width: 1px;
 			height: 20px;
-			background-color: var(--textColor, #fff);
+			background-color: var(--text-color, #fff);
 			opacity: .5;
 			display: inline-block;
 			vertical-align: top;

--- a/src/blocks/blocks/tabs/editor.scss
+++ b/src/blocks/blocks/tabs/editor.scss
@@ -1,8 +1,8 @@
 .wp-block-themeisle-blocks-tabs {
-	--borderWidth: 3px;
-	--borderColor: #000;
-	--activeTitleColor: inherit;
-	--tabColor: transparent;
+	--border-width: 3px;
+	--border-color: #000;
+	--active-title-color: inherit;
+	--tab-color: transparent;
 
     border-color: black;
 
@@ -10,7 +10,7 @@
         display: flex;
         flex-direction: row;
         overflow: hidden;
-        border-color: var( --borderColor );
+        border-color: var( --border-color );
 
         @media ( max-width: 800px ) {
             display: none;
@@ -34,11 +34,11 @@
         }
 
         &.active {
-            color: var( --activeTitleColor );
-            background: var( --tabColor );
+            color: var( --active-title-color );
+            background: var( --tab-color );
             position: relative;
-            border-width: var( --borderWidth );
-            border-color: var( --borderColor );
+            border-width: var( --border-width );
+            border-color: var( --border-color );
             border-style: solid;
             border-bottom-style: none;
 
@@ -52,8 +52,8 @@
                 content: "";
                 position: absolute;
                 box-sizing: border-box;
-                border-width: var( --borderWidth );
-                border-color: var( --borderColor );
+                border-width: var( --border-width );
+                border-color: var( --border-color );
             }
 
             &::after {
@@ -66,8 +66,8 @@
                 content: "";
                 position: absolute;
                 box-sizing: border-box;
-                border-width: var( --borderWidth );
-                border-color: var( --borderColor );
+                border-width: var( --border-width );
+                border-color: var( --border-color );
             }
         }
     }
@@ -81,7 +81,7 @@
             background-color: inherit;
 
             .block-editor-block-list__layout {
-                border-color: var( --borderColor );
+                border-color: var( --border-color );
                 background-color: inherit;
 
                 div {
@@ -112,7 +112,7 @@
         }
 
         .wp-block-themeisle-blocks-tabs-item__header {
-            border: var( --borderWidth ) solid var( --borderColor );
+            border: var( --border-width ) solid var( --border-color );
             padding: 5px 10px;
             cursor: pointer;
 
@@ -121,14 +121,14 @@
             }
 
             &.active {
-                color: var( --activeTitleColor );
-                background: var( --tabColor );
+                color: var( --active-title-color );
+                background: var( --tab-color );
                 border-bottom-style: none;
             }
         }
 
         .wp-block-themeisle-blocks-tabs-item__content {
-            border: var( --borderWidth ) solid var( --borderColor );
+            border: var( --border-width ) solid var( --border-color );
             border-top: 0px;
             padding: 10px;
             display: none;
@@ -136,7 +136,7 @@
             margin-top: 10px;
 
             &.active {
-                background: var( --tabColor );
+                background: var( --tab-color );
                 display: block;
             }
         }

--- a/src/blocks/blocks/tabs/group/edit.js
+++ b/src/blocks/blocks/tabs/group/edit.js
@@ -134,10 +134,10 @@ const Edit = ({
 
 
 	const inlineStyles = {
-		'--borderWidth': undefined !== attributes.borderWidth ? attributes.borderWidth + 'px' : '3px',
-		'--borderColor': attributes.borderColor,
-		'--activeTitleColor': attributes.activeTitleColor,
-		'--tabColor': attributes.tabColor
+		'--border-width': undefined !== attributes.borderWidth ? attributes.borderWidth + 'px' : '3px',
+		'--border-color': attributes.borderColor,
+		'--active-title-color': attributes.activeTitleColor,
+		'--tab-color': attributes.tabColor
 	};
 
 	/**

--- a/src/blocks/blocks/tabs/style.scss
+++ b/src/blocks/blocks/tabs/style.scss
@@ -1,8 +1,8 @@
 .wp-block-themeisle-blocks-tabs {
-	--borderWidth: 3px;
-	--borderColor: #000;
-	--activeTitleColor: inherit;
-	--tabColor: transparent;
+	--border-width: 3px;
+	--border-color: #000;
+	--active-title-color: inherit;
+	--tab-color: transparent;
 
 	.wp-block-themeisle-blocks-tabs__header {
 		display: flex;
@@ -25,10 +25,10 @@
 		border-right-style: none;
 
 		&.active {
-			color: var( --activeTitleColor );
-			background: var( --tabColor );
-			border: var( --borderWidth ) solid;
-			border-color: var( --borderColor );
+			color: var( --active-title-color );
+			background: var( --tab-color );
+			border: var( --border-width ) solid;
+			border-color: var( --border-color );
 			border-bottom-style: none;
 			position: relative;
 
@@ -43,8 +43,8 @@
 				content: "";
 				position: absolute;
 				box-sizing: border-box;
-				border-width: var( --borderWidth );
-				border-color: var( --borderColor );
+				border-width: var( --border-width );
+				border-color: var( --border-color );
 			}
 
 			&::after {
@@ -57,8 +57,8 @@
 				content: "";
 				position: absolute;
 				box-sizing: border-box;
-				border-width: var( --borderWidth );
-				border-color: var( --borderColor );
+				border-width: var( --border-width );
+				border-color: var( --border-color );
 			}
 		}
 	}
@@ -84,7 +84,7 @@
 
 		.wp-block-themeisle-blocks-tabs-item__header {
 			width: 100%;
-			border: var( --borderWidth ) solid var( --borderColor );
+			border: var( --border-width ) solid var( --border-color );
 			padding: 5px 10px;
 			cursor: pointer;
 
@@ -93,21 +93,21 @@
 			}
 
 			&.active {
-				color: var( --activeTitleColor );
-				background: var( --tabColor );
+				color: var( --active-title-color );
+				background: var( --tab-color );
 				border-bottom-style: none;
 			}
 		}
 
 		.wp-block-themeisle-blocks-tabs-item__content {
-			border: var( --borderWidth ) solid var( --borderColor );
+			border: var( --border-width ) solid var( --border-color );
 			width: 100%;
 			padding: 10px;
 			display: none;
 			border-top: 0;
 
 			&.active {
-				background: var( --tabColor );
+				background: var( --tab-color );
 				display: block;
 			}
 

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -312,16 +312,16 @@ export const useCSSNode = options => {
 	 * @example CSS with Media.
 	 * setNodeCSS([
 	 * 			`{
-	 * 				${ attributes.customTitleFontSize && `--titleTextSize: ${ attributes.customTitleFontSize }px;` }
-	 * 				${ attributes.customDescriptionFontSize && `--descriptionTextSize: ${ attributes.customDescriptionFontSize }px;` }
+	 * 				${ attributes.customTitleFontSize && `--title-text-size: ${ attributes.customTitleFontSize }px;` }
+	 * 				${ attributes.customDescriptionFontSize && `--description-text-size: ${ attributes.customDescriptionFontSize }px;` }
 	 * 			}`,
 	 * 			`{
-	 * 				${ attributes.customTitleFontSizeTablet && `--titleTextSize: ${ attributes.customTitleFontSizeTablet }px;` }
-	 * 				${ attributes.customDescriptionFontSizeTablet && `--descriptionTextSize: ${ attributes.customDescriptionFontSizeTablet }px;` }
+	 * 				${ attributes.customTitleFontSizeTablet && `--title-text-size: ${ attributes.customTitleFontSizeTablet }px;` }
+	 * 				${ attributes.customDescriptionFontSizeTablet && `--description-text-size: ${ attributes.customDescriptionFontSizeTablet }px;` }
 	 * 			}`,
 	 * 			`{
-	 * 				${ attributes.customTitleFontSizeMobile && `--titleTextSize: ${ attributes.customTitleFontSizeMobile }px;` }
-	 * 				${ attributes.customDescriptionFontSizeMobile && `--descriptionTextSize: ${ attributes.customDescriptionFontSizeMobile }px;` }
+	 * 				${ attributes.customTitleFontSizeMobile && `--title-text-size: ${ attributes.customTitleFontSizeMobile }px;` }
+	 * 				${ attributes.customDescriptionFontSizeMobile && `--description-text-size: ${ attributes.customDescriptionFontSizeMobile }px;` }
 	 * 			}`
 	 * 		], [
 	 * 			'@media ( min-width: 960px )',

--- a/src/blocks/style.scss
+++ b/src/blocks/style.scss
@@ -14,7 +14,7 @@
             tr {
                 td {
                     &:first-child {
-                        border-left: 1px solid var(--borderColor);
+                        border-left: 1px solid var(--border-color);
                     }
                 }
             }

--- a/src/pro/blocks/woo-comparison/edit.js
+++ b/src/pro/blocks/woo-comparison/edit.js
@@ -56,9 +56,9 @@ const Edit = ({
 		setNodeCSS([
 			`.nv-ct-comparison-table-content {
 				--bgColor: ${ attributes.rowColor };
-				--header-color: ${ attributes.headerColor };
+				--headerColor: ${ attributes.headerColor };
 				--color: ${ attributes.textColor };
-				--border-color: ${ attributes.borderColor };
+				--borderColor: ${ attributes.borderColor };
 				${ Boolean( attributes.altRow ) && `--alternateBg: ${ attributes.altRowColor };` }
 			}`
 		]);

--- a/src/pro/blocks/woo-comparison/edit.js
+++ b/src/pro/blocks/woo-comparison/edit.js
@@ -56,9 +56,9 @@ const Edit = ({
 		setNodeCSS([
 			`.nv-ct-comparison-table-content {
 				--bgColor: ${ attributes.rowColor };
-				--headerColor: ${ attributes.headerColor };
+				--header-color: ${ attributes.headerColor };
 				--color: ${ attributes.textColor };
-				--borderColor: ${ attributes.borderColor };
+				--border-color: ${ attributes.borderColor };
 				${ Boolean( attributes.altRow ) && `--alternateBg: ${ attributes.altRowColor };` }
 			}`
 		]);

--- a/src/pro/blocks/woo-comparison/editor.scss
+++ b/src/pro/blocks/woo-comparison/editor.scss
@@ -1,8 +1,8 @@
 .editor-styles-wrapper {
 	.wp-block-themeisle-blocks-woo-comparison {
-		--border-color: #BDC7CB;
+		--borderColor: #BDC7CB;
 		--color: var(--nv-text-color);
-		--header-color: var(--nv-text-color);
+		--headerColor: var(--nv-text-color);
 		--bgColor: var(--nv-site-bg);
 
 		.nv-ct-2-product {
@@ -36,7 +36,7 @@
 				min-width: 200px;
 				border-style: solid;
 				border-width: 0 1px 1px 0;
-				border-color: var(--border-color);
+				border-color: var(--borderColor);
 
 				@media ( min-width:960px ) {
 					min-width: unset;

--- a/src/pro/blocks/woo-comparison/editor.scss
+++ b/src/pro/blocks/woo-comparison/editor.scss
@@ -1,8 +1,8 @@
 .editor-styles-wrapper {
 	.wp-block-themeisle-blocks-woo-comparison {
-		--borderColor: #BDC7CB;
+		--border-color: #BDC7CB;
 		--color: var(--nv-text-color);
-		--headerColor: var(--nv-text-color);
+		--header-color: var(--nv-text-color);
 		--bgColor: var(--nv-site-bg);
 
 		.nv-ct-2-product {
@@ -36,7 +36,7 @@
 				min-width: 200px;
 				border-style: solid;
 				border-width: 0 1px 1px 0;
-				border-color: var(--borderColor);
+				border-color: var(--border-color);
 
 				@media ( min-width:960px ) {
 					min-width: unset;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #901 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

All CSS vars are now in the snake case.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Insert all the blocks and check if the CSS is working.

#### Query
```javascript
new QueryQA().select('blocks').run()
```

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

