### PR TITLE
CSS Utility Improvements

### DIFF
--- a/inc/css/class-css-utility.php
+++ b/inc/css/class-css-utility.php
@@ -2,7 +2,12 @@
 /**
  * CSS generator.
  *
- * $css = new CSS_Utility( $block );
+ * $default_queries = array(
+ *     'desktop' => '@media ( min-width: 960px )',
+ *     'mobile'  => '@media ( max-width: 960px )'
+ * );
+ * 
+ * $css = new CSS_Utility( $block, $default_queries );
  *
  * $css->add_item( array(
  *  'global'     => 'global', // Put your media query selector here. It's global by default.
@@ -39,6 +44,7 @@
  *          },
  *      ),
  *  ),
+ *  'media'      => 'desktop', // Media query selector.
  * ) );
  *
  * $style = $css->generate();
@@ -63,6 +69,20 @@ class CSS_Utility {
 	public $block = array();
 
 	/**
+	 * Variable to hold media queries.
+	 *
+	 * @var array
+	 */
+	public $media_queries = array();
+
+	/**
+	 * Variable to hold media items.
+	 *
+	 * @var array
+	 */
+	public $media_items = array();
+
+	/**
 	 * Variable to hold CSS array.
 	 *
 	 * @var array
@@ -81,9 +101,11 @@ class CSS_Utility {
 	 *
 	 * @access public
 	 * @param array $block Block object.
+	 * @param array $media_queries Media queries array.
 	 */
-	public function __construct( $block ) {
-		$this->block = $block;
+	public function __construct( $block, $media_queries = array() ) {
+		$this->block         = $block;
+		$this->media_queries = $media_queries;
 	}
 
 	/**
@@ -95,6 +117,21 @@ class CSS_Utility {
 	 */
 	public function set_id( $id ) {
 		$this->block_id = $id;
+	}
+
+	/**
+	 * Filter media queries.
+	 *
+	 * @access public
+	 * @since 2.1.0
+	 * @param string $query Media Query.
+	 */
+	public function get_media_query( $query ) {
+		if ( isset( $this->media_queries[ $query ] ) && 'global' !== $this->media_queries[ $query ] ) {
+			return $this->media_queries[ $query ];
+		}
+
+		return $query;
 	}
 
 	/**
@@ -114,15 +151,75 @@ class CSS_Utility {
 			)
 		);
 
+		$params['query'] = $this->get_media_query( $params['query'] );
+
 		if ( ! isset( $this->css_array[ $params['query'] ] ) ) {
 			$this->css_array[ $params['query'] ] = array();
 		}
 
+		$params['properties'] = $this->filter_out_media_queries( $params['selector'], $params['properties'] );
+
 		if ( ! isset( $this->css_array[ $params['query'] ][ $params['selector'] ] ) ) {
-			$this->css_array[ $params['query'] ][ $params['selector'] ] = array();
+			$this->css_array[ $params['query'] ][ $params['selector'] ] = $params['properties'];
+		} else {
+			$this->css_array[ $params['query'] ][ $params['selector'] ] = array_merge(
+				$this->css_array[ $params['query'] ][ $params['selector'] ],
+				$params['properties']
+			);
+		}
+	}
+
+	/**
+	 * Filter out media query items.
+	 *
+	 * @access public
+	 * @since 2.1.0
+	 * @param array $selector CSS selector.
+	 * @param array $properties CSS properties.
+	 */
+	public function filter_out_media_queries( $selector, $properties ) {
+		$query_items = array_filter(
+			$properties,
+			function( $ar ) {
+				return isset( $ar['media'] );
+			}
+		);
+
+		if ( 0 !== count( $query_items ) ) {
+			if ( ! isset( $this->media_items[ $selector ] ) ) {
+				$this->media_items[ $selector ] = $query_items;
+			} else {
+				$this->media_items[ $selector ] = array_merge( $this->media_items, $query_items );
+			}
 		}
 
-		$this->css_array[ $params['query'] ][ $params['selector'] ] = $params['properties'];
+		$properties = array_diff_key( $properties, array_flip( array_keys( $query_items ) ) );
+
+		return $properties;
+	}
+
+	/**
+	 * Process media items pre-generation.
+	 *
+	 * @access public
+	 * @since 2.1.0
+	 */
+	public function process_media_items() {
+		foreach ( $this->media_items as $selector => $items ) {
+			foreach ( $items as $item ) {
+				$media_query = $this->get_media_query( $item['media'] );
+		
+				if ( ! isset( $this->css_array[ $media_query ] ) ) {
+					$this->css_array[ $media_query ] = array();
+				}
+
+				if ( ! isset( $this->css_array[ $media_query ][ $selector ] ) ) {
+					$this->css_array[ $media_query ][ $selector ] = array();
+				}
+
+				array_push( $this->css_array[ $media_query ][ $selector ], $item );
+			}
+		}
 	}
 
 	/**
@@ -132,6 +229,8 @@ class CSS_Utility {
 	 * @since 1.6.0
 	 */
 	public function generate() {
+		$this->process_media_items();
+
 		$style = '';
 
 		$attrs = $this->block['attrs'];

--- a/inc/css/class-css-utility.php
+++ b/inc/css/class-css-utility.php
@@ -174,8 +174,8 @@ class CSS_Utility {
 	 *
 	 * @access public
 	 * @since 2.1.0
-	 * @param array $selector CSS selector.
-	 * @param array $properties CSS properties.
+	 * @param string $selector CSS selector.
+	 * @param array  $properties CSS properties.
 	 */
 	public function filter_out_media_queries( $selector, $properties ) {
 		$query_items = array_filter(


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #713.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

When you initialize, you can now optionally define a shorthand for the media queries:

```
$default_queries = array(
	'desktop' => '@media ( min-width: 960px )',
	'mobile'  => '@media ( max-width: 960px )'
);

$css = new CSS_Utility( $block, $default_queries );
```

And in your properties, you can also define the media:


```
array(
	'property' => '--o-posts-title-text-size',
	'value'    => 'customTitleFontSizeMobile',
	'unit'     => 'px',
        'media'    => 'mobile' // or even '@media ( max-width: 960px )'
),
```

And always, to keep things separated, you can also use the old way of defining queries. Or you also use the shorthand in the main query property:

```
$css->add_item(
	array(
		'query'      => 'desktop',
		'properties' => array(....)
	....
	)
);
```

### Test instructions
<!-- Describe how this pull request can be tested. -->

When you test this Irinel, can you make sure that all the blocks and their CSS works fine? You can try 4-5 blocks and just make sure CSS works just like before this PR, specially the responsive values and when both than one of same block is on the page.

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

