### PR TITLE
Make EsLint consistent.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,16 @@
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        "prefer-destructuring": ["warn", {
+            "array": true,
+            "object": true
+          }, {
+            "enforceForRenamedProperties": false
+          }
+        ],
+        "array-bracket-spacing": ["warn", "always", { "arraysInArrays": false, "objectsInArrays": false }],
+        "key-spacing": ["warn", { "beforeColon": false, "afterColon": true }],
+        "object-curly-spacing": ["warn", "always", { "arraysInObjects": true, "objectsInObjects": false }],
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,43 +1,66 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": "wordpress",
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": 2021,
-        "sourceType": "module"
-    },
-    "ignorePatterns": [ "node_modules", "assets", "**/*.d.ts" ],
-    "rules": {
-        "indent": [
-            "error",
-            "tab"
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
-        "prefer-destructuring": ["warn", {
-            "array": true,
-            "object": true
-          }, {
-            "enforceForRenamedProperties": false
-          }
-        ],
-        "array-bracket-spacing": ["warn", "always", { "arraysInArrays": false, "objectsInArrays": false }],
-        "key-spacing": ["warn", { "beforeColon": false, "afterColon": true }],
-        "object-curly-spacing": ["warn", "always", { "arraysInObjects": true, "objectsInObjects": false }],
-    }
+	"env": {
+		"browser": true,
+		"es2021": true
+	},
+	"extends": "wordpress",
+	"parserOptions": {
+		"ecmaFeatures": {
+			"jsx": true
+		},
+		"ecmaVersion": 2021,
+		"sourceType": "module"
+	},
+	"ignorePatterns": [ "node_modules", "assets", "**/*.d.ts" ],
+	"rules": {
+		"indent": [
+			"error",
+			"tab"
+		],
+		"linebreak-style": [
+			"error",
+			"unix"
+		],
+		"quotes": [
+			"error",
+			"single"
+		],
+		"semi": [
+			"error",
+			"always"
+		],
+		"prefer-destructuring": [
+			"warn",
+			{
+				"array": false,
+				"object": true
+			},
+			{
+				"enforceForRenamedProperties": false
+			}
+		],
+		"array-bracket-spacing": [
+			"warn",
+			"always",
+			{
+				"arraysInArrays": false,
+				"objectsInArrays": false
+			}
+		],
+		"key-spacing": [
+			"warn",
+			{
+				"beforeColon": false,
+				"afterColon": true
+			}
+		],
+		"object-curly-spacing": [
+			"warn",
+			"always",
+			{
+				"arraysInObjects": true,
+				"objectsInObjects": false
+			}
+		],
+	}
 }

--- a/src/animation/editor.js
+++ b/src/animation/editor.js
@@ -111,7 +111,7 @@ function AnimationControls({
 			hasTypingFormat = block.formats.some( format => true === format.some( format => 'themeisle-blocks/typing-animation' === format.type ) );
 		}
 
-		return { hasCountFormat, hasTypingFormat};
+		return { hasCountFormat, hasTypingFormat };
 	}, []);
 
 	const [ animation, setAnimation ] = useState( 'none' );

