### PR TITLE
Fix lottie reverse mode

### DIFF
--- a/src/blocks/frontend/lottie/index.js
+++ b/src/blocks/frontend/lottie/index.js
@@ -9,10 +9,10 @@ domReady( () => {
 	const initAnimation = animation => {
 		if ( 'false' === animation.dataset.loop ) {
 			animation.setLooping( false );
+		}
 
-			if ( -1 === animation.__direction ) {
-				animation.seek( '100%' );
-			}
+		if ( -1 === animation.__direction ) {
+			animation.seek( '100%' );
 		}
 
 		if ( Boolean( animation.__count ) ) {
@@ -59,7 +59,7 @@ domReady( () => {
 
 				initAnimation( animation );
 
-				return animation.stop();
+				return -1 === animation.__direction ? animation.pause() : animation.stop();
 			}
 
 			if ( 'click' === trigger ) {
@@ -71,7 +71,7 @@ domReady( () => {
 
 				initAnimation( animation );
 
-				return animation.stop();
+				return -1 === animation.__direction ? animation.pause() : animation.stop();
 			}
 
 			return initAnimation( animation );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1273.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix reverse mode for Click and Hover

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

