### PR TITLE
Fix infinite loop in block id generation for Otter block in Query Loop

### DIFF
--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -90,14 +90,14 @@ export const getDefaultValueByField = ({ name, field, defaultAttributes, attribu
 const localIDs = {};
 
 /**
- * Check if the ID is inside a reusable block.
- * @param {string} clientId
+ * Check if the ID is inside a reusable block or a Query Loop.
+ * @param {string} clientId The client id of the block.
  * @returns {boolean}
  */
-const isInReusableBlock = ( clientId ) => {
-	return getBlockParents( clientId )
-		?.some( id => getBlock( id )?.attributes?.ref );
-};
+const isSharedBlock = ( clientId ) => getBlockParents( clientId )?.some( id => {
+	const { attributes, name } = getBlock( id ) ?? {};
+	return 'core/query' === name || attributes?.ref;
+});
 
 /**
  * Generate an Id based on the client id of the block. If the new id is also already used, create a new one using the `uuid`.
@@ -134,6 +134,8 @@ const generatePrefix = ( name ) => {
 	return `wp-block-${ name.replace( '/', '-' ) }-`;
 };
 
+const idGenerationStatus = {};
+
 /**
  * THe args definition for the block id generator
  *
@@ -155,7 +157,9 @@ const generatePrefix = ( name ) => {
  * @external addBlockId
  */
 export const addBlockId = ( args ) => {
+
 	const { attributes, setAttributes, clientId, idPrefix, name, defaultAttributes } = args;
+	idGenerationStatus[clientId] = 'busy';
 
 	/**
 	 * Create an alias for the global id tracker
@@ -210,6 +214,7 @@ export const addBlockId = ( args ) => {
 	}
 
 	return ( savedId ) => {
+		idGenerationStatus[clientId] = 'free';
 		localIDs[name].delete( attributes?.id || savedId );
 	};
 };
@@ -267,12 +272,25 @@ const extractBlockData = ( clientId ) => {
  * }
  */
 export const blockInit = ( clientId, defaultAttributes ) => {
-	return addBlockId({
-		clientId,
-		defaultAttributes,
-		setAttributes: ( ! isInReusableBlock( clientId ) || getSelectedBlockClientId() === clientId ) ? updateAttrs( clientId ) : undefined,
-		...extractBlockData( clientId )
-	});
+	if ( undefined === idGenerationStatus[clientId]) {
+		idGenerationStatus[clientId] = 'free';
+	}
+
+	// TODO: remove after testing
+	if ( 'busy' === idGenerationStatus[clientId]) {
+		console.log( 'Block Id: ' + clientId + '. Another block with the same cliendID is already generating' );
+	}
+
+	return (
+		'busy' !== idGenerationStatus[clientId] &&
+		( ! isSharedBlock( clientId ) || getSelectedBlockClientId() === clientId )
+	) ?
+		addBlockId({
+			clientId,
+			defaultAttributes,
+			setAttributes: updateAttrs( clientId ),
+			...extractBlockData( clientId )
+		}) : () => {};
 };
 
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

I added a lock that blocks multiple blocks with the same client id to change the block id. The lock is unlocked by the `unsubscribe` function.

![image](https://user-images.githubusercontent.com/17597852/183027085-19b8d145-df21-4393-80ec-11aef36ea067.png)


<image src="https://user-images.githubusercontent.com/17597852/183026829-857b63cf-2cd0-47b6-8850-c043ee32e923.jpeg" width="500"/>



### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add a Query Loop block.
2. Insert an Otter block in the Template Part.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

