### PR TITLE
Add hCaptcha Integration

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -497,6 +497,7 @@ class Registration {
 				'themeisleGutenbergForm',
 				array(
 					'reRecaptchaSitekey' => get_option( 'themeisle_google_captcha_api_site_key' ),
+					'reRecaptchaAPIURL'  => apply_filters( 'otter_blocks_recaptcha_api_url', 'https://www.google.com/recaptcha/api.js' ),
 					'root'               => esc_url_raw( rest_url() ),
 					'nonce'              => wp_create_nonce( 'wp_rest' ),
 					'messages'           => array(

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -636,7 +636,7 @@ class Form_Server {
 	public function check_form_captcha( $form_data ) {
 		$secret = get_option( 'themeisle_google_captcha_api_secret_key' );
 		$resp   = wp_remote_post(
-			'https://www.google.com/recaptcha/api/siteverify',
+			apply_filters( 'otter_blocks_recaptcha_verify_url', 'https://www.google.com/recaptcha/api/siteverify' ),
 			array(
 				'body'    => 'secret=' . $secret . '&response=' . $form_data->get_payload_field( 'token' ),
 				'headers' => [

--- a/src/blocks/frontend/form/captcha.js
+++ b/src/blocks/frontend/form/captcha.js
@@ -17,7 +17,7 @@ export const addCaptchaOnPage = ( forms ) => {
 			}, 200 );
 		});
 
-		script.src = 'https://www.google.com/recaptcha/api.js';
+		script.src = window?.themeisleGutenbergForm?.reRecaptchaAPIURL;
 	}
 };
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1053.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This allows Otter Blocks' Form block to replace reCaptcha with hCaptcha API using hCaptcha's WP plugin. Changes required on hCaptcha can be found here: https://github.com/hCaptcha/hcaptcha-wordpress-plugin/pull/208

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

You can install Otter and configure hCaptcha plugin from here: https://github.com/hCaptcha/hcaptcha-wordpress-plugin/pull/208

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

