### PR TITLE
Fix custom CSS not working if used with existing class

### DIFF
--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -37,8 +37,8 @@ const CSSEditor = ({
 		}
 
 		return  attributes.className ?
-			( ! attributes.className.includes( 'ticss-' ) ? [ ...attributes.className.split( ' ' ), `ticss-${uniqueId}` ].join( ' ' ) : attributes.className ) :
-			`ticss-${uniqueId}`;
+			( ! attributes.className.includes( 'ticss-' ) ? [ ...attributes.className.split( ' ' ), `ticss-${ uniqueId }` ].join( ' ' ) : attributes.className ) :
+			`ticss-${ uniqueId }`;
 	};
 
 	const checkInput = ( editor, ignoreErrors = false ) => {
@@ -61,7 +61,7 @@ const CSSEditor = ({
 			initialValue = ( attributes.customCSS ).replace( regex, 'selector' );
 		}
 
-		editorRef.current = wp.CodeMirror( document.getElementById( 'otter-css-editor' ), {
+		editorRef.current = wp.CodeMirror( document.getElementById( 'o-css-editor' ), {
 			value: initialValue,
 			autoCloseBrackets: true,
 			continueComments: true,
@@ -90,7 +90,7 @@ const CSSEditor = ({
 
 	useEffect( () => {
 		const regex = new RegExp( 'selector', 'g' );
-		setCustomCSS( editorValue?.replace( regex, `.${getClassName()}` ) );
+		setCustomCSS( editorValue?.replace( regex, `.${ getClassName().split( ' ' ).find( i => i.includes( 'ticss' ) ) }` ) );
 	}, [ editorValue ]);
 
 	useEffect( () => {
@@ -114,7 +114,7 @@ const CSSEditor = ({
 		<Fragment>
 			<p>{__( 'Add your custom CSS.', 'otter-blocks' )}</p>
 
-			<div id="otter-css-editor" className="otter-css-editor" />
+			<div id="o-css-editor" className="o-css-editor" />
 
 			{ 0 < errors?.length && (
 				<div className='o-css-errors'>
@@ -151,7 +151,7 @@ const CSSEditor = ({
 			<br />
 			<p>{__( 'Example:', 'otter-blocks' )}</p>
 
-			<pre className="otter-css-editor-help">
+			<pre className="o-css-editor-help">
 				{'selector {\n    background: #000;\n}\n\nselector img {\n    border-radius: 100%;\n}'}
 			</pre>
 

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -1,9 +1,9 @@
-.otter-css-editor {
+.o-css-editor {
 	border: 1px solid #e2e4e7;
 	margin-bottom: 20px;
 }
 
-.otter-css-editor-help {
+.o-css-editor-help {
 	background: #f7f7f7;
 	padding: 20px;
 }

--- a/src/css/inject-css.js
+++ b/src/css/inject-css.js
@@ -15,12 +15,12 @@ import {
 } from '@wordpress/data';
 
 const addStyle = style => {
-	let element = document.getElementById( 'otter-css-editor-styles' );
+	let element = document.getElementById( 'o-css-editor-styles' );
 
 	if ( null === element ) {
 		element = document.createElement( 'style' );
 		element.setAttribute( 'type', 'text/css' );
-		element.setAttribute( 'id', 'otter-css-editor-styles' );
+		element.setAttribute( 'id', 'o-css-editor-styles' );
 		document.getElementsByTagName( 'head' )[0].appendChild( element );
 	}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1116.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

It fixes issues with custom CSS when the block already has an existing class. The bug was introduced only recently.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
Make sure CSS works regardless if the block has one class, a million classes, or no class.

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

