### PR TITLE
Fix Button not loading properly in some FSE versions

### DIFF
--- a/src/blocks/blocks/button-group/button/block.json
+++ b/src/blocks/blocks/button-group/button/block.json
@@ -135,5 +135,6 @@
 			"name": "outline",
 			"label": "Outline"
 		}
-	]
+	],
+	"style": "wp-block-button"
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1106.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Fixes the issue with Button Group block styles not loading properly in front in FSE.

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use the default theme in WP 6.0.3 and use the FSE editor to add a Button Group, while no Button Block is present, and the Button Group styles don't look normal.
- With this PR, the issue should be solved.

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

