### PR TITLE
Fixing overriding & preventing same errors from appearing again

### DIFF
--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -18,6 +18,8 @@ import {
 
 let inputTimeout = null;
 
+window.otterCSSLintIgnored = [];
+
 const CSSEditor = ({
 	attributes,
 	setAttributes,
@@ -42,7 +44,13 @@ const CSSEditor = ({
 	};
 
 	const checkInput = ( editor, ignoreErrors = false ) => {
-		const editorErrors = editor?.state?.lint?.marked?.filter( ({ __annotation }) => 'error' === __annotation?.severity )?.map( ({ __annotation }) => __annotation?.message );
+		let editorErrors = editor?.state?.lint?.marked?.filter( ({ __annotation }) => 'error' === __annotation?.severity )?.map( ({ __annotation }) => __annotation?.message );
+
+		if ( ignoreErrors && 0 < editorErrors?.length ) {
+			window.otterCSSLintIgnored = editorErrors;
+		}
+
+		editorErrors = editorErrors?.filter( error => ! window.otterCSSLintIgnored.includes( error ) );
 
 		setErrors( editorErrors );
 		if ( ! ignoreErrors && 0 < editorErrors?.length ) {
@@ -50,7 +58,6 @@ const CSSEditor = ({
 		}
 		setEditorValue( editor?.getValue() );
 	};
-
 
 	useEffect( () => {
 		const classes = attributes.customCSS && attributes.className?.includes( 'ticss-' ) ? attributes.className.split( ' ' ).find( i => i.includes( 'ticss' ) ) : null;
@@ -139,7 +146,7 @@ const CSSEditor = ({
 
 					<Button
 						variant='secondary'
-						onClick={() => checkInput( editorRef, true )}
+						onClick={() => checkInput( editorRef.current, true )}
 						style={{ width: 'max-content', marginBottom: '20px' }}
 					>
 						{ __( 'Override', 'otter-blocks' ) }


### PR DESCRIPTION
Fix: https://github.com/Codeinwp/otter-blocks/issues/1155

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

