### PR TITLE
Fix missing information from Form in FSE

### DIFF
--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -4,6 +4,7 @@
 import classnames from 'classnames';
 
 import { get } from 'lodash';
+import hash from 'object-hash';
 
 /**
  * WordPress dependencies
@@ -158,8 +159,8 @@ const Edit = ({
 	useEffect( () => {
 		if ( attributes.id && select( 'core/edit-widgets' ) ) {
 			setAttributes({ optionName: `widget_${ attributes.id.slice( -8 ) }` });
-		} else if ( attributes.id && Boolean( window.themeisleGutenberg.isBlockEditor ) && select( 'core/editor' )?.getCurrentPostId() ) {
-			setAttributes({ optionName: `${ select( 'core/editor' ).getCurrentPostId() }_${ attributes.id.slice( -8 ) }` });
+		} else if ( attributes.id ) {
+			setAttributes({ optionName: `${ hash({ url: window.location.pathname }) }_${ attributes.id.slice( -8 ) }` });
 		}
 	}, [ attributes.id ]);
 

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -137,16 +137,19 @@ const Edit = ({
 		[ name ]
 	);
 
-	const { children, hasEmailField } = useSelect( select => {
+	const { children, hasEmailField, hasProtection } = useSelect( select => {
 		const {
 			getBlock
 		} = select( 'core/block-editor' );
 		const children = getBlock( clientId ).innerBlocks;
 		return {
 			children,
-			hasEmailField: children?.some( b => ( 'email' === b?.attributes?.type ) )
+			hasEmailField: children?.some( b => ( 'email' === b?.attributes?.type ) ),
+			hasProtection: 0 < children?.filter( ({ name }) => 'themeisle-blocks/form-nonce' === name )?.length
 		};
 	});
+
+	const hasEssentialData = attributes.optionName && hasProtection;
 
 	useEffect( () => {
 		const unsubscribe = blockInit( clientId, defaultAttributes );
@@ -825,14 +828,33 @@ const Edit = ({
 									</button>
 
 									{ isSelected && (
-										<div>
-											<div className='o-form-server-response o-success' style={{ color: attributes.submitMessageColor }}>
-												{ formOptions.submitMessage || __( 'Success', 'otter-blocks' ) }
+										<Fragment>
+											<div>
+												<div className='o-form-server-response o-success' style={{ color: attributes.submitMessageColor }}>
+													{ formOptions.submitMessage || __( 'Success', 'otter-blocks' ) }
+												</div>
+												<div className='o-form-server-response o-error' style={{ color: attributes.submitMessageErrorColor, margin: '0px' }}>
+													{ __( 'Error. Please try again.', 'otter-blocks' ) }
+												</div>
 											</div>
-											<div className='o-form-server-response o-error' style={{ color: attributes.submitMessageErrorColor, margin: '0px' }}>
-												{ __( 'Error. Please try again.', 'otter-blocks' ) }
-											</div>
-										</div>
+											{
+												! hasEssentialData && attributes.id && (
+													<Fragment>
+														<p>{__( 'Some data is missing!', 'otter-blocks' )}</p>
+														{
+															attributes.optionName === undefined && (
+																<p>{__( 'Bad initialization. Please create another Form!', 'otter-blocks' )}</p>
+															)
+														}
+														{
+															false === hasProtection && (
+																<p>{__( 'CSRF protection is missing. Please create another Form!', 'otter-blocks' )}</p>
+															)
+														}
+													</Fragment>
+												)
+											}
+										</Fragment>
 									) }
 								</div>
 							</form>

--- a/src/blocks/blocks/form/index.js
+++ b/src/blocks/blocks/form/index.js
@@ -90,6 +90,12 @@ registerBlockType( name, {
 					}
 				],
 				[
+					'themeisle-blocks/form-nonce',
+					{
+
+					}
+				],
+				[
 					'themeisle-blocks/form-textarea',
 					{
 						label: __( 'Message', 'otter-blocks' )
@@ -124,6 +130,12 @@ registerBlockType( name, {
 						label: __( 'Email', 'otter-blocks' ),
 						type: 'email',
 						isRequired: true
+					}
+				],
+				[
+					'themeisle-blocks/form-nonce',
+					{
+
 					}
 				],
 				[

--- a/src/blocks/blocks/form/nonce/block.json
+++ b/src/blocks/blocks/form/nonce/block.json
@@ -2,11 +2,12 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "themeisle-blocks/form-nonce",
-	"title": "Nonce Field",
+	"title": "CSRF Protection",
 	"category": "themeisle-blocks",
 	"description": "Protect the form from CSRF.",
 	"keywords": [ "protection", "csrf", "field" ],
 	"textdomain": "otter-blocks",
+	"ancestor": [ "themeisle-blocks/form" ],
 	"attributes": {
 		"formId": {
 			"type": "string"


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1340.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix missing data:
 - nonce
 - form option

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add Form in FSE Template
2. Check if it works

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

