### PR TITLE
New Global Defaults UI

### DIFF
--- a/src/blocks/plugins/options/editor.scss
+++ b/src/blocks/plugins/options/editor.scss
@@ -76,6 +76,7 @@
 			.o-options-block-item-label {
 				flex-basis: 40%;
 				flex-grow: 1;
+				padding-right: 5px;
 			}
 		}
 
@@ -84,18 +85,12 @@
 
 			.o-options-block-item-icon {
 				svg {
-					fill: #555555A3 !important;
+					fill: #E5E5E5 !important;
 				}
 			}
 
 			.o-options-block-item-label {
-				color: #e5e5e5;
-			}
-
-			.o-options-block-item-button {
-				svg {
-					fill :#e5e5e5;
-				}
+				color: #E5E5E5;
 			}
 		}
 

--- a/src/blocks/plugins/options/editor.scss
+++ b/src/blocks/plugins/options/editor.scss
@@ -17,148 +17,205 @@
 	}
 }
 
-.o-options-global-defaults {
-	.o-options-global-defaults-list {
-		display: flex;
-		flex-wrap: wrap;
-		margin: 10px 0;
+.padding-20 {
+	padding: 20px;
+}
+
+.components-button.o-navi-button {
+	position: relative;
+	padding: 16px 48px 16px 16px;
+	outline: none;
+	width: 100%;
+	font-weight: 500;
+	text-align: left;
+	color: #1e1e1e;
+	box-shadow: none;
+	transition: background .1s ease-in-out;
+	height: auto;  border-top: 1px solid #e0e0e0;
+	border-bottom: 1px solid #e0e0e0;
+
+	&:hover {
+		color: #1e1e1e;
+		background: #f0f0f0;
 	}
 
-	.o-options-global-defaults-list-item {
-		display: flex;
-		flex-direction: column;
-		flex: 0 0 50%;
-		width: 50%;
-		height: auto;
-		font-size: 13px;
-		color: #32373c;
-		padding: 0 4px;
-		align-items: stretch;
-		justify-content: center;
-		cursor: pointer;
-		background: transparent;
-		word-break: break-word;
-		border-radius: 4px;
-		border: 1px solid transparent;
-		transition: all .05s ease-in-out;
-		position: relative;
-
-		&:focus,
-		&:active {
-			position: relative;
-			color: #191e23;
-			box-shadow: 0 0 0 1px #fff, 0 0 0 3px #00a0d2;
-			outline: 2px solid transparent;
-		}
+	&:focus {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		border-radius: 0;
 	}
 
-	.o-options-global-defaults-list-item-icon {
-		padding: 12px 20px;
-		border-radius: 4px;
-		color: #555d66;
-		transition: all .05s ease-in-out;
+	svg {
+		width: 24px;
+		height: 24px;
+		position: absolute;
+		right: 16px;
+	}
+
+	&.o-navi-button-back {
+		padding: 12px 48px 12px 16px;
 
 		svg {
-			width: 20px;
-			height: 20px;
+			position: relative;
+			left: 0;
+		}
+	}
+}
+
+.o-options-global-defaults {
+	.o-options-block-item {
+		display: flex;
+		background: #ffffff;
+		border: 1px solid #d5dadf;
+		margin: 10px 20px;
+
+		&:hover {
+			background: #fafafb;
+		}
+
+		&.editable {
+			.o-options-block-item-label {
+				flex-basis: 40%;
+				flex-grow: 1;
+			}
+		}
+
+		&.hidden {
+			color: #e5e5e5;
+
+			.o-options-block-item-icon {
+				svg {
+					fill: #555555A3 !important;
+				}
+			}
+
+			.o-options-block-item-label {
+				color: #e5e5e5;
+			}
+
+			.o-options-block-item-button {
+				svg {
+					fill :#e5e5e5;
+				}
+			}
+		}
+
+		.o-options-block-item-icon {
+			display: flex;
+			justify-content: center;
+			align-self: center;
+			flex-basis: 20%;
+			padding: 15px 0;
+
+			svg {
+				width: 18px;
+				height: 18px;
+			}
+		}
+
+		.o-options-block-item-label {
+			cursor: default;
+			flex-basis: 60%;
+			display: flex;
+			align-items: center;
+
+			&::selection {
+				background: none;
+			}
+		}
+
+		.o-options-block-item-button {
+			height: auto;
+			flex-basis: 20%;
+			justify-content: center;
+			padding: 10px 5px;
+			border-left: 1px solid #d5dadf;
+			border-radius: 0;
+
+			&.components-icon-button:not(:disabled):not([aria-disabled="true"]):not(.is-default) {
+
+				&:hover {
+					background: #fafafb;
+					border-radius: 0;
+					box-shadow: none;
+				}
+			}
+
+			svg,
+			.dashicon {
+				margin: 2px;
+			}
 		}
 	}
 
-	.o-options-global-defaults-list-item-title {
-		padding: 4px 2px 8px;
+	.components-placeholder {
+		box-shadow: none;
 	}
 }
 
 .o-options-global-defaults-modal {
-	.components-modal__content {
-		padding: 0;
+	.components-panel__body-toggle {
+		padding: 15px 24px;
+
+		.components-panel__arrow {
+			right: 22px;
+		}
+	}
+
+	.components-base-control,
+	.o-responsive-control {
+		padding: 10px;
 		margin: 0;
-		overflow: hidden;
-		overflow-y: scroll;
+	}
 
-		&::before {
-			min-height: 60px;
-			margin-bottom: 0;
-		}
-
-		.components-modal__header {
-			background: #ffffff;
-			padding: 0 24px;
-			margin: 0;
-		}
-
-		.components-panel__body-toggle {
-			padding: 15px 24px;
-
-			.components-panel__arrow {
-				right: 22px;
-			}
-		}
-
-		.components-base-control,
-		.o-responsive-control {
+	div:not( .components-base-control__field ) {
+		 > .o-sizing-control {
 			padding: 10px;
 			margin: 0;
 		}
+	}
 
-		div:not( .components-base-control__field ) {
-			 > .o-sizing-control {
-				padding: 10px;
-				margin: 0;
-			}
+	.components-base-control {
+		.components-base-control__label {
+			margin-bottom: 1em;
 		}
 
 		.components-base-control {
-			.components-base-control__label {
-				margin-bottom: 1em;
-			}
-	
-			.components-base-control {
-				padding: 0;
-			}
-
-			.components-font-size-picker__header {
-				padding: 0;
-			}
+			padding: 0;
 		}
 
-		.components-font-size-picker__header,
-		.component-box-control__header,
-		.component-box-control__header-control-wrapper {
-			padding: 0 10px;
-		}
-
-		.components-font-size-picker__controls {
-			margin: 0;
-		}
-
-		hr {
-			border: 0.1px solid #f3f3f3;
-		}
-
-		.o-options-global-defaults-actions {
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			padding: 15px 24px;
-
-			button {
-				height: auto;
-				line-height: 28px;
-				padding: 0 12px 2px;
-
-				&.is-primary {
-					margin-left: 10px;
-				}
-			}
+		.components-font-size-picker__header {
+			padding: 0;
 		}
 	}
-}
 
-@media ( min-width: 782px ) {
-	.o-options-global-defaults-modal {
-		.components-modal__frame {
-			width: 360px;
+	.components-font-size-picker__header,
+	.component-box-control__header,
+	.component-box-control__header-control-wrapper {
+		padding: 0 10px;
+	}
+
+	.components-font-size-picker__controls {
+		margin: 0;
+	}
+
+	hr {
+		border: 0.1px solid #f3f3f3;
+	}
+
+	.o-options-global-defaults-actions {
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
+		padding: 15px 24px;
+
+		button {
+			height: auto;
+			line-height: 28px;
+			padding: 0 12px 2px;
+
+			&.is-primary {
+				margin-left: 10px;
+			}
 		}
 	}
 }

--- a/src/blocks/plugins/options/global-defaults/block-item.js
+++ b/src/blocks/plugins/options/global-defaults/block-item.js
@@ -1,95 +1,85 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 
-import { getBlockType } from '@wordpress/blocks';
-
 import {
 	Button,
-	Icon,
-	Modal
+	Icon
 } from '@wordpress/components';
 
-import {
-	Fragment,
-	useState
-} from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+import { useCallback } from '@wordpress/element';
+
+import { settings } from '@wordpress/icons';
+
+import { NavigatorButton } from '../index.js';
 
 const BlockItem = ({
-	blockName,
-	saveConfig,
-	resetConfig,
-	children
+	block,
+	hasSettings,
+	hiddenBlocks,
+	setSelectedBlock
 }) => {
-	const block = getBlockType( blockName );
+	const { showBlockTypes, hideBlockTypes } = useDispatch( 'core/edit-post' );
 
-	const [ isOpen, setOpen ] = useState( false );
-	const [ isLoading, setLoading ] = useState( false );
+	const toggleVisible = useCallback( ( blockName, nextIsChecked ) => {
+		if ( nextIsChecked ) {
+			showBlockTypes( blockName );
+		} else {
+			hideBlockTypes( blockName );
+		}
+	}, []);
 
 	if ( ! block ) {
 		return null;
 	}
 
+	const isHidden = hiddenBlocks.includes( block.name );
+
 	return (
-		<Fragment>
-			<Button
-				className="o-options-global-defaults-list-item block-editor-block-types-list__item"
-				onClick={ () => setOpen( true ) }
-			>
-				<div className="o-options-global-defaults-list-item-icon">
-					<Icon
-						icon={ block.icon.src }
-					/>
-				</div>
-
-				<div className="o-options-global-defaults-list-item-title">
-					{ block.title }
-				</div>
-			</Button>
-
-			{ isOpen && (
-				<Modal
-					title={ block.title }
-					onRequestClose={ () => setOpen( false ) }
-					shouldCloseOnClickOutside={ false }
-					overlayClassName="o-options-global-defaults-modal"
-				>
-					{ children }
-
-					<div className="o-options-global-defaults-actions">
-						<Button
-							isLink
-							isDestructive
-							onClick={ () => resetConfig( blockName ) }
-						>
-							{ __( 'Reset', 'otter-blocks' ) }
-						</Button>
-
-						<div className="o-options-global-defaults-actions-primary">
-							<Button
-								isSecondary
-								onClick={ () => setOpen( false ) }
-							>
-								{ __( 'Close', 'otter-blocks' ) }
-							</Button>
-
-							<Button
-								isPrimary
-								isBusy={ isLoading }
-								onClick={ async() => {
-									setLoading( true );
-									await saveConfig();
-									setLoading( false );
-								} }
-							>
-								{ __( 'Save', 'otter-blocks' ) }
-							</Button>
-						</div>
-					</div>
-				</Modal>
+		<div
+			className={ classnames(
+				'o-options-block-item',
+				{
+					'editable': hasSettings,
+					'hidden': isHidden
+				}
 			) }
-		</Fragment>
+		>
+			<div className="o-options-block-item-icon">
+				<Icon
+					icon={ block.icon.src }
+				/>
+			</div>
+
+			<div className="o-options-block-item-label">{ block.title }</div>
+
+			{ hasSettings && (
+				<NavigatorButton
+					path="/block-settings/global-defaults"
+					icon={ settings }
+					label={ __( 'Open Settings', 'otter-blocks' ) }
+					showTooltip={ true }
+					className="o-options-block-item-button"
+					onClickAction={ () => setSelectedBlock( block.name ) }
+				/>
+			)}
+
+			<Button
+				icon={ isHidden ? 'hidden' : 'visibility' }
+				label={ isHidden ? __( 'Show Block', 'otter-blocks' ) : __( 'Hide Block', 'otter-blocks' ) }
+				showTooltip={ true }
+				className="o-options-block-item-button"
+				onClick={ () => toggleVisible( block.name, isHidden ) }
+			/>
+		</div>
 	);
 };
 

--- a/src/blocks/plugins/options/global-defaults/index.js
+++ b/src/blocks/plugins/options/global-defaults/index.js
@@ -3,71 +3,34 @@
  */
 import { __ } from '@wordpress/i18n';
 
+import { getBlockTypes } from '@wordpress/blocks';
+
 import {
-	PanelBody,
 	Placeholder,
 	Spinner
 } from '@wordpress/components';
+
+import { useSelect } from '@wordpress/data';
+
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import BlockItem from './block-item.js';
-import Accordion from './controls/accordion.js';
-import AdvancedHeading from './controls/advanced-heading.js';
-import Button from './controls/button.js';
-import ButtonGroup from './controls/button-group.js';
-import FontAwesomeIcons from './controls/font-awesome-icons.js';
-import SectionColumns from './controls/section-columns.js';
-import SectionColumn from './controls/section-column.js';
-import ReviewControl from './controls/review.js';
-import Form from './controls/form';
 
 const GlobalDefaults = ({
 	isAPILoaded,
-	blockDefaults,
-	changeConfig,
-	resetConfig,
-	saveConfig
+	globalControls,
+	setSelectedBlock
 }) => {
-	const blocks = [
-		{
-			name: 'themeisle-blocks/accordion',
-			control: Accordion
-		},
-		{
-			name: 'themeisle-blocks/advanced-heading',
-			control: AdvancedHeading
-		},
-		{
-			name: 'themeisle-blocks/button-group',
-			control: ButtonGroup
-		},
-		{
-			name: 'themeisle-blocks/button',
-			control: Button
-		},
-		{
-			name: 'themeisle-blocks/font-awesome-icons',
-			control: FontAwesomeIcons
-		},
-		{
-			name: 'themeisle-blocks/review',
-			control: ReviewControl
-		},
-		{
-			name: 'themeisle-blocks/advanced-columns',
-			control: SectionColumns
-		},
-		{
-			name: 'themeisle-blocks/advanced-column',
-			control: SectionColumn
-		},
-		{
-			name: 'themeisle-blocks/form',
-			control: Form
-		}
-	];
+	const { hiddenBlocks } = useSelect( select => {
+		return {
+			hiddenBlocks: select( 'core/edit-post' ).getPreference( 'hiddenBlockTypes' )
+		};
+	});
+
+	const blocks = getBlockTypes().filter( i => 'themeisle-blocks' === i.category && ( globalControls.find( o => o.name === i.name ) || ( undefined === i.parent && undefined == i.ancestor && ( undefined === i.supports.inserter || true === i.supports.inserter ) ) ) );
 
 	if ( ! isAPILoaded ) {
 		return (
@@ -78,33 +41,23 @@ const GlobalDefaults = ({
 	}
 
 	return (
-		<PanelBody
-			title={ __( 'Global Defaults', 'otter-blocks' ) }
-			className="o-options-global-defaults"
-		>
-			{ __( 'With Global Defaults, you can set site-wide block defaults for Otter.', 'otter-blocks' ) }
+		<Fragment>
+			<p class="padding-20">{ __( 'Manage site-wide block defaults and visibility for Otter Blocks.', 'otter-blocks' ) }</p>
 
-			<div className="o-options-global-defaults-list">
-				{ blocks.map( i => {
-					const Controls = i.control;
+			{ blocks.map( block => {
+				const hasSettings = globalControls.find( i => i.name === block.name );
 
-					return (
-						<BlockItem
-							key={ i.name }
-							blockName={ i.name }
-							saveConfig={ saveConfig }
-							resetConfig={ resetConfig }
-						>
-							<Controls
-								blockName={ i.name }
-								defaults={ blockDefaults[ i.name ] }
-								changeConfig={ changeConfig }
-							/>
-						</BlockItem>
-					);
-				}) }
-			</div>
-		</PanelBody>
+				return (
+					<BlockItem
+						key={ block.name }
+						block={ block }
+						hasSettings={ hasSettings }
+						hiddenBlocks={ hiddenBlocks }
+						setSelectedBlock={ setSelectedBlock }
+					/>
+				);
+			}) }
+		</Fragment>
 	);
 };
 

--- a/src/blocks/plugins/options/index.js
+++ b/src/blocks/plugins/options/index.js
@@ -301,7 +301,7 @@ const Options = () => {
 							icon={ chevronLeftSmall }
 							className="o-navi-button o-navi-button-back"
 						>
-							{ __( 'Back', 'otter-blocks' ) }
+							{ __( 'Settings', 'otter-blocks' ) }
 						</NavigatorButton>
 
 						<GlobalDefaults
@@ -321,7 +321,7 @@ const Options = () => {
 							icon={ chevronLeftSmall }
 							className="o-navi-button o-navi-button-back"
 						>
-							{ __( 'Back', 'otter-blocks' ) }
+							{ __( 'Blocks', 'otter-blocks' ) }
 						</NavigatorButton>
 
 						{ selectedBlock && (


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Part of #1355.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
https://www.loom.com/share/0c913e71e8f74f88b4a30a0b884c6b8b

Part of the Global Defaults UI reworks and changes it from the Popup UI to the new Navigator components introduced in WordPress 5.9.

Feedback appreciated @mghenciu @JohnPixle 

### Screenshots <!-- if applicable -->
<img width="456" alt="Screenshot 2022-12-28 at 2 52 40 AM" src="https://user-images.githubusercontent.com/2649903/209723610-3c65ee43-acd6-4adb-86b9-de91ca9a076e.png">

----


### Test instructions
<!-- Describe how this pull request can be tested. -->
- Try to make sure everything works as previously from 5.9 to 6.1

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

