### PR TITLE
Fix Copy/Paste old definitions & Flip fix 

### DIFF
--- a/inc/css/blocks/class-flip-css.php
+++ b/inc/css/blocks/class-flip-css.php
@@ -272,7 +272,7 @@ class Flip_CSS extends Base_CSS {
 						},
 					),
 					array(
-						'property' => '--padding-tablet',
+						'property' => '--padding',
 						'value'    => 'paddingTablet',
 						'format'   => function( $value, $attrs ) {
 							return CSS_Utility::render_box(
@@ -286,7 +286,7 @@ class Flip_CSS extends Base_CSS {
 						'media'    => 'tablet',
 					),
 					array(
-						'property' => '--padding-mobile',
+						'property' => '--padding',
 						'value'    => 'paddingMobile',
 						'format'   => function( $value, $attrs ) {
 							return CSS_Utility::render_box(

--- a/src/blocks/blocks/flip/block.json
+++ b/src/blocks/blocks/flip/block.json
@@ -25,22 +25,22 @@
 			"default": "flipY"
 		},
 		"width": {
-			"type": ["number", "object"]
+			"type": ["number", "string"]
 		},
 		"widthTablet": {
-			"type": "object"
+			"type": ["string"]
 		},
 		"widthMobile": {
-			"type": "object"
+			"type": ["string"]
 		},
 		"height": {
-			"type": ["number", "object"]
+			"type": ["number", "string"]
 		},
 		"heightTablet": {
-			"type": "object"
+			"type": ["string"]
 		},
 		"heightMobile": {
-			"type": "object"
+			"type": ["string"]
 		},	
 		"padding": {
 			"type": ["number", "object"]

--- a/src/blocks/blocks/flip/edit.tsx
+++ b/src/blocks/blocks/flip/edit.tsx
@@ -38,6 +38,7 @@ import { boxToCSS, getChoice, mergeBoxDefaultValues, stringToBox, _px } from '..
 import { isNumber } from 'lodash';
 import { type FlipProps } from './types';
 import { type BoxType } from '../../helpers/blocks';
+import { useResponsiveAttributes } from '../../helpers/utility-hooks';
 
 const { attributes: defaultAttributes } = metadata;
 
@@ -59,6 +60,10 @@ const Edit = ({
 
 	const [ currentSide, setSide ] = useState( 'front' );
 
+	const {
+		responsiveGetAttributes
+	} = useResponsiveAttributes( setAttributes );
+
 	const getShadowColor = () => {
 		if ( attributes.boxShadowColor ) {
 			if ( attributes.boxShadowColor.includes( '#' ) && attributes?.boxShadowColorOpacity && 0 <= attributes.boxShadowColorOpacity ) {
@@ -70,10 +75,10 @@ const Edit = ({
 	};
 
 	const inlineStyles = {
-		'--width': ( attributes.width !== undefined && isNumber( attributes.width ) && _px( attributes.width ) ) || ( attributes.width ),
+		'--width': responsiveGetAttributes([ isNumber( attributes.width ) ? _px( attributes.width ) : attributes?.width, attributes.widthTablet, attributes?.widthMobile ]) ?? '100%',
 		'--width-tablet': attributes.widthTablet,
 		'--width-mobile': attributes.widthMobile,
-		'--height': ( attributes.height !== undefined && isNumber( attributes.height ) && _px( attributes.height ) ) || attributes.height,
+		'--height': responsiveGetAttributes([ isNumber( attributes.height ) ? _px( attributes.height ) : attributes?.height, attributes.heightTablet, attributes?.heightMobile ]) ?? '300px',
 		'--height-tablet': attributes.heightTablet,
 		'--height-mobile': attributes.heightMobile,
 		'--border-width': attributes.borderWidth !== undefined && boxToCSS( mergeBoxDefaultValues(
@@ -101,7 +106,7 @@ const Edit = ({
 		'--back-vertical-align': attributes.backVerticalAlign,
 		'--front-media-width': _px( attributes.frontMediaWidth ),
 		'--front-media-height': _px( attributes.frontMediaHeight ),
-		'--padding': attributes.padding !== undefined && isNumber( attributes.padding ) && _px( attributes.padding ) || boxToCSS( attributes?.padding as BoxType | undefined ),
+		'--padding': responsiveGetAttributes([ attributes?.padding, attributes.paddingTablet, attributes?.paddingMobile ]) ?? ( isNumber( attributes.padding ) ? stringToBox( _px( attributes.padding ) ) : stringToBox( '20px' ) ),
 		'--padding-tablet': boxToCSS( attributes?.paddingTablet ),
 		'--padding-mobile': boxToCSS( attributes?.paddingMobile )
 

--- a/src/blocks/blocks/flip/editor.scss
+++ b/src/blocks/blocks/flip/editor.scss
@@ -1,7 +1,6 @@
 @import 'style';
 
 .wp-block-themeisle-blocks-flip {
-	@extend .wp-block-themeisle-blocks-flip;
 
 	--height-tablet: var(--height);
 	--height-mobile: var(--height-tablet);
@@ -25,10 +24,9 @@
 	&.is-selected {
 		height: calc( var( --height ) + 60px );
 	}
-}
 
-@media ( max-width: 960px ) {
-	.wp-block-themeisle-blocks-flip {
+	@media ( max-width: 960px ) {
+		
 		height: var( --height-tablet );
 
 		&.is-selected {
@@ -43,10 +41,9 @@
 			padding: var(--padding-tablet);
 		}
 	}
-}
-
-@media ( max-width: 600px ) {
-	.wp-block-themeisle-blocks-flip{
+	
+	@media ( max-width: 600px ) {
+		
 		height: var( --height-mobile );
 
 		&.is-selected {
@@ -62,3 +59,4 @@
 		}
 	}
 }
+

--- a/src/blocks/blocks/flip/inspector.js
+++ b/src/blocks/blocks/flip/inspector.js
@@ -426,7 +426,7 @@ const Inspector = ({
 										}
 
 										responsiveSetAttributes(
-											removeBoxDefaultValues( result, stringToBox( '20px' ) ),
+											result,
 											[ 'padding', 'paddingTablet', 'paddingMobile' ]
 										);
 									} }

--- a/src/blocks/blocks/flip/inspector.js
+++ b/src/blocks/blocks/flip/inspector.js
@@ -361,21 +361,19 @@ const Inspector = ({
 							title={ __( 'Dimensions', 'otter-blocks' ) }
 						>
 							<ResponsiveControl
-								label={ __( 'Width', 'otter-blocks' ) }
+								label={ __( 'Screen Type', 'otter-blocks' ) }
 							>
 								<UnitControl
+									label={ __( 'Width', 'otter-blocks' ) }
 									value={ responsiveGetAttributes([ isNumber( attributes.width ) ? _px( attributes.width ) : attributes?.width, attributes.widthTablet, attributes?.widthMobile ]) ?? '100%' }
 									onChange={ width => responsiveSetAttributes( width, [ 'width', 'widthTablet', 'widthMobile' ], attributes.width ) }
 									isUnitSelectTabbable
 									isResetValueOnUnitChange
 									allowReset={ true }
 								/>
-							</ResponsiveControl>
-
-							<ResponsiveControl
-								label={ __( 'Height', 'otter-blocks' ) }
-							>
+								<br />
 								<UnitControl
+									label={ __( 'Height', 'otter-blocks' ) }
 									value={ responsiveGetAttributes([ isNumber( attributes.height ) ? _px( attributes.height ) : attributes?.height, attributes.heightTablet, attributes?.heightMobile ]) ?? '300px' }
 									onChange={ height => responsiveSetAttributes( height, [ 'height', 'heightTablet', 'heightMobile' ], attributes.height ) }
 									isUnitSelectTabbable
@@ -409,11 +407,8 @@ const Inspector = ({
 										}
 									]}
 								/>
-							</ResponsiveControl>
 
-							<ResponsiveControl
-								label={ __( '', 'otter-blocks' ) }
-							>
+								<br />
 								<BoxControl
 									label={ __( 'Padding', 'otter-blocks' ) }
 									values={

--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -26,9 +26,9 @@
 
 	perspective: 1000px; /* Remove this if you don't want the 3D effect */
 
-	&[class^="block-editor"] {
-		width: auto;
-	}
+	// &[class^="block-editor"] {
+	// 	width: auto;
+	// }
 
 	&.flipX {
 		--flip-anim: rotateX(180deg);

--- a/src/blocks/blocks/progress-bar/types.d.ts
+++ b/src/blocks/blocks/progress-bar/types.d.ts
@@ -13,6 +13,7 @@ type Attributes = Partial<{
 	barBackgroundColor: string
 	titleColor: string
 	percentageColor: string
+	titleFontSize: string
 }>
 
 export type ProgressAttrs = Partial<Attributes>

--- a/src/blocks/plugins/copy-paste/adaptors.ts
+++ b/src/blocks/plugins/copy-paste/adaptors.ts
@@ -1,4 +1,4 @@
-import { omit, pick, pickBy } from 'lodash';
+import { isNumber, omit, pick, pickBy } from 'lodash';
 import { SectionAttrs } from '../../blocks/section/columns/types';
 import {  Storage } from './models';
 import { coreAdaptors } from './core-adaptors';
@@ -428,17 +428,17 @@ export const adaptors = {
 					border: {
 						width: makeBox( addUnit( attrs?.borderWidth, 'px' ) ),
 						radius: {
-							desktop: makeBox( addUnit( attrs?.borderRadius, 'px' ) )
+							desktop: isNumber(  attrs?.borderRadius ) ? makeBox( addUnit( attrs?.borderRadius, 'px' ) ) : attrs?.borderRadius
 						}
 					},
 					width: {
-						desktop: addUnit( attrs?.width, 'px' )
+						desktop: isNumber(  attrs?.width ) ? addUnit( attrs?.width as number | undefined, 'px' ) : attrs?.width as string | undefined
 					},
 					height: {
-						desktop: addUnit( attrs?.height, 'px' )
+						desktop: isNumber(  attrs?.height ) ?  addUnit( attrs?.height, 'px' ) : attrs?.height as string | undefined
 					},
 					padding: {
-						desktop: makeBox( addUnit( attrs?.padding, 'px' ) )
+						desktop: isNumber(  attrs?.padding ) ?  makeBox( addUnit( attrs?.padding, 'px' ) ) : attrs?.padding
 					},
 					font: {
 						size: addUnit( attrs?.titleFontSize, 'px' )

--- a/src/blocks/plugins/copy-paste/adaptors.ts
+++ b/src/blocks/plugins/copy-paste/adaptors.ts
@@ -59,7 +59,7 @@ export const adaptors = {
 					}
 				},
 				private: {
-					...pickBy( attrs, ( value, key ) => {
+					...pickBy( attrs, ( _value, key ) => {
 						return key?.includes( 'background' ) ||  key?.includes( 'boxShadow' ) ||  key?.includes( 'divider' ) ||  key?.includes( 'columnsHeight' ) ||  key?.includes( 'columnsWidth' ) ||  key?.includes( 'reverseColumnsTablet' ) ||  key?.includes( 'layout' ) ;
 					})
 				}
@@ -119,7 +119,7 @@ export const adaptors = {
 					}
 				},
 				private: {
-					...pickBy( attrs, ( value, key ) => {
+					...pickBy( attrs, ( _value, key ) => {
 						return key?.includes( 'background' );
 					})
 				}
@@ -204,7 +204,7 @@ export const adaptors = {
 					}
 				},
 				private: {
-					...pickBy( attrs, ( value, key ) => {
+					...pickBy( attrs, ( _value, key ) => {
 						return key?.includes( 'hover' ) || key?.includes( 'background' ) || key?.includes( 'boxShadow' );
 					})
 				}
@@ -247,7 +247,7 @@ export const adaptors = {
 					}
 				},
 				private: {
-					...pickBy( attrs, ( value, key ) => {
+					...pickBy( attrs, ( _value, key ) => {
 						return key?.includes( 'Hover' );
 					}),
 					align: attrs?.align
@@ -445,7 +445,7 @@ export const adaptors = {
 					}
 				},
 				private: {
-					...( omit( pickBy( attrs, ( value, key ) => {
+					...( omit( pickBy( attrs, ( _value, key ) => {
 						return key?.includes( 'boxShadow' )  || key?.includes( 'front' ) || key?.includes( 'back' ) || key?.includes( 'Color' ) || key?.includes( 'FontSize' );
 					}) ?? {}, [ 'frontMedia' ]) ),
 					animType: attrs.animType
@@ -486,7 +486,7 @@ export const adaptors = {
 					}
 				},
 				private: {
-					...( pickBy( attrs, ( value, key ) => {
+					...( pickBy( attrs, ( _value, key ) => {
 						return key?.includes( 'FontSize' )  || key?.includes( 'Color' ) || key?.includes( 'Width' ) || key?.includes( 'Gap' ) || key?.includes( 'Style' );
 					}) ?? {})
 				}
@@ -559,7 +559,7 @@ export const adaptors = {
 					primaryColor: attrs?.primaryColor,
 					buttonTextColor: attrs?.buttonTextColor,
 					boxShadow: attrs?.boxShadow,
-					...( pickBy( attrs, ( value, key ) => {
+					...( pickBy( attrs, ( _value, key ) => {
 						return key?.includes( 'Color' )  || key?.includes( 'Font' );
 					}) ?? {})
 				}
@@ -633,7 +633,7 @@ export const adaptors = {
 				},
 				private: {
 					...pick( attrs, [ 'marginType', 'paddingType' ] as ( keyof AdvancedHeadingAttrs )[]),
-					...( pickBy( attrs, ( value, key ) => {
+					...( pickBy( attrs, ( _value, key ) => {
 						return key?.includes( 'highlight' )  || key?.includes( 'Tablet' ) || key?.includes( 'Width' ) || key?.includes( 'Mobile' ) || key?.includes( 'textShadow' );
 					}) ?? {})
 				}
@@ -712,7 +712,7 @@ export const adaptors = {
 					}
 				},
 				private: {
-					...pickBy( attrs, ( value, key ) => {
+					...pickBy( attrs, ( _value, key ) => {
 						return key.includes( 'Tablet' ) ||
 						key.includes( 'Mobile' ) ||
 						key.includes( 'gap' ) ||


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1323
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Updating the adaptors based on the recent enhancements.

Fixing Flip Block attributes type and Editor behaviour.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
Affected block: Progress Bar and Flip
<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

