### PR TITLE
Fix Border & Icon Color Inheritance

### DIFF
--- a/inc/css/blocks/class-advanced-column-css.php
+++ b/inc/css/blocks/class-advanced-column-css.php
@@ -350,7 +350,6 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'border-color',
 						'value'     => 'borderColor',
-						'default'   => '#000000',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['border'] ) && is_array( $attrs['border'] );
 						},

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -348,7 +348,6 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'border-color',
 						'value'     => 'borderColor',
-						'default'   => '#000000',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['border'] ) && is_array( $attrs['border'] );
 						},

--- a/src/blocks/blocks/font-awesome-icons/style.scss
+++ b/src/blocks/blocks/font-awesome-icons/style.scss
@@ -2,7 +2,7 @@
 	--align: center;
 	--align-tablet: var(--align);
 	--align-mobile: var(--align-tablet);
-	--border-color: #000;
+	--border-color: inherit;
 	--border-size: unset;
 	--border-radius: 0%;
 	--margin: 0px;
@@ -15,7 +15,8 @@
 	.wp-block-themeisle-blocks-font-awesome-icons-container {
 		display: inline-flex;
 		justify-content: center;
-		border: var( --border-size ) solid var( --border-color );
+		border: var( --border-size ) solid;
+		border-color: var( --border-color );
 		border-radius: var( --border-radius );
 		margin: var( --margin );
 
@@ -30,6 +31,7 @@
 		svg {
 			width: var( --font-size );
 			height: var( --font-size );
+			fill: currentColor;
 		}
 
 		i {

--- a/src/blocks/blocks/icon-list/editor.scss
+++ b/src/blocks/blocks/icon-list/editor.scss
@@ -3,7 +3,6 @@
 	--gap: 5px;
 	--font-size: 20px;
 	--content-color: inherit;
-	--icon-color: inherit;
 
 	display: flex;
 	flex-direction: column;
@@ -67,8 +66,8 @@
 
 	.wp-block-themeisle-blocks-icon-list-item-icon,
 	.wp-block-themeisle-blocks-icon-list-item-icon-custom {
-		fill: var( --icon-color );
-		color: var( --icon-color );
+		fill: var( --icon-color, currentColor );
+		color: var( --icon-color, inherit );
 	}
 }
 

--- a/src/blocks/blocks/icon-list/style.scss
+++ b/src/blocks/blocks/icon-list/style.scss
@@ -3,7 +3,6 @@
 	--gap: 5px;
 	--font-size: 20px;
 	--content-color: inherit;
-	--icon-color: inherit;
 
 	display: flex;
 	flex-direction: column;
@@ -49,7 +48,7 @@
 
 	.wp-block-themeisle-blocks-icon-list-item-icon,
 	.wp-block-themeisle-blocks-icon-list-item-icon-custom {
-		fill: var( --icon-color );
-		color: var( --icon-color );
+		fill: var( --icon-color, currentColor );
+		color: var( --icon-color, inherit );
 	}
 }

--- a/src/blocks/blocks/section/column/block.json
+++ b/src/blocks/blocks/section/column/block.json
@@ -62,8 +62,7 @@
 			"type": "object"
 		},
 		"borderColor": {
-			"type": "string",
-			"default": "#000000"
+			"type": "string"
 		},
 		"borderRadius": {
 			"type": "object"

--- a/src/blocks/blocks/section/columns/block.json
+++ b/src/blocks/blocks/section/columns/block.json
@@ -161,8 +161,7 @@
 			"type": "object"
 		},
 		"borderColor": {
-			"type": "string",
-			"default": "#000000"
+			"type": "string"
 		},
 		"borderRadius": {
 			"type": "object"


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/1210.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Fixes inheritance of Borders in Section & Icon Block, as well as ThemeIsle icon color.
---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

