### PR TITLE
Add Built-in Spam protection for Form Block

### DIFF
--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -34,6 +34,7 @@ class Form_Data_Response {
 	const ERROR_MISSING_PROVIDER     = '107';
 	const ERROR_MISSING_API_KEY      = '108';
 	const ERROR_MISSING_MAIL_LIST_ID = '109';
+	const ERROR_BOT_DETECTED         = '110';
 
 	// Errors from external services.
 	const ERROR_PROVIDER_NOT_REGISTERED            = '201';
@@ -347,6 +348,9 @@ class Form_Data_Response {
 			case self::ERROR_PROVIDER_DUPLICATED_EMAIL:
 				$this->add_reason( __( 'The email was already registered.', 'otter-blocks' ) );
 				break;
+			case self::ERROR_BOT_DETECTED:
+				$this->add_reason( __( 'Failed to validated the data. Please wait for 2 minutes adn try again.', 'otter-blocks' ) );
+				break;  
 		}
 	}
 }

--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -349,7 +349,7 @@ class Form_Data_Response {
 				$this->add_reason( __( 'The email was already registered.', 'otter-blocks' ) );
 				break;
 			case self::ERROR_BOT_DETECTED:
-				$this->add_reason( __( 'Failed to validated the data. Please wait 5 seconds and try again.', 'otter-blocks' ) );
+				$this->add_reason( __( 'Failed to validate the data. Please wait 5 seconds and try again.', 'otter-blocks' ) );
 				break;  
 		}
 	}

--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -349,7 +349,7 @@ class Form_Data_Response {
 				$this->add_reason( __( 'The email was already registered.', 'otter-blocks' ) );
 				break;
 			case self::ERROR_BOT_DETECTED:
-				$this->add_reason( __( 'Failed to validated the data. Please wait for 2 minutes adn try again.', 'otter-blocks' ) );
+				$this->add_reason( __( 'Failed to validated the data. Please wait 5 seconds and try again.', 'otter-blocks' ) );
 				break;  
 		}
 	}

