### PR TITLE
Evergreen Reset Fix

### DIFF
--- a/src/blocks/frontend/countdown/index.ts
+++ b/src/blocks/frontend/countdown/index.ts
@@ -381,15 +381,22 @@ class CountdownRunner {
 	 */
 	startTimer( interval: number = 300 ) {
 		this.timer = setInterval( () => {
-			const currentTime = Date.now();
-			this.running.forEach( ( countdown ) => {
-				this.updateCountdown( this.countdowns[countdown] as CountdownData, currentTime );
-			});
-
-			if ( 0 === this.running.size ) {
-				this.stopTimer();
-			}
+			this.update();
 		}, interval );
+	}
+
+	/**
+	 * Update he countdown using the current time.
+	 */
+	update() {
+		const currentTime = Date.now();
+		this.running.forEach( ( countdown ) => {
+			this.updateCountdown( this.countdowns[countdown] as CountdownData, currentTime );
+		});
+
+		if ( 0 === this.running.size ) {
+			this.stopTimer();
+		}
 	}
 
 	/**
@@ -476,6 +483,8 @@ domReady( () => {
 		const c = new CountdownData( countdown as HTMLDivElement );
 		runner.register( c );
 	});
+
+	runner.update();
 
 	runner.startTimer();
 });


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1377 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add a fix for Evergreen reset and docs.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add a Countdown with the mode Evergreen
2. Set the time, then preview.
3. Test time reset on __refresh__, which has the conditions:
    1. Time is over.
    2. Timezone has changed 
    3. Deadline has changed.

If you think the time should have reset in a situation that is not mentioned, please post the scenario 🙏 .

For Timezone, you can use the Sensor tab from the browser Dev Tools (Chrome)
![image](https://user-images.githubusercontent.com/17597852/206193298-079091af-3119-4b66-804a-d08aa94440a8.png)

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

