### PR TITLE
fix: add null check condiftion when trying to get a CSS var value

### DIFF
--- a/src/blocks/helpers/helper-functions.js
+++ b/src/blocks/helpers/helper-functions.js
@@ -311,6 +311,10 @@ export const isColorDark = color => {
 		value = hex2rgba( value );
 	}
 
+	if ( ! Boolean( value ) ) {
+		return false;
+	}
+
 	// Extract the red, green, and blue values
 	const [ r, g, b ] = value.match( /\d+/g ).map( Number );
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1468 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add an extra check condition.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

See issue.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

