### PR TITLE
Fix countdown border

### DIFF
--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -309,11 +309,11 @@ const Inspector = ({
 				<SelectControl
 					label={__( 'Type', 'otter-blocks' )}
 					value={ attributes.borderStyle ?? 'solid' }
-					onChange={ borderStyle => setAttributes({ borderStyle: borderStyle || undefined })}
+					onChange={ borderStyle => setAttributes({ borderStyle: 'solid' === borderStyle ? undefined : borderStyle })}
 					options={[
 						{
 							label: __( 'None', 'otter-blocks' ),
-							value: ''
+							value: 'none'
 						},
 						{
 							label: __( 'Solid', 'otter-blocks' ),
@@ -321,7 +321,7 @@ const Inspector = ({
 						},
 						{
 							label: __( 'Double', 'otter-blocks' ),
-							value: 'Double'
+							value: 'double'
 						},
 						{
 							label: __( 'Dotted', 'otter-blocks' ),
@@ -335,7 +335,7 @@ const Inspector = ({
 				/>
 
 				{
-					attributes.borderStyle && (
+					'none' !== attributes.borderStyle && (
 						<ResponsiveControl
 							label={ __( 'Width', 'otter-blocks' ) }
 						>

--- a/src/blocks/blocks/countdown/style.scss
+++ b/src/blocks/blocks/countdown/style.scss
@@ -29,6 +29,8 @@
 	--value-font-weight: regular;
 	--label-font-weight: regular;
 
+	border-style: none;
+
 	.otter-countdown__container {
 		display: flex;
 		justify-content: var(--alignment);


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1090.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix border selection and default value handling. Override some WP defaults.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