--- a/inc/render/class-form-nonce-block.php
+++ b/inc/render/class-form-nonce-block.php
@@ -22,12 +22,13 @@ class Form_Nonce_Block {
 	 * @return mixed|string
 	 */
 	public function render( $attributes ) {
-		$output = '<div class="protection">';
+		$output = '<div class="protection" aria-hidden="true">';
 		if ( isset( $attributes['formId'] ) ) {
 			$output .= wp_nonce_field( 'form-verification', $attributes['formId'] . '_nonce_field', true, false );
 		} else {
 			$output .= wp_nonce_field( 'form-verification', '_nonce_field', true, false );
 		}
+		$output .= '<input class="o-anti-bot" type="checkbox">';
 		$output .= '</div>';
 		return $output;
 	}

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -55,7 +55,7 @@ class Form_Server {
 	/**
 	 * Anti Spam timeout
 	 */
-	const ANTI_SPAM_TIMEOUT = 3000; // 3 seconds
+	const ANTI_SPAM_TIMEOUT = 5000; // 5 seconds
 
 
 	/**

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -52,6 +52,11 @@ class Form_Server {
 	 */
 	public $version = 'v1';
 
+	/**
+	 * Anti Spam timeout
+	 */
+	const ANTI_SPAM_TIMEOUT = 3000; // 3 seconds
+
 
 	/**
 	 * Initialize the class
@@ -110,6 +115,7 @@ class Form_Server {
 		add_action( 'otter_form_after_submit', array( $this, 'after_submit' ) );
 		add_filter( 'otter_form_email_build_body', array( $this, 'build_email_content' ) );
 		add_filter( 'otter_form_email_build_body_error', array( $this, 'build_email_error_content' ), 1, 2 );
+		add_filter( 'otter_form_anti_spam_validation', array( $this, 'anti_spam_validation' ) );
 	}
 
 	/**
@@ -220,23 +226,29 @@ class Form_Server {
 			$form_options = Form_Settings_Data::get_form_setting_from_wordpress_options( $form_data->get_payload_field( 'formOption' ) );
 			$form_data->set_form_options( $form_options );
 
-			do_action( 'otter_form_before_submit', $form_data );
-			// Select the submit function based on the provider.
-			$provider_handlers = apply_filters( 'otter_select_form_provider', $form_data );
+			$anti_bot_check = apply_filters( 'otter_form_anti_spam_validation', $form_data );
 
-			if ( $provider_handlers && Form_Providers::provider_has_handler( $provider_handlers, $form_data->get( 'handler' ) ) ) {
+			if ( $anti_bot_check ) {
+				do_action( 'otter_form_before_submit', $form_data );
+				// Select the submit function based on the provider.
+				$provider_handlers = apply_filters( 'otter_select_form_provider', $form_data );
 
-				// Send the data to the provider handler.
-				$provider_response = $provider_handlers[ $form_data->get( 'handler' ) ]( $form_data );
+				if ( $provider_handlers && Form_Providers::provider_has_handler( $provider_handlers, $form_data->get( 'handler' ) ) ) {
+
+					// Send the data to the provider handler.
+					$provider_response = $provider_handlers[ $form_data->get( 'handler' ) ]( $form_data );
+
+					do_action( 'otter_form_after_submit', $form_data );
+
+					return $provider_response;
+				} else {
+					$res->set_code( Form_Data_Response::ERROR_PROVIDER_NOT_REGISTERED );
+				}
 
 				do_action( 'otter_form_after_submit', $form_data );
-
-				return $provider_response;
 			} else {
-				$res->set_code( Form_Data_Response::ERROR_PROVIDER_NOT_REGISTERED );
-			}
-
-			do_action( 'otter_form_after_submit', $form_data );
+				$res->set_code( Form_Data_Response::ERROR_BOT_DETECTED );
+			}       
 		} catch ( Exception $e ) {
 			$res->set_code( Form_Data_Response::ERROR_RUNTIME_ERROR );
 			$res->add_reason( $e->getMessage() );
@@ -356,6 +368,31 @@ class Form_Server {
 		) {
 			$this->send_default_email( $form_data );
 		}
+	}
+
+	/**
+	 * Check if the form was not completed by a bot.
+	 *
+	 * @param Form_Data_Request $form_data The form request data.
+	 * @return boolean
+	 * @since 2.2.3
+	 */
+	public function anti_spam_validation( $form_data ) {
+
+		if (
+			$form_data->payload_has_field( 'antiSpamTime' ) &&
+			is_numeric( $form_data->get_payload_field( 'antiSpamTime' ) ) &&
+			$form_data->payload_has_field( 'antiSpamHoneyPot' )
+		) {
+			if (
+				$form_data->get_payload_field( 'antiSpamTime' ) >= self::ANTI_SPAM_TIMEOUT &&
+				'' === $form_data->get_payload_field( 'antiSpamHoneyPot' )
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -346,7 +346,7 @@
 			margin-top: -10px;
 			margin-left: -10px;
 			border-radius: 50%;
-			border-top: 2px solid var(--submit-color);
+			border-top: 2px solid var(--submit-color, white);
 			border-right: 2px solid transparent;
 			animation: spinner 0.6s linear infinite;
 		}

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -5,6 +5,8 @@ import { addCaptchaOnPage } from './captcha.js';
 import DisplayFormMessage from './message.js';
 import { domReady } from '../../helpers/frontend-helper-functions.js';
 
+let startTimeAntiBot = null;
+
 /**
  * Get the fields with their value from the form.
  *
@@ -128,6 +130,9 @@ const collectAndSendInputFormData = ( form, btn, displayMsg ) => {
 			payload.nonceValue = nonceFieldValue;
 		}
 
+		payload.antiSpamTime = Date.now() - ( startTimeAntiBot ?? Date.now() );
+		payload.antiSpamHoneyPot = Boolean( form.querySelector( ':scope > .otter-form__container > .protection .o-anti-bot' )?.checked ?? false );
+
 		payload.postUrl = window.location.href;
 
 
@@ -229,8 +234,8 @@ const collectAndSendInputFormData = ( form, btn, displayMsg ) => {
  * @param {HTMLDivElement} form
  */
 const cleanInputs = ( form ) => {
-	const inputs = form?.querySelectorAll( '.otter-form__container .wp-block-themeisle-blocks-form-input' );
-	const textarea = form?.querySelectorAll( '.otter-form__container .wp-block-themeisle-blocks-form-textarea' );
+	const inputs = form?.querySelectorAll( ':scope > .otter-form__container > .wp-block-themeisle-blocks-form-input' );
+	const textarea = form?.querySelectorAll( ':scope > .otter-form__container > .wp-block-themeisle-blocks-form-textarea' );
 
 	[ ...inputs, ...textarea ]?.forEach( input => {
 		const valueElem = input.querySelector( '.otter-form-input, .otter-form-textarea-input' );
@@ -271,6 +276,8 @@ domReady( () => {
 	const forms = document.querySelectorAll( '.wp-block-themeisle-blocks-form' );
 
 	addCaptchaOnPage( forms );
+
+	startTimeAntiBot = Date.now();
 
 	forms.forEach( ( form ) => {
 		if ( form.classList.contains( 'can-submit-and-subscribe' ) ) {

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -185,20 +185,13 @@ const collectAndSendInputFormData = ( form, btn, displayMsg ) => {
 					let errorMsgSlug = '';
 
 					// TODO: Write pattern to display a more useful error message.
-					if ( 0 < res?.displayError?.length ) {
+					if ( '110' === res.code ) {
+						displayMsg.setMsg( res?.reasons?.join( '' ), 'error' ).show();
+					} else if ( 0 < res?.displayError?.length ) {
 						errorMsgSlug = res?.displayError;
 
 						displayMsg.setMsg( errorMsgSlug, 'error' ).show();
 					} else {
-
-						// if ( res?.provider && res?.error?.includes( 'invalid' ) || res?.error?.includes( 'fake' ) ) { // mailchimp
-						// 	errorMsgSlug = 'invalid-email';
-						// } else if ( res?.provider && res?.error?.includes( 'duplicate' ) || res?.error?.includes( 'already' ) ) { // sendinblue
-						// 	errorMsgSlug = 'already-registered';
-						// } else {
-						// 	errorMsgSlug = 'try-again';
-						// }
-
 						displayMsg.setMsg( res?.reasons?.join( '' ), 'error' ).show();
 					}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1465
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add two mechanisms for spam protection:
- Interaction time: the user needs to spend at least 5 seconds on the page since it's loading.
- Honey Bot for bots. The protection block now generates an additional checkbox. Since it is invisible, only scripted bots can access it. If the value of the checkbox is "true", then we reject the request.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

See if you can trigger the bot detection. 

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

