### PR TITLE
Fixes for release 

### DIFF
--- a/inc/css/blocks/class-button-css.php
+++ b/inc/css/blocks/class-button-css.php
@@ -53,6 +53,13 @@ class Button_CSS extends Base_CSS {
 						},
 					),
 					array(
+						'property'  => 'justify-content',
+						'default'   => 'center',
+						'condition' => function( $attrs ) {
+							return isset( $attrs['library'] ) && 'themeisle-icons' === $attrs['library'];
+						},
+					),
+					array(
 						'property' => 'color',
 						'value'    => 'color',
 					),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4761,12 +4761,6 @@
 						"yallist": "^2.1.2"
 					}
 				},
-				"prettier": {
-					"version": "npm:wp-prettier@2.2.1-beta-1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-					"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-					"dev": true
-				},
 				"shebang-command": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -17415,6 +17409,12 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
 		},
+		"prettier": {
+			"version": "npm:wp-prettier@2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"dev": true
+		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -17773,14 +17773,6 @@
 					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
 					"dev": true
 				}
-			}
-		},
-		"react-google-font-loader": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/react-google-font-loader/-/react-google-font-loader-1.0.5.tgz",
-			"integrity": "sha512-Cpr3C96lBIQoXgmVwSo52Uc9oMnLOYuqArmPw63CuttBc27R0YpTeDINR39jPM/d5WofIbGpQFi66K4ts9G6Lg==",
-			"requires": {
-				"prop-types": "^15.6.2"
 			}
 		},
 		"react-is": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"deepmerge": "^4.2.2",
 		"dom-scroll-into-view": "^2.0.1",
 		"hex-rgba": "^1.0.2",
-		"react-google-font-loader": "1.0.5",
 		"react-sortable-hoc": "^2.0.0",
 		"uuid": "^8.3.2"
 	},

--- a/src/blocks/blocks/advanced-heading/edit.js
+++ b/src/blocks/blocks/advanced-heading/edit.js
@@ -36,7 +36,7 @@ import metadata from './block.json';
 import { blockInit } from '../../helpers/block-utility.js';
 import Controls from './controls.js';
 import Inspector from './inspector.js';
-import googleFontsLoader from '../../helpers/google-fonts';
+import googleFontsLoader from '../../helpers/google-fonts.js';
 
 const { attributes: defaultAttributes } = metadata;
 

--- a/src/blocks/blocks/button-group/group/edit.js
+++ b/src/blocks/blocks/button-group/group/edit.js
@@ -26,7 +26,7 @@ import {
 import metadata from './block.json';
 import Inspector from './inspector.js';
 import { blockInit } from '../../../helpers/block-utility.js';
-import googleFontsLoader from '../../../helpers/google-fonts';
+import googleFontsLoader from '../../../helpers/google-fonts.js';
 
 const { attributes: defaultAttributes } = metadata;
 

--- a/src/blocks/blocks/button-group/group/edit.js
+++ b/src/blocks/blocks/button-group/group/edit.js
@@ -26,6 +26,7 @@ import {
 import metadata from './block.json';
 import Inspector from './inspector.js';
 import { blockInit } from '../../../helpers/block-utility.js';
+import googleFontsLoader from '../../../helpers/google-fonts';
 
 const { attributes: defaultAttributes } = metadata;
 

--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -21,7 +21,7 @@
 	align-items: center;
 	margin-left: auto;
 	margin-right: auto;
-	height: var(--height);
+	height: var( --height );
 
 	perspective: 1000px; /* Remove this if you don't want the 3D effect */
 

--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -21,7 +21,6 @@
 	align-items: center;
 	margin-left: auto;
 	margin-right: auto;
-	width: var(--width);
 	height: var(--height);
 
 	perspective: 1000px; /* Remove this if you don't want the 3D effect */
@@ -48,7 +47,7 @@
 
 	.o-flip-inner {
 		position: relative;
-		width: 100%;
+		width: var(--width);
 		height: 100%;
 		text-align: center;
 		transition: transform 0.8s;

--- a/src/blocks/blocks/icon-list/editor.scss
+++ b/src/blocks/blocks/icon-list/editor.scss
@@ -71,3 +71,11 @@
 		color: var( --icon-color );
 	}
 }
+
+.editor-styles-wrapper .wp-block.wp-block-themeisle-blocks-icon-list-item {
+	/* We add this to override Neve styles */
+	margin-top: 0;
+	margin-left: 0;
+	margin-bottom: 0;
+	margin-right: 0;
+}

--- a/src/blocks/blocks/progress-bar/style.scss
+++ b/src/blocks/blocks/progress-bar/style.scss
@@ -18,27 +18,6 @@
 		margin-top: 43px;
 	}
 
-	.wp-block-themeisle-blocks-progress-bar__outer {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		margin-bottom: .25em;
-	}
-
-	.wp-block-themeisle-blocks-progress-bar__outer__title {
-		color: var( --title-color );
-		margin: 0px;
-		display: grid;
-		align-items: center;
-	}
-
-	.wp-block-themeisle-blocks-progress-bar__outer__value {
-		color: var( --percentage-color-outer );
-		margin-left: auto;
-		display: grid;
-		align-items: center;
-	}
-
 	.wp-block-themeisle-blocks-progress-bar__area {
 		position: relative;
 		width: 100%;
@@ -163,6 +142,28 @@
 			height: var( --height );
 			line-height: 30px;
 		}
+	}
+
+	.wp-block-themeisle-blocks-progress-bar__outer {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		margin-bottom: .25em;
+	}
+
+	.wp-block-themeisle-blocks-progress-bar__outer__title {
+		color: var( --title-color );
+		margin: 0px;
+		display: grid;
+		align-items: center;
+	}
+
+	.wp-block-themeisle-blocks-progress-bar__outer__value {
+		color: var( --percentage-color-outer );
+		margin-left: auto;
+		display: grid;
+		align-items: center;
+		position: inherit;
 	}
 }
 

--- a/src/blocks/components/google-fonts-control/index.js
+++ b/src/blocks/components/google-fonts-control/index.js
@@ -34,7 +34,7 @@ import {
 * Internal dependencies
 */
 import './editor.scss';
-import googleFontsLoader from '../../helpers/google-fonts';
+import googleFontsLoader from '../../helpers/google-fonts.js';
 
 
 const GoogleFontsControl = ({


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1100.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix:

- Progress Bar outer percentage value position (which makes it look like there is a problem with the color)
- Missing fonts loader for Button Group
- Flip width

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

