### PR TITLE
Activate Otter Pro on E2E tests

### DIFF
--- a/.github/workflows/deploy-stagging.yml
+++ b/.github/workflows/deploy-stagging.yml
@@ -3,7 +3,7 @@ name: Sync with staging
 on:
   pull_request:
     types: [ opened, synchronize, ready_for_review ]
-    branches: [development]
+    branches: [master]
 
 jobs:
     deploy:

--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -54,6 +54,8 @@ jobs:
 
       # run the node.js puppeteer script (which takes the screenshots and controls chrome)
       - run: npm run test:e2e
+        env:
+          OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
       
       - name: Print the results
         run: |

--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -51,6 +51,8 @@ jobs:
       - name: setup wp env
         run: |
           npm run wp-env start
+        env:
+          OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
 
       # run the node.js puppeteer script (which takes the screenshots and controls chrome)
       - run: npm run test:e2e

--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -51,10 +51,7 @@ jobs:
       - name: setup wp env
         run: |
           npm run wp-env start
-          npm run wp-env run cli wp eval 'echo $( secrets.OTTER_PRO_LICENSE );'
-          npm run wp-env run cli wp eval 'apply_filters( 'themeisle_sdk_license_process_otter', $( secrets.OTTER_PRO_LICENSE ), 'activate' );'
-        env:
-          OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
+          npm run wp-env run cli wp wp option add otter_pro_license_data 'O:8:"stdClass":18:{s:7:"success";b:1;s:7:"license";s:5:"valid";s:7:"item_id";b:0;s:9:"item_name";s:9:"Otter Pro";s:8:"checksum";s:32:"cb2b562b41513047e26c483111d9d877";s:7:"expires";s:19:"2023-10-12 23:59:59";s:10:"payment_id";i:8574767;s:13:"customer_name";s:14:"Hardeep Asrani";s:14:"customer_email";s:21:"test@localhost.com";s:13:"license_limit";i:999;s:10:"site_count";i:0;s:16:"activations_left";i:999;s:8:"price_id";i:20;s:9:"otter_pro";b:1;s:11:"download_id";i:8656086;s:7:"version";s:5:"2.1.6";s:4:"plan";i:20;s:3:"key";s:32:"1f23153969a0bcb1f23153969a0bcb";}'
 
       # run the node.js puppeteer script (which takes the screenshots and controls chrome)
       - run: npm run test:e2e

--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -51,7 +51,7 @@ jobs:
       - name: setup wp env
         run: |
           npm run wp-env start
-          wp-env run cli wp eval 'echo ${{ secrets.OTTER_PRO_LICENSE }};'
+          npm run wp-env run cli wp eval 'echo ${{ secrets.OTTER_PRO_LICENSE }};'
         env:
           OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
 

--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -44,21 +44,20 @@ jobs:
         run: |
           npm ci
           
-      # - name: Make dev build
-      #   run: |
-      #     npm run build-dev
+      - name: Make dev build
+        run: |
+          npm run build-dev
 
       - name: setup wp env
         run: |
           npm run wp-env start
-          npm run wp-env run cli wp eval 'echo ${{ secrets.OTTER_PRO_LICENSE }};'
+          npm run wp-env run cli wp eval 'echo $( secrets.OTTER_PRO_LICENSE );'
+          npm run wp-env run cli wp eval 'apply_filters( 'themeisle_sdk_license_process_otter', $( secrets.OTTER_PRO_LICENSE ), 'activate' );'
         env:
           OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
 
       # run the node.js puppeteer script (which takes the screenshots and controls chrome)
-      # - run: npm run test:e2e
-      #   env:
-      #     OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
+      - run: npm run test:e2e
       
       # - name: Print the results
       #   run: |

--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -52,6 +52,9 @@ jobs:
         run: |
           npm run wp-env start
 
+      - name: Setup WP-CLI
+        uses: godaddy-wordpress/setup-wp-cli@main
+
       - name: testing
         run: |
           wp eval 'echo ${{ secrets.OTTER_PRO_LICENSE }};'

--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -51,13 +51,7 @@ jobs:
       - name: setup wp env
         run: |
           npm run wp-env start
-
-      - name: Setup WP-CLI
-        uses: godaddy-wordpress/setup-wp-cli@main
-
-      - name: testing
-        run: |
-          wp eval 'echo ${{ secrets.OTTER_PRO_LICENSE }};'
+          wp-env run cli wp eval 'echo ${{ secrets.OTTER_PRO_LICENSE }};'
         env:
           OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
 

--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -44,44 +44,48 @@ jobs:
         run: |
           npm ci
           
