### PR TITLE
Add missing null checker for Alignment Toolbar Control

### DIFF
--- a/src/blocks/blocks/button-group/group/inspector.js
+++ b/src/blocks/blocks/button-group/group/inspector.js
@@ -164,23 +164,7 @@ const Inspector = ({
 						]}
 						onChange={ onAlignmentChange }
 						hideLabels
-						style={{
-							button: {
-								color: 'black',
-								boxShadow: 'none',
-								borderRadius: '0px'
-							},
-							active: {
-								color: 'white',
-								backgroundColor: 'black',
-								boxShadow: 'none',
-								borderRadius: '0px'
-							},
-							group: {
-								marginLeft: '0px',
-								marginRight: '0px'
-							}
-						}}
+						hasIcon
 					/>
 				</ResponsiveControl>
 			</PanelBody>

--- a/src/blocks/components/toogle-group-control/editor.scss
+++ b/src/blocks/components/toogle-group-control/editor.scss
@@ -5,6 +5,26 @@
 	justify-content: center;
 	width: 100%;
 
+	&.has-icon {
+		margin-left: 0px;
+		margin-right: '0px';
+
+		.components-button {
+			&.is-primary {
+				color: white;
+				background-color: black;
+				box-shadow: none;
+				border-radius: 0;
+			}
+
+			&.is-secondary {
+				color: #000;
+				box-shadow: none;
+				border-radius: 0px;
+			}
+		}
+	}
+
 	.o-toggle-option {
 		&:root {
 			--o-toogle-btn-rad: 0px;

--- a/src/blocks/components/toogle-group-control/index.js
+++ b/src/blocks/components/toogle-group-control/index.js
@@ -16,7 +16,6 @@ import {
  */
 import './editor.scss';
 
-
 /**
  *	A group of buttons that actions as a toggle
  *
@@ -30,19 +29,22 @@ const ToogleGroupControl = ({
 	hideLabels,
 	hideTooltip,
 	showBottomLabels,
-	style
+	hasIcon = false
 }) => {
 	return (
 		<ButtonGroup
-			className="o-toggle-group-control"
-			style={ style?.group }
+			className={ classNames(
+				'o-toggle-group-control',
+				{
+					'has-icon': hasIcon
+				}
+			) }
 		>
 			{ options?.map( option => {
 				return (
 					<div
 						key={ option?.value }
 						className="o-toggle-option"
-						style={ style?.option }
 					>
 						<Button
 							isPrimary={ value == option?.value }
@@ -51,12 +53,11 @@ const ToogleGroupControl = ({
 							label={ option?.label }
 							onClick={ () => onChange( option?.value )}
 							showTooltip={ Boolean( hideTooltip ) }
-							style={ value == option?.value ? ( style?.active ?? style?.button ) : style?.button }
 						>
 							{ option?.label && ! Boolean( hideLabels ) && ! Boolean( showBottomLabels ) ? option?.label : '' }
 						</Button>
 
-						<p style={ style?.label }>{ option?.label && ! Boolean( hideLabels ) && Boolean( showBottomLabels ) ?  option?.label : '' }</p>
+						<p>{ option?.label && ! Boolean( hideLabels ) && Boolean( showBottomLabels ) ?  option?.label : '' }</p>
 					</div>
 				);
 			}) }

--- a/src/blocks/components/toogle-group-control/index.js
+++ b/src/blocks/components/toogle-group-control/index.js
@@ -51,7 +51,7 @@ const ToogleGroupControl = ({
 							label={ option?.label }
 							onClick={ () => onChange( option?.value )}
 							showTooltip={ Boolean( hideTooltip ) }
-							style={ value == option?.value ? ( style.active ?? style?.button ) : style?.button }
+							style={ value == option?.value ? ( style?.active ?? style?.button ) : style?.button }
 						>
 							{ option?.label && ! Boolean( hideLabels ) && ! Boolean( showBottomLabels ) ? option?.label : '' }
 						</Button>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1123.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add missing `?`.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

