### PR TITLE
Fix sharing alignment

### DIFF
--- a/src/blocks/blocks/sharing-icons/style.scss
+++ b/src/blocks/blocks/sharing-icons/style.scss
@@ -1,4 +1,6 @@
 .wp-block-themeisle-blocks-sharing-icons {
+	width: 100%;
+	
 	&[class*="align"] {
 		float: unset;
 	}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1274 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Sharing alignment now uses the entire width of the container

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add two paragraphs and a sharing icons block between them.
2. Change the alignment for sharing icons.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

