### PR TITLE
Query String improvements

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -290,7 +290,7 @@ class Block_Conditions {
 					return false;
 				}
 			} elseif ( ! isset( $cond_param['value'] ) ) {
-				if ( empty( $params[ $cond_param['key'] ] ) ) {
+				if ( ! isset( $params[ $cond_param['key'] ] ) ) {
 					return false;
 				}
 			} else {

--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -240,16 +240,26 @@ class Block_Conditions {
 			return false;
 		}
 
-		$query_string = preg_replace( '/\s/', '', $condition['query_string'] );
+		$query_string = preg_replace( '/\n/', '&', $condition['query_string'] );
+		$query_string = preg_replace( '/\s/', '', $query_string );
 
 		parse_str( $url_components['query'], $params );
 		parse_str( $query_string, $cond_params );
 
+		$result = array_intersect( array_map( 'serialize', $cond_params ), array_map( 'serialize', $params ) );
+		$result = array_map( 'unserialize', $result );
+
 		if ( 'any' === $condition['match'] ) {
-			return count( array_intersect( $cond_params, $params ) ) > 0;
+			$empty_keys = array_keys( $cond_params, '', ARRAY_FILTER_USE_KEY );
+
+			if ( $empty_keys > 0 && count( array_intersect( $empty_keys, array_keys( $params ) ) ) > 0 ) {
+				return true;
+			}
+
+			return count( $result ) > 0;
 		}
 
-		return array_intersect( $cond_params, $params ) === $cond_params;
+		return $result === $cond_params;
 	}
 
 	/**

--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -252,7 +252,7 @@ class Block_Conditions {
 		if ( 'any' === $condition['match'] ) {
 			$empty_keys = array_keys( $cond_params, '', ARRAY_FILTER_USE_KEY );
 
-			if ( $empty_keys > 0 && count( array_intersect( $empty_keys, array_keys( $params ) ) ) > 0 ) {
+			if ( count( $empty_keys ) > 0 && count( array_intersect( $empty_keys, array_keys( $params ) ) ) > 0 ) {
 				return true;
 			}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1401.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This PR improves how we detect and handle query in Block Conditions' Query String option.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
I'll be good to try this out with various different combinations to see if it works well or if it gives any errors. Here are few types of things that can be used

1. Just using this to match anything that has utm_source in the URL string or even if it's only utm_source like example.com?utm_source or example.com?utm_source=facebook
`utm_source`

2. Similarly using multiple query strings.

```
utm_source=facebook
utm_campaign=discount
```
3. Another is to use array instead of a single value, like example.com?utm_source[]=facebook&utm_source[]=twitter

```
utm_source[]=facebook
utm_source[]=twitter
```

And various different combinations to make sure it works fine and you don't see any errors in debug logs.

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

