### PR TITLE
Fix Review Padding issue. closes #1221

### DIFF
--- a/src/blocks/blocks/review/style.scss
+++ b/src/blocks/blocks/review/style.scss
@@ -49,6 +49,7 @@
 
 		.o-review__right {
 			border-left: var( --border-width ) solid var( --border-color );
+			padding: 20px var( --padding-right ) 20px var( --padding-left );
 		}
 	}
 

--- a/src/blocks/components/sync-color-panel/index.tsx
+++ b/src/blocks/components/sync-color-panel/index.tsx
@@ -1,10 +1,6 @@
 /**
  * WordPress dependencies
  */
-
-// @ts-ignore
-import { __ } from '@wordpress/i18n';
-
 import {
 
 	// @ts-ignore
@@ -59,7 +55,7 @@ const SyncColorPanel = ( props: SyncColorPanelProps ) => {
 
 			{ options.map( ( option, index ) => (
 				<Disabled
-					key={index}
+					key={ index }
 
 					// @ts-ignore
 					isDisabled={ isSynced?.includes( option.slug ) || false }

--- a/src/blocks/helpers/helper-functions.js
+++ b/src/blocks/helpers/helper-functions.js
@@ -389,7 +389,7 @@ export const getActiveStyle = ( styles, className ) => {
 
 		const potentialStyleName = style.substring( 9 );
 
-		if ( styleValues.indexOf( potentialStyleName )  ) {
+		if ( -1 < styleValues.indexOf( potentialStyleName ) ) {
 			return potentialStyleName;
 		}
 	}
@@ -411,7 +411,7 @@ export const changeActiveStyle = ( className, styles, newStyle ) =>{
 	const activeStyle = getActiveStyle( styles, className );
 	const defaultValue = styles.find( i => i.isDefault )?.value || '';
 
-	if ( activeStyle ) {
+	if ( activeStyle && -1 < classes.indexOf( `is-style-${ activeStyle }` ) ) {
 		classes.splice( classes.indexOf( `is-style-${ activeStyle }` ), 1 );
 	}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1221.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

It should address Review Block padding not working for Pros/Cons when used with one column layout.

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

