### PR TITLE
Replace the link from patterns upsell

### DIFF
--- a/inc/class-pro.php
+++ b/inc/class-pro.php
@@ -87,6 +87,16 @@ class Pro {
 	}
 
 	/**
+	 * Get Otter Pro Patterns URL
+	 *
+	 * @access  public
+	 * @return  string
+	 */
+	public static function get_patterns_url() {
+		return 'https://themeisle.com/plugins/otter-blocks/patterns/';
+	}
+
+	/**
 	 * Get Otter reference install.
 	 *
 	 * @since   2.0.14

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -242,6 +242,7 @@ class Registration {
 				'hasPro'                  => Pro::is_pro_installed(),
 				'isProActive'             => Pro::is_pro_active(),
 				'upgradeLink'             => tsdk_utmify( Pro::get_url(), 'editor', Pro::get_reference() ),
+				'patternsLink'            => tsdk_utmify( Pro::get_patterns_url(), 'editor', Pro::get_reference() ),
 				'should_show_upsell'      => Pro::should_show_upsell(),
 				'assetsPath'              => OTTER_BLOCKS_URL . 'assets',
 				'updatePath'              => admin_url( 'update-core.php' ),

--- a/plugins/otter-pro/inc/plugins/class-patterns.php
+++ b/plugins/otter-pro/inc/plugins/class-patterns.php
@@ -94,7 +94,7 @@ class Patterns {
 			if ( ! version_compare( get_bloginfo( 'version' ), $block_pattern['minimum'], '>=' ) ) {
 				continue;
 			}
-	
+
 			register_block_pattern( 'otter-pro/' . $block_pattern['slug'], $block_pattern );
 		}
 	}

--- a/src/blocks/global.d.ts
+++ b/src/blocks/global.d.ts
@@ -1,10 +1,12 @@
 declare global {
 	interface Window {
 		themeisleGutenberg?: {
+			hasNeve: boolean
 			version: string
 			isCompatible: boolean
 			hasPro: boolean
 			upgradeLink: string
+			patternsLink: string
 			should_show_upsell: boolean
 			assetsPath: string
 			updatePath: string

--- a/src/blocks/plugins/upsell-block/index.js
+++ b/src/blocks/plugins/upsell-block/index.js
@@ -62,7 +62,7 @@ const edit = props => {
 			<h3>{ __( 'Get more Patterns with Otter Pro.', 'otter-blocks' ) }</h3>
 
 			<div className="o-block-patterns-upsell__actions">
-				<a href={ setUtm( window.themeisleGutenberg.upgradeLink, 'patterns' ) } target="_blank">
+				<a href={ setUtm( window.themeisleGutenberg.patternsLink, 'patterns' ) } target="_blank">
 					{ __( 'Get Otter Pro', 'otter-blocks' ) }
 				</a>
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1511.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Replace the link form the patterns upsell from
`themeisle.com/plugins/otter-blocks/upgrade/` to `themeisle.com/plugins/otter-blocks/patterns/`

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

