### PR TITLE
Add Image Size option to Review Block

### DIFF
--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -98,7 +98,7 @@ class Review_Block {
 			$html .= '	<div class="o-review__header_details ' . trim( $details_class ) . '">';
 			if ( isset( $attributes['image'] ) ) {
 				if ( isset( $attributes['image']['id'] ) && wp_attachment_is_image( $attributes['image']['id'] ) ) {
-					$html .= wp_get_attachment_image( $attributes['image']['id'], 'medium' );
+					$html .= wp_get_attachment_image( $attributes['image']['id'], isset( $attributes['imageSize'] ) ? $attributes['imageSize'] : 'medium' );
 				} else {
 					$html .= '	<img src="' . esc_url( $attributes['image']['url'] ) . '" alt="' . esc_attr( $attributes['image']['alt'] ) . '"/>';
 				}

--- a/src/blocks/blocks/review/block.json
+++ b/src/blocks/blocks/review/block.json
@@ -97,6 +97,9 @@
 		"imageWidth": {
 			"type": "number"
 		},
+		"imageSize": {
+			"type": "string"
+		},
 		"mainHeading": {
 			"type": "string"
 		},

--- a/src/blocks/blocks/review/edit.js
+++ b/src/blocks/blocks/review/edit.js
@@ -287,7 +287,7 @@ const Edit = ({
 						className={ classnames(
 							'o-review__header_details',
 							{
-								'is-single': ! attributes.image || ( ! isSelected && ! attributes.description ),
+								'is-single': ! image || ( ! isSelected && ! attributes.description ),
 								[ detailsWidth[ attributes.imageWidth ] ]: ( attributes.imageWidth && 33 !== attributes.imageWidth )
 							}
 						) }

--- a/src/blocks/blocks/review/edit.js
+++ b/src/blocks/blocks/review/edit.js
@@ -23,6 +23,8 @@ import {
 	Spinner
 } from '@wordpress/components';
 
+import { useSelect } from '@wordpress/data';
+
 import {
 	Fragment,
 	useEffect
@@ -87,6 +89,27 @@ const Edit = ({
 		const unsubscribe = blockInit( clientId, defaultAttributes );
 		return () => unsubscribe( attributes.id );
 	}, [ attributes.id ]);
+
+	const { image } = useSelect( select => {
+		let image = undefined;
+		const size = attributes.imageSize || 'medium';
+
+		if ( attributes.image?.id || productAttributes.image?.id ) {
+			image = select( 'core' ).getMedia( attributes.image?.id || productAttributes.image?.id, { context: 'view' });
+		}
+
+		image = image ?
+			0 < Object.keys( image.media_details.sizes ).length ?
+				image.media_details.sizes[size] ?
+					image.media_details.sizes[size].source_url :
+					image.source_url :
+				image.source_url :
+			null;
+
+		return {
+			image
+		};
+	}, [ attributes.image, attributes.imageSize, productAttributes ]);
 
 	const getValue = field => getDefaultValueByField({ name, field, defaultAttributes, attributes });
 
@@ -271,12 +294,12 @@ const Edit = ({
 					>
 						{ ( productAttributes?.image ) ? (
 							<img
-								src={ productAttributes?.image?.url }
+								src={ image }
 								alt={ productAttributes?.image?.alt }
 							/>
 						) : attributes.image && (
 							<img
-								src={ attributes.image.url }
+								src={ image }
 								alt={ attributes.image.alt }
 							/>
 						) }

--- a/src/blocks/blocks/review/inspector.js
+++ b/src/blocks/blocks/review/inspector.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { pick } from 'lodash';
+import {
+	startCase,
+	toLower,
+	pick
+} from 'lodash';
 
 import { __ } from '@wordpress/i18n';
 
@@ -294,29 +298,41 @@ const Inspector = ({
 						/>
 
 						{ ( attributes.image || productAttributes?.image ) && (
-							<ButtonToggle
-								label={ __( 'Image Width', 'otter-blocks' ) }
-								options={[
-									{
-										label: __( '25%', 'otter-blocks' ),
-										value: 25
-									},
-									{
-										label: __( '33%', 'otter-blocks' ),
-										value: 33
-									},
-									{
-										label: __( '50%', 'otter-blocks' ),
-										value: 50
-									},
-									{
-										label: __( '100%', 'otter-blocks' ),
-										value: 100
-									}
-								]}
-								value={ attributes.imageWidth || 33 }
-								onChange={ imageWidth => setAttributes({ imageWidth: Number( imageWidth ) }) }
-							/>
+							<Fragment>
+								<ButtonToggle
+									label={ __( 'Image Width', 'otter-blocks' ) }
+									options={[
+										{
+											label: __( '25%', 'otter-blocks' ),
+											value: 25
+										},
+										{
+											label: __( '33%', 'otter-blocks' ),
+											value: 33
+										},
+										{
+											label: __( '50%', 'otter-blocks' ),
+											value: 50
+										},
+										{
+											label: __( '100%', 'otter-blocks' ),
+											value: 100
+										}
+									]}
+									value={ attributes.imageWidth || 33 }
+									onChange={ imageWidth => setAttributes({ imageWidth: Number( imageWidth ) }) }
+								/>
+
+								<SelectControl
+									label={ __( 'Image Size', 'otter-blocks' ) }
+									value={ attributes.imageSize }
+									options={ window.themeisleGutenberg.imageSizes.map( size => ({
+										label: startCase( toLower( size ) ),
+										value: size
+									}) ) }
+									onChange={ imageSize => setAttributes({ imageSize }) }
+								/>
+							</Fragment>
 						) }
 					</PanelBody>
 

--- a/src/blocks/blocks/review/inspector.js
+++ b/src/blocks/blocks/review/inspector.js
@@ -300,7 +300,7 @@ const Inspector = ({
 						{ ( attributes.image || productAttributes?.image ) && (
 							<Fragment>
 								<ButtonToggle
-									label={ __( 'Image Width', 'otter-blocks' ) }
+									label={ __( 'Image Area Width', 'otter-blocks' ) }
 									options={[
 										{
 											label: __( '25%', 'otter-blocks' ),

--- a/src/blocks/blocks/review/style.scss
+++ b/src/blocks/blocks/review/style.scss
@@ -180,10 +180,6 @@
 
 		&.is-single {
 			grid-template-columns: 1fr;
-
-			img {
-				max-width: 400px;
-			}
 		}
 	}
 

--- a/src/blocks/blocks/review/type.d.ts
+++ b/src/blocks/blocks/review/type.d.ts
@@ -16,6 +16,7 @@ type Attributes = {
 	consLabel: string
 	buttonsLabel: string
 	imageWidth: number
+	imageSize: string
 	mainHeading: string
 	subHeading: string
 	contentFontSize: number

--- a/src/pro/plugins/wc-integration/index.js
+++ b/src/pro/plugins/wc-integration/index.js
@@ -26,7 +26,7 @@ const addAttribute = ( props ) => {
 
 const withWooCommerceExtension = createHigherOrderComponent( BlockEdit => {
 	return props => {
-		if ( 'themeisle-blocks/review' === props.name && ( props.isSelected || undefined !== props.attributes.product) ) {
+		if ( 'themeisle-blocks/review' === props.name && ( props.isSelected || undefined !== props.attributes.product ) ) {
 			return (
 				<Edit
 					BlockEdit={ BlockEdit }

--- a/src/pro/plugins/wc-integration/index.js
+++ b/src/pro/plugins/wc-integration/index.js
@@ -26,7 +26,7 @@ const addAttribute = ( props ) => {
 
 const withWooCommerceExtension = createHigherOrderComponent( BlockEdit => {
 	return props => {
-		if ( 'themeisle-blocks/review' === props.name && props.isSelected ) {
+		if ( 'themeisle-blocks/review' === props.name && ( props.isSelected || undefined !== props.attributes.product) ) {
 			return (
 				<Edit
 					BlockEdit={ BlockEdit }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1397.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This will add a new Image Size option to allow users to select which image size to load, defaults to Medium.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Test it with Review Block normally as well as with it being synced to Woo and make sure there are no console errors.

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

