### PR TITLE
Add Magic Tags

### DIFF
--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -24,7 +24,7 @@ class Dynamic_Content {
 	 */
 	public function init() {
 		add_filter( 'render_block', array( $this, 'apply_dynamic_content' ) );
-		add_filter( 'render_block', array( $this, 'apply_dynamic_content_magic_tags' ) );
+		add_filter( 'render_block', array( $this, 'apply_dynamic_magic_tags' ) );
 		add_filter( 'render_block', array( $this, 'apply_dynamic_link' ) );
 		add_filter( 'render_block', array( $this, 'apply_dynamic_link_button' ) );
 		add_filter( 'render_block', array( $this, 'apply_dynamic_images' ) );
@@ -55,7 +55,7 @@ class Dynamic_Content {
 	 *
 	 * @return string
 	 */
-	public function apply_dynamic_content_magic_tags( $content ) {
+	public function apply_dynamic_magic_tags( $content ) {
 		if ( false === strpos( $content, '{otterDynamic?type' ) ) {
 			return $content;
 		}
@@ -84,7 +84,7 @@ class Dynamic_Content {
 			$data['default'] = '';
 		}
 	
-		$data = $this->apply_data( $data );
+		$data = $this->apply_data( $data, true );
 
 		return $data;
 	}
@@ -225,11 +225,12 @@ class Dynamic_Content {
 	 * Apply dynamic data.
 	 *
 	 * @param array $data Dynamic request.
+	 * @param bool  $magic_tags Is a request for Magic Tags.
 	 *
 	 * @return string
 	 */
-	public function apply_data( $data ) {
-		$value = $this->get_data( $data );
+	public function apply_data( $data, $magic_tags = false ) {
+		$value = $this->get_data( $data, $magic_tags );
 
 		if ( isset( $data['before'] ) || isset( $data['after'] ) ) {
 			$value = $this->apply_formatting( $value, $data );
@@ -267,11 +268,12 @@ class Dynamic_Content {
 	 * Get dynamic data.
 	 *
 	 * @param array $data Dynamic request.
+	 * @param bool  $magic_tags Is a request for Magic Tags.
 	 *
 	 * @return string
 	 */
-	public function get_data( $data ) {
-		if ( ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+	public function get_data( $data, $magic_tags ) {
+		if ( ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || true === $magic_tags ) {
 			if ( isset( $data['context'] ) && 'query' === $data['context'] ) {
 				$data['context'] = get_the_ID();
 			} else {

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -24,6 +24,7 @@ class Dynamic_Content {
 	 */
 	public function init() {
 		add_filter( 'render_block', array( $this, 'apply_dynamic_content' ) );
+		add_filter( 'render_block', array( $this, 'apply_dynamic_content_magic_tags' ) );
 		add_filter( 'render_block', array( $this, 'apply_dynamic_link' ) );
 		add_filter( 'render_block', array( $this, 'apply_dynamic_link_button' ) );
 		add_filter( 'render_block', array( $this, 'apply_dynamic_images' ) );
@@ -45,6 +46,47 @@ class Dynamic_Content {
 		$re = '/<o-dynamic(?:\s+(?:data-type=["\'](?P<type>[^"\'<>]+)["\']|data-id=["\'](?P<id>[^"\'<>]+)["\']|data-before=["\'](?P<before>[^"\'<>]+)["\']|data-after=["\'](?P<after>[^"\'<>]+)["\']|data-length=["\'](?P<length>[^"\'<>]+)["\']|data-date-type=["\'](?P<dateType>[^"\'<>]+)["\']|data-date-format=["\'](?P<dateFormat>[^"\'<>]+)["\']|data-date-custom=["\'](?P<dateCustom>[^"\'<>]+)["\']|data-time-type=["\'](?P<timeType>[^"\'<>]+)["\']|data-time-format=["\'](?P<timeFormat>[^"\'<>]+)["\']|data-time-custom=["\'](?P<timeCustom>[^"\'<>]+)["\']|data-term-type=["\'](?P<termType>[^"\'<>]+)["\']|data-term-separator=["\'](?P<termSeparator>[^"\'<>]+)["\']|data-meta-key=["\'](?P<metaKey>[^"\'<>]+)["\']|data-context=["\'](?P<context>[^"\'<>]+)["\']|[a-zA-Z-]+=["\'][^"\'<>]+["\']))*\s*>(?<default>[^ $].*?)<\s*\/\s*o-dynamic>/';
 
 		return preg_replace_callback( $re, array( $this, 'apply_data' ), $content );
+	}
+
+	/**
+	 * Filter post content for Magic Tags.
+	 *
+	 * @param string $content Post content.
+	 *
+	 * @return string
+	 */
+	public function apply_dynamic_content_magic_tags( $content ) {
+		if ( false === strpos( $content, '{otterDynamic?type' ) ) {
+			return $content;
+		}
+
+		$re = '/{(otterDynamic\/?.[^"]*)}/';
+
+		return preg_replace_callback( $re, array( $this, 'apply_magic_tags' ), $content );
+	}
+
+	/**
+	 * Apply dynamic data for Magic Tags.
+	 *
+	 * @param array $data Dynamic request.
+	 *
+	 * @return string
+	 */
+	public function apply_magic_tags( $data ) {
+		if ( ! isset( $data[1] ) ) {
+			return;
+		}
+
+		$data = explode( 'otterDynamic', $data[1] );
+		$data = self::query_string_to_array( $data[1] );
+
+		if ( ! isset( $data['default'] ) ) {
+			$data['default'] = '';
+		}
+	
+		$data = $this->apply_data( $data );
+
+		return $data;
 	}
 
 	/**
@@ -71,7 +113,7 @@ class Dynamic_Content {
 	 *
 	 * @return string
 	 */
-	public function apply_dynamic_link_button( $content ) { 
+	public function apply_dynamic_link_button( $content ) {
 		if ( false === strpos( $content, '#otterDynamicLink' ) ) {
 			return $content;
 		}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/19.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

This allows users to use magic tags to display Dynamic Values in places where they can't simply use the formats. The format of the dynamic tags will be something like this:

Tag Structure: {otterDynamic?type=postTitle&context=widgets}

All the possible options are same as Dynamic Value.

Global Parameters

- type: Dynamic Value type to show. Possible values are:

- before: The text to prepend the dynamic value.
- after: The text to append the dynamic value.
- context: The ID of the post. If not used the current post will be used. It can be widgets for widgets screen and query if used inside the query block
- default: The default value to return.

Here are all the available types and possible values that can be used with them.

Free:

- postID
- postTitle
- postContent
- postExcerpt
— length: Excerpt length.
- postType
- postStatus
- siteTitle
- siteTagline
- authorName
- authorDescription
- loggedInUserName
- loggedInUserDescription
- loggedInUserEmail
- archiveTitle
- archiveDescription
- date
— dateFormat: Supported date formats: https://wordpress.org/support/article/formatting-date-and-time/
- time
— timeFormat: Supported time formats: https://wordpress.org/support/article/formatting-date-and-time/

Pro: 

- postDate
— dateFormat: Supported date formats: https://wordpress.org/support/article/formatting-date-and-time/
— dateType: Leave empty of published date, and put ‘modified’ to get date for the last time post was modified
- postTime
— timeFormat: Supported time formats: https://wordpress.org/support/article/formatting-date-and-time/
— timeType: Leave empty of published time, and put ‘modified’ to get time for the last time post was modified
- postTerms
— termSeparator: Term separator. Defaults to a comma.
— termType: Term type. Default is categories, can also be set to ‘tags’.
- postMeta
— metaKey: Meta key to pull.
- acf
— metaKey: Meta key to pull.
- authorMeta
— metaKey: Meta key to pull.
- loggedInUserMeta
— metaKey: Meta key to pull.



### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.

