### PR TITLE
Fix BackgroundSelectorControl

### DIFF
--- a/src/blocks/components/background-selector-control/index.js
+++ b/src/blocks/components/background-selector-control/index.js
@@ -84,92 +84,100 @@ const BackgroundSelectorControl = ({
 				</div>
 			</div>
 
-			{ 'color' === backgroundType && (
-				<ColorGradientControl
-					label={ __( 'Background Color', 'otter-blocks' ) }
-					colorValue={ backgroundColor }
-					onColorChange={ changeColor }
-				/>
-			) || 'image' === backgroundType && (
-				image?.url ? (
-					<Fragment>
-						<FocalPointPicker
-							label={ __( 'Focal point picker', 'otter-blocks' ) }
-							url={ image.url }
-							value={ focalPoint }
-							onDragStart={ changeFocalPoint }
-							onDrag={ changeFocalPoint }
-							onChange={ changeFocalPoint }
-						/>
-
-						<ControlPanelControl
-							label={ __( 'Background Settings', 'otter-blocks' ) }
-						>
-							<SelectControl
-								label={ __( 'Background Attachment', 'otter-blocks' ) }
-								value={ backgroundAttachment }
-								options={ [
-									{ label: __( 'Scroll', 'otter-blocks' ), value: 'scroll' },
-									{ label: __( 'Fixed', 'otter-blocks' ), value: 'fixed' },
-									{ label: __( 'Local', 'otter-blocks' ), value: 'local' }
-								] }
-								onChange={ changeBackgroundAttachment }
-							/>
-
-							<SelectControl
-								label={ __( 'Background Repeat', 'otter-blocks' ) }
-								value={ backgroundRepeat }
-								options={ [
-									{ label: __( 'Repeat', 'otter-blocks' ), value: 'repeat' },
-									{ label: __( 'No-repeat', 'otter-blocks' ), value: 'no-repeat' }
-								] }
-								onChange={ changeBackgroundRepeat }
-							/>
-
-							<SelectControl
-								label={ __( 'Background Size', 'otter-blocks' ) }
-								value={ backgroundSize }
-								options={ [
-									{ label: __( 'Auto', 'otter-blocks' ), value: 'auto' },
-									{ label: __( 'Cover', 'otter-blocks' ), value: 'cover' },
-									{ label: __( 'Contain', 'otter-blocks' ), value: 'contain' }
-								] }
-								onChange={ changeBackgroundSize }
-							/>
-						</ControlPanelControl>
-
-						<PanelRow>
-							<Button
-								isSmall
-								isSecondary
-								onClick={ removeImage }
-							>
-								{ __( 'Clear Image', 'otter-blocks' ) }
-							</Button>
-						</PanelRow>
-					</Fragment>
-				) : (
-					<MediaPlaceholder
-						icon="format-image"
-						labels={ {
-							title: __( 'Background Image', 'otter-blocks' ),
-							name: __( 'an image', 'otter-blocks' )
-						} }
-						value={ image?.id }
-						onSelect={ changeImage }
-						accept="image/*"
-						allowedTypes={ [ 'image' ] }
+			{
+				( 'color' === backgroundType || undefined === backgroundType ) && (
+					<ColorGradientControl
+						label={ __( 'Background Color', 'otter-blocks' ) }
+						colorValue={ backgroundColor }
+						onColorChange={ changeColor }
 					/>
 				)
-			) || 'gradient' === backgroundType && (
-				<ColorGradientControl
-					label={ __( 'Background Gradient', 'otter-blocks' ) }
-					gradientValue={ gradient }
-					disableCustomColors={ true }
-					onGradientChange={ changeGradient }
-					clearable={ false }
-				/>
-			) }
+			}
+			{
+				'image' === backgroundType && (
+					image?.url ? (
+						<Fragment>
+							<FocalPointPicker
+								label={ __( 'Focal point picker', 'otter-blocks' ) }
+								url={ image.url }
+								value={ focalPoint }
+								onDragStart={ changeFocalPoint }
+								onDrag={ changeFocalPoint }
+								onChange={ changeFocalPoint }
+							/>
+
+							<ControlPanelControl
+								label={ __( 'Background Settings', 'otter-blocks' ) }
+							>
+								<SelectControl
+									label={ __( 'Background Attachment', 'otter-blocks' ) }
+									value={ backgroundAttachment }
+									options={ [
+										{ label: __( 'Scroll', 'otter-blocks' ), value: 'scroll' },
+										{ label: __( 'Fixed', 'otter-blocks' ), value: 'fixed' },
+										{ label: __( 'Local', 'otter-blocks' ), value: 'local' }
+									] }
+									onChange={ changeBackgroundAttachment }
+								/>
+
+								<SelectControl
+									label={ __( 'Background Repeat', 'otter-blocks' ) }
+									value={ backgroundRepeat }
+									options={ [
+										{ label: __( 'Repeat', 'otter-blocks' ), value: 'repeat' },
+										{ label: __( 'No-repeat', 'otter-blocks' ), value: 'no-repeat' }
+									] }
+									onChange={ changeBackgroundRepeat }
+								/>
+
+								<SelectControl
+									label={ __( 'Background Size', 'otter-blocks' ) }
+									value={ backgroundSize }
+									options={ [
+										{ label: __( 'Auto', 'otter-blocks' ), value: 'auto' },
+										{ label: __( 'Cover', 'otter-blocks' ), value: 'cover' },
+										{ label: __( 'Contain', 'otter-blocks' ), value: 'contain' }
+									] }
+									onChange={ changeBackgroundSize }
+								/>
+							</ControlPanelControl>
+
+							<PanelRow>
+								<Button
+									isSmall
+									isSecondary
+									onClick={ removeImage }
+								>
+									{ __( 'Clear Image', 'otter-blocks' ) }
+								</Button>
+							</PanelRow>
+						</Fragment>
+					) : (
+						<MediaPlaceholder
+							icon="format-image"
+							labels={ {
+								title: __( 'Background Image', 'otter-blocks' ),
+								name: __( 'an image', 'otter-blocks' )
+							} }
+							value={ image?.id }
+							onSelect={ changeImage }
+							accept="image/*"
+							allowedTypes={ [ 'image' ] }
+						/>
+					)
+				)
+			}
+			{
+				'gradient' === backgroundType && (
+					<ColorGradientControl
+						label={ __( 'Background Gradient', 'otter-blocks' ) }
+						gradientValue={ gradient }
+						disableCustomColors={ true }
+						onGradientChange={ changeGradient }
+						clearable={ false }
+					/>
+				)
+			}
 		</div>
 	);
 };


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1093.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix ambiguous chaining that can show some unrelated color options when navigating back and forth.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Insert a Section color.
2. Set some background colors.
3. Switch between Color, Image, and Gradient continuously and check if Color options are not appearing in Gradient and vice versa
<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

