### PR TITLE
Make sure Review Ratings are minimum 1 for Schema

### DIFF
--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -78,8 +78,8 @@ class Review_Block {
 		$html .= '		<div class="o-review__header_meta">';
 		$html .= '			<div class="o-review__header_ratings">';
 		$html .= $this->get_overall_stars( $this->get_overall_ratings( $attributes['features'] ), $scale );
-		// translators: Overall rating from 0 to 10.
-		$html .= '				<span>' . sprintf( __( '%1$g out of %2$g', 'otter-blocks' ), round( $this->get_overall_ratings( $attributes['features'] ) / $scale, 1 ), 10 / $scale ) . '</span>';
+		// translators: Overall rating from 1 to 10.
+		$html .= '				<span>' . sprintf( __( '%1$g out of %2$g', 'otter-blocks' ), $this->get_overall_ratings( $attributes['features'], $scale ), 10 / $scale ) . '</span>';
 		$html .= '			</div>';
 
 		if ( ( isset( $attributes['price'] ) && ! empty( $attributes['price'] ) ) || isset( $attributes['discounted'] ) ) {
@@ -123,8 +123,8 @@ class Review_Block {
 
 				$html .= '		<div class="o-review__left_feature_ratings">';
 				$html .= $this->get_overall_stars( $feature['rating'], $scale );
-				// translators: Overall rating from 0 to 10.
-				$html .= '			<span>' . sprintf( __( '%1$g out of %2$g', 'otter-blocks' ), round( $feature['rating'] / $scale, 1 ), 10 / $scale ) . '</span>';
+				// translators: Overall rating from 1 to 10.
+				$html .= '			<span>' . sprintf( __( '%1$g out of %2$g', 'otter-blocks' ), 1 <= round( $feature['rating'] / $scale, 1 ) ? round( $feature['rating'] / $scale, 1 ) : 1, 10 / $scale ) . '</span>';
 				$html .= '		</div>';
 				$html .= '	</div>';
 			}
@@ -190,10 +190,11 @@ class Review_Block {
 	 * Get overall ratings
 	 *
 	 * @param array $features An array of features.
+	 * @param int   $divide The scale of ratings.
 	 *
 	 * @return int
 	 */
-	public function get_overall_ratings( $features ) {
+	public function get_overall_ratings( $features, $divide = 1 ) {
 		if ( count( $features ) <= 0 ) {
 			return 0;
 		}
@@ -207,9 +208,9 @@ class Review_Block {
 			0
 		);
 
-		$rating = round( $rating / count( $features ), 1 );
+		$rating = round( ( $rating / count( $features ) ) / $divide, 1 );
 
-		return $rating;
+		return 1 <= $rating ? $rating : 1;
 	}
 
 	/**
@@ -262,7 +263,7 @@ class Review_Block {
 			'@type'        => 'Review',
 			'reviewRating' => array(
 				'@type'       => 'Rating',
-				'ratingValue' => round( $this->get_overall_ratings( $attributes['features'] ) / 2, 1 ),
+				'ratingValue' => $this->get_overall_ratings( $attributes['features'], 2 ),
 				'bestRating'  => 5,
 			),
 			'author'       => array(

--- a/src/blocks/blocks/review/edit.js
+++ b/src/blocks/blocks/review/edit.js
@@ -242,10 +242,10 @@ const Edit = ({
 
 					<div className="o-review__header_meta">
 						<div className="o-review__header_ratings">
-							<Stars rating={ overallRatings } />
+							<Stars rating={ Math.max( overallRatings, 1 ) } />
 
 							<span>
-								{ /** translators: %s Rating score. */ sprintf( __( '%f out of %f', 'otter-blocks' ), Math.abs( overallRatings / divide ).toFixed( 1 ) || 0, 10 / divide ) }
+								{ /** translators: %s Rating score. */ sprintf( __( '%f out of %f', 'otter-blocks' ), Math.max( Math.abs( overallRatings / divide ).toFixed( 1 ) || 0, 1 ), 10 / divide ) }
 							</span>
 						</div>
 
@@ -312,10 +312,10 @@ const Edit = ({
 									/>
 
 									<div className="o-review__left_feature_ratings">
-										<Stars rating={ feature.rating } />
+										<Stars rating={ Math.max( feature.rating, 1 ) } />
 
 										<span>
-											{ /** translators: %s Rating score. */ sprintf( __( '%f out of %f', 'otter-blocks' ), Math.abs( feature.rating / divide ).toFixed( 1 ) || 0, 10 / divide ) }
+											{ /** translators: %s Rating score. */ sprintf( __( '%f out of %f', 'otter-blocks' ), Math.max( Math.abs( feature.rating / divide ).toFixed( 1 ) || 0, 1 ), 10 / divide ) }
 										</span>
 									</div>
 								</div>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1375.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

This makes sure whatever the rating is, the minimum value stays at 1.
----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Please make sure the rating numbers, both in front/back, are same and consistent regardless of the weight scale used, 1-10 or 1-5, which can be toggled from Otter settings

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

