### PR TITLE
Blocks Preview in Inserted

### DIFF
--- a/src/blocks/blocks/accordion/group/index.js
+++ b/src/blocks/blocks/accordion/group/index.js
@@ -26,5 +26,27 @@ registerBlockType( name, {
 		'faq'
 	],
 	edit,
-	save
+	save,
+	example: {
+		attributes: {},
+		innerBlocks: [
+			{
+				name: 'themeisle-blocks/accordion-item',
+				attributes: {
+					initialOpen: true,
+					title: 'Lorem ipsum'
+				},
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: {
+							customFontSize: 48,
+							content: 'Lorem ipsum dolor sit amet, eu liber saperet est. Recusabo volutpat has ne, sed dicit eruditi detraxit ut, modus ancillae mei eu.',
+							align: 'left'
+						}
+					}
+				]
+			}
+		]
+	}
 });

--- a/src/blocks/blocks/advanced-heading/index.js
+++ b/src/blocks/blocks/advanced-heading/index.js
@@ -31,5 +31,10 @@ registerBlockType( name, {
 	deprecated,
 	transforms,
 	edit,
-	save
+	save,
+	example: {
+		attributes: {
+			content: 'Lorem ipsum dolor sit amet, eu liber saperet est.'
+		}
+	}
 });

--- a/src/blocks/blocks/circle-counter/index.js
+++ b/src/blocks/blocks/circle-counter/index.js
@@ -32,5 +32,10 @@ registerBlockType( name, {
 	],
 	transforms,
 	edit,
-	save
+	save,
+	example: {
+		attributes: {
+			title: 'Lorem ipsum'
+		}
+	}
 });

--- a/src/blocks/blocks/countdown/index.js
+++ b/src/blocks/blocks/countdown/index.js
@@ -30,6 +30,11 @@ registerBlockType( name, {
 		'counter'
 	],
 	edit,
-	save
+	save,
+	example: {
+		attributes: {
+			date: '2024-07-15T15:03:00'
+		}
+	}
 });
 

--- a/src/blocks/blocks/form/index.js
+++ b/src/blocks/blocks/form/index.js
@@ -16,6 +16,7 @@ import save from './save.js';
 import './input/index.js';
 import './nonce/index.js';
 import './textarea/index.js';
+import attributes from '../lottie/attributes';
 
 const { name } = metadata;
 
@@ -32,6 +33,40 @@ registerBlockType( name, {
 	edit,
 	save,
 	deprecated,
+	example: {
+		attributes: {},
+		innerBlocks: [
+			{
+				name: 'themeisle-blocks/form-input',
+				attributes: {
+					label: __( 'Name', 'otter-blocks' ),
+					type: 'text',
+					isRequired: true
+				}
+			},
+			{
+				name: 'themeisle-blocks/form-input',
+				attributes: {
+					label: __( 'Email', 'otter-blocks' ),
+					type: 'email',
+					isRequired: true
+				}
+			},
+			{
+				name: 'themeisle-blocks/form-textarea',
+				attributes: {
+					label: __( 'Message', 'otter-blocks' )
+				}
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: __( 'You agree to receive email communication from us by submitting this form and understand that your contact information will be stored with us.', 'otter-blocks' ),
+					fontSize: 'extra-small'
+				}
+			}
+		]
+	},
 	variations: [
 		{
 			name: 'themeisle-blocks/form-contact',

--- a/src/blocks/blocks/leaflet-map/index.js
+++ b/src/blocks/blocks/leaflet-map/index.js
@@ -27,5 +27,8 @@ registerBlockType( name, {
 	],
 	transforms,
 	edit,
-	save: () => null
+	save: () => null,
+	example: {
+		attributes: {}
+	}
 });

--- a/src/blocks/blocks/posts/index.js
+++ b/src/blocks/blocks/posts/index.js
@@ -27,5 +27,8 @@ registerBlockType( name, {
 	],
 	deprecated,
 	edit,
-	save: () => null
+	save: () => null,
+	example: {
+		attributes: {}
+	}
 });

--- a/src/blocks/blocks/progress-bar/index.js
+++ b/src/blocks/blocks/progress-bar/index.js
@@ -27,5 +27,6 @@ registerBlockType( name, {
 	],
 	transforms,
 	edit,
-	save
+	save,
+	example: {}
 });

--- a/src/blocks/blocks/review/index.js
+++ b/src/blocks/blocks/review/index.js
@@ -41,5 +41,8 @@ registerBlockType( name, {
 		}
 	],
 	edit,
-	save: () => null
+	save: () => null,
+	example: {
+		attributes: {}
+	}
 });


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #811.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add preview for the blocks.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Open the block inserter and hover around the blocks to check their preview.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

