### PR TITLE
Fix Conditions when used in Customizer.

### DIFF
--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -241,18 +241,35 @@ const Separator = ({ label }) => {
 
 const Edit = ({
 	attributes,
-	setAttributes
+	setAttributes: _setAttributes
 }) => {
+	const setAttributes = ( attributes ) => {
+
+		// window?.wp?.customize.state( 'saved' ).set( false );
+
+		for ( const [ key, value ] of Object.entries( wp.customize.dirtyValues() ) ) {
+			console.log( '[Dirty]', key, value?.raw_instance?.content );
+		}
+
+		_setAttributes({ ...attributes });
+	};
 	const [ conditions, setConditions ] = useState({});
 	const [ flatConditions, setFlatConditions ] = useState([]);
 	const [ toggleVisibility, setToggleVisibility ] = useState([]);
+
+	// TODO: remove after testing
+	useEffect( () => {
+		if ( attributes.otterConditions ) {
+			console.log( 'Attrs', attributes.otterConditions );
+		}
+	}, [ attributes.otterConditions ]);
 
 	useEffect( () => {
 		if ( ! Boolean( attributes?.otterConditions?.length ) ) {
 			return;
 		}
 
-		let otterConditions = attributes.otterConditions?.filter( c => ! isEmpty( c ) );
+		let otterConditions = [ ...attributes.otterConditions?.filter( c => ! isEmpty( c ) ) ];
 
 		if ( ! Boolean( otterConditions.length ) ) {
 			otterConditions = undefined;

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -267,16 +267,6 @@ const Edit = ({
 
 	};
 
-	// TODO: remove after testing
-	useEffect( () => {
-		if ( attributes.otterConditions ) {
-			console.log( 'Attrs', attributes.otterConditions );
-		}
-		for ( const [ key, value ] of Object.entries( wp.customize.dirtyValues() ) ) {
-			console.log( '[Dirty]', key, value?.raw_instance?.content );
-		}
-	}, [ attributes.otterConditions ]);
-
 	/**
 	 * Use an intermediary buffer to add the real attributes to the block.
 	 */

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -15,8 +15,7 @@ import {
 	PanelBody,
 	SelectControl,
 	Spinner,
-	Placeholder,
-	Notice
+	Placeholder
 } from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
@@ -34,6 +33,7 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies.
  */
 import PanelTab from '../../components/panel-tab/index.js';
+import Notice from '../../components/notice/index.js';
 
 const hasPro = Boolean( window.themeisleGutenberg.hasPro );
 const postTypes = Object.keys( window.themeisleGutenberg.postTypes );
@@ -539,24 +539,6 @@ const Edit = ({
 						variant="upsell"
 					/>
 				) }
-
-				{
-					window.wp.hasOwnProperty( 'customize' ) && (
-						<Notice
-							status="warning"
-							isDismissible={ false }
-						>
-							{ __( 'The changes in conditions might not be saved. Please use the Widgets screen to edit the conditions.', 'otter-blocks' ) }
-							<ExternalLink
-								href="/wp-admin/widgets.php"
-								target='_blank'
-								style={{ display: 'inline-block' }}
-							>
-								{ __( 'Go to Widgets', 'otter-blocks' ) }
-							</ExternalLink>
-						</Notice>
-					)
-				}
 
 				{ applyFilters( 'otter.poweredBy', '' ) }
 			</PanelBody>

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -15,7 +15,8 @@ import {
 	PanelBody,
 	SelectControl,
 	Spinner,
-	Placeholder
+	Placeholder,
+	Notice
 } from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
@@ -33,7 +34,6 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies.
  */
 import PanelTab from '../../components/panel-tab/index.js';
-import Notice from '../../components/notice/index.js';
 
 const hasPro = Boolean( window.themeisleGutenberg.hasPro );
 const postTypes = Object.keys( window.themeisleGutenberg.postTypes );
@@ -517,6 +517,24 @@ const Edit = ({
 						variant="upsell"
 					/>
 				) }
+
+				{
+					window.wp.hasOwnProperty( 'customize' ) && (
+						<Notice
+							status="warning"
+							isDismissible={ false }
+						>
+							{ __( 'The changes in conditions might not be saved. Please use the Widgets screen to edit the conditions.', 'otter-blocks' ) }
+							<ExternalLink
+								href="/wp-admin/widgets.php"
+								target='_blank'
+								style={{ display: 'inline-block' }}
+							>
+								{ __( 'Go to Widgets', 'otter-blocks' ) }
+							</ExternalLink>
+						</Notice>
+					)
+				}
 
 				{ applyFilters( 'otter.poweredBy', '' ) }
 			</PanelBody>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #999.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add a notice to the user that the conditions might not be saved when used in Customizer.

### Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/17597852/182379160-b814008e-66ad-4c03-8cb8-5df91112dd2c.png)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a widget using an Otter block.
2. Go to Customizer
3. Select the block and go to Conditions
4. Check if the notice appears

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

