### PR TITLE
Change sorting order in Dynamic Value

### DIFF
--- a/src/blocks/plugins/dynamic-content/autocompleter.js
+++ b/src/blocks/plugins/dynamic-content/autocompleter.js
@@ -15,23 +15,11 @@ import { addFilter } from '@wordpress/hooks';
  */
 import options from './options.js';
 
-const autocompleteOptions = [];
+let autocompleteOptions = [];
 
 Object.keys( options ).forEach( option => autocompleteOptions.push( ...options[option].options ) );
 
-autocompleteOptions.sort( ( a, b ) => {
-	if ( ! a?.isDisabled || ( a?.isDisabled && b?.isDisabled ) ) {
-		return false;
-	}
-
-	if ( ! a?.isDisabled && b?.isDisabled ) {
-		return -1;
-	}
-
-	if ( a?.isDisabled && ! b?.isDisabled ) {
-		return true;
-	}
-});
+autocompleteOptions =  [ ...autocompleteOptions.filter( i => true !== i.isDisabled ), ...autocompleteOptions.filter( i => true === i.isDisabled ) ];
 
 const dynamicValue = {
 	name: 'dynamic-value',

--- a/src/blocks/plugins/dynamic-content/autocompleter.js
+++ b/src/blocks/plugins/dynamic-content/autocompleter.js
@@ -19,6 +19,20 @@ const autocompleteOptions = [];
 
 Object.keys( options ).forEach( option => autocompleteOptions.push( ...options[option].options ) );
 
+autocompleteOptions.sort( ( a, b ) => {
+	if ( ! a?.isDisabled || ( a?.isDisabled && b?.isDisabled ) ) {
+		return false;
+	}
+
+	if ( ! a?.isDisabled && b?.isDisabled ) {
+		return -1;
+	}
+
+	if ( a?.isDisabled && ! b?.isDisabled ) {
+		return true;
+	}
+});
+
 const dynamicValue = {
 	name: 'dynamic-value',
 	triggerPrefix: '%',

--- a/src/blocks/plugins/dynamic-content/components/inline-controls.js
+++ b/src/blocks/plugins/dynamic-content/components/inline-controls.js
@@ -43,7 +43,7 @@ const InlineControls = ({
 			attrs[ o ] = obj[ o ];
 		});
 
-		attrs = Object.fromEntries( Object.entries( attrs ).filter( ([ _, v ]) => ( null !== v && '' !== v ) ) );
+		attrs = Object.fromEntries( Object.entries( attrs ).filter( ([ _, v ]) => ( null !== v && '' !== v && undefined !== v ) ) );
 
 		setAttributes({ ...attrs });
 	};

--- a/src/blocks/plugins/dynamic-content/edit.js
+++ b/src/blocks/plugins/dynamic-content/edit.js
@@ -46,7 +46,7 @@ const Edit = ({
 			attrs[ o ] = obj[ o ];
 		});
 
-		attrs = Object.fromEntries( Object.entries( attrs ).filter( ([ _, v ]) => ( null !== v && '' !== v ) ) );
+		attrs = Object.fromEntries( Object.entries( attrs ).filter( ([ _, v ]) => ( null !== v && '' !== v && undefined !== v ) ) );
 
 		setAttributes({ ...attrs });
 	};
@@ -57,7 +57,7 @@ const Edit = ({
 
 	const onApply = () => {
 		const autocompleteOptions = [];
-		const attrs = Object.fromEntries( Object.entries( attributes ).filter( ([ _, v ]) => ( null !== v && '' !== v ) ) );
+		const attrs = Object.fromEntries( Object.entries( attributes ).filter( ([ _, v ]) => ( null !== v && '' !== v && undefined !== v ) ) );
 
 		if ( value.start === value.end ) { // Here we try to append the format if no text is selected.
 			const dynamicOptions = applyFilters( 'otter.dynamicContent.text.options', options );

--- a/src/blocks/plugins/dynamic-content/editor.scss
+++ b/src/blocks/plugins/dynamic-content/editor.scss
@@ -30,6 +30,7 @@ o-dynamic {
 	background: rgba(237, 111, 87, 0.1);
 	padding: 2px 5px;
 	border-radius: 8px;
+	cursor: pointer;
 }
 
 .o-dynamic-modal {

--- a/src/blocks/plugins/dynamic-content/media/media-content.js
+++ b/src/blocks/plugins/dynamic-content/media/media-content.js
@@ -216,7 +216,7 @@ const MediaContent = ({
 			attrs[ o ] = obj[ o ];
 		});
 
-		attrs = Object.fromEntries( Object.entries( attrs ).filter( ([ _, v ]) => ( null !== v && '' !== v ) ) );
+		attrs = Object.fromEntries( Object.entries( attrs ).filter( ([ _, v ]) => ( null !== v && '' !== v && undefined !== v ) ) );
 
 		const url = window.themeisleGutenberg.restRoot + '/dynamic/?' + getQueryStringFromObject( attrs );
 

--- a/src/pro/plugins/dynamic-content/edit.js
+++ b/src/pro/plugins/dynamic-content/edit.js
@@ -33,10 +33,15 @@ const Edit = ({
 	attributes,
 	changeAttributes
 }) => {
-	const { groups } = useSelect( select => {
+	const {
+		isLoaded,
+		groups
+	} = useSelect( select => {
 		const { groups } = select( 'otter-pro' ).getACFData();
+		const isLoaded = select( 'otter-pro' ).isACFLoaded();
 
 		return {
+			isLoaded,
 			groups
 		};
 	}, []);
@@ -214,7 +219,7 @@ const Edit = ({
 						<BaseControl
 							label={ __( 'Meta Key', 'otter-blocks' ) }
 						>
-							{ ! isEmpty( groups ) ? (
+							{ isLoaded ? (
 								<select
 									value={ attributes.metaKey || 'none' }
 									onChange={ event => changeAttributes({ metaKey: event.target.value  }) }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1032.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

It fixes:

- When using the `%` keyword with Otter free, show disabled Pro options in the end.
- Allow users to add dynamic tags even when no text is selected.
- Fix Spinner loading even when ACF fields are empty.
- Fix dynamic value breaking when you add and remove a custom meta.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Just make sure everything works as normal without any errors.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

