### PR TITLE
[WIP] Code checking for Custom CSS Editor

### DIFF
--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -44,6 +44,7 @@ const CSSEditor = ({
 			gutters: [ 'CodeMirror-lint-markers' ],
 			styleActiveLine: true,
 			styleActiveSelected: true,
+			mode: 'css',
 			extraKeys: {
 				'Ctrl-Space': 'autocomplete',
 				'Alt-F': 'findPersistent',

--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -55,6 +55,11 @@ const CSSEditor = ({
 		editorRef.current.on( 'change', () => {
 			const regex = new RegExp( 'selector', 'g' );
 			const generatedCSS = editorRef.current.getValue().replace( regex, `.${ classArRef.current }` );
+
+			if ( 0 < editor?.lint?.marked?.length ) {
+				return ;
+			}
+
 			customCSSRef.current = generatedCSS;
 
 			if ( ( 'selector {\n}\n' ).replace( /\s+/g, '' ) === customCSSRef.current.replace( /\s+/g, '' ) ) {

--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -4,13 +4,17 @@
 import { __ } from '@wordpress/i18n';
 
 import {
+	Button,
+	Notice
+} from '@wordpress/components';
+
+import {
 	Fragment,
 	useEffect,
 	useRef,
 	memo,
 	useState
 } from '@wordpress/element';
-import { Button } from '@wordpress/components';
 
 let inputTimeout = null;
 
@@ -79,7 +83,6 @@ const CSSEditor = ({
 		editorRef.current.on( 'change', () => {
 			clearTimeout( inputTimeout );
 			inputTimeout = setTimeout( () => {
-				console.count( 'timeout' ); // Remove after final review
 				checkInput( editorRef.current );
 			}, 500 );
 		});
@@ -107,36 +110,42 @@ const CSSEditor = ({
 		});
 	}, [ attributes ]);
 
-
 	return (
 		<Fragment>
 			<p>{__( 'Add your custom CSS.', 'otter-blocks' )}</p>
 
 			<div id="otter-css-editor" className="otter-css-editor" />
 
-			{
-				0 < errors?.length && (
-					<div className='o-css-errors'>
-						<p>{__( 'Attention needed! There are some errors: ', 'otter-blocks' )}</p>
-						<ul style={{ marginTop: '0px' }}>
+			{ 0 < errors?.length && (
+				<div className='o-css-errors'>
+					<Notice
+						status="error"
+						isDismissible={ false }
+					>
+						{ __( 'Attention needed! We found following errors with your code:', 'otter-blocks' ) }
+					</Notice>
+
+					<pre>
+						<ul>
 							{
 								errors.map( ( e, i ) => {
 									return (
-										<li key={i} style={{ color: 'red' }}> {e} </li>
+										<li key={ i } >{ e }</li>
 									);
 								})
 							}
 						</ul>
-						<Button
-							variant='primary'
-							onClick={() => checkInput( editorRef, true )}
-							style={{ width: 'max-content', marginBottom: '20px'}}
-						>
-							{__( 'Apply CSS', 'otter-blocks' )}
-						</Button>
-					</div>
-				)
-			}
+					</pre>
+
+					<Button
+						variant='secondary'
+						onClick={() => checkInput( editorRef, true )}
+						style={{ width: 'max-content', marginBottom: '20px'}}
+					>
+						{ __( 'Override', 'otter-blocks' ) }
+					</Button>
+				</div>
+			) }
 
 			<p>{__( 'Use', 'otter-blocks' )} <code>selector</code> {__( 'to target block wrapper.', 'otter-blocks' )}</p>
 			<br />

--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -76,9 +76,8 @@ const CSSEditor = ({
 			}
 		});
 
-		editorRef.current.on( 'changes', ( editor ) => {
+		editorRef.current.on( 'change', () => {
 			clearTimeout( inputTimeout );
-			checkInput( editor );
 			inputTimeout = setTimeout( () => {
 				console.count( 'timeout' ); // Remove after final review
 				checkInput( editorRef.current );
@@ -96,8 +95,9 @@ const CSSEditor = ({
 			setAttributes({ customCSS: null });
 			return;
 		}
-
-		setAttributes({ customCSS });
+		if ( customCSS ) {
+			setAttributes({ customCSS });
+		}
 	}, [ customCSS ]);
 
 	useEffect( () => {

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -11,7 +11,21 @@
 .o-css-errors {
 	display: flex;
 	flex-direction: column;
+
 	.span {
 		font-family: 'Courier New', Courier, monospace;
+	}
+
+	.components-notice {
+		&.is-error {
+			margin: 0;
+		}
+	}
+
+	pre {
+		overflow-x: scroll;
+		background: #f7f7f7;
+		border: 1px solid #e2e4e7;
+		padding: 5px;
 	}
 }

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -7,3 +7,11 @@
 	background: #f7f7f7;
 	padding: 20px;
 }
+
+.o-css-errors {
+	display: flex;
+	flex-direction: column;
+	.span {
+		font-family: 'Courier New', Courier, monospace;
+	}
+}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1007.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add mechanism for detecting wrong CSS code.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

