### PR TITLE
Fix Icon List default icon not working

### DIFF
--- a/src/blocks/blocks/icon-list/block.json
+++ b/src/blocks/blocks/icon-list/block.json
@@ -15,7 +15,7 @@
 			"type": "string",
 			"default": "fontawesome"
 		},
-		"defaultIconPrefix": {
+		"defaultPrefix": {
 			"type": "string",
 			"default": "fas"
 		},

--- a/src/blocks/blocks/icon-list/item/edit.js
+++ b/src/blocks/blocks/icon-list/item/edit.js
@@ -77,7 +77,7 @@ const Edit = ({
 		setAttributes({
 			library: attributes.library || parentAttributes.defaultLibrary,
 			icon: attributes.icon || parentAttributes.defaultIcon,
-			iconPrefix: attributes.iconPrefix || parentAttributes.defaultIconPrefix
+			iconPrefix: attributes.iconPrefix || parentAttributes.defaultPrefix
 		});
 	}, [ hasParent, parentAttributes, attributes ]);
 
@@ -97,7 +97,7 @@ const Edit = ({
 
 	const Icon = themeIsleIcons.icons[ attributes.icon ];
 
-	const iconClassName = `${ attributes.iconPrefix || parentAttributes.defaultIconPrefix } fa-${ attributes.icon || parentAttributes.defaultIcon }`;
+	const iconClassName = `${ attributes.iconPrefix || parentAttributes.defaultPrefix } fa-${ attributes.icon || parentAttributes.defaultIcon }`;
 
 	const changeContent = value => {
 		setAttributes({ content: value });

--- a/src/blocks/blocks/icon-list/types.d.ts
+++ b/src/blocks/blocks/icon-list/types.d.ts
@@ -3,7 +3,7 @@ import { BlockProps, InspectorProps } from '../../helpers/blocks'
 type Attributes= {
 	id: string
 	defaultLibrary: string
-	defaultIconPrefix: string
+	defaultPrefix: string
 	defaultIcon: string
 	defaultContentColor: string
 	defaultIconColor: string


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1083.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
We had the wrong attribute name so the default icon in Font Awesome never worked if it was a brand icon. This should fix it.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

It should really be tested to make sure things don't break when coming from past versions.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

