### PR TITLE
Add Logged-in user meta condition to Block Conditions module

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -155,7 +155,7 @@ class Block_Conditions {
 	/**
 	 * Check meta compare.
 	 *
-	 * @param array $condition Condition.
+	 * @param array  $condition Condition.
 	 * @param string $type If it's a post or the user.
 	 *
 	 * @since  1.7.0

--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -156,6 +156,7 @@ class Block_Conditions {
 	 * Check meta compare.
 	 *
 	 * @param array $condition Condition.
+	 * @param string $type If it's a post or the user.
 	 *
 	 * @since  1.7.0
 	 * @access public

--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -41,12 +41,22 @@ class Block_Conditions {
 	 * @return bool
 	 */
 	public function evaluate_condition( $bool, $condition, $visibility ) {
+		if ( 'loggedInUserMeta' === $condition['type'] ) {
+			if ( isset( $condition['meta_key'] ) ) {
+				if ( $visibility ) {
+					return $this->has_meta( $condition, 'user' );
+				} else {
+					return ! $this->has_meta( $condition, 'user' );
+				}
+			}
+		}
+
 		if ( 'postMeta' === $condition['type'] ) {
 			if ( isset( $condition['meta_key'] ) ) {
 				if ( $visibility ) {
-					return $this->has_meta( $condition );
+					return $this->has_meta( $condition, 'post' );
 				} else {
-					return ! $this->has_meta( $condition );
+					return ! $this->has_meta( $condition, 'post' );
 				}
 			}
 		}
@@ -150,13 +160,23 @@ class Block_Conditions {
 	 * @since  1.7.0
 	 * @access public
 	 */
-	public function has_meta( $condition ) {
+	public function has_meta( $condition, $type = 'post' ) {
 		if ( ! isset( $condition['meta_key'] ) || ! isset( $condition['meta_compare'] ) ) {
 			return true;
 		}
 
-		$id   = get_the_ID();
-		$meta = get_post_meta( $id, $condition['meta_key'], true );
+		$id   = '';
+		$meta = '';
+
+		if ( 'post' === $type ) {
+			$id   = get_the_ID();
+			$meta = get_post_meta( $id, $condition['meta_key'], true );
+		}
+
+		if ( 'user' === $type ) {
+			$id   = get_current_user_id();
+			$meta = get_user_meta( $id, $condition['meta_key'], true );
+		}
 
 		if ( 'is_true' === $condition['meta_compare'] ) {
 			return true === boolval( $meta );

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -57,6 +57,12 @@ const defaultConditions = {
 				label: __( 'User Roles', 'otter-blocks' ),
 				help: __( 'The selected block will be visible based on user roles.' ),
 				toogleVisibility: true
+			},
+			{
+				value: 'loggedInUserMeta',
+				label: __( 'Logged-in User Meta (Pro)', 'otter-blocks' ),
+				help: __( 'The selected block will be visible based on meta of the logged-in user condition.' ),
+				isDisabled: true
 			}
 		]
 	},

--- a/src/pro/plugins/conditions/edit.js
+++ b/src/pro/plugins/conditions/edit.js
@@ -394,7 +394,7 @@ const Edit = ({
 
 	return (
 		<Fragment>
-			{ 'postMeta' === item.type && (
+			{ [ 'postMeta', 'loggedInUserMeta' ].includes( item.type ) && (
 				<Fragment>
 					<TextControl
 						label={ __( 'Meta Key', 'otter-blocks' ) }

--- a/src/pro/plugins/conditions/index.js
+++ b/src/pro/plugins/conditions/index.js
@@ -19,6 +19,17 @@ const { Notice } = window.otterComponents;
 
 const applyProConditions = conditions => {
 	const proConditions = {
+		'users': {
+			label: __( 'Users', 'otter-blocks' ),
+			conditions: [
+				{
+					value: 'loggedInUserMeta',
+					label: __( 'Logged-in User Meta', 'otter-blocks' ),
+					help: __( 'The selected block will be visible based on meta of the logged-in user condition.' ),
+					toogleVisibility: true
+				}
+			]
+		},
 		'posts': {
 			label: __( 'Posts', 'otter-blocks' ),
 			conditions: [


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1020.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This adds a new condition to the module which enables you to display blocks based on the logged-in user's meta value.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check if different conditions of the meta work and how they react if the user is not logged-in.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

