### PR TITLE
Fix js loading when not needed

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -372,6 +372,20 @@ class Registration {
 
 		$this->enqueue_block_styles( $post );
 
+		if ( has_block( 'core/block', $post ) ) {
+			$blocks = parse_blocks( $content );
+			$blocks = array_filter(
+				$blocks,
+				function( $block ) {
+					return 'core/block' === $block['blockName'] && isset( $block['attrs']['ref'] );
+				}
+			);
+
+			foreach ( $blocks as $block ) {
+				$this->enqueue_dependencies( $block['attrs']['ref'] );
+			}
+		}
+
 		if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) || is_admin() ) {
 			return;
 		}
@@ -529,20 +543,6 @@ class Registration {
 			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/progress-bar.asset.php';
 			wp_register_script( 'otter-progress-bar', OTTER_BLOCKS_URL . 'build/blocks/progress-bar.js', $asset_file['dependencies'], $asset_file['version'], true );
 			wp_script_add_data( 'otter-progress-bar', 'defer', true );
-		}
-
-		if ( has_block( 'core/block', $post ) ) {
-			$blocks = parse_blocks( $content );
-			$blocks = array_filter(
-				$blocks,
-				function( $block ) {
-					return 'core/block' === $block['blockName'] && isset( $block['attrs']['ref'] );
-				}
-			);
-
-			foreach ( $blocks as $block ) {
-				$this->enqueue_dependencies( $block['attrs']['ref'] );
-			}
 		}
 	}
 

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -41,7 +41,17 @@ class Registration {
 	 * @var array
 	 */
 	public static $scripts_loaded = array(
-		'sticky' => false,
+		'circle-counter' => false,
+		'countdown'      => false,
+		'form'           => false,
+		'google-map'     => false,
+		'leaflet-map'    => false,
+		'lottie'         => false,
+		'slider'         => false,
+		'sticky'         => false,
+		'tabs'           => false,
+		'popup'          => false,
+		'progress-bar'   => false,
 	);
 
 	/**
@@ -176,145 +186,6 @@ class Registration {
 		wp_style_add_data( 'glidejs-core', 'path', OTTER_BLOCKS_PATH . '/assets/glide/glide.core.min.css' );
 		wp_register_style( 'glidejs-theme', OTTER_BLOCKS_URL . 'assets/glide/glide.theme.min.css', [], $asset_file['version'] );
 		wp_style_add_data( 'glidejs-theme', 'path', OTTER_BLOCKS_PATH . '/assets/glide/glide.theme.min.css' );
-
-		if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) || is_admin() ) {
-			return;
-		}
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/circle-counter.asset.php';
-		wp_register_script( 'otter-circle-counter', OTTER_BLOCKS_URL . 'build/blocks/circle-counter.js', $asset_file['dependencies'], $asset_file['version'], true );
-		wp_script_add_data( 'otter-circle-counter', 'defer', true );
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/countdown.asset.php';
-		wp_register_script( 'otter-countdown', OTTER_BLOCKS_URL . 'build/blocks/countdown.js', $asset_file['dependencies'], $asset_file['version'], true );
-		wp_script_add_data( 'otter-countdown', 'defer', true );
-
-		$offset    = (float) get_option( 'gmt_offset' );
-		$hours     = (int) $offset;
-		$minutes   = ( $offset - $hours );
-		$sign      = ( $offset < 0 ) ? '-' : '+';
-		$abs_hour  = abs( $hours );
-		$abs_mins  = abs( $minutes * 60 );
-		$tz_offset = sprintf( '%s%02d:%02d', $sign, $abs_hour, $abs_mins );
-
-		wp_localize_script(
-			'otter-countdown',
-			'themeisleGutenbergCountdown',
-			array(
-				'i18n'     => array(
-					'second'  => __( 'Second', 'otter-blocks' ),
-					'seconds' => __( 'Seconds', 'otter-blocks' ),
-					'minute'  => __( 'Minute', 'otter-blocks' ),
-					'minutes' => __( 'Minutes', 'otter-blocks' ),
-					'hour'    => __( 'Hour', 'otter-blocks' ),
-					'hours'   => __( 'Hours', 'otter-blocks' ),
-					'day'     => __( 'Day', 'otter-blocks' ),
-					'days'    => __( 'Days', 'otter-blocks' ),
-				),
-				'timezone' => $tz_offset,
-			)
-		);
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/form.asset.php';
-		wp_register_script( 'otter-form', OTTER_BLOCKS_URL . 'build/blocks/form.js', $asset_file['dependencies'], $asset_file['version'], true );
-		wp_script_add_data( 'otter-form', 'defer', true );
-
-		wp_localize_script(
-			'otter-form',
-			'themeisleGutenbergForm',
-			array(
-				'reRecaptchaSitekey' => get_option( 'themeisle_google_captcha_api_site_key' ),
-				'root'               => esc_url_raw( rest_url() ),
-				'nonce'              => wp_create_nonce( 'wp_rest' ),
-				'messages'           => array(
-					'submission'         => __( 'Form submission from', 'otter-blocks' ),
-					'captcha-not-loaded' => __( 'Captcha is not loaded. Please check your browser plugins to allow the Google reCaptcha.', 'otter-blocks' ),
-					'check-captcha'      => __( 'Please check the captcha.', 'otter-blocks' ),
-					'invalid-email'      => __( 'The email address is invalid!', 'otter-blocks' ),
-					'already-registered' => __( 'The email was already registered!', 'otter-blocks' ),
-					'try-again'          => __( 'Error. Something is wrong with the server! Try again later.', 'otter-blocks' ),
-					'privacy'            => __( 'I have read and agreed the privacy statement.', 'otter-blocks' ),
-				),
-			)
-		);
-
-		$apikey = get_option( 'themeisle_google_map_block_api_key' );
-
-		// Don't output anything if there is no API key.
-		if ( null !== $apikey && ! empty( $apikey ) ) {
-			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/maps.asset.php';
-			wp_register_script( 'otter-google-map', OTTER_BLOCKS_URL . 'build/blocks/maps.js', $asset_file['dependencies'], $asset_file['version'], true );
-			wp_script_add_data( 'otter-google-map', 'defer', true );
-			wp_register_script( 'google-maps', 'https://maps.googleapis.com/maps/api/js?key=' . esc_attr( $apikey ) . '&libraries=places&callback=initMapScript', array( 'otter-google-map' ), '', true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
-			wp_script_add_data( 'google-maps', 'defer', true );
-		}
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/leaflet-map.asset.php';
-
-		wp_register_script(
-			'otter-leaflet',
-			OTTER_BLOCKS_URL . 'build/blocks/leaflet-map.js',
-			array_merge(
-				$asset_file['dependencies'],
-				array( 'leaflet', 'leaflet-gesture-handling' )
-			),
-			$asset_file['version'],
-			true
-		);
-
-		wp_script_add_data( 'otter-leaflet', 'defer', true );
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/lottie.asset.php';
-		wp_register_script( 'lottie-interactivity', OTTER_BLOCKS_URL . 'assets/lottie/lottie-interactivity.min.js', array( 'lottie-player' ), $asset_file['version'], true );
-		wp_script_add_data( 'lottie-interactivity', 'async', true );
-
-		wp_register_script(
-			'otter-lottie',
-			OTTER_BLOCKS_URL . 'build/blocks/lottie.js',
-			array_merge(
-				$asset_file['dependencies'],
-				array( 'lottie-player', 'lottie-interactivity' )
-			),
-			$asset_file['version'],
-			true
-		);
-
-		wp_script_add_data( 'otter-lottie', 'defer', true );
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/slider.asset.php';
-
-		wp_register_script(
-			'otter-slider',
-			OTTER_BLOCKS_URL . 'build/blocks/slider.js',
-			array_merge(
-				$asset_file['dependencies'],
-				array( 'glidejs' )
-			),
-			$asset_file['version'],
-			true
-		);
-
-		wp_script_add_data( 'otter-slider', 'async', true );
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/tabs.asset.php';
-		wp_register_script( 'otter-tabs', OTTER_BLOCKS_URL . 'build/blocks/tabs.js', $asset_file['dependencies'], $asset_file['version'], true );
-		wp_script_add_data( 'otter-tabs', 'defer', true );
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/popup.asset.php';
-		wp_register_script( 'otter-popup', OTTER_BLOCKS_URL . 'build/blocks/popup.js', $asset_file['dependencies'], $asset_file['version'], true );
-		wp_script_add_data( 'otter-popup', 'defer', true );
-
-		wp_localize_script(
-			'otter-popup',
-			'themeisleGutenberg',
-			array(
-				'isPreview' => is_preview(),
-			)
-		);
-
-		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/progress-bar.asset.php';
-		wp_register_script( 'otter-progress-bar', OTTER_BLOCKS_URL . 'build/blocks/progress-bar.js', $asset_file['dependencies'], $asset_file['version'], true );
-		wp_script_add_data( 'otter-progress-bar', 'defer', true );
 	}
 
 	/**
@@ -500,6 +371,165 @@ class Registration {
 		}
 
 		$this->enqueue_block_styles( $post );
+
+		if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) || is_admin() ) {
+			return;
+		}
+
+		if ( ! self::$scripts_loaded['circle-counter'] && has_block( 'themeisle-blocks/circle-counter', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/circle-counter.asset.php';
+			wp_register_script( 'otter-circle-counter', OTTER_BLOCKS_URL . 'build/blocks/circle-counter.js', $asset_file['dependencies'], $asset_file['version'], true );
+			wp_script_add_data( 'otter-circle-counter', 'defer', true );
+		}
+
+		if ( ! self::$scripts_loaded['countdown'] && has_block( 'themeisle-blocks/countdown', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/countdown.asset.php';
+			wp_register_script( 'otter-countdown', OTTER_BLOCKS_URL . 'build/blocks/countdown.js', $asset_file['dependencies'], $asset_file['version'], true );
+			wp_script_add_data( 'otter-countdown', 'defer', true );
+
+			$offset    = (float) get_option( 'gmt_offset' );
+			$hours     = (int) $offset;
+			$minutes   = ( $offset - $hours );
+			$sign      = ( $offset < 0 ) ? '-' : '+';
+			$abs_hour  = abs( $hours );
+			$abs_mins  = abs( $minutes * 60 );
+			$tz_offset = sprintf( '%s%02d:%02d', $sign, $abs_hour, $abs_mins );
+
+			wp_localize_script(
+				'otter-countdown',
+				'themeisleGutenbergCountdown',
+				array(
+					'i18n'     => array(
+						'second'  => __( 'Second', 'otter-blocks' ),
+						'seconds' => __( 'Seconds', 'otter-blocks' ),
+						'minute'  => __( 'Minute', 'otter-blocks' ),
+						'minutes' => __( 'Minutes', 'otter-blocks' ),
+						'hour'    => __( 'Hour', 'otter-blocks' ),
+						'hours'   => __( 'Hours', 'otter-blocks' ),
+						'day'     => __( 'Day', 'otter-blocks' ),
+						'days'    => __( 'Days', 'otter-blocks' ),
+					),
+					'timezone' => $tz_offset,
+				)
+			);
+		}
+
+		if ( ! self::$scripts_loaded['form'] && has_block( 'themeisle-blocks/form', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/form.asset.php';
+			wp_register_script( 'otter-form', OTTER_BLOCKS_URL . 'build/blocks/form.js', $asset_file['dependencies'], $asset_file['version'], true );
+			wp_script_add_data( 'otter-form', 'defer', true );
+
+			wp_localize_script(
+				'otter-form',
+				'themeisleGutenbergForm',
+				array(
+					'reRecaptchaSitekey' => get_option( 'themeisle_google_captcha_api_site_key' ),
+					'root'               => esc_url_raw( rest_url() ),
+					'nonce'              => wp_create_nonce( 'wp_rest' ),
+					'messages'           => array(
+						'submission'         => __( 'Form submission from', 'otter-blocks' ),
+						'captcha-not-loaded' => __( 'Captcha is not loaded. Please check your browser plugins to allow the Google reCaptcha.', 'otter-blocks' ),
+						'check-captcha'      => __( 'Please check the captcha.', 'otter-blocks' ),
+						'invalid-email'      => __( 'The email address is invalid!', 'otter-blocks' ),
+						'already-registered' => __( 'The email was already registered!', 'otter-blocks' ),
+						'try-again'          => __( 'Error. Something is wrong with the server! Try again later.', 'otter-blocks' ),
+						'privacy'            => __( 'I have read and agreed the privacy statement.', 'otter-blocks' ),
+					),
+				)
+			);
+		}
+
+		if ( ! self::$scripts_loaded['google-map'] && has_block( 'themeisle-blocks/google-map', $post ) ) {
+			$apikey = get_option( 'themeisle_google_map_block_api_key' );
+
+			// Don't output anything if there is no API key.
+			if ( null !== $apikey && ! empty( $apikey ) ) {
+				$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/maps.asset.php';
+				wp_register_script( 'otter-google-map', OTTER_BLOCKS_URL . 'build/blocks/maps.js', $asset_file['dependencies'], $asset_file['version'], true );
+				wp_script_add_data( 'otter-google-map', 'defer', true );
+				wp_register_script( 'google-maps', 'https://maps.googleapis.com/maps/api/js?key=' . esc_attr( $apikey ) . '&libraries=places&callback=initMapScript', array( 'otter-google-map' ), '', true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
+				wp_script_add_data( 'google-maps', 'defer', true );
+			}
+		}
+
+		if ( ! self::$scripts_loaded['leaflet-map'] && has_block( 'themeisle-blocks/leaflet-map', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/leaflet-map.asset.php';
+
+			wp_register_script(
+				'otter-leaflet',
+				OTTER_BLOCKS_URL . 'build/blocks/leaflet-map.js',
+				array_merge(
+					$asset_file['dependencies'],
+					array( 'leaflet', 'leaflet-gesture-handling' )
+				),
+				$asset_file['version'],
+				true
+			);
+
+			wp_script_add_data( 'otter-leaflet', 'defer', true );
+		}
+
+		if ( ! self::$scripts_loaded['lottie'] && has_block( 'themeisle-blocks/lottie', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/lottie.asset.php';
+			wp_register_script( 'lottie-interactivity', OTTER_BLOCKS_URL . 'assets/lottie/lottie-interactivity.min.js', array( 'lottie-player' ), $asset_file['version'], true );
+			wp_script_add_data( 'lottie-interactivity', 'async', true );
+
+			wp_register_script(
+				'otter-lottie',
+				OTTER_BLOCKS_URL . 'build/blocks/lottie.js',
+				array_merge(
+					$asset_file['dependencies'],
+					array( 'lottie-player', 'lottie-interactivity' )
+				),
+				$asset_file['version'],
+				true
+			);
+
+			wp_script_add_data( 'otter-lottie', 'defer', true );
+		}
+
+		if ( ! self::$scripts_loaded['slider'] && has_block( 'themeisle-blocks/slider', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/slider.asset.php';
+
+			wp_register_script(
+				'otter-slider',
+				OTTER_BLOCKS_URL . 'build/blocks/slider.js',
+				array_merge(
+					$asset_file['dependencies'],
+					array( 'glidejs' )
+				),
+				$asset_file['version'],
+				true
+			);
+
+			wp_script_add_data( 'otter-slider', 'async', true );
+		}
+
+		if ( ! self::$scripts_loaded['tabs'] && has_block( 'themeisle-blocks/tabs', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/tabs.asset.php';
+			wp_register_script( 'otter-tabs', OTTER_BLOCKS_URL . 'build/blocks/tabs.js', $asset_file['dependencies'], $asset_file['version'], true );
+			wp_script_add_data( 'otter-tabs', 'defer', true );
+		}
+
+		if ( ! self::$scripts_loaded['popup'] && has_block( 'themeisle-blocks/popup', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/popup.asset.php';
+			wp_register_script( 'otter-popup', OTTER_BLOCKS_URL . 'build/blocks/popup.js', $asset_file['dependencies'], $asset_file['version'], true );
+			wp_script_add_data( 'otter-popup', 'defer', true );
+
+			wp_localize_script(
+				'otter-popup',
+				'themeisleGutenberg',
+				array(
+					'isPreview' => is_preview(),
+				)
+			);
+		}
+
+		if ( ! self::$scripts_loaded['progress-bar'] && has_block( 'themeisle-blocks/progress-bar', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/progress-bar.asset.php';
+			wp_register_script( 'otter-progress-bar', OTTER_BLOCKS_URL . 'build/blocks/progress-bar.js', $asset_file['dependencies'], $asset_file['version'], true );
+			wp_script_add_data( 'otter-progress-bar', 'defer', true );
+		}
 
 		if ( has_block( 'core/block', $post ) ) {
 			$blocks = parse_blocks( $content );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/1141.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

It should make sure that the JS only loads when the block is being used + also in FSE.