### PR TITLE
Otter Tools Shortcuts

### DIFF
--- a/src/blocks/components/otter-tools/index.tsx
+++ b/src/blocks/components/otter-tools/index.tsx
@@ -12,7 +12,8 @@ import {
 	Button,
 	ToolbarDropdownMenu,
 	ToolbarGroup,
-	createSlotFill
+	createSlotFill,
+	KeyboardShortcuts
 } from '@wordpress/components';
 
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -20,6 +21,8 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { Fragment, useState } from '@wordpress/element';
 
 import { addFilter } from '@wordpress/hooks';
+import { isAppleOS } from '@wordpress/keycodes';
+
 
 /**
  * Internal dependencies.
@@ -48,70 +51,66 @@ const withOtterTools = createHigherOrderComponent( BlockEdit => {
 			setStatus( 'notSubmitted' );
 		};
 
-		if ( props.isSelected ) {
-			return (
-				<Fragment>
-					<BlockEdit { ...props } />
-					<Slot>
-						{
-							fills => {
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<KeyboardShortcuts
 
-								if ( ! Boolean( fills.length ) ) {
-									return null;
-								}
-
-								return (
-									<BlockControls>
-										<ToolbarGroup>
-											<ToolbarDropdownMenu
-												label={__( 'Otter Tools', 'otter-blocks' )}
-												icon={ otterIcon }
-											>
-												{
-													({ onClose }) => (
-														<div onClick={onClose}>
-															{
-																sortBy( fills ?? [], fill => {
-																	return fill[0]?.props.order;
-																}).map( fill => {
-																	return fill[0]?.props?.children;
-																})
-															}
-															<Button
-																id="o-feedback"
-																variant={ 'link' }
-																onClick={() => {
-																	setIsOpen( ! isOpen );
-																	onClose();
-																}}
-																style={{
-																	paddingLeft: '8px'
-																}}
-															>
-																{ __( 'Help us improve Otter Blocks', 'otter-blocks' ) }
-															</Button>
-														</div>
-													)
-												}
-											</ToolbarDropdownMenu>
-										</ToolbarGroup>
-										<FeedbackModalComponent
-											isOpen={isOpen}
-											status={status}
-											closeModal={closeModal}
-											source={'control-tools'}
-											setStatus={ setStatus }
-										/>
-									</BlockControls>
-								);
-							}
+					// Sometime it works, sometime is not. Not to reliable
+					shortcuts={
+						isAppleOS() ? {
+							'mod+ctrl+j': window?.oPlugins?.copy,
+							'mod+ctrl+k': window?.oPlugins?.paste
+						} : {
+							'ctrl+alt+j': window?.oPlugins?.copy,
+							'ctrl+alt+k': window?.oPlugins?.paste
 						}
-					</Slot>
-				</Fragment>
-			);
-		}
+					}
+					bindGlobal={true}
+				/>
+				{ ( props.isSelected ) && (
+					<Fragment>
+						<Slot>
+							{
+								fills => {
 
-		return <BlockEdit { ...props } />;
+									if ( ! Boolean( fills.length ) ) {
+										return null;
+									}
+
+									return (
+										<BlockControls>
+
+											<ToolbarGroup>
+												<ToolbarDropdownMenu
+													label={__( 'Otter Tools', 'otter-blocks' )}
+													icon={ otterIcon }
+												>
+													{
+														({ onClose }) => (
+															<div onClick={onClose}>
+																{
+																	sortBy( fills ?? [], fill => {
+																		return fill[0]?.props.order;
+																	}).map( fill => {
+																		return fill[0]?.props?.children;
+																	})
+																}
+															</div>
+														)
+													}
+												</ToolbarDropdownMenu>
+											</ToolbarGroup>
+										</BlockControls>
+									);
+								}
+							}
+						</Slot>
+					</Fragment>
+				)}
+
+			</Fragment>
+		);
 	};
 }, 'withOtterTools' );
 

--- a/src/blocks/global.d.ts
+++ b/src/blocks/global.d.ts
@@ -84,6 +84,10 @@ declare global {
 			Notice?: ( props: { notice: any, variant: string, instructions: 'string'}) => JSX.Element
 			useInspectorSlot?: ( name: string ) => any
 			OtterControlTools?: ( props: any ) => any
+		},
+		oPlugins: {
+			copy?: () => void,
+			paste?: () => void
 		}
 	}
 }

--- a/src/blocks/plugins/copy-paste/copy-paste.ts
+++ b/src/blocks/plugins/copy-paste/copy-paste.ts
@@ -30,11 +30,11 @@ class CopyPaste {
 		this.pull();
 	}
 
-	copy( block: OtterBlock<unknown> ) {
-		let success = false;
+	copy( block: OtterBlock<unknown> ): 'SUCCESS' | 'NO-ADAPTOR' | 'ERROR' {
+		let success: 'SUCCESS' | 'NO-ADAPTOR' | 'ERROR'  = 'ERROR';
 		try {
 			if ( ! ( adaptors as Adaptors )?.[block.name]) {
-				return success;
+				return 'NO-ADAPTOR';
 			}
 
 			const copied = compactObject( pickBy( ( adaptors as Adaptors )?.[block.name]?.copy( block.attributes ), x => ! ( isNil( x ) ) ) ) as Storage<unknown>;
@@ -45,7 +45,7 @@ class CopyPaste {
 			this.storage.private = copied?.private;
 			this.sync();
 
-			success = true;
+			success = 'SUCCESS';
 		} catch ( e ) {
 			console.error( e );
 			this.storage = {};

--- a/src/blocks/plugins/copy-paste/index.js
+++ b/src/blocks/plugins/copy-paste/index.js
@@ -8,6 +8,7 @@ import { PluginBlockSettingsMenuItem } from '@wordpress/edit-post';
 import { Fragment } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { MenuGroup, MenuItem } from '@wordpress/components';
+import { isAppleOS, displayShortcut } from '@wordpress/keycodes';
 
 /**
   * Internal dependencies.
@@ -57,24 +58,24 @@ function copy() {
 
 	const { createNotice } = dispatch( 'core/notices' );
 
-	if ( copied?.every( x => x ) ) {
+	if ( 0 < copied?.filter( x => 'SUCCESS' == x )?.length ) {
 		createNotice(
 			'info',
 			__( 'Copied the styles.', 'otter-blocks' ),
 			{
 				isDismissible: true,
 				type: 'snackbar',
-				id: 'o-copied'
+				id: 'o-copied-success'
 			}
 		);
-	} else {
+	} else if ( 0 < copied?.filter( x => 'ERROR' == x )?.length ) {
 		createNotice(
 			'error',
-			__( 'An error occured when trying to copy the style.', 'otter-blocks' ),
+			__( 'An error occurred when trying to copy the style.', 'otter-blocks' ),
 			{
 				isDismissible: true,
 				type: 'snackbar',
-				id: 'o-copied'
+				id: 'o-copied-error'
 			}
 		);
 	}
@@ -148,6 +149,7 @@ const CopyPasteComponent = ( ) => {
 	);
 };
 
+
 const withCopyPasteExtension = createHigherOrderComponent( BlockEdit => {
 	return ( props ) => {
 
@@ -155,11 +157,12 @@ const withCopyPasteExtension = createHigherOrderComponent( BlockEdit => {
 
 			return (
 				<Fragment>
+
 					<BlockEdit { ...props } />
 					{
 
 						/**
-							Might be usefull in the future.
+							Might be useful in the future.
 							<CopyPasteComponent {...props} />
 						*/
 					}
