### PR TITLE
Fix Google Fonts for view change n Post/Page

### DIFF
--- a/src/blocks/blocks/advanced-heading/edit.js
+++ b/src/blocks/blocks/advanced-heading/edit.js
@@ -77,6 +77,7 @@ const Edit = ({
 	const isSmaller = useViewportMatch( 'small', '<=' );
 
 	useEffect( () => {
+		googleFontsLoader.attach( );
 		const unsubscribe = blockInit( clientId, defaultAttributes );
 		return () => unsubscribe( attributes.id );
 	}, [ attributes.id ]);

--- a/src/blocks/blocks/button-group/group/edit.js
+++ b/src/blocks/blocks/button-group/group/edit.js
@@ -72,6 +72,7 @@ const Edit = ({
 	const isSmaller = useViewportMatch( 'small', '<=' );
 
 	useEffect( () => {
+		googleFontsLoader.attach();
 		const unsubscribe = blockInit( clientId, defaultAttributes );
 		return () => unsubscribe( attributes.id );
 	}, []);

--- a/src/blocks/helpers/google-fonts.js
+++ b/src/blocks/helpers/google-fonts.js
@@ -23,9 +23,9 @@ class GoogleFontsLoader {
 		this.node = document.createElement( 'style' );
 		this.node.type = 'text/css';
 		this.node.setAttribute( 'data-generator', 'otter-blocks-fonts-loader' );
+		this.isAttaching = false;
 
 		this.usedFonts = [];
-		this.nodeAppended = false;
 	}
 
 	/**
@@ -142,13 +142,22 @@ class GoogleFontsLoader {
 	 * Update the node CSS.
 	 */
 	updateCSSNode() {
-		if ( ! this.nodeAppended ) {
-			const doc = getEditorIframe()?.contentWindow?.document ?? document;
-			doc.head.appendChild( this.node );
-			this.nodeAppended = true;
-		}
 		this.node.innerHTML = this.renderCSSFont();
 	}
+
+	attach() {
+		if ( ! this.isAttaching ) {
+			this.isAttaching = true;
+			setTimeout( () => {
+				const currentDocument = getEditorIframe()?.contentWindow?.document ?? document;
+				if ( ! currentDocument?.querySelector( '[data-generator*="otter-blocks-fonts-loader"' ) ) {
+					currentDocument?.head?.appendChild( this.node );
+				}
+				this.isAttaching = false;
+			}, 500 );
+		}
+	}
+
 
 	/**
 	 * Render the Font Face for every used font.


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Make the google fonts work on Mobile/Tablet in Post/Page.

### Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/17597852/188626186-1686b861-eef3-480e-bc67-a42d9c06a0cc.png)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a Page/Post
2. Insert Adv Heading and select a Google Font
3. Switch to Mobile/Tablet

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

