### PR TITLE
Fix Form in Popup Block

### DIFF
--- a/src/blocks/frontend/form/captcha.js
+++ b/src/blocks/frontend/form/captcha.js
@@ -42,10 +42,14 @@ const renderCapthcaOn = ( form ) => {
 		{
 			sitekey: window?.themeisleGutenbergForm?.reRecaptchaSitekey,
 			callback: ( token ) => {
-				if ( ! window.themeisleGutenberg?.tokens ) {
+				if ( ! window.themeisleGutenberg ) {
 					window.themeisleGutenberg = {};
+				}
+
+				if ( ! window.themeisleGutenberg?.tokens ) {
 					window.themeisleGutenberg.tokens = {};
 				}
+
 				window.themeisleGutenberg.tokens[id] = {
 					token,
 					reset: () => window.grecaptcha?.reset( captcha )

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -70,7 +70,7 @@ const collectAndSendInputFormData = ( form, btn, displayMsg ) => {
 	const formIsEmpty = 2 > formFieldsData?.length;
 	const nonceFieldValue = extractNonceValue( form );
 	const hasCaptcha = form?.classList?.contains( 'has-captcha' );
-	const hasValidToken = id && window.themeisleGutenberg?.tokens[id].token;
+	const hasValidToken = id && window.themeisleGutenberg?.tokens?.[id]?.token;
 
 
 	const spinner = document.createElement( 'span' );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1424.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix the checking condition when verifying the existence of captcha tokens.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

