### PR TITLE
Hide animations until fully load

### DIFF
--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -49,6 +49,7 @@ class Blocks_Animation {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_frontend_assets' ) );
 		add_filter( 'render_block', array( $this, 'frontend_load' ), 800, 2 );
+		add_filter( 'script_loader_tag', array( $this, 'add_no_script_tag' ), 10, 3 );
 	}
 
 	/**
@@ -185,6 +186,23 @@ class Blocks_Animation {
 		}
 
 		return $block_content;
+	}
+
+	/**
+	 * Add no script tag.
+	 *
+	 * @param string $tag The <script> tag for the enqueued script.
+	 * @param array  $handle The script's registered handle.
+	 * @param string $src The script's source URL.
+	 * @return string
+	 * @since 2.0.12
+	 */
+	public function add_no_script_tag( $tag, $handle, $src ) {
+		if ( 'otter-animation-frontend' === $handle ) {
+			$content = '<style>.animated { visibility: visible; }</style>';
+			$tag    .= '<noscript>' . $content . '</noscript>';
+		}
+		return $tag;
 	}
 
 	/**

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -195,12 +195,16 @@ class Blocks_Animation {
 	 * @param array  $handle The script's registered handle.
 	 * @param string $src The script's source URL.
 	 * @return string
-	 * @since 2.0.12
+	 * @since 2.0.14
 	 */
 	public function add_no_script_tag( $tag, $handle, $src ) {
 		if ( 'otter-animation-frontend' === $handle ) {
-			$content = '<style>.animated { visibility: visible; animation-play-state: running; }</style>';
-			$tag    .= '<noscript>' . $content . '</noscript>';
+			$hide_anim = '<style id="o-anim-hide-inline-css"> .animated:not(.o-anim-ready) {
+				visibility: hidden;
+				animation-play-state: paused;
+			 }</style>';
+			$noscript  = '<noscript><style>.animated { visibility: visible; animation-play-state: running; }</style></noscript>';
+			$tag      .= $hide_anim . $noscript;
 		}
 		return $tag;
 	}

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -199,7 +199,7 @@ class Blocks_Animation {
 	 */
 	public function add_no_script_tag( $tag, $handle, $src ) {
 		if ( 'otter-animation-frontend' === $handle ) {
-			$content = '<style>.animated { visibility: visible; }</style>';
+			$content = '<style>.animated { visibility: visible; animation-play-state: running; }</style>';
 			$tag    .= '<noscript>' . $content . '</noscript>';
 		}
 		return $tag;

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -49,7 +49,6 @@ class Blocks_Animation {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_frontend_assets' ) );
 		add_filter( 'render_block', array( $this, 'frontend_load' ), 800, 2 );
-		add_filter( 'script_loader_tag', array( $this, 'add_no_script_tag' ), 10, 3 );
 	}
 
 	/**
@@ -154,6 +153,9 @@ class Blocks_Animation {
 			);
 
 			wp_script_add_data( 'otter-animation-frontend', 'async', true );
+
+			add_action( 'wp_head', array( $this, 'add_fontend_anim_inline_style' ), 10, 3 );
+
 			self::$scripts_loaded['animation'] = true;
 		}
 
@@ -191,22 +193,15 @@ class Blocks_Animation {
 	/**
 	 * Add no script tag.
 	 *
-	 * @param string $tag The <script> tag for the enqueued script.
-	 * @param array  $handle The script's registered handle.
-	 * @param string $src The script's source URL.
-	 * @return string
+	 * @access public
 	 * @since 2.0.14
 	 */
-	public function add_no_script_tag( $tag, $handle, $src ) {
-		if ( 'otter-animation-frontend' === $handle ) {
-			$hide_anim = '<style id="o-anim-hide-inline-css"> .animated:not(.o-anim-ready) {
-				visibility: hidden;
-				animation-play-state: paused;
-			 }</style>';
-			$noscript  = '<noscript><style>.animated { visibility: visible; animation-play-state: running; }</style></noscript>';
-			$tag      .= $hide_anim . $noscript;
-		}
-		return $tag;
+	public static function add_fontend_anim_inline_style() {
+		echo '<style id="o-anim-hide-inline-css"> .animated:not(.o-anim-ready) {
+			visibility: hidden;
+			animation-play-state: paused;
+		 }</style>
+		 <noscript><style>.animated { visibility: visible; animation-play-state: running; }</style></noscript>';
 	}
 
 	/**

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -93,7 +93,7 @@ class Dashboard {
 				array(
 					'version'     => OTTER_BLOCKS_VERSION,
 					'assetsPath'  => OTTER_BLOCKS_URL . 'assets/',
-					'stylesExist' => is_dir( $basedir ),
+					'stylesExist' => is_dir( $basedir ) || boolval( get_transient( 'otter_animations_parsed' ) ),
 					'hasPro'      => Pro::is_pro_installed(),
 					'upgradeLink' => Pro::get_url(),
 					'docsLink'    => Pro::get_docs_url(),

--- a/inc/server/class-dashboard-server.php
+++ b/inc/server/class-dashboard-server.php
@@ -107,7 +107,7 @@ class Dashboard_Server {
 
 		$transient_deleted = false;
 
-		if( get_transient( 'otter_animations_parsed' ) ) {
+		if ( get_transient( 'otter_animations_parsed' ) ) {
 			delete_transient( 'otter_animations_parsed' );
 			$transient_deleted = true;
 		}

--- a/inc/server/class-dashboard-server.php
+++ b/inc/server/class-dashboard-server.php
@@ -105,6 +105,8 @@ class Dashboard_Server {
 			);
 		}
 
+		delete_transient( 'otter_animations_parsed' );
+
 		if ( ! is_dir( $basedir ) ) {
 			return rest_ensure_response(
 				array(

--- a/inc/server/class-dashboard-server.php
+++ b/inc/server/class-dashboard-server.php
@@ -105,14 +105,20 @@ class Dashboard_Server {
 			);
 		}
 
-		delete_transient( 'otter_animations_parsed' );
+		$transient_deleted = false;
+
+		if( get_transient( 'otter_animations_parsed' ) ) {
+			delete_transient( 'otter_animations_parsed' );
+			$transient_deleted = true;
+		}
+
 
 		if ( ! is_dir( $basedir ) ) {
 			return rest_ensure_response(
 				array(
 					'success' => false,
 					'data'    => array(
-						'message' => __( 'Sorry, the directory doesn\'t exist.', 'otter-blocks' ),
+						'message' => $transient_deleted ? __( 'Optimized code deleted.', 'otter-blocks' ) : __( 'Sorry, the directory doesn\'t exist.', 'otter-blocks' ),
 					),
 				)
 			);

--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -119,11 +119,6 @@
 	}
 }
 
-.animated {
-   visibility: hidden;
-   animation-play-state: paused;
-}
-
 .block-editor, .block-editor-block-list__layout {
    .animated {
       visibility: initial;

--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -118,3 +118,13 @@
 	  top: 16px;
 	}
 }
+
+.animated {
+   visibility: hidden;
+}
+
+.block-editor {
+   .animated {
+      visibility: initial;
+   }
+}

--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -124,7 +124,7 @@
    animation-play-state: paused;
 }
 
-.block-editor {
+.block-editor, .block-editor-block-list__layout {
    .animated {
       visibility: initial;
    }

--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -121,6 +121,7 @@
 
 .animated {
    visibility: hidden;
+   animation-play-state: paused;
 }
 
 .block-editor {

--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -127,6 +127,7 @@
 .block-editor, .block-editor-block-list__layout {
    .animated {
       visibility: initial;
+      animation-play-state: running;
    }
 }
 

--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -129,3 +129,7 @@
       visibility: initial;
    }
 }
+
+.customize-control-sidebar_block_editor .animated {
+   animation: none;
+}

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -162,6 +162,8 @@ window.addEventListener( 'load', () => {
 		classes = element.classList;
 		element.animationClasses = [];
 
+		element.style.visibility = 'initial';
+
 		if ( ! isElementInViewport( element ) ) {
 			const animationClass = animations.find( ( i ) => {
 				return Array.from( classes ).find( ( o ) => o === i );

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -158,12 +158,12 @@ const speed = [ 'none', 'slow', 'slower', 'fast', 'faster' ];
 
 window.addEventListener( 'load', () => {
 	const elements = document.querySelectorAll( '.animated' );
+
 	for ( const element of elements ) {
 		classes = element.classList;
 		element.animationClasses = [];
 
-		element.style.visibility = 'initial';
-		element.style.animationPlayState = 'running';
+		classes.add( 'o-anim-ready' );
 
 		if ( ! isElementInViewport( element ) ) {
 			const animationClass = animations.find( ( i ) => {
@@ -220,6 +220,7 @@ window.addEventListener( 'load', () => {
 				) {
 					const classes = element.animationClasses;
 					classes.forEach( ( i ) => element.classList.add( i ) );
+
 					element.classList.remove( 'hidden-animated' );
 					delete element.animationClasses;
 				}

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -163,6 +163,7 @@ window.addEventListener( 'load', () => {
 		element.animationClasses = [];
 
 		element.style.visibility = 'initial';
+		element.style.animationPlayState = 'running';
 
 		if ( ! isElementInViewport( element ) ) {
 			const animationClass = animations.find( ( i ) => {

--- a/src/animation/index.js
+++ b/src/animation/index.js
@@ -11,7 +11,9 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 
 import { InspectorControls } from '@wordpress/block-editor';
 
-import { Fragment } from '@wordpress/element';
+import {
+	Fragment
+} from '@wordpress/element';
 
 import {
 	addFilter,
@@ -29,7 +31,10 @@ import './typing/index.js';
 
 const excludedBlocks = [ 'themeisle-blocks/popup' ];
 
+const removeTimeouts = {};
+
 const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
+
 	return ( props ) => {
 		const hasCustomClassName = hasBlockSupport(
 			props.name,
@@ -38,6 +43,16 @@ const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
 		);
 
 		if ( hasCustomClassName && props.isSelected && ! excludedBlocks.includes( props.name ) ) {
+
+			let block = document.querySelector( `.customize-control-sidebar_block_editor #block-${ props.clientId } .animated` ) || document.querySelector( `#block-${ props.clientId }.animated` );
+
+			if ( block ) {
+				clearTimeout( removeTimeouts[ props.clientId ]);
+				removeTimeouts[ props.clientId ] = setTimeout( () => {
+					block.classList.remove( 'animated' );
+				}, 5_000 );
+			}
+
 			return (
 				<Fragment>
 					<BlockEdit { ...props } />

--- a/src/animation/index.js
+++ b/src/animation/index.js
@@ -11,9 +11,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 
 import { InspectorControls } from '@wordpress/block-editor';
 
-import {
-	Fragment
-} from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 
 import {
 	addFilter,
@@ -31,10 +29,7 @@ import './typing/index.js';
 
 const excludedBlocks = [ 'themeisle-blocks/popup' ];
 
-const removeTimeouts = {};
-
 const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
-
 	return ( props ) => {
 		const hasCustomClassName = hasBlockSupport(
 			props.name,
@@ -43,16 +38,6 @@ const withInspectorControls = createHigherOrderComponent( ( BlockEdit ) => {
 		);
 
 		if ( hasCustomClassName && props.isSelected && ! excludedBlocks.includes( props.name ) ) {
-
-			let block = document.querySelector( `.customize-control-sidebar_block_editor #block-${ props.clientId } .animated` ) || document.querySelector( `#block-${ props.clientId }.animated` );
-
-			if ( block ) {
-				clearTimeout( removeTimeouts[ props.clientId ]);
-				removeTimeouts[ props.clientId ] = setTimeout( () => {
-					block.classList.remove( 'animated' );
-				}, 5_000 );
-			}
-
 			return (
 				<Fragment>
 					<BlockEdit { ...props } />


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1060

⚠️ If you reuse a WP instance with another version of the plugin. After replacing the build. Go to Settings > Otter and press Regenerate.

<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Hide animations until the JS handler is loaded. This is a minor enhancement for slow internet connections.

Regenerate style now will delete the transient for optimized CSS.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add any block.
2. Put some animation.
3. Preview and be sure to use ⚠️ slow 3G to see if the animation is hidden.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

