### PR TITLE
Add last updated date option to Posts block

### DIFF
--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -204,12 +204,21 @@ class Posts_Grid_Block {
 					$posted_on = '';
 
 					if ( isset( $attributes['displayDate'] ) && $attributes['displayDate'] ) {
-						$posted_on .= sprintf(
-							'%1$s <time datetime="%2$s">%3$s</time> ',
-							__( 'Posted on', 'otter-blocks' ),
-							esc_attr( get_the_date( 'c', $id ) ),
-							esc_html( get_the_date( get_option( 'date_format' ), $id ) )
-						);
+						if ( isset( $attributes['displayUpdatedDate'] ) && $attributes['displayUpdatedDate'] ) {
+							$posted_on .= sprintf(
+								'%1$s <time datetime="%2$s">%3$s</time> ',
+								__( 'Updated on', 'otter-blocks' ),
+								esc_attr( get_the_modified_date( 'c', $id ) ),
+								esc_html( get_the_modified_date( get_option( 'date_format' ), $id ) )
+							);
+						} else {
+							$posted_on .= sprintf(
+								'%1$s <time datetime="%2$s">%3$s</time> ',
+								__( 'Posted on', 'otter-blocks' ),
+								esc_attr( get_the_date( 'c', $id ) ),
+								esc_html( get_the_date( get_option( 'date_format' ), $id ) )
+							);
+						}
 					}
 
 					if ( isset( $attributes['displayAuthor'] ) && $attributes['displayAuthor'] ) {

--- a/src/blocks/blocks/posts/block.json
+++ b/src/blocks/blocks/posts/block.json
@@ -90,6 +90,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"displayUpdatedDate": {
+			"type": "boolean",
+			"default": false
+		},
 		"displayAuthor": {
 			"type": "boolean",
 			"default": true

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -125,9 +125,15 @@ export const PostsMeta = ({ attributes, element, post, author, categories }) => 
 		let postedOn = '';
 
 		if ( attributes.displayDate ) {
+			if ( attributes.displayUpdatedDate ) {
 
-			/* translators: %s Date posted */
-			postedOn += sprintf( __( 'Posted on %s', 'otter-blocks' ), formatDate( post.date ) );
+				/* translators: %s Date updated */
+				postedOn += sprintf( __( 'Updated on %s', 'otter-blocks' ), formatDate( post.modified ) );
+			} else {
+
+				/* translators: %s Date posted */
+				postedOn += sprintf( __( 'Posted on %s', 'otter-blocks' ), formatDate( post.date ) );
+			}
 		}
 
 		if ( attributes.displayAuthor && undefined !== author ) {

--- a/src/blocks/blocks/posts/components/sortable.js
+++ b/src/blocks/blocks/posts/components/sortable.js
@@ -177,12 +177,20 @@ export const SortableItem = ({
 					) }
 
 					{ ( 'meta' === template ) && (
-						<Fragment >
+						<Fragment>
 							<ToggleControl
 								label={ __( 'Display Post Date', 'otter-blocks' ) }
 								checked={ attributes.displayDate }
 								onChange={ displayDate => setAttributes({ displayDate }) }
 							/>
+
+							{ attributes.displayDate && (
+								<ToggleControl
+									label={ __( 'Display Last Updated Date', 'otter-blocks' ) }
+									checked={ attributes.displayUpdatedDate }
+									onChange={ displayUpdatedDate => setAttributes({ displayUpdatedDate }) }
+								/>
+							)}
 
 							<ToggleControl
 								label={ __( 'Display Author', 'otter-blocks' ) }

--- a/src/blocks/blocks/posts/types.d.ts
+++ b/src/blocks/blocks/posts/types.d.ts
@@ -20,6 +20,7 @@ type Attributes = {
 	displayDescription: boolean
 	excerptLength: number
 	displayDate: boolean
+	displayUpdatedDate: boolean
 	displayAuthor: boolean
 	displayComments: boolean
 	displayPostCategory: boolean


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1432.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Adds option to display last modified date in Posts Block. Skipping QA as it's a simple edit that works without an issue.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

