### PR TITLE
Add closing to Sticky in Float Mode

### DIFF
--- a/docs/blocks/editor.md
+++ b/docs/blocks/editor.md
@@ -15,7 +15,7 @@ This is what we create, a visual interface so that the WordPress user can create
 
 You can edit the text between the `p` tag. The change will be reflected when you go back. 
 
-To go back, fallow the same steps and select the `Visual editor` (or `Ctrl+Shift+Alt+M`).
+To go back, follow the same steps and select the `Visual editor` (or `Ctrl+Shift+Alt+M`).
 
 Now that we know [we are burdened with a glorious purpose](https://en.wikipedia.org/wiki/Glorious_Purpose), let's see what WordPress can offer us.
 

--- a/docs/blocks/first-block.md
+++ b/docs/blocks/first-block.md
@@ -26,7 +26,7 @@ import { registerBlockType } from '@wordpress/block-editor';
 // If your WordPress use a different language, you will probably see the below strings translated (where is the case)
 import { __ } from '@wordpress/i18n';
 
-// Register the block under the internal name as 'themeisle-blocks/tutorial-1' with the fallowing options
+// Register the block under the internal name as 'themeisle-blocks/tutorial-1' with the following options
 registerBlockType( 'themeisle-blocks/tutorial-1', {
 	title: __( 'My first Block - Tutorial 1' ), // The title of the block that the user will see in the menu
 	description: __( 'Small Example' ), // Description of the block
@@ -145,7 +145,7 @@ registerBlockType( 'themeisle-blocks/tutorial-1', {
 
 You can check the `index` file of the block in the `src/block` and see that they follow this pattern.
 
-The `attributes.js` fallow this tructure:
+The `attributes.js` follow this tructure:
 ```javascript
 const attributes = {
 	text: {

--- a/docs/blocks/style-with-php.md
+++ b/docs/blocks/style-with-php.md
@@ -22,7 +22,7 @@ This steps are similar with the registration of the block.
 
 When you create a class, just duplicated another PHP file and change it. I will choose the `inc/css/blocks/class-accordion-css` since it has a small code and I can delete it faster. 
 
-:warning: *When it comes to naming things we want to fallow the same convention*. For this part the name blueprint is `class-{block name in kebab case [1]}-css.php`
+:warning: *When it comes to naming things we want to follow the same convention*. For this part the name blueprint is `class-{block name in kebab case [1]}-css.php`
 
 So, the name of the file will be: `class-tutorial-2-css.php`
 
@@ -122,7 +122,7 @@ public function autoload_block_classes() {
 
 :warning: If you come back to your page and refresh an PHP error will rise (check the preview page). We made Gutenberg Blocks to know about the existance of this class, but Otter Blocks still does not who is this.
 
-We need to register the class in two more files: `autoload_classmap.php` and `autoload_static.php` in `otter-blocks/vendor/composer`. Fallow the same pattern as the ones in the file for writing the path to the class. Or, you can run `composer dumpautoload -o` in the Otter root folder (`otter-blocks/`) to auto detect the class. It will give you a message like this:
+We need to register the class in two more files: `autoload_classmap.php` and `autoload_static.php` in `otter-blocks/vendor/composer`. Follow the same pattern as the ones in the file for writing the path to the class. Or, you can run `composer dumpautoload -o` in the Otter root folder (`otter-blocks/`) to auto detect the class. It will give you a message like this:
 ```
 Generating optimized autoload files
 Generated optimized autoload files containing 55 classes

--- a/src/blocks/frontend/sticky/index.ts
+++ b/src/blocks/frontend/sticky/index.ts
@@ -613,10 +613,9 @@ class StickyRunner {
 		if ( ! sticky.config.isFloatMode ) {
 			return;
 		}
+
 		const classes = sticky.elem.querySelectorAll( '.o-sticky-close' );
 		const anchors = sticky.elem.querySelectorAll( 'a[href=\'#o-sticky-close\']' );
-
-		console.log( classes, anchors );
 
 		[ ...Array.from( classes ), ...Array.from( anchors ) ].forEach( elm => {
 			elm.addEventListener( 'click', ( e ) => {

--- a/src/blocks/frontend/sticky/index.ts
+++ b/src/blocks/frontend/sticky/index.ts
@@ -133,7 +133,7 @@ class StickyData {
 	readonly selector: HTMLDivElement | string;
 	readonly containerSelector: HTMLDivElement | string;
 	orderInPage: number;
-	status: 'active' | 'dormant' | 'inactive';
+	status: 'active' | 'dormant' | 'inactive' | 'hidden';
 	isActive: boolean;
 	isDormant: boolean;
 	positionStatus: typeof positions[Position];
@@ -287,6 +287,8 @@ class StickyRunner {
 			return;
 		}
 
+		this.bindCloseButton( stickyElem );
+
 		stickyElem.orderInPage = this.orderInPageCounter;
 		this.items.push( stickyElem );
 		this.orderInPageCounter++;
@@ -316,6 +318,10 @@ class StickyRunner {
 				sticky.container.style.border = '1px dashed black';
 			}
 			sticky.elem.style.border = '1px dashed red';
+		}
+
+		if ( 'hidden' === sticky.status ) {
+			return;
 		}
 
 		sticky.status = 'inactive';
@@ -603,6 +609,24 @@ class StickyRunner {
 		document.body.classList.toggle( 'o-sticky-is-active', value );
 	}
 
+	bindCloseButton( sticky: StickyData ) {
+		if ( ! sticky.config.isFloatMode ) {
+			return;
+		}
+		const classes = sticky.elem.querySelectorAll( '.o-sticky-close' );
+		const anchors = sticky.elem.querySelectorAll( 'a[href=\'#o-sticky-close\']' );
+
+		console.log( classes, anchors );
+
+		[ ...Array.from( classes ), ...Array.from( anchors ) ].forEach( elm => {
+			elm.addEventListener( 'click', ( e ) => {
+				e.preventDefault();
+				sticky.status = 'hidden';
+				sticky.elem.classList.add( 'o-is-close' );
+			});
+		});
+	}
+
 	/**
 	 * Get the active sticky elements.
 	 *
@@ -633,6 +657,9 @@ domReady( () => {
 		.o-is-sticky {
 			position: fixed;
 			z-index: 9999;
+		}
+		.o-is-close {
+			display: none;
 		}
 	`;
 

--- a/src/pro/plugins/sticky/index.js
+++ b/src/pro/plugins/sticky/index.js
@@ -128,16 +128,16 @@ const StickyControls = (
 			{
 				isActive && (
 					<BaseControl
-						label={ __( 'Closing the sticky', 'otter-blocks' ) }
+						label={ __( 'Closing the Sticky', 'otter-blocks' ) }
 					>
 						<p>
-							{ __( 'You can make another block that it is inside the sticky element to behave like a closing button. Select the desired block, go to Inspector > Advanced, and paste into the field "Additional CSS class"', 'otter-blocks' )}
+							{ __( 'You can make another block that is inside the sticky element to behave like a closing button by adding the following CSS class.' )}
 						</p>
 						<code style={{ display: 'block', padding: '10px', marginBottom: '5px' }}>
 							{ 'o-sticky-close' }
 						</code>
 						<p>
-							{ __( 'You can transfrom a Button into a close button by inserting the fallowing code as an anchor with Link option.', 'otter-blocks' )}
+							{ __( 'You can transform a Button into a Close button by inserting the fallowing anchor.', 'otter-blocks' )}
 						</p>
 						<code style={{ display: 'block', padding: '10px' }}>
 							{ '#o-sticky-close' }

--- a/src/pro/plugins/sticky/index.js
+++ b/src/pro/plugins/sticky/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 
 import {
+	BaseControl,
 	RangeControl,
 	SelectControl,
 	ToggleControl
@@ -34,6 +35,7 @@ const StickyControls = (
 		);
 	}
 
+	const isActive = attributes?.className?.includes( FILTER_OPTIONS.float );
 	const position = attributes?.className?.includes( 'o-sticky-pos-bottom' ) ? 'o-sticky-pos-bottom' : 'o-sticky-pos-top';
 	const behaviour = attributes?.className?.split( ' ' ).filter( c => c.includes( 'o-sticky-bhvr' ) ).pop() || 'o-sticky-bhvr-keep';
 	const useOnMobile = Boolean( attributes?.className?.split( ' ' ).filter( c => c.includes( 'o-sticky-use-mobile' ) ).pop() || false );
@@ -122,6 +124,27 @@ const StickyControls = (
 				checked={ useOnMobile }
 				onChange={ ( value ) => addOption( value ? 'o-sticky-use-mobile' : undefined, FILTER_OPTIONS.usage ) }
 			/>
+
+			{
+				isActive && (
+					<BaseControl
+						label={ __( 'Closing the sticky', 'otter-blocks' ) }
+					>
+						<p>
+							{ __( 'You can make another block that it is inside the sticky element to behave like a closing button. Select the desired block, go to Inspector > Advanced, and paste into the field "Additional CSS class"', 'otter-blocks' )}
+						</p>
+						<code style={{ display: 'block', padding: '10px', marginBottom: '5px' }}>
+							{ 'o-sticky-close' }
+						</code>
+						<p>
+							{ __( 'You can transfrom a Button into a close button by inserting the fallowing code as an anchor with Link option.', 'otter-blocks' )}
+						</p>
+						<code style={{ display: 'block', padding: '10px' }}>
+							{ '#o-sticky-close' }
+						</code>
+					</BaseControl>
+				)
+			}
 		</Fragment>
 	);
 };

--- a/src/pro/plugins/sticky/index.js
+++ b/src/pro/plugins/sticky/index.js
@@ -137,7 +137,7 @@ const StickyControls = (
 							{ 'o-sticky-close' }
 						</code>
 						<p>
-							{ __( 'You can transform a Button into a Close button by inserting the fallowing anchor.', 'otter-blocks' )}
+							{ __( 'You can transform a Button into a Close button by inserting the following anchor.', 'otter-blocks' )}
 						</p>
 						<code style={{ display: 'block', padding: '10px' }}>
 							{ '#o-sticky-close' }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- When a sticky element is active, add a global class name to the `body`.
- Add closing via class or anchor (PRO feature)

### Screenshots <!-- if applicable -->

<img height="350" src="https://user-images.githubusercontent.com/17597852/194540940-185809c8-3400-464a-98d5-283ba8db128d.png" />

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a Section/Column/Group a Sticky.
2. Add a Button inside, then add a link to `#o-sticky-close`
3. Set the sticky to FLOAT MODE.
4. Preview the page; when you press the button, the sticky should disappear.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

