### PR TITLE
Dynamic Link for Buttons

### DIFF
--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -72,11 +72,11 @@ class Dynamic_Content {
 	 * @return string
 	 */
 	public function apply_dynamic_link_button( $content ) { 
-		if ( false === strpos( $content, '#otterDynamic' ) ) {
+		if ( false === strpos( $content, '#otterDynamicLink' ) ) {
 			return $content;
 		}
 
-		$re = '/#otterDynamic\/?.[^"]*/';
+		$re = '/#otterDynamicLink\/?.[^"]*/';
 
 		return preg_replace_callback( $re, array( $this, 'apply_link_button' ), $content );
 	}
@@ -527,7 +527,7 @@ class Dynamic_Content {
 			return;
 		}
 
-		$data = explode( '#otterDynamic', $data[0] );
+		$data = explode( '#otterDynamicLink', $data[0] );
 		$data = self::query_string_to_array( $data[1] );
 	
 		$link = $this->get_link( $data );

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -471,7 +471,7 @@ class Dynamic_Content {
 			if ( strpos( $qry, '?' ) !== false ) {
 				$qry = str_replace( array( '&#038;', '&amp;' ), '&', $qry );
 				$q   = wp_parse_url( $qry );
-				$qry = $q['query'] ?? $q['fragment'];
+				$qry = isset( $q['query'] ) ? $q['query'] : $q['fragment'];
 			}
 		} else {
 			return false;

--- a/src/animation/index.js
+++ b/src/animation/index.js
@@ -30,7 +30,7 @@ import './typing/index.js';
 const excludedBlocks = [ 'themeisle-blocks/popup' ];
 
 const withInspectorControls = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		const hasCustomClassName = hasBlockSupport(
 			props.name,
 			'customClassName',

--- a/src/blocks/plugins/conditions/index.js
+++ b/src/blocks/plugins/conditions/index.js
@@ -32,7 +32,7 @@ const addAttribute = ( props ) => {
 };
 
 const withConditions = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		return (
 			<Fragment>
 				<BlockEdit { ...props } />
@@ -43,7 +43,7 @@ const withConditions = createHigherOrderComponent( BlockEdit => {
 }, 'withConditions' );
 
 const withConditionsIndicator = createHigherOrderComponent( BlockListBlock => {
-	return ( props ) => {
+	return props => {
 		return (
 			<BlockListBlock
 				{ ...props }

--- a/src/blocks/plugins/dynamic-content/link/fields.js
+++ b/src/blocks/plugins/dynamic-content/link/fields.js
@@ -33,6 +33,7 @@ const Fields = ({
 	attributes,
 	changeAttributes,
 	isInline = false,
+	isLinkControl = false,
 	onChange,
 	changeType,
 	onRemove
@@ -75,13 +76,17 @@ const Fields = ({
 					</select>
 				</BaseControl>
 
-				<br />
+				{ ! isLinkControl && (
+					<Fragment>
+						<br />
 
-				<ToggleControl
-					label={ __( 'Open in a new tab', 'otter-blocks' ) }
-					checked={ '_blank' === attributes.target || false }
-					onChange={ () => changeAttributes({ target: '_blank' === attributes.target ? undefined : '_blank' }) }
-				/>
+						<ToggleControl
+							label={ __( 'Open in a new tab', 'otter-blocks' ) }
+							checked={ '_blank' === attributes.target || false }
+							onChange={ () => changeAttributes({ target: '_blank' === attributes.target ? undefined : '_blank' }) }
+						/>
+					</Fragment>
+				)	}
 
 				{ ( ! Boolean( window.themeisleGutenberg.hasPro ) ) && (
 					<Notice
@@ -113,7 +118,7 @@ const Fields = ({
 						{ __( 'Apply', 'otter-blocks' ) }
 					</Button>
 
-					{ isInline && (
+					{ ( isInline || isLinkControl ) && (
 						<Button
 							isDestructive
 							variant="tertiary"

--- a/src/blocks/plugins/dynamic-content/link/index.js
+++ b/src/blocks/plugins/dynamic-content/link/index.js
@@ -142,12 +142,12 @@ const DynamicLinkControl = ({
 						icon={ globe }
 						title={ __( 'Dynamic Link', 'otter-blocks' ) }
 						ref={ buttonRef }
-						onClick={ () => setOpen( true ) }
+						onClick={ () => setOpen( ! isOpen ) }
 					/>
 				</ToolbarGroup>
 			</BlockControls>
 
-			{ isOpen && (
+			{ ( isOpen && props.isSelected ) && (
 				<Popover
 					position="bottom right"
 					anchorRef={ buttonRef.current }

--- a/src/blocks/plugins/dynamic-content/link/index.js
+++ b/src/blocks/plugins/dynamic-content/link/index.js
@@ -1,14 +1,39 @@
 /**
+ * External dependencies.
+ */
+import { globe } from '@wordpress/icons';
+
+/**
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
 
+import { BlockControls } from '@wordpress/block-editor';
+
 import { registerFormatType } from '@wordpress/rich-text';
+
+import {
+	Popover,
+	ToolbarButton,
+	ToolbarGroup
+} from '@wordpress/components';
+
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+import {
+	Fragment,
+	useRef,
+	useState
+} from '@wordpress/element';
+
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies.
  */
 import edit from './edit.js';
+
+import Fields from './fields.js';
 
 export const name = 'themeisle-blocks/dynamic-link';
 
@@ -27,3 +52,79 @@ export const format = {
 };
 
 registerFormatType( name, format );
+
+const supportedBlocks = {
+	'core/button': {
+		link: 'url',
+		target: 'linkTarget'
+	},
+	'themeisle-blocks/button': {
+		link: 'link',
+		target: 'newTab'
+	},
+	'themeisle-blocks/font-awesome-icons': {
+		link: 'link',
+		target: 'newTab'
+	}
+};
+
+const DynamicLinkControl = ({
+	props,
+	children
+}) => {
+	const [ isOpen, setOpen ] = useState( false );
+	const buttonRef = useRef( null );
+
+	const attributes = props.attributes[ supportedBlocks[ props.name ].link ] || {};
+
+	return (
+		<Fragment>
+			{ children }
+
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						name="dynamic-link"
+						icon={ globe }
+						title={ __( 'Dynamic Link', 'otter-blocks' ) }
+						ref={ buttonRef }
+						onClick={ () => setOpen( true ) }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+
+			{ isOpen && (
+				<Popover
+					position="bottom right"
+					anchorRef={ buttonRef.current }
+					className="o-dynamic-popover"
+					onClose={ () => setOpen( false ) }
+				>
+					<Fields
+						activeAttributes={ {} }
+						attributes={ {} }
+						changeAttributes={ () => {} }
+						changeType={ () => {} }
+						onChange={ () => {} }
+					/>
+				</Popover>
+			) }
+		</Fragment>
+	);
+};
+
+const withDynamicLink = createHigherOrderComponent( BlockEdit => {
+	return props => {
+		if ( Object.keys( supportedBlocks ).includes( props.name ) ) {
+			return (
+				<DynamicLinkControl props={ props }>
+					<BlockEdit { ...props } />
+				</DynamicLinkControl>
+			);
+		}
+
+		return <BlockEdit { ...props } />;
+	};
+}, 'withConditions' );
+
+addFilter( 'editor.BlockEdit', 'otter-pro/autocompleters/dynamic-link', withDynamicLink );

--- a/src/blocks/plugins/dynamic-content/link/index.js
+++ b/src/blocks/plugins/dynamic-content/link/index.js
@@ -73,7 +73,7 @@ const supportedBlocks = {
 const getAttributes = ( attributes, name ) => {
 	const link = attributes[ supportedBlocks[ name ].link ] || '';
 
-	if ( ! link.includes( '#otterDynamic' ) ) {
+	if ( ! link.includes( '#otterDynamicLink' ) ) {
 		return {};
 	}
 
@@ -123,7 +123,7 @@ const DynamicLinkControl = ({
 			attrs.context = 'query';
 		}
 
-		props.setAttributes({ [ supportedBlocks[ props.name ].link ]: `#otterDynamic?${ getQueryStringFromObject( attrs ) }` });
+		props.setAttributes({ [ supportedBlocks[ props.name ].link ]: `#otterDynamicLink?${ getQueryStringFromObject( attrs ) }` });
 	};
 
 	const onRemove = () => {

--- a/src/blocks/plugins/galley-extension/index.js
+++ b/src/blocks/plugins/galley-extension/index.js
@@ -21,7 +21,7 @@ import domReady from '@wordpress/dom-ready';
 import ImageGrid from './../../components/image-grid/index.js';
 
 const withGalleryExtension = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		const onSelectImages = images => {
 			props.setAttributes({
 				images: images.map( image => ({

--- a/src/blocks/plugins/image-extension/index.js
+++ b/src/blocks/plugins/image-extension/index.js
@@ -46,7 +46,7 @@ const addAttribute = props => {
 };
 
 const withImageExtension = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		if ( 'core/image' === props.name && props.attributes.url ) {
 			return (
 				<Edit

--- a/src/blocks/plugins/masonry-extension-old/index.js
+++ b/src/blocks/plugins/masonry-extension-old/index.js
@@ -33,7 +33,7 @@ const addAttribute = ( props ) => {
 };
 
 const withMasonryExtension = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 
 		// We need to omit the uploading state of the images, because it can result in duplicated images
 		const imagesUploading = props.attributes?.images?.some(

--- a/src/blocks/plugins/masonry-extension/index.js
+++ b/src/blocks/plugins/masonry-extension/index.js
@@ -33,7 +33,7 @@ const addAttribute = ( props ) => {
 };
 
 const withMasonryExtension = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		if ( 'core/gallery' !== props.name ) {
 			return <BlockEdit { ...props } />;
 		}

--- a/src/blocks/plugins/menu-icons/index.js
+++ b/src/blocks/plugins/menu-icons/index.js
@@ -28,7 +28,7 @@ import './editor.scss';
 const IconPickerControl = lazy( () => import( '../../components/icon-picker-control/toolbar.js' ) );
 
 const withBlockControls = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		if ( ( 'core/navigation-link' === props.name || 'core/navigation-submenu' === props.name ) && props.isSelected ) {
 			return (
 				<Fragment>

--- a/src/blocks/plugins/sticky/index.js
+++ b/src/blocks/plugins/sticky/index.js
@@ -24,7 +24,7 @@ import Edit from './edit';
 const EXCEPTED_BLOCK_CONDITIONS = [ '-item', 'form-' ]; // Exclude sub-blocks
 
 const withStickyExtension = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		const hasCustomClassName = hasBlockSupport(
 			props.name,
 			'customClassName',

--- a/src/css/index.js
+++ b/src/css/index.js
@@ -49,7 +49,7 @@ const addAttribute = ( settings ) => {
 };
 
 const withInspectorControls = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		const hasCustomClassName = hasBlockSupport( props.name, 'customClassName', true );
 		if ( hasCustomClassName && props.isSelected ) {
 			let Inspector = InspectorControls;

--- a/src/pro/plugins/wc-integration/index.js
+++ b/src/pro/plugins/wc-integration/index.js
@@ -25,7 +25,7 @@ const addAttribute = ( props ) => {
 };
 
 const withWooCommerceExtension = createHigherOrderComponent( BlockEdit => {
-	return ( props ) => {
+	return props => {
 		if ( 'themeisle-blocks/review' === props.name && props.isSelected ) {
 			return (
 				<Edit


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1199.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This Dynamic Link format doesn't work for few blocks like:

- Buttons
- Advanced Buttons
- Icon

Now we have a different control for that. Her's a picture:

### Screenshots <!-- if applicable -->

<img width="775" alt="Screenshot 2022-09-23 at 5 16 04 AM" src="https://user-images.githubusercontent.com/2649903/191870443-5e919656-5725-40e1-aee4-dde02bc1c779.png">

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

