### PR TITLE
Add Countdown new features to Pro

### DIFF
--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -21,7 +21,8 @@ import {
 	SelectControl,
 	__experimentalUnitControl as UnitContol,
 	TextControl,
-	BaseControl
+	BaseControl,
+	ExternalLink
 } from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
@@ -37,8 +38,9 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 import ResponsiveControl from '../../components/responsive-control/index.js';
-import { mergeBoxDefaultValues, removeBoxDefaultValues, buildResponsiveSetAttributes, buildResponsiveGetAttributes, objectCleaner } from '../../helpers/helper-functions.js';
+import { mergeBoxDefaultValues, removeBoxDefaultValues, buildResponsiveSetAttributes, buildResponsiveGetAttributes, objectCleaner, setUtm } from '../../helpers/helper-functions.js';
 import { Fragment } from '@wordpress/element';
+import Notice from '../../components/notice/index.js';
 
 const defaultFontSizes = [
 	{
@@ -138,11 +140,8 @@ const NonProFeaturesSettings = ({ attributes, setAttributes }) => (
 	/>
 );
 
-const TemplateProFeaturesEnd = ({ children }) => (
-	<PanelBody
-		title={ __( 'End Action', 'otter-blocks' ) }
-		initialOpen={false}
-	>
+const TemplateProFeaturesEnd = () => (
+	<Fragment>
 		<SelectControl
 			label={ __( 'On Expire', 'otter-blocks' ) }
 			value={ '' }
@@ -172,8 +171,12 @@ const TemplateProFeaturesEnd = ({ children }) => (
 			disabled
 		/>
 
-		{ children }
-	</PanelBody>
+		{ ! Boolean( window.themeisleGutenberg?.hasPro ) && (
+			<Notice
+				notice={<ExternalLink href={setUtm( window.themeisleGutenberg.upgradeLink, 'countdownfeature' )}>{__( 'Get more options with Otter Pro.', 'otter-blocks' )}</ExternalLink>}
+				variant="upsell" instructions={undefined}				/>
+		) }
+	</Fragment>
 );
 
 /**
@@ -410,7 +413,13 @@ const Inspector = ({
 
 			</PanelBody>
 
-			{ applyFilters( 'otter.countdown.controls.end', TemplateProFeaturesEnd, { attributes: attributes, setAttributes: setAttributes }) }
+			<PanelBody
+				title={ __( 'End Action', 'otter-blocks' ) }
+				initialOpen={false}
+			>
+				{ applyFilters( 'otter.countdown.controls.end', <TemplateProFeaturesEnd />, { attributes: attributes, setAttributes: setAttributes }) }
+			</PanelBody>
+
 
 			<PanelBody
 				title={ __( 'Dimensions', 'otter-blocks' ) }

--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -31,6 +31,8 @@ import {
 	__experimentalGetSettings
 } from '@wordpress/date';
 
+import { applyFilters } from '@wordpress/hooks';
+
 /**
  * Internal dependencies
  */
@@ -63,7 +65,7 @@ const defaultFontSizes = [
 
 const fontWeights = [ '', '100', '200', '300', '400', '500', '600', '700', '800', '900' ].map( x => ({ label: x ? x : 'Default', value: x }) );
 
-const onExpireHelpMsg = ( behaviour ) => {
+export const onExpireHelpMsgCountdown = ( behaviour ) => {
 	switch ( behaviour ) {
 	case 'redirectLink':
 		return __( 'Redirect the user to another URL, when the countdown reaches 0', 'otter-blocks' );
@@ -76,7 +78,7 @@ const onExpireHelpMsg = ( behaviour ) => {
 	}
 };
 
-const countdownMoveHelpMsg = ( mode ) => {
+export const countdownMoveHelpMsgCountdown = ( mode ) => {
 	switch ( mode ) {
 	case 'timer':
 		return __( 'A fixed amount of time for each browser session (Evergreen Countdown)', 'otter-blocks' );
@@ -86,6 +88,44 @@ const countdownMoveHelpMsg = ( mode ) => {
 		return __( 'A universal deadline for all visitors', 'otter-blocks' );
 	}
 };
+
+const ProFeatures = ({ children }) => (
+	<PanelBody
+		title={ __( 'End Action', 'otter-blocks' ) }
+		initialOpen={false}
+	>
+		<SelectControl
+			label={ __( 'On Expire', 'otter-blocks' ) }
+			value={ '' }
+			onChange={ () => {}}
+			options={[
+				{
+					label: __( 'No action', 'otter-blocks' ),
+					value: ''
+				},
+				{
+					label: __( 'Hide the Countdown', 'otter-blocks' ),
+					value: 'hide'
+				},
+				{
+					label: __( 'Redirect to link', 'otter-blocks' ),
+					value: 'redirectLink'
+				}
+			]}
+			help={ onExpireHelpMsgCountdown(  ) }
+			disabled
+		/>
+
+		<ToggleControl
+			label={ __( 'Enable Hide/Show other blocks when the Countdown ends.', 'otter-blocks' ) }
+			checked={ false }
+			onChange={ () => {}}
+			disabled
+		/>
+
+		{ children }
+	</PanelBody>
+);
 
 /**
  *
@@ -173,7 +213,7 @@ const Inspector = ({
 							value: 'interval'
 						}
 					]}
-					help={ countdownMoveHelpMsg( attributes.mode )}
+					help={ countdownMoveHelpMsgCountdown( attributes.mode )}
 				/>
 
 				{
@@ -364,82 +404,7 @@ const Inspector = ({
 
 			</PanelBody>
 
-			<PanelBody
-				title={ __( 'End Action', 'otter-blocks' ) }
-				initialOpen={false}
-			>
-				<SelectControl
-					label={ __( 'On Expire', 'otter-blocks' ) }
-					value={ attributes.behaviour }
-					onChange={ behaviour => {
-						if ( 'redirectLink' === behaviour ) {
-							setAttributes({ behaviour, redirectLink: undefined });
-						} else {
-							setAttributes({ behaviour });
-						}
-					}}
-					options={[
-						{
-							label: __( 'No action', 'otter-blocks' ),
-							value: ''
-						},
-						{
-							label: __( 'Hide the Countdown', 'otter-blocks' ),
-							value: 'hide'
-						},
-						...( 'timer' === attributes.mode ? [{
-							label: __( 'Restart the Countdown', 'otter-blocks' ),
-							value: 'restart'
-						}] : []),
-						{
-							label: __( 'Redirect to link', 'otter-blocks' ),
-							value: 'redirectLink'
-						}
-					]}
-					help={ onExpireHelpMsg( attributes.behaviour ) }
-				/>
-
-				{
-					'redirectLink' === attributes.behaviour && (
-						<TextControl
-							label={ __( 'Redirect Link', 'otter-blocks' ) }
-							value={ attributes.redirectLink }
-							onChange={ redirectLink => setAttributes({ redirectLink })}
-						/>
-					)
-				}
-
-				<ToggleControl
-					label={ __( 'Enable Hide/Show other blocks when the Countdown ends.', 'otter-blocks' ) }
-					checked={ attributes.onEndAction !== undefined }
-					onChange={ value => {
-						if ( value ) {
-							setAttributes({ onEndAction: 'all' });
-						} else {
-							setAttributes({ onEndAction: undefined });
-						}
-					}}
-				/>
-
-				{
-					attributes?.onEndAction && (
-						<Fragment>
-							<p>
-								{ __( 'Paste the following code in the block that you want to show up or hide (in the same page) when the countdown end. Select the block, go to Inspector > Advanced, and paste into the field "Additional CSS class"', 'otter-blocks' ) }
-							</p>
-							<p style={{ marginTop: '10px', marginBottom: '5px' }}>{ __( 'Show trigger', 'otter-blocks' ) }</p>
-							<code style={{ display: 'block', padding: '10px' }}>
-								{ `o-countdown-trigger-on-end-${ attributes.id?.split( '-' ).pop()} o-cntdn-bhv-show` }
-							</code>
-							<p style={{ marginTop: '10px', marginBottom: '5px' }}>{ __( 'Hide trigger', 'otter-blocks' ) }</p>
-							<code style={{ display: 'block', padding: '10px' }}>
-								{ `o-countdown-trigger-on-end-${ attributes.id?.split( '-' ).pop()} o-cntdn-bhv-hide` }
-							</code>
-						</Fragment>
-					)
-				}
-
-			</PanelBody>
+			{ applyFilters( 'otter.countdown.controls', ProFeatures, { attributes: attributes, setAttributes: setAttributes }) }
 
 			<PanelBody
 				title={ __( 'Dimensions', 'otter-blocks' ) }

--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -92,52 +92,60 @@ export const countdownMoveHelpMsgCountdown = ( mode ) => {
 };
 
 const NonProFeaturesSettings = ({ attributes, setAttributes }) => (
-	<SelectControl
-		label={ __( 'Countdown Type', 'otter-blocks' ) }
-		value={  attributes.mode }
-		onChange={
-			value => {
-				const attrs = {
-					mode: value ? value : undefined
-				};
+	<Fragment>
+		<SelectControl
+			label={ __( 'Countdown Type', 'otter-blocks' ) }
+			value={  attributes.mode }
+			onChange={
+				value => {
+					const attrs = {
+						mode: value ? value : undefined
+					};
 
-				if ( ! value ) {
-					attrs.date = undefined;
-				}
-
-				if ( 'timer' !== value ) {
-					attrs.timer = undefined;
-					if ( 'restart' === attributes.behaviour ) {
-						attrs.behaviour = undefined;
+					if ( ! value ) {
+						attrs.date = undefined;
 					}
-				}
 
-				if ( 'interval' !== value ) {
-					attrs.startInterval = undefined;
-					attrs.endInterval = undefined;
-				}
+					if ( 'timer' !== value ) {
+						attrs.timer = undefined;
+						if ( 'restart' === attributes.behaviour ) {
+							attrs.behaviour = undefined;
+						}
+					}
 
-				setAttributes( attrs );
+					if ( 'interval' !== value ) {
+						attrs.startInterval = undefined;
+						attrs.endInterval = undefined;
+					}
+
+					setAttributes( attrs );
+				}
 			}
-		}
-		options={[
-			{
-				label: __( 'Static', 'otter-blocks' ),
-				value: ''
-			},
-			{
-				label: __( 'Evergeen (Pro)', 'otter-blocks' ),
-				value: 'timer',
-				disabled: true
-			},
-			{
-				label: __( 'Interval (Pro)', 'otter-blocks' ),
-				value: 'interval',
-				disabled: true
-			}
-		]}
-		help={ countdownMoveHelpMsgCountdown( attributes.mode )}
-	/>
+			options={[
+				{
+					label: __( 'Static', 'otter-blocks' ),
+					value: ''
+				},
+				{
+					label: __( 'Evergeen (Pro)', 'otter-blocks' ),
+					value: 'timer',
+					disabled: true
+				},
+				{
+					label: __( 'Interval (Pro)', 'otter-blocks' ),
+					value: 'interval',
+					disabled: true
+				}
+			]}
+			help={ countdownMoveHelpMsgCountdown( attributes.mode )}
+		/>
+
+		{ ! Boolean( window.themeisleGutenberg?.hasPro ) && (
+			<Notice
+				notice={<ExternalLink href={setUtm( window.themeisleGutenberg.upgradeLink, 'countdownfeature' )}>{__( 'Get more options with Otter Pro.', 'otter-blocks' )}</ExternalLink>}
+				variant="upsell" instructions={undefined}				/>
+		) }
+	</Fragment>
 );
 
 const TemplateProFeaturesEnd = () => (

--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -85,11 +85,60 @@ export const countdownMoveHelpMsgCountdown = ( mode ) => {
 	case 'interval':
 		return __( 'The countdown will be active only between the Start Date and the End Date', 'otter-blocks' );
 	default:
-		return __( 'A universal deadline for all visitors', 'otter-blocks' );
+		return __( 'An universal deadline for all visitors', 'otter-blocks' );
 	}
 };
 
-const ProFeatures = ({ children }) => (
+const NonProFeaturesSettings = ({ attributes, setAttributes }) => (
+	<SelectControl
+		label={ __( 'Countdown Type', 'otter-blocks' ) }
+		value={  attributes.mode }
+		onChange={
+			value => {
+				const attrs = {
+					mode: value ? value : undefined
+				};
+
+				if ( ! value ) {
+					attrs.date = undefined;
+				}
+
+				if ( 'timer' !== value ) {
+					attrs.timer = undefined;
+					if ( 'restart' === attributes.behaviour ) {
+						attrs.behaviour = undefined;
+					}
+				}
+
+				if ( 'interval' !== value ) {
+					attrs.startInterval = undefined;
+					attrs.endInterval = undefined;
+				}
+
+				setAttributes( attrs );
+			}
+		}
+		options={[
+			{
+				label: __( 'Static', 'otter-blocks' ),
+				value: ''
+			},
+			{
+				label: __( 'Evergeen (Pro)', 'otter-blocks' ),
+				value: 'timer',
+				disabled: true
+			},
+			{
+				label: __( 'Interval (Pro)', 'otter-blocks' ),
+				value: 'interval',
+				disabled: true
+			}
+		]}
+		help={ countdownMoveHelpMsgCountdown( attributes.mode )}
+	/>
+);
+
+const TemplateProFeaturesEnd = ({ children }) => (
 	<PanelBody
 		title={ __( 'End Action', 'otter-blocks' ) }
 		initialOpen={false}
@@ -170,51 +219,8 @@ const Inspector = ({
 				title={ __( 'Time Settings', 'otter-blocks' ) }
 			>
 
-				<SelectControl
-					label={ __( 'Countdown Type', 'otter-blocks' ) }
-					value={  attributes.mode }
-					onChange={ value => {
+				{ applyFilters( 'otter.countdown.controls.settings', <NonProFeaturesSettings attributes={attributes} setAttributes={setAttributes} />, { attributes: attributes, setAttributes: setAttributes }) }
 
-						const attrs = {
-							mode: value ? value : undefined
-						};
-
-						if ( ! value ) {
-							attrs.date = undefined;
-						}
-
-						if ( 'timer' !== value ) {
-							attrs.timer = undefined;
-							if ( 'restart' === attributes.behaviour ) {
-								attrs.behaviour = undefined;
-							}
-						}
-
-						if ( 'interval' !== value ) {
-							attrs.startInterval = undefined;
-							attrs.endInterval = undefined;
-						}
-
-						setAttributes( attrs );
-					}
-
-					}
-					options={[
-						{
-							label: __( 'Static', 'otter-blocks' ),
-							value: ''
-						},
-						{
-							label: __( 'Evergeen', 'otter-blocks' ),
-							value: 'timer'
-						},
-						{
-							label: __( 'Interval', 'otter-blocks' ),
-							value: 'interval'
-						}
-					]}
-					help={ countdownMoveHelpMsgCountdown( attributes.mode )}
-				/>
 
 				{
 					attributes.mode === undefined && (
@@ -404,7 +410,7 @@ const Inspector = ({
 
 			</PanelBody>
 
-			{ applyFilters( 'otter.countdown.controls', ProFeatures, { attributes: attributes, setAttributes: setAttributes }) }
+			{ applyFilters( 'otter.countdown.controls.end', TemplateProFeaturesEnd, { attributes: attributes, setAttributes: setAttributes }) }
 
 			<PanelBody
 				title={ __( 'Dimensions', 'otter-blocks' ) }

--- a/src/pro/blocks/countdown/index.tsx
+++ b/src/pro/blocks/countdown/index.tsx
@@ -90,22 +90,17 @@ const CountdownProFeaturesEnd = ( Template: React.FC<{}>, {
 	if ( ! Boolean( window?.otterPro?.isActive ) ) {
 		return (
 			<Fragment>
-				{/** @ts-ignore */}
-				<Template>
-					<Notice
-						notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-						instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-blocks' ) }
-					/>
-				</Template>
+				{ Template }
+				<Notice
+					notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
+					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-blocks' ) }
+				/>
 			</Fragment>
 		);
 	}
 
 	return (
-		<PanelBody
-			title={ __( 'End Action', 'otter-blocks' ) }
-			initialOpen={false}
-		>
+		<Fragment>
 			<SelectControl
 				label={ __( 'On Expire', 'otter-blocks' ) }
 				value={ attributes.behaviour }
@@ -177,7 +172,7 @@ const CountdownProFeaturesEnd = ( Template: React.FC<{}>, {
 				)
 			}
 
-		</PanelBody>
+		</Fragment>
 	);
 };
 

--- a/src/pro/blocks/countdown/index.tsx
+++ b/src/pro/blocks/countdown/index.tsx
@@ -4,21 +4,15 @@
 import { __ } from '@wordpress/i18n';
 
 import {
-	PanelBody,
 	ToggleControl,
-	RangeControl,
-	Dropdown,
-	Button,
-	DateTimePicker,
-	FontSizePicker,
 	SelectControl,
-	TextControl,
-	BaseControl
+	TextControl
 } from '@wordpress/components';
 
 import { Fragment } from '@wordpress/element';
 
 import { addFilter } from '@wordpress/hooks';
+
 import { CountdownInspectorProps } from '../../../blocks/blocks/countdown/types';
 import { countdownMoveHelpMsgCountdown, onExpireHelpMsgCountdown } from '../../../blocks/blocks/countdown/inspector';
 const { Notice } = window.otterComponents;

--- a/src/pro/blocks/countdown/index.tsx
+++ b/src/pro/blocks/countdown/index.tsx
@@ -1,0 +1,125 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+
+import {
+	PanelBody,
+	ToggleControl,
+	RangeControl,
+	Dropdown,
+	Button,
+	DateTimePicker,
+	FontSizePicker,
+	SelectControl,
+	TextControl,
+	BaseControl
+} from '@wordpress/components';
+
+import { Fragment } from '@wordpress/element';
+
+import { addFilter } from '@wordpress/hooks';
+import { CountdownInspectorProps } from '../../../blocks/blocks/countdown/types';
+import { onExpireHelpMsgCountdown } from '../../../blocks/blocks/countdown/inspector';
+const { Notice } = window.otterComponents;
+
+const CountdownProFeatures = ( Template: React.FC<{}>, {
+	attributes,
+	setAttributes
+}: CountdownInspectorProps ) => {
+
+	if ( ! Boolean( window?.otterPro?.isActive ) ) {
+		return (
+			<Fragment>
+				{/** @ts-ignore */}
+				<Template>
+					<Notice
+						notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
+						instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-blocks' ) }
+					/>
+				</Template>
+			</Fragment>
+		);
+	}
+
+	return (
+		<PanelBody
+			title={ __( 'End Action', 'otter-blocks' ) }
+			initialOpen={false}
+		>
+			<SelectControl
+				label={ __( 'On Expire', 'otter-blocks' ) }
+				value={ attributes.behaviour }
+				onChange={ behaviour => {
+					if ( 'redirectLink' === behaviour ) {
+						setAttributes({ behaviour, redirectLink: undefined });
+					} else {
+						setAttributes({ behaviour });
+					}
+				}}
+				options={[
+					{
+						label: __( 'No action', 'otter-blocks' ),
+						value: ''
+					},
+					{
+						label: __( 'Hide the Countdown', 'otter-blocks' ),
+						value: 'hide'
+					},
+					...( 'timer' === attributes.mode ? [{
+						label: __( 'Restart the Countdown', 'otter-blocks' ),
+						value: 'restart'
+					}] : []),
+					{
+						label: __( 'Redirect to link', 'otter-blocks' ),
+						value: 'redirectLink'
+					}
+				]}
+				help={ onExpireHelpMsgCountdown( attributes.behaviour ) }
+			/>
+
+			{
+				'redirectLink' === attributes.behaviour && (
+					<TextControl
+						label={ __( 'Redirect Link', 'otter-blocks' ) }
+						value={ attributes.redirectLink ?? ''}
+						onChange={ redirectLink => setAttributes({ redirectLink })}
+					/>
+				)
+			}
+
+			<ToggleControl
+				label={ __( 'Enable Hide/Show other blocks when the Countdown ends.', 'otter-blocks' ) }
+				checked={ attributes.onEndAction !== undefined }
+				onChange={ value => {
+					if ( value ) {
+						setAttributes({ onEndAction: 'all' });
+					} else {
+						setAttributes({ onEndAction: undefined });
+					}
+				}}
+			/>
+
+			{
+				attributes?.onEndAction && (
+					<Fragment>
+						<p>
+							{ __( 'Paste the following code in the block that you want to show up or hide (in the same page) when the countdown end. Select the block, go to Inspector > Advanced, and paste into the field "Additional CSS class"', 'otter-blocks' ) }
+						</p>
+						<p style={{ marginTop: '10px', marginBottom: '5px' }}>{ __( 'Show trigger', 'otter-blocks' ) }</p>
+						<code style={{ display: 'block', padding: '10px' }}>
+							{ `o-countdown-trigger-on-end-${ attributes.id?.split( '-' ).pop()} o-cntdn-bhv-show` }
+						</code>
+						<p style={{ marginTop: '10px', marginBottom: '5px' }}>{ __( 'Hide trigger', 'otter-blocks' ) }</p>
+						<code style={{ display: 'block', padding: '10px' }}>
+							{ `o-countdown-trigger-on-end-${ attributes.id?.split( '-' ).pop()} o-cntdn-bhv-hide` }
+						</code>
+					</Fragment>
+				)
+			}
+
+		</PanelBody>
+	);
+};
+
+addFilter( 'otter.countdown.controls', 'themeisle-gutenberg/countdown-controls', CountdownProFeatures );

--- a/src/pro/blocks/countdown/index.tsx
+++ b/src/pro/blocks/countdown/index.tsx
@@ -20,10 +20,69 @@ import { Fragment } from '@wordpress/element';
 
 import { addFilter } from '@wordpress/hooks';
 import { CountdownInspectorProps } from '../../../blocks/blocks/countdown/types';
-import { onExpireHelpMsgCountdown } from '../../../blocks/blocks/countdown/inspector';
+import { countdownMoveHelpMsgCountdown, onExpireHelpMsgCountdown } from '../../../blocks/blocks/countdown/inspector';
 const { Notice } = window.otterComponents;
 
-const CountdownProFeatures = ( Template: React.FC<{}>, {
+const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, setAttributes }: CountdownInspectorProps ) => {
+	if ( ! Boolean( window?.otterPro?.isActive ) ) {
+		return (
+			<Fragment>
+				{ Template }
+			</Fragment>
+		);
+	}
+
+	return (
+		<SelectControl
+			label={ __( 'Countdown Type', 'otter-blocks' ) }
+			value={  attributes.mode }
+			onChange={ value => {
+
+				const attrs: any = {
+					mode: value ? value : undefined
+				};
+
+				if ( ! value ) {
+					attrs.date = undefined;
+				}
+
+				if ( 'timer' !== value ) {
+					attrs.timer = undefined;
+					if ( 'restart' === attributes.behaviour ) {
+						attrs.behaviour = undefined;
+					}
+				}
+
+				if ( 'interval' !== value ) {
+					attrs.startInterval = undefined;
+					attrs.endInterval = undefined;
+				}
+
+				setAttributes( attrs );
+			}
+
+			}
+			options={[
+				{
+					label: __( 'Static', 'otter-blocks' ),
+					value: ''
+				},
+				{
+					label: __( 'Evergeen', 'otter-blocks' ),
+					value: 'timer'
+				},
+				{
+					label: __( 'Interval', 'otter-blocks' ),
+					value: 'interval'
+				}
+			]}
+			help={ countdownMoveHelpMsgCountdown( attributes.mode )}
+		/>
+	);
+};
+
+
+const CountdownProFeaturesEnd = ( Template: React.FC<{}>, {
 	attributes,
 	setAttributes
 }: CountdownInspectorProps ) => {
@@ -122,4 +181,5 @@ const CountdownProFeatures = ( Template: React.FC<{}>, {
 	);
 };
 
-addFilter( 'otter.countdown.controls', 'themeisle-gutenberg/countdown-controls', CountdownProFeatures );
+addFilter( 'otter.countdown.controls.settings', 'themeisle-gutenberg/countdown-controls', CountdownProFeaturesSettings );
+addFilter( 'otter.countdown.controls.end', 'themeisle-gutenberg/countdown-controls', CountdownProFeaturesEnd );

--- a/src/pro/blocks/index.js
+++ b/src/pro/blocks/index.js
@@ -5,3 +5,4 @@ import './add-to-cart-button/index.js';
 import './business-hours/index.js';
 import './review-comparison/index.js';
 import './woo-comparison/index.js';
+import './countdown/index';


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Pro Features:

 - Timer Mode
 - Interval Mode
 - End Action tab

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Make sure the mentioned features are locked for Non-Pro users. 

#### Query
```javascript
new QueryQA().select('blocks').where({ has: { blocks: ['countdown'] }}).run()
```

You can use the Query Engine since it has some countdown with pro features activated. You can test it to see if they are breaking when used in Non-Pro.

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