--- a/src/blocks/blocks/accordion/group/edit.js
+++ b/src/blocks/blocks/accordion/group/edit.js
@@ -73,7 +73,7 @@ const Edit = ({
 			<div { ...blockProps }>
 				<InnerBlocks
 					allowedBlocks={ [ 'themeisle-blocks/accordion-item' ] }
-					template={ [ [ 'themeisle-blocks/accordion-item' ] ] }
+					template={ [[ 'themeisle-blocks/accordion-item' ]] }
 					renderAppender={ isSelected ? InnerBlocks.ButtonBlockAppender : '' }
 				/>
 			</div>

--- a/src/blocks/blocks/accordion/item/edit.js
+++ b/src/blocks/blocks/accordion/item/edit.js
@@ -76,7 +76,7 @@ const Edit = ({
 				{ isOpen && (
 					<div className="wp-block-themeisle-blocks-accordion-item__content">
 						<InnerBlocks
-							template={ [ [ 'core/paragraph' ] ] }
+							template={ [[ 'core/paragraph' ]] }
 						/>
 					</div>
 				) }

--- a/src/blocks/blocks/advanced-heading/deprecated.js
+++ b/src/blocks/blocks/advanced-heading/deprecated.js
@@ -9,7 +9,7 @@ import hexToRgba from 'hex-rgba';
  */
 import { RichText } from '@wordpress/block-editor';
 
-const deprecated = [ {
+const deprecated = [{
 	attributes: {
 		id: {
 			type: 'string'
@@ -254,6 +254,6 @@ const deprecated = [ {
 			/>
 		);
 	}
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/advanced-heading/edit.js
+++ b/src/blocks/blocks/advanced-heading/edit.js
@@ -181,10 +181,10 @@ const Edit = ({
 			</style>
 
 			{ attributes.fontFamily && (
-				<GoogleFontLoader fonts={ [ {
+				<GoogleFontLoader fonts={ [{
 					font: attributes.fontFamily,
 					weights: attributes.fontVariant && [ `${ attributes.fontVariant + ( 'italic' === attributes.fontStyle ? ':i' : '' ) }` ]
-				} ] } />
+				}] } />
 			) }
 
 			<Controls

--- a/src/blocks/blocks/button-group/group/deprecated.js
+++ b/src/blocks/blocks/button-group/group/deprecated.js
@@ -126,7 +126,7 @@ const attributes = {
 	}
 };
 
-const deprecated = [ {
+const deprecated = [{
 	attributes,
 
 	save: ({
@@ -485,6 +485,6 @@ const deprecated = [ {
 			</div>
 		);
 	}
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/button-group/group/edit.js
+++ b/src/blocks/blocks/button-group/group/edit.js
@@ -117,10 +117,10 @@ const Edit = ({
 	return (
 		<Fragment>
 			{ attributes.fontFamily && (
-				<GoogleFontLoader fonts={ [ {
+				<GoogleFontLoader fonts={ [{
 					font: attributes.fontFamily,
 					weights: attributes.fontVariant && [ `${ attributes.fontVariant + ( 'italic' === attributes.fontStyle ? ':i' : '' ) }` ]
-				} ] } />
+				}] } />
 			) }
 
 			<Inspector
@@ -134,7 +134,7 @@ const Edit = ({
 					allowedBlocks={ [ 'themeisle-blocks/button' ] }
 					__experimentalMoverDirection="horizontal"
 					orientation="horizontal"
-					template={ [ [ 'themeisle-blocks/button' ] ] }
+					template={ [[ 'themeisle-blocks/button' ]] }
 					renderAppender={ InnerBlocks.DefaultAppender }
 				/>
 			</div>

--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -73,37 +73,37 @@ const Inspector = ({
 
 	const onGapChange = value => {
 		if ( 'Desktop' === getView ) {
-			setAttributes({ gap: Number( value )});
+			setAttributes({ gap: Number( value ) });
 		}
 		if ( 'Tablet' === getView ) {
-			setAttributes({ gapTablet: Number( value )});
+			setAttributes({ gapTablet: Number( value ) });
 		}
 		if ( 'Mobile' === getView ) {
-			setAttributes({ gapMobile: Number( value )});
+			setAttributes({ gapMobile: Number( value ) });
 		}
 	};
 
 	const onWidthChange = value => {
 		if ( 'Desktop' === getView ) {
-			setAttributes({ width: Number( value )});
+			setAttributes({ width: Number( value ) });
 		}
 		if ( 'Tablet' === getView ) {
-			setAttributes({ widthTablet: Number( value )});
+			setAttributes({ widthTablet: Number( value ) });
 		}
 		if ( 'Mobile' === getView ) {
-			setAttributes({ widthMobile: Number( value )});
+			setAttributes({ widthMobile: Number( value ) });
 		}
 	};
 
 	const onHeightChange = value => {
 		if ( 'Desktop' === getView ) {
-			setAttributes({ height: Number( value )});
+			setAttributes({ height: Number( value ) });
 		}
 		if ( 'Tablet' === getView ) {
-			setAttributes({ heightTablet: Number( value )});
+			setAttributes({ heightTablet: Number( value ) });
 		}
 		if ( 'Mobile' === getView ) {
-			setAttributes({ heightMobile: Number( value )});
+			setAttributes({ heightMobile: Number( value ) });
 		}
 	};
 
@@ -112,10 +112,10 @@ const Inspector = ({
 			setAttributes({ valueFontSize: Number( value ) });
 		}
 		if ( 'Tablet' === getView ) {
-			setAttributes({ valueFontSizeTablet: Number( value )});
+			setAttributes({ valueFontSizeTablet: Number( value ) });
 		}
 		if ( 'Mobile' === getView ) {
-			setAttributes({ valueFontSizeMobile: Number( value )});
+			setAttributes({ valueFontSizeMobile: Number( value ) });
 		}
 	};
 
@@ -124,10 +124,10 @@ const Inspector = ({
 			setAttributes({ labelFontSize: Number( value ) });
 		}
 		if ( 'Tablet' === getView ) {
-			setAttributes({ labelFontSizeTablet: Number( value )});
+			setAttributes({ labelFontSizeTablet: Number( value ) });
 		}
 		if ( 'Mobile' === getView ) {
-			setAttributes({ labelFontSizeMobile: Number( value )});
+			setAttributes({ labelFontSizeMobile: Number( value ) });
 		}
 	};
 
@@ -136,10 +136,10 @@ const Inspector = ({
 			setAttributes({ borderWidth: Number( value ) });
 		}
 		if ( 'Tablet' === getView ) {
-			setAttributes({ borderWidthTablet: Number( value )});
+			setAttributes({ borderWidthTablet: Number( value ) });
 		}
 		if ( 'Mobile' === getView ) {
-			setAttributes({ borderWidthMobile: Number( value )});
+			setAttributes({ borderWidthMobile: Number( value ) });
 		}
 	};
 

--- a/src/blocks/blocks/font-awesome-icons/deprecated.js
+++ b/src/blocks/blocks/font-awesome-icons/deprecated.js
@@ -1,5 +1,5 @@
 import themeIsleIcons from '../../helpers/themeisle-icons';
-import {useBlockProps} from '@wordpress/block-editor';
+import { useBlockProps } from '@wordpress/block-editor';
 
 
 const attributes = {
@@ -347,6 +347,6 @@ const deprecated = [
 				</p>
 			);
 		}
-	} ];
+	}];
 
 export default deprecated;

--- a/src/blocks/blocks/form/deprecated.js
+++ b/src/blocks/blocks/form/deprecated.js
@@ -13,7 +13,7 @@ import {
 	useBlockProps
 } from '@wordpress/block-editor';
 
-const deprecated = [ {
+const deprecated = [{
 	attributes: {
 		id: {
 			type: 'string'
@@ -80,6 +80,6 @@ const deprecated = [ {
 			</div>
 		);
 	}
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -97,12 +97,12 @@ const Edit = ({
 	});
 
 	const setFormOption = option => {
-		setFormOptions( options => ({...options, ...option}) );
+		setFormOptions( options => ({ ...options, ...option }) );
 	};
 
 	const [ savedFormOptions, setSavedFormOptions ] = useState( true );
 
-	const [ listIDOptions, setListIDOptions ] = useState([ { label: __( 'None', 'otter-blocks' ), value: '' } ]);
+	const [ listIDOptions, setListIDOptions ] = useState([{ label: __( 'None', 'otter-blocks' ), value: '' }]);
 
 	const {
 		insertBlock,
@@ -217,13 +217,13 @@ const Edit = ({
 	useEffect( () => {
 		let controller = new AbortController();
 		const t = setTimeout( () => {
-			setLoading({formOptions: 'done', formIntegration: 'done'});
+			setLoading({ formOptions: 'done', formIntegration: 'done' });
 		}, 3000 );
 
 
 		if ( attributes.optionName ) {
 			api.loadPromise.then( () => {
-				setLoading({ formOptions: 'loading', formIntegration: 'loading'});
+				setLoading({ formOptions: 'loading', formIntegration: 'loading' });
 				( new api.models.Settings() ).fetch({ signal: controller.signal }).done( res => {
 					controller = null;
 					const formData = extractDataFromWpOptions( res.themeisle_blocks_form_emails );
@@ -639,15 +639,15 @@ const Edit = ({
 	useEffect( () => {
 		let controller = new AbortController();
 		const getCaptchaAPIData = () => {
-			setLoading({ captcha: 'loading'});
+			setLoading({ captcha: 'loading' });
 			try {
 				( new api.models.Settings() )?.fetch({ signal: controller.signal }).then( response => {
 					controller = null;
 
 					if ( '' !== response.themeisle_google_captcha_api_site_key && '' !== response.themeisle_google_captcha_api_secret_key ) {
-						setLoading({ captcha: 'done'});
+						setLoading({ captcha: 'done' });
 					} else {
-						setLoading({ captcha: 'missing'});
+						setLoading({ captcha: 'missing' });
 						setGoogleCaptchaAPISiteKey( response.themeisle_google_captcha_api_site_key );
 						setGoogleCaptchaAPISecretKey( response.themeisle_google_captcha_api_secret_key );
 					}

--- a/src/blocks/blocks/form/input/deprecated.js
+++ b/src/blocks/blocks/form/input/deprecated.js
@@ -8,7 +8,7 @@ import {
 	RichText
 } from '@wordpress/block-editor';
 
-const deprecated = [ {
+const deprecated = [{
 	attributes: {
 		id: {
 			type: 'string'
@@ -68,6 +68,6 @@ const deprecated = [ {
 			</div>
 		);
 	}
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -255,7 +255,7 @@ const Inspector = ({
 				>
 					<BoxControl
 						label={ __( 'Input Padding', 'otter-blocks' ) }
-						values={ attributes.inputPadding ?? {'top': '8px', 'right': '8px', 'bottom': '8px', 'left': '8px'} }
+						values={ attributes.inputPadding ?? { 'top': '8px', 'right': '8px', 'bottom': '8px', 'left': '8px' } }
 						inputProps={ {
 							min: 0,
 							max: 500
@@ -356,7 +356,7 @@ const Inspector = ({
 							value: 'full'
 						}
 					]}
-					onChange={ submitStyle => setAttributes({ submitStyle}) }
+					onChange={ submitStyle => setAttributes({ submitStyle }) }
 				/>
 
 				<SyncControl
@@ -409,7 +409,7 @@ const Inspector = ({
 					placeholder={ __( 'Default is to admin site', 'otter-blocks' ) }
 					type="email"
 					value={ formOptions.emailTo }
-					onChange={ emailTo => setFormOption({emailTo}) }
+					onChange={ emailTo => setFormOption({ emailTo }) }
 					help={ __( 'Send the form\'s data to another email. (Admin\'s email is default).', 'otter-blocks' ) }
 				/>
 
@@ -418,7 +418,7 @@ const Inspector = ({
 					placeholder={ __( 'Send copies to', 'otter-blocks' ) }
 					type="text"
 					value={ formOptions.cc }
-					onChange={ cc => setFormOption({cc}) }
+					onChange={ cc => setFormOption({ cc }) }
 					help={ __( 'Add emails separated by commas: example1@otter.com, example2@otter.com.', 'otter-blocks' ) }
 				/>
 
@@ -427,7 +427,7 @@ const Inspector = ({
 					placeholder={ __( 'Send copies to', 'otter-blocks' ) }
 					type="text"
 					value={ formOptions.bcc }
-					onChange={ bcc => setFormOption({bcc}) }
+					onChange={ bcc => setFormOption({ bcc }) }
 					help={ __( 'Add emails separated by commas: example1@otter.com, example2@otter.com.', 'otter-blocks' ) }
 				/>
 
@@ -444,7 +444,7 @@ const Inspector = ({
 					type="url"
 					placeholder={ __( 'https://example.com', 'otter-blocks' ) }
 					value={ formOptions.redirectLink }
-					onChange={ redirectLink => setFormOption({redirectLink})  }
+					onChange={ redirectLink => setFormOption({ redirectLink })  }
 					help={ __( 'Redirect the user to another page when submit is successful.', 'otter-blocks' ) }
 				/>
 
@@ -503,7 +503,7 @@ const Inspector = ({
 				<Button
 					variant="primary"
 					isPrimary
-					style={{ marginTop: '8px'}}
+					style={{ marginTop: '8px' }}
 					onClick={ sendTestEmail }
 				>
 					{ __( 'Send Test Email', 'otter-blocks' )  }
@@ -580,7 +580,7 @@ const Inspector = ({
 										'mailchimp' === formOptions?.provider && (
 											<ExternalLink
 												href="https://us5.admin.mailchimp.com/account/api/"
-												style={{ marginBottom: '10px', display: 'block'}}
+												style={{ marginBottom: '10px', display: 'block' }}
 												target="_blank"
 											>
 												{ __( 'Guide to generate the API Key.', 'otter-blocks' ) }
@@ -591,7 +591,7 @@ const Inspector = ({
 										'sendinblue' === formOptions?.provider && (
 											<ExternalLink
 												href="https://help.sendinblue.com/hc/en-us/articles/209467485-What-s-an-API-key-and-how-can-I-get-mine-"
-												style={{ marginBottom: '10px', display: 'block'}}
+												style={{ marginBottom: '10px', display: 'block' }}
 												target="_blank"
 											>
 												{ __( 'Guide to generate the API Key.', 'otter-blocks' ) }
@@ -629,7 +629,7 @@ const Inspector = ({
 
 									<ExternalLink
 										target="_blank"
-										style={{ marginBottom: '10px', display: 'block'}}
+										style={{ marginBottom: '10px', display: 'block' }}
 										href={ 'sendinblue' === formOptions.provider ? 'https://account.sendinblue.com/advanced/api' : 'https://us5.admin.mailchimp.com/account/api/' }
 									>
 										{ __( 'Go to Dashboard.', 'otter-blocks' ) }

--- a/src/blocks/blocks/form/textarea/deprecated.js
+++ b/src/blocks/blocks/form/textarea/deprecated.js
@@ -8,7 +8,7 @@ import {
 	RichText
 } from '@wordpress/block-editor';
 
-const deprecated = [ {
+const deprecated = [{
 	attributes: {
 		id: {
 			type: 'string'
@@ -69,6 +69,6 @@ const deprecated = [ {
 			</div>
 		);
 	}
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/google-map/edit.js
+++ b/src/blocks/blocks/google-map/edit.js
@@ -305,8 +305,8 @@ const Edit = ({
 
 	const cycleMarkers = markers => {
 		markers.forEach( marker => {
-			const latitude = marker.latitude;
-			const longitude = marker.longitude;
+			const { latitude } = marker;
+			const { longitude } = marker;
 			const position = new window.google.maps.LatLng( latitude, longitude );
 
 			const mark = new window.google.maps.Marker({

--- a/src/blocks/blocks/google-map/inspector.js
+++ b/src/blocks/blocks/google-map/inspector.js
@@ -77,14 +77,14 @@ const Inspector = ({
 	const changeLatitude = value => {
 		setAttributes({ latitude: value.toString() });
 		const latitude = Number( value );
-		const longitude = attributes.longitude;
+		const { longitude } = attributes;
 		const latLng = new window.google.maps.LatLng( latitude, longitude );
 		map.setCenter( latLng );
 	};
 
 	const changeLongitude = value => {
 		setAttributes({ longitude: value.toString() });
-		const latitude = attributes.latitude;
+		const { latitude } = attributes;
 		const longitude = Number( value );
 		const latLng = new window.google.maps.LatLng( latitude, longitude );
 		map.setCenter( latLng );

--- a/src/blocks/blocks/icon-list/edit.js
+++ b/src/blocks/blocks/icon-list/edit.js
@@ -64,7 +64,7 @@ const Edit = ({
 					allowedBlocks={ [ 'themeisle-blocks/icon-list-item' ] }
 					__experimentalMoverDirection="vertical"
 					orientation="vertical"
-					template={ [ [ 'themeisle-blocks/icon-list-item' ] ] }
+					template={ [[ 'themeisle-blocks/icon-list-item' ]] }
 					renderAppender={ InnerBlocks.DefaultAppender }
 				/>
 			</div>

--- a/src/blocks/blocks/leaflet-map/edit.js
+++ b/src/blocks/blocks/leaflet-map/edit.js
@@ -175,7 +175,7 @@ const Edit = ({
 			return;
 		}
 
-		let L = window.L;
+		let { L } = window;
 
 		const iframe = getEditorIframe();
 		if ( Boolean( iframe ) ) {

--- a/src/blocks/blocks/lottie/components/lottie-player.js
+++ b/src/blocks/blocks/lottie/components/lottie-player.js
@@ -4,7 +4,7 @@
 import { isEmpty } from 'lodash';
 
 import { useEffect } from '@wordpress/element';
-import {copyScriptAssetToIframe, getEditorIframe} from '../../../helpers/block-utility';
+import { copyScriptAssetToIframe, getEditorIframe } from '../../../helpers/block-utility';
 
 const LottiePlayer = ({
 	attributes,

--- a/src/blocks/blocks/lottie/edit.js
+++ b/src/blocks/blocks/lottie/edit.js
@@ -57,7 +57,7 @@ const Edit = ({
 			obj.url = value;
 		}
 
-		setAttributes({ file: { ...obj } });
+		setAttributes({ file: { ...obj }});
 		setEditing( false );
 	};
 

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -156,7 +156,7 @@ export const PostsMeta = ({ attributes, element, post, author, category }) => {
 	return '';
 };
 
-export const PostsDescription = ({attributes,  element, post }) => {
+export const PostsDescription = ({ attributes,  element, post }) => {
 	if ( 0 < attributes.excerptLength && attributes.displayDescription ) {
 		return (
 			<div key={ element } className="o-posts-grid-post-description">

--- a/src/blocks/blocks/posts/deprecated.js
+++ b/src/blocks/blocks/posts/deprecated.js
@@ -5,7 +5,7 @@ import metadata from './block.json';
 
 const { attributes } = metadata;
 
-const deprecated = [ {
+const deprecated = [{
 	attributes: {
 		...attributes,
 		categories: {
@@ -21,13 +21,13 @@ const deprecated = [ {
 	migrate: oldAttributes => {
 		return {
 			...oldAttributes,
-			categories: [ { id: Number( oldAttributes.categories ) } ]
+			categories: [{ id: Number( oldAttributes.categories ) }]
 		};
 	},
 
 	isEligible: ({ categories }) => categories && 'string' === typeof categories,
 
 	save: () => null
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -84,10 +84,10 @@ const Inspector = ({
 				}).filter( e => undefined !== e );
 			}
 		} else if ( '' !== value ) {
-			categories = [ {
+			categories = [{
 				id: value,
 				name: categoriesList.find( e => e.id === Number( value ) ).name
-			} ];
+			}];
 		}
 
 		setAttributes({ categories });

--- a/src/blocks/blocks/section/column/deprecated.js
+++ b/src/blocks/blocks/section/column/deprecated.js
@@ -312,7 +312,7 @@ const attributes = {
 	}
 };
 
-const deprecated = [ {
+const deprecated = [{
 	attributes,
 
 	supports: {
@@ -911,6 +911,6 @@ const deprecated = [ {
 			</Tag>
 		);
 	}
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -148,8 +148,8 @@ const Edit = ({
 
 	if ( attributes.columnWidth === undefined ) {
 		const index = parentBlock.innerBlocks.findIndex( i => i.clientId === clientId );
-		const columns = parentBlock.attributes.columns;
-		const layout = parentBlock.attributes.layout;
+		const { columns } = parentBlock.attributes;
+		const { layout } = parentBlock.attributes;
 		updateBlockAttributes( clientId, {
 			columnWidth: layouts[columns][layout][index]
 		});

--- a/src/blocks/blocks/section/columns/deprecated.js
+++ b/src/blocks/blocks/section/columns/deprecated.js
@@ -835,7 +835,7 @@ const SeparatorsNew = ({
 	);
 };
 
-const deprecated = [ {
+const deprecated = [{
 	attributes,
 
 	supports: {
@@ -1929,6 +1929,6 @@ const deprecated = [ {
 			</Tag>
 		);
 	}
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/section/columns/variations.js
+++ b/src/blocks/blocks/section/columns/variations.js
@@ -20,7 +20,7 @@ const variations = [
 			layoutMobile: 'equal'
 		},
 		innerBlocks: [
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '100' } ]
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '100' }]
 		],
 		scope: [ 'block' ]
 	},
@@ -36,8 +36,8 @@ const variations = [
 			layoutMobile: 'equal'
 		},
 		innerBlocks: [
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '50' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '50' } ]
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '50' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '50' }]
 		],
 		scope: [ 'block' ]
 	},
@@ -53,8 +53,8 @@ const variations = [
 			layoutMobile: 'equal'
 		},
 		innerBlocks: [
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.34' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '66.66' } ]
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.34' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '66.66' }]
 		],
 		scope: [ 'block' ]
 	},
@@ -70,8 +70,8 @@ const variations = [
 			layoutMobile: 'equal'
 		},
 		innerBlocks: [
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '66.66' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.33' } ]
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '66.66' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.33' }]
 		],
 		scope: [ 'block' ]
 	},
@@ -87,9 +87,9 @@ const variations = [
 			layoutMobile: 'equal'
 		},
 		innerBlocks: [
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.33' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.33' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.33' } ]
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.33' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.33' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '33.33' }]
 		],
 		scope: [ 'block' ]
 	},
@@ -105,9 +105,9 @@ const variations = [
 			layoutMobile: 'equal'
 		},
 		innerBlocks: [
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '50' } ]
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '50' }]
 		],
 		scope: [ 'block' ]
 	},
@@ -123,9 +123,9 @@ const variations = [
 			layoutMobile: 'equal'
 		},
 		innerBlocks: [
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '50' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' } ]
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '50' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' }]
 		],
 		scope: [ 'block' ]
 	},
@@ -141,10 +141,10 @@ const variations = [
 			layoutMobile: 'equal'
 		},
 		innerBlocks: [
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' } ],
-			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' } ]
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' }],
+			[ 'themeisle-blocks/advanced-column', { columnWidth: '25' }]
 		],
 		scope: [ 'block' ]
 	}

--- a/src/blocks/blocks/sharing-icons/controls.js
+++ b/src/blocks/blocks/sharing-icons/controls.js
@@ -33,7 +33,7 @@ const Controls = ({
 		const newValue = { ...attributes[ item ] };
 		newValue.active = ! newValue.active;
 
-		setAttributes({ [ item ]: { ...newValue } });
+		setAttributes({ [ item ]: { ...newValue }});
 	};
 
 	return (

--- a/src/blocks/blocks/sharing-icons/inspector.js
+++ b/src/blocks/blocks/sharing-icons/inspector.js
@@ -26,7 +26,7 @@ const Inspector = ({
 		const newValue = { ...attributes[item] };
 		newValue[field] = value;
 
-		setAttributes({ [ item ]: { ...newValue } });
+		setAttributes({ [ item ]: { ...newValue }});
 	};
 
 	return (

--- a/src/blocks/blocks/slider/deprecated.js
+++ b/src/blocks/blocks/slider/deprecated.js
@@ -74,7 +74,7 @@ const attributes = {
 	}
 };
 
-const deprecated = [ {
+const deprecated = [{
 	attributes: {
 		...omit(
 			attributes,
@@ -222,6 +222,6 @@ const deprecated = [ {
 			</div>
 		);
 	}
-} ];
+}];
 
 export default deprecated;

--- a/src/blocks/blocks/structural/pricing/edit.js
+++ b/src/blocks/blocks/structural/pricing/edit.js
@@ -14,7 +14,7 @@ const TEMPLATE = [
 		align: 'center',
 		tag: 'h3',
 		fontSize: 24
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( '$9.99', 'otter-blocks' ),
 		align: 'center',
@@ -22,39 +22,39 @@ const TEMPLATE = [
 		fontSize: 36,
 		fontFamily: 'Roboto Slab',
 		fontVariant: 'normal'
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( 'Per Month', 'otter-blocks' ),
 		align: 'center',
 		tag: 'p',
 		fontSize: 12,
 		marginBottom: 0
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( 'First Feature', 'otter-blocks' ),
 		align: 'center',
 		tag: 'p',
 		fontSize: 12,
 		marginBottom: 0
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( 'Second Feature', 'otter-blocks' ),
 		align: 'center',
 		tag: 'p',
 		fontSize: 12,
 		marginBottom: 0
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( 'Last Feature', 'otter-blocks' ),
 		align: 'center',
 		tag: 'p',
 		fontSize: 12,
 		marginBottom: 0
-	} ],
+	}],
 	[ 'themeisle-blocks/button-group', {
 		align: 'center',
 		buttons: 1,
-		data: [ {
+		data: [{
 			text: __( 'Buy Now', 'otter-blocks' ),
 			newTab: false,
 			color: '#ffffff',
@@ -77,8 +77,8 @@ const TEMPLATE = [
 			iconType: 'none',
 			paddingTopBottom: 12,
 			paddingLeftRight: 24
-		} ]
-	} ]
+		}]
+	}]
 ];
 
 const Edit = () => {

--- a/src/blocks/blocks/structural/service/edit.js
+++ b/src/blocks/blocks/structural/service/edit.js
@@ -13,13 +13,13 @@ const TEMPLATE = [
 		fontSize: 62,
 		prefix: 'fab',
 		icon: 'angellist'
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( 'Basic', 'otter-blocks' ),
 		align: 'center',
 		tag: 'h4',
 		marginBottom: 20
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( 'Lorem ipsum dolor sit amet elit do, consectetur adipiscing, sed eiusmod tempor incididunt ut labore et dolore magna aliqua.', 'otter-blocks' ),
 		align: 'center',
@@ -27,11 +27,11 @@ const TEMPLATE = [
 		tag: 'p',
 		fontSize: 14,
 		marginBottom: 20
-	} ],
+	}],
 	[ 'themeisle-blocks/button-group', {
 		align: 'center',
 		buttons: 1,
-		data: [ {
+		data: [{
 			text: __( 'Know More', 'otter-blocks' ),
 			newTab: false,
 			color: '#ffffff',
@@ -54,8 +54,8 @@ const TEMPLATE = [
 			iconType: 'none',
 			paddingTopBottom: 12,
 			paddingLeftRight: 24
-		} ]
-	} ]
+		}]
+	}]
 ];
 
 const Edit = () => {

--- a/src/blocks/blocks/structural/testimonials/edit.js
+++ b/src/blocks/blocks/structural/testimonials/edit.js
@@ -11,7 +11,7 @@ import {
 const TEMPLATE = [
 	[ 'core/image', {
 		align: 'center'
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( 'John Doe', 'otter-blocks' ),
 		align: 'center',
@@ -21,7 +21,7 @@ const TEMPLATE = [
 		marginBottom: 10,
 		marginTopTablet: 25,
 		marginTopMobile: 25
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( 'Jedi Master', 'otter-blocks' ),
 		align: 'center',
@@ -29,7 +29,7 @@ const TEMPLATE = [
 		tag: 'h4',
 		marginTop: 10,
 		marginBottom: 10
-	} ],
+	}],
 	[ 'themeisle-blocks/advanced-heading', {
 		content: __( '"What is the point of being alive if you don’t at least try to do something remarkable?"', 'otter-blocks' ),
 		align: 'center',
@@ -38,7 +38,7 @@ const TEMPLATE = [
 		fontSize: 14,
 		marginTop: 10,
 		marginBottom: 20
-	} ]
+	}]
 ];
 
 const Edit = () => {

--- a/src/blocks/blocks/tabs/group/edit.js
+++ b/src/blocks/blocks/tabs/group/edit.js
@@ -227,7 +227,7 @@ const Edit = ({
 				>
 					<InnerBlocks
 						allowedBlocks={ [ 'themeisle-blocks/tabs-item' ] }
-						template={ [ [ 'themeisle-blocks/tabs-item' ] ] }
+						template={ [[ 'themeisle-blocks/tabs-item' ]] }
 						orientation="horizontal"
 						renderAppender={ false }
 					/>

--- a/src/blocks/blocks/tabs/item/edit.js
+++ b/src/blocks/blocks/tabs/item/edit.js
@@ -99,7 +99,7 @@ const Edit = ({
 
 				<div className="wp-block-themeisle-blocks-tabs-item__content">
 					<InnerBlocks
-						template={ [ [ 'core/paragraph' ] ] } />
+						template={ [[ 'core/paragraph' ]] } />
 				</div>
 			</div>
 		</Fragment>

--- a/src/blocks/components/icon-picker-control/index.js
+++ b/src/blocks/components/icon-picker-control/index.js
@@ -81,7 +81,7 @@ const IconPickerControl = ({
 		Object.keys( data ).forEach( i => {
 			Object.keys( data[i].styles ).forEach( o => {
 				let prefix = '';
-				let terms = data[i].search.terms;
+				let { terms } = data[i].search;
 
 				switch ( data[i].styles[o]) {
 				case 'brands':
@@ -187,7 +187,7 @@ const IconPickerControl = ({
 							options={ [
 								{ label: __( 'Font Awesome', 'otter-blocks' ), value: 'fontawesome' },
 								{ label: __( 'ThemeIsle Icons', 'otter-blocks' ), value: 'themeisle-icons' },
-								...( allowImage ? [ { label: __( 'Custom Image', 'otter-blocks' ), value: 'image' } ] : [])
+								...( allowImage ? [{ label: __( 'Custom Image', 'otter-blocks' ), value: 'image' }] : [])
 							] }
 							onChange={ changeLibrary }
 						/>
@@ -330,7 +330,7 @@ export const IconPickerToolbarControl = ({
 		Object.keys( data ).forEach( i => {
 			Object.keys( data[i].styles ).forEach( o => {
 				let prefix = '';
-				let terms = data[i].search.terms;
+				let { terms } = data[i].search;
 
 				switch ( data[i].styles[o]) {
 				case 'brands':

--- a/src/blocks/components/select-products-control/index.js
+++ b/src/blocks/components/select-products-control/index.js
@@ -51,7 +51,7 @@ const SelectProducts = ({
 		return {
 			results,
 			status,
-			isLoading: select( COLLECTIONS_STORE_KEY ).isResolving( 'getCollection', [ '/wc/store', 'products', { per_page: 100 } ])
+			isLoading: select( COLLECTIONS_STORE_KEY ).isResolving( 'getCollection', [ '/wc/store', 'products', { per_page: 100 }])
 		};
 	}, []);
 

--- a/src/blocks/frontend/circle-counter/index.js
+++ b/src/blocks/frontend/circle-counter/index.js
@@ -16,12 +16,12 @@ domReady( () => {
 			Dataset
 		*/
 		const duration = progressBar.dataset.duration * 1000;
-		const percentage = progressBar.dataset.percentage;
+		const { percentage } = progressBar.dataset;
 		const size = progressBar.dataset.height;
-		const strokeWidth = progressBar.dataset.strokeWidth;
+		const { strokeWidth } = progressBar.dataset;
 		const fontSize = progressBar.dataset.fontSizePercent;
-		const backgroundStroke = progressBar.dataset.backgroundStroke;
-		const progressStroke = progressBar.dataset.progressStroke;
+		const { backgroundStroke } = progressBar.dataset;
+		const { progressStroke } = progressBar.dataset;
 
 		const center = size / 2;
 		const radius = center - ( strokeWidth / 2 );

--- a/src/blocks/frontend/countdown/index.js
+++ b/src/blocks/frontend/countdown/index.js
@@ -109,7 +109,7 @@ domReady( () => {
 	const countdowns = document.querySelectorAll( '.wp-block-themeisle-blocks-countdown' );
 
 	countdowns.forEach( countdown => {
-		const date = countdown.dataset.date;
+		const { date } = countdown.dataset;
 
 		if ( date ) {
 			const update = updateTime( date, getComponentsUpdate( countdown ) );

--- a/src/blocks/frontend/form/captcha.js
+++ b/src/blocks/frontend/form/captcha.js
@@ -31,7 +31,7 @@ const renderCapthcaOn = ( form ) => {
 		return;
 	}
 
-	const id = form.id;
+	const { id } = form;
 
 	const captchaNode = document.createElement( 'div' );
 	const container = form.querySelector( '.otter-form__container' );

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -15,7 +15,7 @@ const extractFormFields = form => {
 
 	/** @type {Array.<HTMLDivElement>} */
 	const elemsWithError = [];
-	const formFieldsData = [ { label: window?.themeisleGutenbergForm?.messages['form-submission'] || 'Form submission from', value: window.location.href } ];
+	const formFieldsData = [{ label: window?.themeisleGutenbergForm?.messages['form-submission'] || 'Form submission from', value: window.location.href }];
 
 	const inputs = form?.querySelectorAll( '.otter-form__container .wp-block-themeisle-blocks-form-input' );
 	const textarea = form?.querySelectorAll( '.otter-form__container .wp-block-themeisle-blocks-form-textarea' );
@@ -41,7 +41,7 @@ const extractFormFields = form => {
 		}
 	});
 
-	return {formFieldsData, elemsWithError};
+	return { formFieldsData, elemsWithError };
 };
 
 /**
@@ -66,7 +66,7 @@ const collectAndSendInputFormData = ( form, btn, displayMsg ) => {
 	const payload = {};
 
 	// Get the data from the form fields.
-	const {formFieldsData, elemsWithError} = extractFormFields( form );
+	const { formFieldsData, elemsWithError } = extractFormFields( form );
 	const formIsEmpty = 2 > formFieldsData?.length;
 	const nonceFieldValue = extractNonceValue( form );
 	const hasCaptcha = form?.classList?.contains( 'has-captcha' );

--- a/src/blocks/frontend/lottie/index.js
+++ b/src/blocks/frontend/lottie/index.js
@@ -40,11 +40,11 @@ domReady( () => {
 				return window.LottieInteractivity.create({
 					mode: 'scroll',
 					player: `#${ animation.id }`,
-					actions: [ {
+					actions: [{
 						visibility: [ 0, 1 ],
 						type: 'seek',
 						frames: [ 0, animation.getLottie().totalFrames ]
-					} ]
+					}]
 				});
 			}
 

--- a/src/blocks/frontend/popup/popup.js
+++ b/src/blocks/frontend/popup/popup.js
@@ -159,7 +159,7 @@ class PopupBlock {
 
 	getScrolledPercent() {
 		const height = document.documentElement;
-		const body = document.body;
+		const { body } = document;
 		const st = 'scrollTop';
 		const sh = 'scrollHeight';
 

--- a/src/blocks/frontend/sticky/index.js
+++ b/src/blocks/frontend/sticky/index.js
@@ -45,7 +45,7 @@ const createObserver = () => {
 
 	const register = ( block, config, container, metadata ) => {
 		indexBlock += 1;
-		blocks[indexBlock.toString()] = {block, config, container, metadata};
+		blocks[indexBlock.toString()] = { block, config, container, metadata };
 		return indexBlock;
 	};
 
@@ -61,7 +61,7 @@ const createObserver = () => {
 		activeIndex.forEach( otherIndex => {
 			if ( container === blocks[otherIndex.toString()].container ) {
 				if ( otherIndex < index ) {
-					const {block, metadata} = blocks[otherIndex.toString()];
+					const { block, metadata } = blocks[otherIndex.toString()];
 					earlyActivation += metadata.activationOffset + ( block?.getBoundingClientRect()?.height || 0 );
 				}
 			}
@@ -83,7 +83,7 @@ const createObserver = () => {
 		activeIndex.forEach( otherIndex => {
 			if ( container === blocks[otherIndex.toString()].container ) {
 				if ( otherIndex < index ) {
-					const {config: otherConfig, block: otherBlock, metadata: otherMetadata} = blocks[otherIndex.toString()];
+					const { config: otherConfig, block: otherBlock, metadata: otherMetadata } = blocks[otherIndex.toString()];
 
 					if ( 'o-sticky-bhvr-stack' === otherConfig?.behaviour &&  blockWidth > Math.abs( metadata.elemLeftPositionInPage - otherMetadata.elemLeftPositionInPage ) ) {
 						gap += otherConfig.offset + otherBlock?.getBoundingClientRect()?.height || 0;
@@ -111,7 +111,7 @@ const createObserver = () => {
 		for ( let otherIndex of ( new Set([ ...dormantIndex, ...activeIndex ]) ) ) {
 			if ( container === blocks[otherIndex.toString()].container ) {
 				if ( otherIndex > index ) {
-					const { block: otherBlock, metadata: otherMetadata} = blocks[otherIndex.toString()];
+					const { block: otherBlock, metadata: otherMetadata } = blocks[otherIndex.toString()];
 					const otherBlockHeight = otherBlock.getBoundingClientRect()?.height || 0;
 
 					// Check if the the blocks collide / Check if the block in on top, and not left or right.
@@ -439,7 +439,7 @@ const getConfigOptions = ( elem ) => {
 			config.useOnMobile = true;
 		}
 		return config;
-	}, { position: 'top', offset: 40, scope: 'o-sticky-scope-main-area', behaviour: 'o-sticky-bhvr-keep', useOnMobile: false});
+	}, { position: 'top', offset: 40, scope: 'o-sticky-scope-main-area', behaviour: 'o-sticky-bhvr-keep', useOnMobile: false });
 };
 
 domReady( () => {

--- a/src/blocks/frontend/tabs/index.js
+++ b/src/blocks/frontend/tabs/index.js
@@ -25,7 +25,7 @@ domReady( () => {
 				content.classList.add( 'active' );
 				openedTab = true;
 			} else {
-				closedTabs.push({headerItem, content});
+				closedTabs.push({ headerItem, content });
 			}
 
 			headerItem.innerHTML = item.dataset.title || `Tab ${ index + 1 }`;

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -20,7 +20,7 @@ import {
  * Internal dependencies.
  */
 import globalDefaultsBlocksAttrs from '../plugins/options/global-defaults/defaults.js';
-import {useEffect, useMemo, useRef, useState} from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Initiate the global id tracker with an empty list if it is the case.
@@ -214,10 +214,10 @@ export const addBlockId = ( args ) => {
 	};
 };
 
-const getBlock = select( 'core/block-editor' ).getBlock;
-const getBlockParents = select( 'core/block-editor' ).getBlockParents;
-const updateBlockAttributes = dispatch( 'core/block-editor' ).updateBlockAttributes;
-const getSelectedBlockClientId = select( 'core/block-editor' ).getSelectedBlockClientId;
+const { getBlock } = select( 'core/block-editor' );
+const { getBlockParents } = select( 'core/block-editor' );
+const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+const { getSelectedBlockClientId } = select( 'core/block-editor' );
 
 /**
  * Create the function that behaves like `setAttributes` using the client id

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -181,7 +181,7 @@ const AuthorsFieldToken = ( props ) => {
 
 		return {
 			postAuthors: ( getUsers({ who: 'authors' }) ?? []).map( author => author.username ),
-			isLoading: isResolving( 'getUsers', [ { who: 'authors' } ])
+			isLoading: isResolving( 'getUsers', [{ who: 'authors' }])
 		};
 	}, [ ]);
 
@@ -206,7 +206,7 @@ const CategoriesFieldToken = ( props ) => {
 
 		return {
 			postCategories: ( getEntityRecords( 'taxonomy', 'category', { 'per_page': 100 }) ?? []).map( category => category.slug ),
-			isLoading: isResolving( 'getEntityRecords', [ 'taxonomy', 'category', { 'per_page': 100 } ])
+			isLoading: isResolving( 'getEntityRecords', [ 'taxonomy', 'category', { 'per_page': 100 }])
 		};
 	}, [ ]);
 
@@ -272,7 +272,7 @@ const Edit = ({
 
 	const addGroup = () => {
 		const otterConditions = [ ...( attributes.otterConditions || []) ];
-		otterConditions.push([ {} ]);
+		otterConditions.push([{}]);
 		setAttributes({ otterConditions });
 	};
 

--- a/src/blocks/plugins/masonry-extension-old/edit.js
+++ b/src/blocks/plugins/masonry-extension-old/edit.js
@@ -102,7 +102,7 @@ const Edit = ({
 			setTimeout( () => macy.current?.recalculate( true, true ), 300 );
 
 			observer.current?.disconnect();
-			observer.current?.observe( container, {childList: true});
+			observer.current?.observe( container, { childList: true });
 
 			if ( container?.style.height ) {
 				container.style.height = '';

--- a/src/blocks/plugins/options/global-defaults/controls/form.js
+++ b/src/blocks/plugins/options/global-defaults/controls/form.js
@@ -192,7 +192,7 @@ const Form = ({
 				>
 					<BoxControl
 						label={ __( 'Input Padding', 'otter-blocks' ) }
-						values={ attributes.inputPadding ?? {'top': '8px', 'right': '8px', 'bottom': '8px', 'left': '8px'} }
+						values={ attributes.inputPadding ?? { 'top': '8px', 'right': '8px', 'bottom': '8px', 'left': '8px' } }
 						inputProps={ {
 							min: 0,
 							max: 500
@@ -293,7 +293,7 @@ const Form = ({
 							value: 'full'
 						}
 					]}
-					onChange={ submitStyle => setAttributes({ submitStyle}) }
+					onChange={ submitStyle => setAttributes({ submitStyle }) }
 				/>
 
 				<SyncControl

--- a/src/blocks/plugins/options/index.js
+++ b/src/blocks/plugins/options/index.js
@@ -120,7 +120,7 @@ const Options = () => {
 
 	const resetConfig = block => {
 		const defaultValues = cloneDeep( blockDefaults );
-		const blockConfig = { ...defaultsAttrs[ block ]};
+		const blockConfig = { ...defaultsAttrs[ block ] };
 		defaultValues[ block ] = blockConfig;
 		setBlockDefaults( defaultValues );
 	};

--- a/src/blocks/plugins/sticky/edit.js
+++ b/src/blocks/plugins/sticky/edit.js
@@ -111,10 +111,10 @@ const Edit = ({
 	setAttributes,
 	clientId
 }) => {
-	const [ containerOptions, setContainerOptions ] = useState([ {
+	const [ containerOptions, setContainerOptions ] = useState([{
 		label: __( 'Screen', 'otter-blocks' ),
 		value: 'o-sticky-scope-screen'
-	} ]);
+	}]);
 
 	/*
 		E.g:

--- a/src/pro/plugins/conditions/edit.js
+++ b/src/pro/plugins/conditions/edit.js
@@ -157,7 +157,7 @@ const ProductsMultiselect = ( props ) => {
 
 		return {
 			products,
-			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products', { 'per_page': 100 } ])
+			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products', { 'per_page': 100 }])
 		};
 	}, []);
 
@@ -520,7 +520,7 @@ const Edit = ({
 								max="23"
 								value={ item.start_time ? item.start_time.split( ':' )[0] : '' }
 								onChange={ e => {
-									const value = e.target.value;
+									const { value } = e.target;
 
 									if ( 0 > value || 23 < value ) {
 										return;
@@ -545,7 +545,7 @@ const Edit = ({
 								max="59"
 								value={ item.start_time ? item.start_time.split( ':' )[1] : '' }
 								onChange={ e => {
-									const value = e.target.value;
+									const { value } = e.target;
 
 									if ( 0 > value || 59 < value ) {
 										return;
@@ -587,7 +587,7 @@ const Edit = ({
 								max="23"
 								value={ item.end_time ? item.end_time.split( ':' )[0] : '' }
 								onChange={ e => {
-									const value = e.target.value;
+									const { value } = e.target;
 
 									if ( 0 > value || 23 < value ) {
 										return;
@@ -612,7 +612,7 @@ const Edit = ({
 								max="59"
 								value={ item.end_time ? item.end_time.split( ':' )[1] : '' }
 								onChange={ e => {
-									const value = e.target.value;
+									const { value } = e.target;
 
 									if ( 0 > value || 59 < value ) {
 										return;

--- a/src/pro/plugins/data/index.js
+++ b/src/pro/plugins/data/index.js
@@ -141,7 +141,7 @@ registerStore( 'otter-pro', {
 			const data = yield actions.fetchFromAPI( 'otter/v1/acf-fields' );
 
 			if ( data?.success ) {
-				const groups = data.groups;
+				const { groups } = data;
 				const fields = groups
 					?.map( ({ fields, data }) => {
 						return fields.map( field => {

--- a/src/pro/plugins/wc-integration/utility.js
+++ b/src/pro/plugins/wc-integration/utility.js
@@ -19,7 +19,7 @@ export const extractProductData = rawProduct => {
 		price: ( window.wc.priceFormat.formatPrice( Number( rawProduct?.prices?.regular_price ) ) ).replace( /[^0-9.-]+/g, '' ),
 		discounted: rawProduct?.prices?.regular_price !== rawProduct?.prices?.sale_price ? ( window.wc.priceFormat.formatPrice( Number( rawProduct?.prices?.sale_price ) ) ).replace( /[^0-9.-]+/g, '' ) : undefined,
 		currency: rawProduct?.prices?.currency_code,
-		links: [ { label: __( 'Buy Now', 'otter-blocks' ), href: rawProduct?.add_to_cart?.url, isSpoonsored: 'external' === rawProduct?.type } ],
+		links: [{ label: __( 'Buy Now', 'otter-blocks' ), href: rawProduct?.add_to_cart?.url, isSpoonsored: 'external' === rawProduct?.type }],
 		image: 0 < rawProduct?.images?.length ? extractImageData( rawProduct?.images[0]) : undefined
 	};
 };


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Make EsLint consistent with the coding style. 

Code like `{ name}` is accepted instead of `{ name }`.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

