### PR TITLE
Query loops with Otter Dynamic Values and Images

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -257,6 +257,7 @@ class Registration {
 				'postTypes'               => get_post_types( [ 'public' => true ] ),
 				'rootUrl'                 => get_site_url(),
 				'restRoot'                => get_rest_url( null, 'otter/v1' ),
+				'isPrettyPermalinks'      => boolval( get_option( 'permalink_structure' ) ),
 				'showOnboarding'          => $this->show_onboarding(),
 				'ratingScale'             => get_option( 'themeisle_blocks_settings_review_scale', false ),
 				'hasModule'               => array(

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -175,7 +175,7 @@ class Dynamic_Content {
 
 		$id = ( defined( 'REST_REQUEST' ) && REST_REQUEST || ( isset( $data['context'] ) && 'query' === $data['context'] ) ) ? $post->ID : get_queried_object_id();
 
-		if ( isset( $data['context'] ) && ( 0 === $data['context'] || null === $data['context'] || ( is_singular() && $data['context'] !== $id ) ) ) {
+		if ( isset( $data['context'] ) && ( 0 === $data['context'] || null === $data['context'] || 'query' === $data['context'] || ( is_singular() && $data['context'] !== $id ) ) ) {
 			$data['context'] = $id;
 		}
 
@@ -386,11 +386,15 @@ class Dynamic_Content {
 		$excerpt = $post->post_excerpt; // Here we don't use get_the_excerpt() function as it causes an infinite loop.
 
 		if ( empty( $excerpt ) ) {
-			return $data['default'];
+			$excerpt = wp_trim_excerpt( '', $post );
 		}
 
 		if ( isset( $data['length'] ) && ! empty( $data['length'] ) ) {
 			$excerpt = substr( $excerpt, 0, intval( $data['length'] ) ) . '…';
+		}
+
+		if ( empty( $excerpt ) ) {
+			return $data['default'];
 		}
 
 		return sanitize_text_field( $excerpt );

--- a/src/blocks/plugins/dynamic-content/media/media-content.js
+++ b/src/blocks/plugins/dynamic-content/media/media-content.js
@@ -73,6 +73,10 @@ const types = [
 	}
 ];
 
+const routeBase = window.themeisleGutenberg.restRoot.includes( '?rest_route=' ) ? '/dynamic/&' : '/dynamic/?';
+
+const getRouteBase = url => url.includes( '?rest_route=' ) ? '/dynamic/&' : '/dynamic/?';
+
 const MediaItem = ({
 	uid,
 	item,
@@ -80,7 +84,7 @@ const MediaItem = ({
 	isSelected,
 	onSelect
 }) => {
-	const url = window.themeisleGutenberg.restRoot + '/dynamic/?type=' + item.type + '&context=' + context + '&uid=' + uid;
+	const url = window.themeisleGutenberg.restRoot + routeBase + 'type=' + item.type + '&context=' + context + '&uid=' + uid;
 
 	const isDisabled = ( undefined !== item?.isAvailable && ! item?.isAvailable );
 
@@ -223,7 +227,7 @@ const MediaContent = ({
 
 		const attrs = getObjectFromQueryString( target || '' );
 		attrs.uid = uid;
-		const url = window.themeisleGutenberg.restRoot + '/dynamic/?' + getQueryStringFromObject( attrs );
+		const url = window.themeisleGutenberg.restRoot + routeBase + getQueryStringFromObject( attrs );
 		onSelect( url );
 		window.otterCurrentMediaProps = {};
 	}, []);
@@ -242,7 +246,7 @@ const MediaContent = ({
 
 		attrs = Object.fromEntries( Object.entries( attrs ).filter( ([ _, v ]) => ( null !== v && '' !== v && undefined !== v ) ) );
 
-		const url = window.themeisleGutenberg.restRoot + '/dynamic/?' + getQueryStringFromObject( attrs );
+		const url = window.themeisleGutenberg.restRoot + routeBase + getQueryStringFromObject( attrs );
 
 		onSelectImage({
 			id: uid,
@@ -276,7 +280,7 @@ const MediaContent = ({
 								uid={ uid }
 								item={ item }
 								context={ isQueryChild ? 'query' : getCurrentPostId }
-								isSelected={ selected ? selected?.includes( `dynamic/?type=${ item.type }` ) : false }
+								isSelected={ selected ? selected?.includes( `${ getRouteBase( selected ) }type=${ item.type }` ) : false }
 								onSelect={ onSelect }
 							/>
 						);


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1272 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
This should fix https://github.com/Codeinwp/otter-blocks/issues/1272 as well as the issue with Dynamic Images not working correctly without Pretty Permalinks.

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

