### PR TITLE
Fix animation issue with Reusable blocks

### DIFF
--- a/inc/class-base-css.php
+++ b/inc/class-base-css.php
@@ -269,7 +269,7 @@ class Base_CSS {
 		}
 
 		$blocks     = parse_blocks( $reusable_block->post_content );
-		$animations = boolval( preg_match( '/\banimated\b/', $content ) );
+		$animations = boolval( preg_match( '/\banimated\b/', $reusable_block->post_content ) );
 
 		return $this->cycle_through_static_blocks( $blocks, $animations );
 	}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