-      - name: Make dev build
-        run: |
-          npm run build-dev
+      # - name: Make dev build
+      #   run: |
+      #     npm run build-dev
 
       - name: setup wp env
         run: |
           npm run wp-env start
+
+      - name: testing
+        run: |
+          wp eval 'echo ${{ secrets.OTTER_PRO_LICENSE }};'
         env:
           OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
 
       # run the node.js puppeteer script (which takes the screenshots and controls chrome)
-      - run: npm run test:e2e
-        env:
-          OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
+      # - run: npm run test:e2e
+      #   env:
+      #     OTTER_PRO_LICENSE: ${{ secrets.OTTER_PRO_LICENSE }}
       
-      - name: Print the results
-        run: |
-          echo "::set-output name=TYPING_AVG::$(jq '.summary.type.average' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
-          echo "::set-output name=TYPING_SD::$(jq '.summary.type.standardDeviation' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
-          echo "::set-output name=TYPING_MD::$(jq '.summary.type.median' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
-          echo "::set-output name=TYPING_QR60::$(jq '.summary.type.quantileRank60' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
-          echo "::set-output name=TYPING_ABOVE_60::$(jq -c '.summary.type.above60' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
-          echo "::set-output name=TYPING_QR80::$(jq '.summary.type.quantileRank80' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
-        id: summary  
+      # - name: Print the results
+      #   run: |
+      #     echo "::set-output name=TYPING_AVG::$(jq '.summary.type.average' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
+      #     echo "::set-output name=TYPING_SD::$(jq '.summary.type.standardDeviation' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
+      #     echo "::set-output name=TYPING_MD::$(jq '.summary.type.median' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
+      #     echo "::set-output name=TYPING_QR60::$(jq '.summary.type.quantileRank60' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
+      #     echo "::set-output name=TYPING_ABOVE_60::$(jq -c '.summary.type.above60' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
+      #     echo "::set-output name=TYPING_QR80::$(jq '.summary.type.quantileRank80' ./src/blocks/test/e2e/performance/performance.spec.results.json)"
+      #   id: summary  
 
-      - name: Comment
-        uses: NejcZdovc/comment-pr@v1
-        with:
-          file: 'e2e-summary.md'
-          identifier: "GITHUB_E2E_SUMMARY"
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-          TYPING_AVG: ${{ steps.summary.outputs.TYPING_AVG }}
-          TYPING_SD: ${{ steps.summary.outputs.TYPING_SD }}
-          TYPING_MD: ${{ steps.summary.outputs.TYPING_MD }}
-          TYPING_QR60: ${{ steps.summary.outputs.TYPING_QR60 }}
-          TYPING_QR80: ${{ steps.summary.outputs.TYPING_QR80 }}
-          TYPING_ABOVE_60: ${{ steps.summary.outputs.TYPING_ABOVE_60 }}
+      # - name: Comment
+      #   uses: NejcZdovc/comment-pr@v1
+      #   with:
+      #     file: 'e2e-summary.md'
+      #     identifier: "GITHUB_E2E_SUMMARY"
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      #     TYPING_AVG: ${{ steps.summary.outputs.TYPING_AVG }}
+      #     TYPING_SD: ${{ steps.summary.outputs.TYPING_SD }}
+      #     TYPING_MD: ${{ steps.summary.outputs.TYPING_MD }}
+      #     TYPING_QR60: ${{ steps.summary.outputs.TYPING_QR60 }}
+      #     TYPING_QR80: ${{ steps.summary.outputs.TYPING_QR80 }}
+      #     TYPING_ABOVE_60: ${{ steps.summary.outputs.TYPING_ABOVE_60 }}
 
   
   

