### PR TITLE
Fix Button Color issue in Section

### DIFF
--- a/inc/css/blocks/class-advanced-column-css.php
+++ b/inc/css/blocks/class-advanced-column-css.php
@@ -225,7 +225,7 @@ class Advanced_Column_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'selector'   => ' a',
+				'selector'   => ' a:not( .wp-block-button__link )',
 				'properties' => array(
 					array(
 						'property'  => 'color',

--- a/inc/css/blocks/class-advanced-column-css.php
+++ b/inc/css/blocks/class-advanced-column-css.php
@@ -210,6 +210,21 @@ class Advanced_Column_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
+				'selector'   => ' wp-block-themeisle-blocks-advanced-column a',
+				'properties' => array(
+					array(
+						'property'  => 'color',
+						'value'     => 'var( --link-color )',
+						'condition' => function( $attrs ) {
+							return isset( $attrs['linkColor'] );
+						},
+					),
+				),
+			)
+		);
+
+		$css->add_item(
+			array(
 				'selector'   => ' > .wp-block-themeisle-blocks-advanced-column-overlay',
 				'properties' => Shared_CSS::section_overlay(),
 			)

--- a/inc/css/blocks/class-advanced-column-css.php
+++ b/inc/css/blocks/class-advanced-column-css.php
@@ -210,11 +210,26 @@ class Advanced_Column_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'selector'   => ' wp-block-themeisle-blocks-advanced-column a',
+				'selector'   => ':hover',
 				'properties' => array(
 					array(
 						'property'  => 'color',
-						'value'     => 'var( --link-color )',
+						'default'   => 'var( --content-color-hover )',
+						'condition' => function( $attrs ) {
+							return isset( $attrs['colorHover'] );
+						},
+					),
+				),
+			)
+		);
+
+		$css->add_item(
+			array(
+				'selector'   => ' a',
+				'properties' => array(
+					array(
+						'property'  => 'color',
+						'default'   => 'var( --link-color )',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['linkColor'] );
 						},

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -228,7 +228,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'selector'   => ' .wp-block-themeisle-blocks-advanced-column a',
+				'selector'   => ' a:not( .wp-block-button__link )',
 				'properties' => array(
 					array(
 						'property'  => 'color',

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -220,6 +220,21 @@ class Advanced_Columns_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
+				'selector'   => ' wp-block-themeisle-blocks-advanced-column a',
+				'properties' => array(
+					array(
+						'property'  => 'color',
+						'value'     => 'var( --link-color )',
+						'condition' => function( $attrs ) {
+							return isset( $attrs['linkColor'] );
+						},
+					),
+				),
+			)
+		);
+
+		$css->add_item(
+			array(
 				'selector'   => ' .wp-block-themeisle-blocks-advanced-columns-separators.top svg',
 				'properties' => array(
 					array(

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -213,23 +213,38 @@ class Advanced_Columns_CSS extends Base_CSS {
 
 		$css->add_item(
 			array(
-				'selector'   => ' > .wp-block-themeisle-blocks-advanced-columns-overlay',
-				'properties' => Shared_CSS::section_overlay(),
+				'selector'   => ':hover',
+				'properties' => array(
+					array(
+						'property'  => 'color',
+						'default'   => 'var( --content-color-hover )',
+						'condition' => function( $attrs ) {
+							return isset( $attrs['colorHover'] );
+						},
+					),
+				),
 			)
 		);
 
 		$css->add_item(
 			array(
-				'selector'   => ' wp-block-themeisle-blocks-advanced-column a',
+				'selector'   => ' .wp-block-themeisle-blocks-advanced-column a',
 				'properties' => array(
 					array(
 						'property'  => 'color',
-						'value'     => 'var( --link-color )',
+						'default'   => 'var( --link-color )',
 						'condition' => function( $attrs ) {
 							return isset( $attrs['linkColor'] );
 						},
 					),
 				),
+			)
+		);
+
+		$css->add_item(
+			array(
+				'selector'   => ' > .wp-block-themeisle-blocks-advanced-columns-overlay',
+				'properties' => Shared_CSS::section_overlay(),
 			)
 		);
 

--- a/inc/css/blocks/class-shared-css.php
+++ b/inc/css/blocks/class-shared-css.php
@@ -153,6 +153,13 @@ class Shared_CSS {
 				},
 			),
 			array(
+				'property'  => 'color',
+				'default'   => 'var( --content-color )',
+				'condition' => function( $attrs ) {
+					return isset( $attrs['color'] );
+				},
+			),
+			array(
 				'property'       => 'border-width',
 				'pattern'        => 'top right bottom left',
 				'pattern_values' => array(

--- a/src/blocks/blocks/advanced-heading/inspector.js
+++ b/src/blocks/blocks/advanced-heading/inspector.js
@@ -200,7 +200,7 @@ const Inspector = ({
 								>
 
 									<FontSizePicker
-										value={ _px( responsiveGetAttributes([ attributes.fontSize, attributes.fontSizeTablet, attributes.fontSizeMobile  ]) ) ?? '20px'}
+										value={ _px( responsiveGetAttributes([ attributes.fontSize, attributes.fontSizeTablet, attributes.fontSizeMobile  ]) ) }
 										onChange={ value => responsiveSetAttributes( value, [ 'fontSize', 'fontSizeTablet', 'fontSizeMobile' ]) }
 										fontSizes={
 											[

--- a/src/blocks/blocks/advanced-heading/style.scss
+++ b/src/blocks/blocks/advanced-heading/style.scss
@@ -16,21 +16,18 @@ span.wp-block-themeisle-blocks-advanced-heading {
 	--text-align-tablet: var(--text-align);
 	--text-align-mobile: var(--text-align-tablet);
 
-	font-size: var(--font-size);
 	padding: var(--padding);
 	margin: var(--margin);
 	text-align: var(--text-align);
 
 
 	@media ( min-width: 600px ) and ( max-width: 960px ) {
-		font-size: var(--font-size-tablet);
 		padding: var(--padding-tablet);
 		margin: var(--margin-tablet);
 		text-align: var(--text-align-tablet);
 	}
 
 	@media ( max-width: 600px ) {
-		font-size: var(--font-size-mobile);
 		padding: var(--padding-mobile);
 		margin: var(--margin-mobile);
 		text-align: var(--text-align-mobile);

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -262,9 +262,7 @@ const Edit = ({
 		...borderStyle,
 		...borderRadiusStyle,
 		...boxShadowStyle,
-		'--content-color': attributes.color,
 		'--link-color': attributes.linkColor,
-		'--content-color-hover': attributes.colorHover,
 		'--background-color-hover': attributes.backgroundColorHover
 	};
 
@@ -313,6 +311,19 @@ const Edit = ({
 
 	return (
 		<Fragment>
+			<style>
+				{
+					`#block-${ clientId } ` + _cssBlock([
+						[ 'color', attributes.color ]
+					])
+				}
+				{
+					`#block-${ clientId }:hover ` + _cssBlock([
+						[ 'color', attributes.colorHover ]
+					])
+				}
+			</style>
+
 			<Controls
 				attributes={ attributes }
 				setAttributes={ setAttributes }

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -37,6 +37,7 @@ import {
 	blockInit,
 	getDefaultValueByField
 } from '../../../helpers/block-utility.js';
+import { _cssBlock } from '../../../helpers/helper-functions';
 
 const { attributes: defaultAttributes } = metadata;
 

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -53,6 +53,7 @@ import {
 	blockInit,
 	getDefaultValueByField
 } from '../../../helpers/block-utility.js';
+import { _cssBlock } from '../../../helpers/helper-functions';
 
 const { attributes: defaultAttributes } = metadata;
 
@@ -311,9 +312,7 @@ const Edit = ({
 		...borderStyle,
 		...borderRadiusStyle,
 		...boxShadowStyle,
-		'--content-color': attributes.color,
-		'--link-color': attributes.linkColor,
-		'--content-color-hover': attributes.colorHover
+		'--link-color': attributes.linkColor
 	};
 
 	if ( 'color' === attributes.backgroundOverlayType ) {
@@ -411,6 +410,19 @@ const Edit = ({
 
 	return (
 		<Fragment>
+			<style>
+				{
+					`#block-${ clientId } ` + _cssBlock([
+						[ 'color', attributes.color ]
+					])
+				}
+				{
+					`#block-${ clientId }:hover ` + _cssBlock([
+						[ 'color', attributes.colorHover ]
+					])
+				}
+			</style>
+
 			<Controls
 				attributes={ attributes }
 				setAttributes={ setAttributes }

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -11,6 +11,14 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	--background: transparent;
 	--columns-width: initial;
 	display: flex;
+	--text-color: var( --content-color, inherit );
+	--text-color-hover: var( --content-color-hover, inherit );
+
+	color: var( --text-color );
+
+	&:hover {
+		color: var( --text-color-hover );
+	}
 
 	> .innerblocks-wrap {
 		flex-basis: 100%;

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -11,14 +11,6 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	--background: transparent;
 	--columns-width: initial;
 	display: flex;
-	--text-color: var( --content-color, inherit );
-	--text-color-hover: var( --content-color-hover, inherit );
-
-	color: var( --text-color );
-
-	&:hover {
-		color: var( --text-color-hover );
-	}
 
 	> .innerblocks-wrap {
 		flex-basis: 100%;
@@ -50,15 +42,10 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	.wp-block-themeisle-blocks-advanced-column {
 		--background: transparent;
 		--background-color-hover: var( --background );
-		--text-color: var( --content-color, inherit );
-		--link-color: inherit;
-		--text-color-hover: var( --content-color-hover, inherit );
 
-		color: var( --text-color );
 		background: var( --background );
 
 		&:hover {
-			color: var( --text-color-hover );
 			background: var( --background-color-hover );
 		}
 
@@ -66,7 +53,7 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 			position: relative;
 		}
 	
-		a {
+		a:not( .wp-block-button__link ) {
 			color: var( --link-color );
 		}
 

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -67,10 +67,6 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 		> * {
 			position: relative;
 		}
-	
-		a {
-			color: var( --link-color );
-		}
 
 		.wp-block-themeisle-blocks-advanced-column-overlay {
 			position: absolute;

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -52,15 +52,11 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	.wp-block-themeisle-blocks-advanced-column {
 		--background: transparent;
 		--background-color-hover: var( --background );
-		--text-color: var( --content-color, inherit );
 		--link-color: inherit;
-		--text-color-hover: var( --content-color-hover, inherit );
 
-		color: var( --text-color );
 		background: var( --background );
 
 		&:hover {
-			color: var( --text-color-hover );
 			background: var( --background-color-hover );
 		}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1328.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

This should fix the issue introduced by the last version, where Buttons were inheriting the color of links too.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Instructions on how to reproduce and test: https://github.com/Codeinwp/otter-blocks/issues/1328

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

