### PR TITLE
[wip] Fix CSS Min failing

### DIFF
--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -436,6 +436,7 @@ class CSS_Handler extends Base_CSS {
 		$compressor->setMaxExecutionTime( 120 );
 		$compressor->setPcreBacktrackLimit( 3000000 );
 		$compressor->setPcreRecursionLimit( 150000 );
+		ini_set( 'pcre.jit', '0' );
 
 		$css = htmlspecialchars_decode( $css );
 		$css = $compressor->run( $css );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1087.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Fix CSSMin not working in some cases

----

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