--- a/development.php
+++ b/development.php
@@ -38,4 +38,10 @@ if ( ENABLE_OTTER_PRO_DEV && defined( 'WPINC' ) && class_exists( '\ThemeIsle\Ott
 	add_filter( 'otter_pro_hide_license_field', '__return_true' );
 
 	\ThemeIsle\OtterPro\Main::instance();
+
+	$license = getenv( 'OTTER_PRO_LICENSE' );
+
+	if ( ! empty( $license ) ) {
+		apply_filters( 'themeisle_sdk_license_process_otter', $license, 'activate' );
+	}
 }

--- a/development.php
+++ b/development.php
@@ -38,10 +38,4 @@ if ( ENABLE_OTTER_PRO_DEV && defined( 'WPINC' ) && class_exists( '\ThemeIsle\Ott
 	add_filter( 'otter_pro_hide_license_field', '__return_true' );
 
 	\ThemeIsle\OtterPro\Main::instance();
-
-	$license = getenv( 'OTTER_PRO_LICENSE' );
-
-	if ( ! empty( $license ) ) {
-		apply_filters( 'themeisle_sdk_license_process_otter', $license, 'activate' );
-	}
 }

--- a/src/blocks/test/e2e/reliability/uniq-id-checking.spec.js
+++ b/src/blocks/test/e2e/reliability/uniq-id-checking.spec.js
@@ -36,10 +36,20 @@ describe( 'Otter Block ID', () => {
 			console.warn( 'No Otter Pro license provided!' );
 		}
 		await page.evaluate( ( _licenseKey ) => {
-			window.wp.apiFetch({ path: 'otter/v1/toggle_license', method: 'POST', data: {
-				action: 'activate',
-				key: _licenseKey
-			}});
+
+			// window.wp.apiFetch({ path: 'otter/v1/toggle_license', method: 'POST', data: {
+			// 	action: 'activate',
+			// 	key: _licenseKey
+			// }});
+
+			// Temporary solution
+			window.otterPro = Object.assign(
+				window.otterPro,
+				{
+					isActive: true,
+					isExpired: true
+				}
+			);
 		}, licenseKey );
 
 		await page.waitForTimeout( 2000 );

--- a/src/blocks/test/e2e/reliability/uniq-id-checking.spec.js
+++ b/src/blocks/test/e2e/reliability/uniq-id-checking.spec.js
@@ -28,6 +28,20 @@ describe( 'Otter Block ID', () => {
 		);
 
 		await createNewPost();
+
+		// Activate Otter Pro
+		const licenseKey = process?.env?.OTTER_PRO_LICENSE ?? '';
+
+		if ( '' === licenseKey ) {
+			console.warn( 'No Otter Pro license provided!' );
+		}
+		await page.evaluate( ( _licenseKey ) => {
+			window.wp.apiFetch({ path: 'otter/v1/toggle_license', method: 'POST', data: {
+				action: 'activate',
+				key: _licenseKey
+			}});
+		}, licenseKey );
+
 		await page.evaluate( ( _html ) => {
 			const { parse } = window.wp.blocks;
 			const { dispatch } = window.wp.data;
@@ -98,9 +112,13 @@ describe( 'Otter Block ID', () => {
 
 		});
 
-		console.log( `Ids that appear more than once: ${Object.keys( duplicates ).filter( i => 1 < duplicates[i]).map( i => `\n| ${duplicates[i].toString().padStart( 2, ' ' )} ${i}` ).join( '' )}`  );
+		const hasNoDuplicates = Object.keys( duplicates ).every( i => 1 === duplicates[i]);
 
-		expect( otterIds.length === s.size ).toBe( true );
+		if ( ! hasNoDuplicates ) {
+			console.log( `Ids that appear more than once: ${Object.keys( duplicates ).filter( i => 1 < duplicates[i]).map( i => `\n| ${duplicates[i].toString().padStart( 2, ' ' )} ${i}` ).join( '' )}`  );
+		}
+
+		expect( hasNoDuplicates ).toBe( true );
 	});
 
 	it( 'Insert extra blocks and check for uniq id', async() => {
@@ -159,9 +177,13 @@ describe( 'Otter Block ID', () => {
 
 		});
 
-		console.log( `Ids that appear more than once: ${Object.keys( duplicates ).filter( i => 1 < duplicates[i]).map( i => `\n| ${duplicates[i].toString().padStart( 2, ' ' )} ${i}` ).join( '' )}`  );
+		const hasNoDuplicates = Object.keys( duplicates ).every( i => 1 === duplicates[i]);
 
-		expect( otterIds.length === s.size ).toBe( true );
+		if ( ! hasNoDuplicates ) {
+			console.log( `Ids that appear more than once: ${Object.keys( duplicates ).filter( i => 1 < duplicates[i]).map( i => `\n| ${duplicates[i].toString().padStart( 2, ' ' )} ${i}` ).join( '' )}`  );
+		}
+
+		expect( hasNoDuplicates ).toBe( true );
 
 		expect( beforeCount < afterCount ).toBe( true );
 

--- a/src/blocks/test/e2e/reliability/uniq-id-checking.spec.js
+++ b/src/blocks/test/e2e/reliability/uniq-id-checking.spec.js
@@ -42,6 +42,8 @@ describe( 'Otter Block ID', () => {
 			}});
 		}, licenseKey );
 
+		await page.waitForTimeout( 2000 );
+
 		await page.evaluate( ( _html ) => {
 			const { parse } = window.wp.blocks;
 			const { dispatch } = window.wp.data;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Activate Otter Pro via Github secrets with `OTTER_PRO_LICENSE` as env variable.
For activation, we take the key and use the API endpoint for activation like in`LicenseField` component.



