### PR TITLE
Fix Flip block back face visibility for Firefox

### DIFF
--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -77,6 +77,7 @@
 
 	.o-flip-front {
 		background: var( --front-background );
+		transform: rotate(0deg);
 
 		&:hover {
 			box-shadow: var( --box-shadow );
@@ -118,7 +119,7 @@
 		}
 
 		.o-flip-back {
-			transform: unset;
+			transform: rotate(0deg);
 			box-shadow: unset;
 			&:hover {
 				box-shadow: var( --box-shadow );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1179 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix a bug that did not make the `backface-visibility` work without extra props.

### Screenshots <!-- if applicable -->



----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Use Firefox
2. Add a Flip with content on both faces
3. The back face should be visible from the front and vice versa

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

