### PR TITLE
Remove padding from frontend for FA Block

### DIFF
--- a/inc/css/blocks/class-font-awesome-icons-css.php
+++ b/inc/css/blocks/class-font-awesome-icons-css.php
@@ -94,7 +94,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 							'value'    => 'backgroundColor',
 							'hasSync'  => 'icon-background-color',
 						),
-					),
+					)
 				),
 			)
 		);

--- a/inc/css/blocks/class-font-awesome-icons-css.php
+++ b/inc/css/blocks/class-font-awesome-icons-css.php
@@ -79,21 +79,6 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 			)
 		);
 
-		$padding = array();
-
-		// This argument isn't used inside condition because of global defaults.
-		if ( isset( $block['attrs']['library'] ) && 'themeisle-icons' === $this->get_attr_value( $block['attrs']['library'], 'fontawesome' ) ) {
-			$padding = array(
-				array(
-					'property' => 'padding',
-					'value'    => 'padding',
-					'default'  => 5,
-					'unit'     => 'px',
-					'hasSync'  => 'icon-padding',
-				),
-			);
-		}
-
 		$css->add_item(
 			array(
 				'selector'   => ' .wp-block-themeisle-blocks-font-awesome-icons-container',
@@ -110,7 +95,6 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 							'hasSync'  => 'icon-background-color',
 						),
 					),
-					$padding
 				),
 			)
 		);


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #998.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Some unnecessary code was left after changing the formula for icon dimensions.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add FA Blocks with Temeisle Icons and FA Icons
2. Set the same size and padding.
3. They should look the same.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

