### PR TITLE
Fix alignment selection for GroupButton in FSE

### DIFF
--- a/src/blocks/blocks/button-group/group/inspector.js
+++ b/src/blocks/blocks/button-group/group/inspector.js
@@ -9,8 +9,8 @@ import {
 	PanelBody,
 	RangeControl,
 	SelectControl,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon
+	ButtonGroup,
+	Button
 } from '@wordpress/components';
 
 import {
@@ -18,8 +18,11 @@ import {
 	positionLeft,
 	positionRight,
 	stretchFullWidth,
-	stretchWide,
-	alignNone
+	alignNone,
+	alignJustify,
+	alignLeft,
+	alignCenter,
+	alignRight
 } from '@wordpress/icons';
 
 /**
@@ -28,6 +31,7 @@ import {
 import GoogleFontsControl from '../../../components/google-fonts-control/index.js';
 import SizingControl from '../../../components/sizing-control/index.js';
 import ResponsiveControl from '../../../components/responsive-control';
+import ToogleGroupControl from '../../../components/toogle-group-control/index.js';
 
 /**
  *
@@ -134,8 +138,39 @@ const Inspector = ({
 					label={ __( 'Alignment', 'otter-blocks' ) }
 					className="buttons-alignment-control"
 				>
-
-					<ToggleGroupControl
+					<ToogleGroupControl
+						value={ attributes?.align?.[ currentDevice ] ?? 'none' }
+						options={[
+							{
+								icon: alignNone,
+								label: __( 'None', 'otter-blocks' ),
+								value: 'none'
+							},
+							{
+								icon: stretchFullWidth,
+								label: __( 'Full', 'otter-blocks' ),
+								value: 'full'
+							},
+							{
+								icon: alignLeft,
+								label: __( 'Left', 'otter-blocks' ),
+								value: 'left'
+							},
+							{
+								icon: alignCenter,
+								label: __( 'Center', 'otter-blocks' ),
+								value: 'center'
+							},
+							{
+								icon: alignRight,
+								label: __( 'Right', 'otter-blocks' ),
+								value: 'right'
+							}
+						]}
+						onChange={ onAlignmentChange }
+						hideLabels
+					/>
+					{/* <ToggleGroupControl
 						value={ attributes?.align?.[ currentDevice ] ?? 'none' }
 						onChange={ onAlignmentChange }
 						hideLabelFromVision
@@ -172,7 +207,7 @@ const Inspector = ({
 							showTooltip={ true }
 							aria-label={ __( 'Right', 'otter-blocks' ) }
 						/>
-					</ToggleGroupControl>
+					</ToggleGroupControl> */}
 				</ResponsiveControl>
 			</PanelBody>
 

--- a/src/blocks/blocks/button-group/group/inspector.js
+++ b/src/blocks/blocks/button-group/group/inspector.js
@@ -8,8 +8,19 @@ import { InspectorControls, BlockAlignmentToolbar } from '@wordpress/block-edito
 import {
 	PanelBody,
 	RangeControl,
-	SelectControl
+	SelectControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon
 } from '@wordpress/components';
