### PR TITLE
Make Custom CSS work with FSE

### DIFF
--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -41,6 +41,12 @@ class Blocks_CSS {
 	 * @access  public
 	 */
 	public function enqueue_editor_assets() {
+		$current_screen = get_current_screen();
+
+		if ( 'widgets' === $current_screen->base || 'customize' === $current_screen->base ) {
+			return;
+		}
+
 		wp_enqueue_code_editor( array( 'type' => 'text/css' ) );
 
 		wp_add_inline_script( 

--- a/src/css/index.js
+++ b/src/css/index.js
@@ -86,7 +86,5 @@ const withInspectorControls = createHigherOrderComponent( BlockEdit => {
 	};
 }, 'withInspectorControl' );
 
-if ( ! select( 'core/edit-site' ) ) {
-	addFilter( 'blocks.registerBlockType', 'themeisle-custom-css/attribute', addAttribute );
-	addFilter( 'editor.BlockEdit', 'themeisle-custom-css/with-inspector-controls', withInspectorControls );
-}
+addFilter( 'blocks.registerBlockType', 'themeisle-custom-css/attribute', addAttribute );
+addFilter( 'editor.BlockEdit', 'themeisle-custom-css/with-inspector-controls', withInspectorControls );

--- a/src/css/inject-css.js
+++ b/src/css/inject-css.js
@@ -15,13 +15,14 @@ import {
 } from '@wordpress/data';
 
 const addStyle = style => {
-	let element = document.getElementById( 'o-css-editor-styles' );
+	let anchor = window.parent.document.querySelector( 'iframe[name="editor-canvas"]' )?.contentWindow.document.head || document.head;
+	let element = anchor.querySelector( '#o-css-editor-styles' );
 
 	if ( null === element ) {
 		element = document.createElement( 'style' );
 		element.setAttribute( 'type', 'text/css' );
 		element.setAttribute( 'id', 'o-css-editor-styles' );
-		document.getElementsByTagName( 'head' )[0].appendChild( element );
+		anchor?.appendChild( element );
 	}
 
 	if ( element.textContent === style ) {
@@ -79,19 +80,30 @@ const getCustomCssFromBlocks = ( blocks, reusableBlocks ) => {
 };
 
 let previousBlocks = [];
+let previewView = false;
 
 subscribe( () => {
 	const { getBlocks } = select( 'core/block-editor' );
+	const __experimentalGetPreviewDeviceType = select( 'core/edit-post' ) ? select( 'core/edit-post' ).__experimentalGetPreviewDeviceType() : false;
 	const blocks = getBlocks();
 	const reusableBlocks = select( 'core' ).getEntityRecords( 'postType', 'wp_block', { context: 'view' });
 
-	if ( ! isEqual( previousBlocks, blocks ) ) {
-		previousBlocks = blocks;
-
+	if ( ! isEqual( previousBlocks, blocks ) || previewView !== __experimentalGetPreviewDeviceType ) {
 		const blocksStyle = getCustomCssFromBlocks( blocks, reusableBlocks );
 
 		if ( blocksStyle ) {
-			addStyle( blocksStyle );
+			if ( previewView !== __experimentalGetPreviewDeviceType && 'Desktop' === previewView ) {
+				setTimeout( () => {
+
+					// A small delay for the iFrame to properly initialize.
+					addStyle( blocksStyle );
+				}, 500 );
+			} else {
+				addStyle( blocksStyle );
+			}
 		}
+
+		previousBlocks = blocks;
+		previewView = __experimentalGetPreviewDeviceType;
 	}
 });

--- a/src/css/inject-css.js
+++ b/src/css/inject-css.js
@@ -14,9 +14,25 @@ import {
 	subscribe
 } from '@wordpress/data';
 
+let isInitialCall = true;
+
 const addStyle = style => {
-	let anchor = window.parent.document.querySelector( 'iframe[name="editor-canvas"]' )?.contentWindow.document.head || document.head;
+	const iFrame = window.parent.document.querySelector( 'iframe[name="editor-canvas"]' )?.contentWindow;
+	let anchor = iFrame?.document.head || document.head;
 	let element = anchor.querySelector( '#o-css-editor-styles' );
+
+	if ( isInitialCall && iFrame ) {
+		iFrame.addEventListener( 'DOMContentLoaded', function() {
+			setTimeout( () => {
+
+				// A small delay for the iFrame to properly initialize.
+				addStyle( style );
+			}, 500 );
+		});
+
+		isInitialCall = false;
+		return;
+	}
 
 	if ( null === element ) {
 		element = document.createElement( 'style' );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This fixes the issue with Custom CSS extension not working with FSE & Tablet/Mobile view in Post Editor.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Make sure it works correctly both in back/front in both FSE/Post Editor. It won't work on Widgets/Customizer.

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.

