### PR TITLE
Remove About Author Block from the Inserter

### DIFF
--- a/src/blocks/blocks/about-author/index.js
+++ b/src/blocks/blocks/about-author/index.js
@@ -30,7 +30,7 @@ registerBlockType( name, {
 	edit,
 	save: () => null,
 	supports: {
-		inserter: undefined !== getBlockType( 'core/post-author' ),
+		inserter: undefined === getBlockType( 'core/post-author' ),
 		html: false
 	},
 	example: {}

--- a/src/blocks/blocks/about-author/index.js
+++ b/src/blocks/blocks/about-author/index.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 
-import { registerBlockType } from '@wordpress/blocks';
+import {
+	registerBlockType,
+	getBlockType
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -26,5 +29,9 @@ registerBlockType( name, {
 	],
 	edit,
 	save: () => null,
+	supports: {
+		inserter: undefined !== getBlockType( 'core/post-author' ),
+		html: false
+	},
 	example: {}
 });

--- a/src/blocks/blocks/about-author/index.js
+++ b/src/blocks/blocks/about-author/index.js
@@ -3,10 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 
-import {
-	registerBlockType,
-	getBlockType
-} from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -30,7 +27,7 @@ registerBlockType( name, {
 	edit,
 	save: () => null,
 	supports: {
-		inserter: undefined === getBlockType( 'core/post-author' ),
+		inserter: Boolean( window.themeisleGutenberg.isLegacyPre59 ),
 		html: false
 	},
 	example: {}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1115.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

If you're using WordPress version 5.9 or above, the About Author block will not appear in the Inserter. It'll work as normally before 5.8.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
Make sure it appears in 5.8 and doesn't appear in 5.9 or above.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