@@ -168,12 +171,14 @@ const withCopyPasteExtension = createHigherOrderComponent( BlockEdit => {
 						<MenuGroup>
 							<MenuItem
 								onClick={ copy }
+								shortcut={ isAppleOS() ? displayShortcut.ctrl( '' ) + displayShortcut.primary( 'j' ) : displayShortcut.ctrl( '' ) + displayShortcut.alt( 'j' ) }
 							>
 								{ __( 'Copy Style', 'otter-blocks' ) }
 							</MenuItem>
 
 							<MenuItem
 								onClick={ paste }
+								shortcut={ isAppleOS() ? displayShortcut.ctrl( '' ) + displayShortcut.primary( 'k' ) : displayShortcut.ctrl( '' ) + displayShortcut.alt( 'k' ) }
 							>
 								{ __( 'Paste Style', 'otter-blocks' ) }
 							</MenuItem>
@@ -190,4 +195,10 @@ const withCopyPasteExtension = createHigherOrderComponent( BlockEdit => {
 if ( select?.( 'core/editor' ) !== undefined ) {
 	addFilter( 'editor.BlockEdit', 'themeisle-gutenberg/copy-paste-extension', withCopyPasteExtension );
 }
+
+// Load to global scope
+window.oPlugins = {
+	copy: copy,
+	paste: paste
+};
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1350.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Approved changes for Otter Tools toolbar:
- remove the feedback button
- shortcuts for Copy/Paste 

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
Please make sure that the shortcuts are displayed and that they work.
⚠️ For Windows, you will need a machine for it. Browserstack does not seem to work well.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

