### PR TITLE
Fix Section responsive inheritance

### DIFF
--- a/inc/class-pro.php
+++ b/inc/class-pro.php
@@ -107,6 +107,10 @@ class Pro {
 	public static function should_show_upsell() {
 		$show_upsell = false;
 
+		if ( defined( 'OTTER_PRO_VERSION' ) ) {
+			return $show_upsell;
+		}
+
 		$installed     = get_option( 'otter_blocks_install' );
 		$notifications = get_option( 'themeisle_blocks_settings_notifications', array() );
 

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -39,7 +39,7 @@ import ResponsiveControl from '../../../components/responsive-control/index.js';
 import BackgroundSelectorControl from '../../../components/background-selector-control/index.js';
 import ControlPanelControl from '../../../components/control-panel-control/index.js';
 import SyncControl from '../../../components/sync-control/index.js';
-import { isNullObject } from '../../../helpers/helper-functions.js';
+import { isNullObject, removeBoxDefaultValues } from '../../../helpers/helper-functions.js';
 
 /**
  *
@@ -90,13 +90,14 @@ const Inspector = ({
 	};
 
 	const getPadding = () => {
+		console.log({ getView });
 		switch ( getView ) {
 		case 'Desktop':
 			return getValue( 'padding' );
 		case 'Tablet':
-			return merge( getValue( 'padding' ), getValue( 'paddingTablet' ) );
+			return merge({ ...getValue( 'padding' ) }, getValue( 'paddingTablet' ) );
 		case 'Mobile':
-			return merge( getValue( 'padding' ), getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) );
+			return merge({ ...getValue( 'padding' ) }, getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) );
 		default:
 			return undefined;
 		}
@@ -111,9 +112,9 @@ const Inspector = ({
 		case 'Desktop':
 			return setAttributes({ padding: value });
 		case 'Tablet':
-			return setAttributes({ paddingTablet: value });
+			return setAttributes({ paddingTablet: removeBoxDefaultValues( value, attributes.padding ) });
 		case 'Mobile':
-			return setAttributes({ paddingMobile: value });
+			return setAttributes({ paddingMobile: removeBoxDefaultValues( value, { ...attributes.padding, ...attributes.paddingTablet }) });
 		default:
 			return undefined;
 		}
@@ -137,9 +138,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'margin' );
 		case 'Tablet':
-			return merge( getValue( 'margin' ), getValue( 'marginTablet' ) );
+			return merge({ ...getValue( 'margin' ) }, getValue( 'marginTablet' ) );
 		case 'Mobile':
-			return merge( getValue( 'margin' ), getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
+			return merge({ ...getValue( 'margin' ) }, getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
 		default:
 			return undefined;
 		}
@@ -154,9 +155,9 @@ const Inspector = ({
 		case 'Desktop':
 			return setAttributes({ margin: value });
 		case 'Tablet':
-			return setAttributes({ marginTablet: value });
+			return setAttributes({ marginTablet: removeBoxDefaultValues( value, attributes.margin ) });
 		case 'Mobile':
-			return setAttributes({ marginMobile: value });
+			return setAttributes({ marginMobile: removeBoxDefaultValues( value, { ...attributes.margin, ...attributes.marginTablet }) });
 		default:
 			return undefined;
 		}

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -39,7 +39,10 @@ import ResponsiveControl from '../../../components/responsive-control/index.js';
 import BackgroundSelectorControl from '../../../components/background-selector-control/index.js';
 import ControlPanelControl from '../../../components/control-panel-control/index.js';
 import SyncControl from '../../../components/sync-control/index.js';
-import { isNullObject, removeBoxDefaultValues } from '../../../helpers/helper-functions.js';
+import {
+	isNullObject,
+	removeBoxDefaultValues
+} from '../../../helpers/helper-functions.js';
 
 /**
  *
@@ -90,7 +93,6 @@ const Inspector = ({
 	};
 
 	const getPadding = () => {
-		console.log({ getView });
 		switch ( getView ) {
 		case 'Desktop':
 			return getValue( 'padding' );

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -44,7 +44,7 @@ import ControlPanelControl from '../../../components/control-panel-control/index
 import HTMLAnchorControl from '../../../components/html-anchor-control/index.js';
 import BackgroundSelectorControl from '../../../components/background-selector-control/index.js';
 import SyncControl from '../../../components/sync-control/index.js';
-import { isNullObject } from '../../../helpers/helper-functions.js';
+import { isNullObject, removeBoxDefaultValues } from '../../../helpers/helper-functions.js';
 import ToogleGroupControl from '../../../components/toogle-group-control/index.js';
 
 /**
@@ -186,8 +186,6 @@ const Inspector = ({
 		if ( isNullObject( value ) ) {
 			value = undefined;
 		}
-
-		console.log( value );
 
 		if ( 'object' === typeof value ) {
 			value = Object.fromEntries( Object.entries( value ).filter( ([ _, v ]) => null !== v ) );

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -131,9 +131,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'padding' );
 		case 'Tablet':
-			return merge( getValue( 'padding' ), getValue( 'paddingTablet' ) );
+			return merge({ ...getValue( 'padding' ) }, getValue( 'paddingTablet' ) );
 		case 'Mobile':
-			return merge( getValue( 'padding' ), getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) ) ;
+			return merge({ ...getValue( 'padding' ) }, getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) ) ;
 		default:
 			return undefined;
 		}
@@ -148,9 +148,9 @@ const Inspector = ({
 		case 'Desktop':
 			return setAttributes({ padding: value });
 		case 'Tablet':
-			return setAttributes({ paddingTablet: value });
+			return setAttributes({ paddingTablet: removeBoxDefaultValues( value, attributes.padding ) });
 		case 'Mobile':
-			return setAttributes({ paddingMobile: value });
+			return setAttributes({ paddingMobile: removeBoxDefaultValues( value, { ...attributes.padding, ...attributes.paddingTablet }) });
 		default:
 			return undefined;
 		}
@@ -174,9 +174,9 @@ const Inspector = ({
 		case 'Desktop':
 			return getValue( 'margin' );
 		case 'Tablet':
-			return merge( getValue( 'margin' ), getValue( 'marginTablet' ) );
+			return merge({ ...getValue( 'margin' ) }, getValue( 'marginTablet' ) );
 		case 'Mobile':
-			return merge( getValue( 'margin' ), getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
+			return merge({ ...getValue( 'margin' ) }, getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
 		default:
 			return undefined;
 		}
@@ -197,9 +197,9 @@ const Inspector = ({
 		case 'Desktop':
 			return setAttributes({ margin: value });
 		case 'Tablet':
-			return setAttributes({ marginTablet: value });
+			return setAttributes({ marginTablet: removeBoxDefaultValues( value, attributes.margin ) });
 		case 'Mobile':
-			return setAttributes({ marginMobile: value });
+			return setAttributes({ marginMobile: removeBoxDefaultValues( value, { ...attributes.margin, ...attributes.marginTablet }) });
 		default:
 			return undefined;
 		}

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -44,7 +44,10 @@ import ControlPanelControl from '../../../components/control-panel-control/index
 import HTMLAnchorControl from '../../../components/html-anchor-control/index.js';
 import BackgroundSelectorControl from '../../../components/background-selector-control/index.js';
 import SyncControl from '../../../components/sync-control/index.js';
-import { isNullObject, removeBoxDefaultValues } from '../../../helpers/helper-functions.js';
+import {
+	isNullObject,
+	removeBoxDefaultValues
+} from '../../../helpers/helper-functions.js';
 import ToogleGroupControl from '../../../components/toogle-group-control/index.js';
 
 /**


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1077.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix the usage of `merge` from Lodash since the first parameter will be changed, thus causing a bug that gives the Desktop the value from Mobile/Tablet.

Add box cleaning to default values (introduced in Countdown PR).

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Section
2. Play with the padding/margin

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