+
+import {
+	positionCenter,
+	positionLeft,
+	positionRight,
+	stretchFullWidth,
+	stretchWide,
+	alignNone
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -61,7 +72,7 @@ const Inspector = ({
 			mobile: attributes.align.mobile
 		} : {};
 
-		newValue[ currentDevice ] = value;
+		newValue[ currentDevice ] = 'none' === value ? undefined : value;
 		setAttributes({ align: newValue });
 	};
 
@@ -123,14 +134,45 @@ const Inspector = ({
 					label={ __( 'Alignment', 'otter-blocks' ) }
 					className="buttons-alignment-control"
 				>
-					<BlockAlignmentToolbar
-						value={ attributes.align ? attributes.align[ currentDevice ] : undefined }
-						isCollapsed={ false }
-						controls={ [ 'left', 'center', 'right', 'full' ] }
-						onChange={ value => {
-							onAlignmentChange( value );
-						} }
-					/>
+
+					<ToggleGroupControl
+						value={ attributes?.align?.[ currentDevice ] ?? 'none' }
+						onChange={ onAlignmentChange }
+						hideLabelFromVision
+						isBlock
+						isAdaptiveWidth
+					>
+						<ToggleGroupControlOptionIcon
+							value="none"
+							icon={alignNone}
+							showTooltip={ true }
+							aria-label={ __( 'None', 'otter-blocks' ) }
+						/>
+						<ToggleGroupControlOptionIcon
+							value="full"
+							icon={stretchFullWidth}
+							showTooltip={ true }
+							aria-label={ __( 'Full', 'otter-blocks' ) }
+						/>
+						<ToggleGroupControlOptionIcon
+							value="left"
+							icon={positionLeft}
+							showTooltip={ true }
+							aria-label={ __( 'Left', 'otter-blocks' ) }
+						/>
+						<ToggleGroupControlOptionIcon
+							value="center"
+							icon={positionCenter}
+							showTooltip={ true }
+							aria-label={ __( 'Center', 'otter-blocks' ) }
+						/>
+						<ToggleGroupControlOptionIcon
+							value="right"
+							icon={positionRight}
+							showTooltip={ true }
+							aria-label={ __( 'Right', 'otter-blocks' ) }
+						/>
+					</ToggleGroupControl>
 				</ResponsiveControl>
 			</PanelBody>
 

--- a/src/blocks/blocks/button-group/group/inspector.js
+++ b/src/blocks/blocks/button-group/group/inspector.js
@@ -3,14 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 
-import { InspectorControls, BlockAlignmentToolbar } from '@wordpress/block-editor';
+import { InspectorControls } from '@wordpress/block-editor';
 
 import {
 	PanelBody,
 	RangeControl,
-	SelectControl,
-	ButtonGroup,
-	Button
+	SelectControl
+
 } from '@wordpress/components';
 
 import {
@@ -18,11 +17,7 @@ import {
 	positionLeft,
 	positionRight,
 	stretchFullWidth,
-	alignNone,
-	alignJustify,
-	alignLeft,
-	alignCenter,
-	alignRight
+	alignNone
 } from '@wordpress/icons';
 
 /**
@@ -152,62 +147,41 @@ const Inspector = ({
 								value: 'full'
 							},
 							{
-								icon: alignLeft,
+								icon: positionLeft,
 								label: __( 'Left', 'otter-blocks' ),
 								value: 'left'
 							},
 							{
-								icon: alignCenter,
+								icon: positionCenter,
 								label: __( 'Center', 'otter-blocks' ),
 								value: 'center'
 							},
 							{
-								icon: alignRight,
+								icon: positionRight,
 								label: __( 'Right', 'otter-blocks' ),
 								value: 'right'
 							}
 						]}
 						onChange={ onAlignmentChange }
 						hideLabels
+						style={{
+							button: {
+								color: 'black',
+								boxShadow: 'none',
+								borderRadius: '0px'
+							},
+							active: {
+								color: 'white',
+								backgroundColor: 'black',
+								boxShadow: 'none',
+								borderRadius: '0px'
+							},
+							group: {
+								marginLeft: '0px',
+								marginRight: '0px'
+							}
+						}}
 					/>
-					{/* <ToggleGroupControl
-						value={ attributes?.align?.[ currentDevice ] ?? 'none' }
-						onChange={ onAlignmentChange }
-						hideLabelFromVision
-						isBlock
-						isAdaptiveWidth
-					>
-						<ToggleGroupControlOptionIcon
-							value="none"
-							icon={alignNone}
-							showTooltip={ true }
-							aria-label={ __( 'None', 'otter-blocks' ) }
-						/>
-						<ToggleGroupControlOptionIcon
-							value="full"
-							icon={stretchFullWidth}
-							showTooltip={ true }
-							aria-label={ __( 'Full', 'otter-blocks' ) }
-						/>
-						<ToggleGroupControlOptionIcon
-							value="left"
-							icon={positionLeft}
-							showTooltip={ true }
-							aria-label={ __( 'Left', 'otter-blocks' ) }
-						/>
-						<ToggleGroupControlOptionIcon
-							value="center"
-							icon={positionCenter}
-							showTooltip={ true }
-							aria-label={ __( 'Center', 'otter-blocks' ) }
-						/>
-						<ToggleGroupControlOptionIcon
-							value="right"
-							icon={positionRight}
-							showTooltip={ true }
-							aria-label={ __( 'Right', 'otter-blocks' ) }
-						/>
-					</ToggleGroupControl> */}
 				</ResponsiveControl>
 			</PanelBody>
 

--- a/src/blocks/components/toogle-group-control/index.js
+++ b/src/blocks/components/toogle-group-control/index.js
@@ -16,40 +16,11 @@ import {
  */
 import './editor.scss';
 
-/**
- * Style properties.
- * @typedef {Object} Style
- * @property {object} group - The group style.
- * @property {object} option - The option style.
- * @property {object} button - The button style.
- * @property {object} label - The group style.
- */
-
-
-/**
- * Option definition.
- * @typedef {Object} Option
- * @property {(number|string)} label - The current value.
- * @property {(number|string)} value - Hide the labels.
- * @property {any} icon - Hide the labels.
- */
-
-/**
- * Toggle Group Control properties.
- * @typedef {Object} ToogleGroupControlProps
- * @property {(number|string)} value - The current value.
- * @property {Array.<Option>} options - The options.
- * @property {Func} onChange - Handler for changing the current value.
- * @property {boolean} hideLabels - Hide the labels.
- * @property {boolean} hideTooltip - Hide tooltip.
- * @property {boolean} showBottomLabels - Display the labels under the buttons.
- * @property {Style} style - The component style.
- */
 
 /**
  *	A group of buttons that actions as a toggle
  *
- * @param {ToogleGroupControlProps} props
+ * @param {import('./type').ToggleGroupControlProps} props
  * @returns {JSX.Element}
  */
 const ToogleGroupControl = ({
@@ -80,7 +51,7 @@ const ToogleGroupControl = ({
 							label={ option?.label }
 							onClick={ () => onChange( option?.value )}
 							showTooltip={ Boolean( hideTooltip ) }
-							style={ style?.button }
+							style={ value == option?.value ? style.active : style?.button }
 						>
 							{ option?.label && ! Boolean( hideLabels ) && ! Boolean( showBottomLabels ) ? option?.label : '' }
 						</Button>

--- a/src/blocks/components/toogle-group-control/index.js
+++ b/src/blocks/components/toogle-group-control/index.js
@@ -51,7 +51,7 @@ const ToogleGroupControl = ({
 							label={ option?.label }
 							onClick={ () => onChange( option?.value )}
 							showTooltip={ Boolean( hideTooltip ) }
-							style={ value == option?.value ? style.active : style?.button }
+							style={ value == option?.value ? ( style.active ?? style?.button ) : style?.button }
 						>
 							{ option?.label && ! Boolean( hideLabels ) && ! Boolean( showBottomLabels ) ? option?.label : '' }
 						</Button>

--- a/src/blocks/components/toogle-group-control/type.d.ts
+++ b/src/blocks/components/toogle-group-control/type.d.ts
@@ -1,0 +1,26 @@
+import { Icon } from "@wordpress/components"
+import { CSSProperties } from "react"
+
+type Style = {
+    group: CSSProperties,
+    option: CSSProperties,
+    button: CSSProperties,
+    label: CSSProperties,
+    active: CSSProperties
+}
+
+type Option = {
+    label?: number | string
+    value: number | string
+    icon?: Icon.Props<any>['icon'] | undefined;
+}
+
+export type ToggleGroupControlProps = {
+    value: number | string,
+    options: Option[],
+    onChange: (value: number | string) => void
+    hideLabel?: boolean
+    hideTooltip?: boolean
+    showBottomLabels?: boolean
+    style?: Style
+}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1078.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Remade the alignment selector to something that can work in FSE.

### Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/17597852/182784876-565297cb-ccb9-4abb-8c6c-51ebb9e50614.png)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Button Group block
2. Check the Alignment in inspector

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

