### PR TITLE
fix: increase the number of contact list (mailcimp)

### DIFF
--- a/inc/integrations/providers/class-mailchimp.php
+++ b/inc/integrations/providers/class-mailchimp.php
@@ -71,7 +71,7 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 			'success' => false,
 		);
 
-		$url  = 'https://' . $this->server_name . '.api.mailchimp.com/3.0/lists';
+		$url  = 'https://' . $this->server_name . '.api.mailchimp.com/3.0/lists?count=1000';
 		$args = array(
 			'method'  => 'GET',
 			'headers' => array(


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1489 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Increase the limit of the contact list requested.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

ℹ️ You need Mailchimp Pro to have more than 1 list of contacts. A license is required.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

