### PR TITLE
Remove Height automatic change on Circle Counter

### DIFF
--- a/src/blocks/blocks/circle-counter/edit.js
+++ b/src/blocks/blocks/circle-counter/edit.js
@@ -115,16 +115,6 @@ const CircularProgressBarBlock = ({
 		};
 	}, [ attributes.percentage, attributes.height ]);
 
-	const onHeightChange = value => {
-		const innerTextFontSizeRatio = ( attributes.fontSizePercent || 27 ) / attributes.height;
-		const titleFontSizeRatio = ( attributes.fontSizeTitle || 37 ) / attributes.height;
-
-		setAttributes({
-			height: value,
-			fontSizePercent: Math.round( value * innerTextFontSizeRatio ),
-			fontSizeTitle: Math.round( value * titleFontSizeRatio )
-		});
-	};
 
 	const onTitleChange = value => {
 		setAttributes({ title: value });
@@ -145,7 +135,6 @@ const CircularProgressBarBlock = ({
 			<Inspector
 				attributes={ attributes }
 				setAttributes={ setAttributes }
-				onHeightChange={ onHeightChange }
 			/>
 
 			<div { ...blockProps }>
@@ -157,7 +146,7 @@ const CircularProgressBarBlock = ({
 							className="wp-block-themeisle-blocks-circle-counter-title__value"
 							placeholder={ isSelected ? __( 'Write caption…', 'otter-blocks' ) : null }
 							value={ attributes.title }
-							onChange={ onTitleChange }
+							onChange={ title => setAttributes({ title }) }
 							multiline={ false }
 							style={ {
 								color: attributes.titleColor
@@ -181,7 +170,7 @@ const CircularProgressBarBlock = ({
 					} }
 					showHandle={ isSelected }
 					onResizeStop={ ( event, direction, elt, delta ) => {
-						onHeightChange( parseInt( attributes.height + delta.height, 10 ) );
+						setAttributes({height: parseInt( attributes.height + delta.height, 10 )});
 						toggleSelection( true );
 					} }
 					onResizeStart={ () => {
@@ -203,7 +192,7 @@ const CircularProgressBarBlock = ({
 							className="wp-block-themeisle-blocks-circle-counter-title__value"
 							placeholder={ isSelected ? __( 'Write caption…', 'otter-blocks' ) : null }
 							value={ attributes.title }
-							onChange={ onTitleChange }
+							onChange={ title => setAttributes({ title }) }
 							multiline={ false }
 							style={ {
 								color: attributes.titleColor

--- a/src/blocks/blocks/circle-counter/inspector.js
+++ b/src/blocks/blocks/circle-counter/inspector.js
@@ -23,8 +23,7 @@ import {
  */
 const Inspector = ({
 	attributes,
-	setAttributes,
-	onHeightChange
+	setAttributes
 }) => {
 	const onPercentageChange = value => {
 		if ( value === undefined ) {
@@ -34,22 +33,6 @@ const Inspector = ({
 		setAttributes({ percentage: value });
 	};
 
-	const selectTitleStyle = value => {
-		setAttributes({ titleStyle: value });
-	};
-
-	const onStrokeWidthChange = value => {
-		setAttributes({ strokeWidth: value });
-	};
-
-	const onBackgroundColorChange = value => {
-		setAttributes({ backgroundColor: value });
-	};
-
-	const onProgressColorChange = value => {
-		setAttributes({ progressColor: value });
-	};
-
 	const onDurationChange = value => {
 		if ( value === undefined ) {
 			return;
@@ -57,18 +40,6 @@ const Inspector = ({
 
 		value = clamp( value, 0, 3 );
 		setAttributes({ duration: value });
-	};
-
-	const onTitleColorChange = value => {
-		setAttributes({ titleColor: value });
-	};
-
-	const onFontSizePercentChange = value => {
-		setAttributes({ fontSizePercent: value });
-	};
-
-	const onFontSizeTitleChange = value => {
-		setAttributes({ fontSizeTitle: value });
 	};
 
 	return (
@@ -102,7 +73,7 @@ const Inspector = ({
 						{ label: __( 'Hide', 'otter-blocks' ), value: 'hide' },
 						{ label: __( 'Bottom', 'otter-blocks' ), value: 'bottom' }
 					] }
-					onChange={ selectTitleStyle }
+					onChange={ titleStyle => setAttributes({ titleStyle }) }
 				/>
 			</PanelBody>
 
@@ -113,7 +84,7 @@ const Inspector = ({
 					label={ __( 'Height', 'otter-blocks' ) }
 					help={ __( 'The height of the circle counter.', 'otter-blocks' ) }
 					value={ attributes.height }
-					onChange={ onHeightChange }
+					onChange={ height => setAttributes({ height }) }
 					min={ 0 }
 					max={ 240 }
 				/>
@@ -122,7 +93,7 @@ const Inspector = ({
 					label={ __( 'Circle Thickness', 'otter-blocks' ) }
 					help={ __( 'Change the thickness (stroke width) of the circle.', 'otter-blocks' ) }
 					value={ attributes.strokeWidth }
-					onChange={ onStrokeWidthChange }
+					onChange={ strokeWidth => setAttributes({ strokeWidth }) }
 					initialPosition={ 10 }
 					min={ 0 }
 					max={ 20 }
@@ -132,40 +103,40 @@ const Inspector = ({
 					label={ __( 'Font Size Title', 'otter-blocks' ) }
 					help={ __( 'Change the font size of the title.', 'otter-blocks' ) }
 					value={ attributes.fontSizeTitle }
-					onChange={ onFontSizeTitleChange }
+					onChange={ fontSizeTitle => setAttributes({ fontSizeTitle}) }
 					initialPosition={ 37 }
 					min={ 0 }
-					max={ Math.round( attributes.height * 0.60 ) }
+					max={ 100 }
 				/>
 
 				<RangeControl
 					label={ __( 'Font Size Percent', 'otter-blocks' ) }
 					help={ __( 'Change the font size of the inner text.', 'otter-blocks' ) }
 					value={ attributes.fontSizePercent }
-					onChange={ onFontSizePercentChange }
+					onChange={ fontSizePercent => setAttributes({ fontSizePercent }) }
 					initialPosition={ 27 }
 					min={ 0 }
-					max={ Math.round( attributes.height * 0.27 ) }
+					max={ 80 }
 				/>
 
 				{ ( 'hide' !== attributes.titleStyle ) && (
 					<ColorGradientControl
 						label={ __( 'Title Color', 'otter-blocks' ) }
 						colorValue={ attributes.titleColor }
-						onColorChange={ onTitleColorChange }
+						onColorChange={ titleColor => setAttributes({ titleColor }) }
 					/>
 				) }
 
 				<ColorGradientControl
 					label={ __( 'Progress Color', 'otter-blocks' ) }
 					colorValue={ attributes.progressColor }
-					onColorChange={ onProgressColorChange }
+					onColorChange={ progressColor => setAttributes({ progressColor }) }
 				/>
 
 				<ColorGradientControl
 					label={ __( 'Background Color', 'otter-blocks' ) }
 					colorValue={ attributes.backgroundColor }
-					onColorChange={ onBackgroundColorChange }
+					onColorChange={ backgroundColor => setAttributes({ backgroundColor }) }
 				/>
 			</PanelBody>
 		</InspectorControls>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1051.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Remove automatic height adjustement that cause the font size to take huge values when the user break the Range component for height.

Code clean-up.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert A Circle Counter block.
2. Play with the Height option and see if the font-size breaks.

Video from the issue: https://www.loom.com/share/dc14e467f1fc4eb0a5b6fb8d92e666b4

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

