### PR TITLE
Progress Bar enhancement

### DIFF
--- a/inc/css/blocks/class-progress-bar-css.php
+++ b/inc/css/blocks/class-progress-bar-css.php
@@ -94,6 +94,10 @@ class Progress_Bar_CSS extends Base_CSS {
 						'property' => '--bar-background',
 						'value'    => 'barBackgroundColor',
 					),
+					array(
+						'property' => '--title-font-size',
+						'value'    => 'titleFontSize',
+					),
 				),
 			)
 		);

--- a/src/blocks/blocks/progress-bar/block.json
+++ b/src/blocks/blocks/progress-bar/block.json
@@ -49,6 +49,9 @@
 		},
 		"percentageColor": {
 			"type": "string"
+		},
+		"titleFontSize": {
+			"type": "string"
 		}
 	},
 	"editorStyle": "otter-progress-bar-editor",

--- a/src/blocks/blocks/progress-bar/edit.js
+++ b/src/blocks/blocks/progress-bar/edit.js
@@ -42,8 +42,6 @@ const ProgressBar = ({
 	toggleSelection
 }) => {
 
-	console.log( attributes );
-
 	useEffect( () => {
 		const unsubscribe = blockInit( clientId, defaultAttributes );
 		return () => unsubscribe( attributes.id );

--- a/src/blocks/blocks/progress-bar/edit.js
+++ b/src/blocks/blocks/progress-bar/edit.js
@@ -159,7 +159,7 @@ const ProgressBar = ({
 						) }
 
 						{ 'outer' === attributes.percentagePosition && showPercentage && (
-							<div className="wp-block-themeisle-blocks-progress-bar__progress wp-block-themeisle-blocks-progress-bar__outer__value">
+							<div className="wp-block-themeisle-blocks-progress-bar__outer__value wp-block-themeisle-blocks-progress-bar__number">
 								{ `${ attributes.percentage }%` }
 							</div>
 						)}

--- a/src/blocks/blocks/progress-bar/edit.js
+++ b/src/blocks/blocks/progress-bar/edit.js
@@ -42,6 +42,8 @@ const ProgressBar = ({
 	toggleSelection
 }) => {
 
+	console.log( attributes );
+
 	useEffect( () => {
 		const unsubscribe = blockInit( clientId, defaultAttributes );
 		return () => unsubscribe( attributes.id );
@@ -95,7 +97,8 @@ const ProgressBar = ({
 		'--background-color': attributes.backgroundColor,
 		'--border-radius': attributes.borderRadius !== undefined && ( attributes.borderRadius + 'px' ),
 		'--height': attributes.height !== undefined && ( attributes.height + 'px' ),
-		'--bar-background': attributes.barBackgroundColor
+		'--bar-background': attributes.barBackgroundColor,
+		'--title-font-size': attributes.titleFontSize
 	};
 
 	const onHeightChange = value => {

--- a/src/blocks/blocks/progress-bar/inspector.js
+++ b/src/blocks/blocks/progress-bar/inspector.js
@@ -18,6 +18,7 @@ import {
 	TextControl,
 	FontSizePicker
 } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 const defaultFontSizes = [
 	{
@@ -223,13 +224,16 @@ const Inspector = ({
 
 				{
 					( ( 'outer' === attributes.titleStyle ) || ( 'tooltip' === attributes.percentagePosition && 'outer' === attributes.percentagePosition ) ) && (
-						<FontSizePicker
-							label={ __( 'Outer Text Font Size', 'otter-blocks' ) }
-							fontSizes={ defaultFontSizes }
-							withReset
-							value={ attributes.titleFontSize }
-							onChange={ titleFontSize => setAttributes({ titleFontSize }) }
-						/>
+						<Fragment>
+							<h2>{__( 'Outer Text Font Size', 'otter-blocks' )}</h2>
+							<FontSizePicker
+
+								fontSizes={ defaultFontSizes }
+								withReset
+								value={ attributes.titleFontSize }
+								onChange={ titleFontSize => setAttributes({ titleFontSize }) }
+							/>
+						</Fragment>
 					)
 				}
 

--- a/src/blocks/blocks/progress-bar/inspector.js
+++ b/src/blocks/blocks/progress-bar/inspector.js
@@ -7,15 +7,40 @@ import { clamp } from 'lodash';
 
 import {
 	__experimentalColorGradientControl as ColorGradientControl,
-	InspectorControls
+	InspectorControls,
+	PanelColorSettings
 } from '@wordpress/block-editor';
 
 import {
 	PanelBody,
 	RangeControl,
 	SelectControl,
-	TextControl
+	TextControl,
+	FontSizePicker
 } from '@wordpress/components';
+
+const defaultFontSizes = [
+	{
+		name: __( 'Small', 'otter-blocks' ),
+		size: '0.875em',
+		slug: 'small'
+	},
+	{
+		name: __( 'Medium', 'otter-blocks' ),
+		size: '1em',
+		slug: 'medium'
+	},
+	{
+		name: __( 'Large', 'otter-blocks' ),
+		size: '1.125em',
+		slug: 'large'
+	},
+	{
+		name: __( 'XL', 'otter-blocks' ),
+		size: '1.25em',
+		slug: 'xl'
+	}
+];
 
 /**
  *
@@ -114,6 +139,41 @@ const Inspector = ({
 					step={ 0.1 }
 				/>
 
+			</PanelBody>
+
+			<PanelColorSettings
+				title={ __( 'Color', 'otter-blocks' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						value: attributes.titleColor,
+						onChange: titleColor => setAttributes({ titleColor }),
+						label: __( 'Title', 'otter-blocks' )
+					},
+					{
+						value: attributes.barBackgroundColor,
+						onChange: barBackgroundColor => setAttributes({ barBackgroundColor }),
+						label: __( 'Progress', 'otter-blocks' )
+					},
+					{
+						value: attributes.percentageColor,
+						onChange: percentageColor => setAttributes({ percentageColor }),
+						label: __( 'Percentage', 'otter-blocks' )
+					},
+					{
+						value: attributes.backgroundColor,
+						onChange: backgroundColor => setAttributes({ backgroundColor }),
+						label: __( 'Background', 'otter-blocks' )
+					}
+				] }
+			>
+
+			</PanelColorSettings>
+
+			<PanelBody
+				title={ __( 'Style', 'otter-blocks' ) }
+				initialOpen={ false }
+			>
 				{ 30 <= attributes.height && (
 					<SelectControl
 						label={ __( 'Title Style', 'otter-blocks' ) }
@@ -139,12 +199,7 @@ const Inspector = ({
 					] }
 					onChange={ selectPercentagePosition }
 				/>
-			</PanelBody>
 
-			<PanelBody
-				title={ __( 'Style', 'otter-blocks' ) }
-				initialOpen={ false }
-			>
 				<RangeControl
 					label={ __( 'Height', 'otter-blocks' ) }
 					help={ __( 'The height of the progress bar.', 'otter-blocks' ) }
@@ -166,29 +221,19 @@ const Inspector = ({
 					max={ 35 }
 				/>
 
-				<ColorGradientControl
-					label={ __( 'Progress Color', 'otter-blocks' ) }
-					colorValue={ attributes.barBackgroundColor }
-					onColorChange={ onBarBackgroundColorChange }
-				/>
+				{
+					( ( 'outer' === attributes.titleStyle ) || ( 'tooltip' === attributes.percentagePosition && 'outer' === attributes.percentagePosition ) ) && (
+						<FontSizePicker
+							label={ __( 'Outer Text Font Size', 'otter-blocks' ) }
+							fontSizes={ defaultFontSizes }
+							withReset
+							value={ attributes.titleFontSize }
+							onChange={ titleFontSize => setAttributes({ titleFontSize }) }
+						/>
+					)
+				}
 
-				<ColorGradientControl
-					label={ __( 'Title Color', 'otter-blocks' ) }
-					colorValue={ attributes.titleColor }
-					onColorChange={ onTitleColorChange }
-				/>
 
-				<ColorGradientControl
-					label={ __( 'Percentage Color', 'otter-blocks' ) }
-					colorValue={ attributes.percentageColor }
-					onColorChange={ onPerncetageColorChange }
-				/>
-
-				<ColorGradientControl
-					label={ __( 'Background Color', 'otter-blocks' ) }
-					colorValue={ attributes.backgroundColor }
-					onColorChange={ onBackgroundColorChange }
-				/>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/src/blocks/blocks/progress-bar/style.scss
+++ b/src/blocks/blocks/progress-bar/style.scss
@@ -10,6 +10,7 @@
 	--height: 30px;
 	--font-size: calc( var( --height ) * 0.65 );
 	--bar-background: #6adcfa;
+	--title-font-size: initial;
 
 	display: flex;
 	flex-direction: column;
@@ -85,10 +86,12 @@
 		transition: all 1s;
 		position: relative;
 		padding: 4px 10px 7px 10px;
-		background-color: rgba(67, 66, 76, 0.81);
+		background-color: var(--bar-background);
 		border-radius: 2px;
 		line-height: 20px;
 		opacity: 0;
+		font-size: clamp(0px, var(--title-font-size), 1.25rem);
+		text-align: center;
 
 		&.show {
 			opacity: 1;
@@ -107,7 +110,7 @@
 		display: block;
 		border-style: solid;
 		border-width: 5px 5px 0 5px;
-		border-color: rgba(67, 66, 76, 0.81) transparent transparent transparent;
+		border-color: var(--bar-background) transparent transparent transparent;
 	}
 
 	.wp-block-themeisle-blocks-progress-bar__area__title {
@@ -148,7 +151,7 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
-		margin-bottom: .25em;
+		margin-bottom: 10px;
 	}
 
 	.wp-block-themeisle-blocks-progress-bar__outer__title {
@@ -156,7 +159,8 @@
 		margin: 0px;
 		display: grid;
 		align-items: center;
-		font-size: var( --font-size );
+		font-size: var( --title-font-size );
+		line-height: 70%;
 	}
 
 	.wp-block-themeisle-blocks-progress-bar__outer__value {
@@ -165,6 +169,8 @@
 		display: grid;
 		align-items: center;
 		position: inherit;
+		font-size: var( --title-font-size );
+		line-height: 70%;
 	}
 }
 

--- a/src/blocks/blocks/progress-bar/style.scss
+++ b/src/blocks/blocks/progress-bar/style.scss
@@ -10,7 +10,7 @@
 	--height: 30px;
 	--font-size: calc( var( --height ) * 0.65 );
 	--bar-background: #6adcfa;
-	--title-font-size: initial;
+	--title-font-size: var(--font-size);
 
 	display: flex;
 	flex-direction: column;

--- a/src/blocks/blocks/progress-bar/types.d.ts
+++ b/src/blocks/blocks/progress-bar/types.d.ts
@@ -12,7 +12,8 @@ type Attributes = {
 	backgroundColor: string
 	barBackgroundColor: string
 	titleColor: string
-	percentageColor: string
+	percentageColor: string,
+	titleFontSize: string
 }
 
 export type ProgressBarProps = BlockProps<Attributes>

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -40,7 +40,7 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 
 	.wp-block-themeisle-blocks-advanced-column {
 		.wp-block-themeisle-blocks-slider {
-			display: grid;
+			display: block;
 		}
 	}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #818.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Add font-size for Title and Value on Outer style
- Tooltip will inherit the progress bar as the background color

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

