### PR TITLE
Fix Block id duplication on Duplicated Block action

### DIFF
--- a/src/blocks/blocks/advanced-heading/edit.js
+++ b/src/blocks/blocks/advanced-heading/edit.js
@@ -58,6 +58,7 @@ const Edit = ({
 	useEffect( () => {
 		googleFontsLoader.attach( );
 		const unsubscribe = blockInit( clientId, defaultAttributes );
+		console.log( 'Advanced Heading block init' );
 		return () => unsubscribe( attributes.id );
 	}, [ attributes.id ]);
 

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -199,8 +199,9 @@ export const addBlockId = ( args ) => {
 			setAttributes({ id: instanceId });
 
 			return ( savedId ) => {
-				console.log( `Clean up ${instanceId} from global pool.` );
-				localIDs[name].delete( instanceId || savedId );
+				return ( savedId ) => {
+					console.log( `Generating. Do not remove ${savedId} from global pool.` );
+				};
 			};
 
 		} else if ( idIsAlreadyUsed ) {

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -180,8 +180,6 @@ export const addBlockId = ( args ) => {
 	// Check if the ID is already used. EXCLUDE the one that come from reusable blocks.
 	const idIsAlreadyUsed = Boolean( attributes.id && localIDs[name].has( attributes.id ) );
 
-	console.log({ idIsAlreadyUsed, attributes, localIDs: localIDs[name], name });
-
 	if ( attributes.id === undefined || idIsAlreadyUsed ) {
 
 		// Auto-generate idPrefix if not provided
@@ -199,23 +197,17 @@ export const addBlockId = ( args ) => {
 			setAttributes({ id: instanceId });
 
 			return ( savedId ) => {
-				return ( savedId ) => {
-					console.log( `Generating. Do not remove ${savedId} from global pool.` );
-				};
+				return ( savedId ) => {};
 			};
 
 		} else if ( idIsAlreadyUsed ) {
-
-			console.log( `ID conflict detected. Generating a new one. ${name} with ${instanceId} from ${attributes.id}` );
 
 			// The block must be a copy and its is already used
 			// Generate a new one and save it to `localIDs` to keep track of it in local mode.
 			localIDs[name].add( instanceId );
 			setAttributes({ id: instanceId });
 
-			return ( savedId ) => {
-				console.log( `Duplication. Keep original ${savedId} to global pool.` );
-			};
+			return ( savedId ) => {};
 		}
 	} else {
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1510 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The duplicated block was deleting the id of the original block from Global Id pool. Now when an ID is changed is case of duplication, it will not longer delete its original ID via cleaning function.

ℹ️ Console log will be removed after QA.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a block
2. Duplicate it
3. Check the console. The console should show the fallowing information:

![image](https://user-images.githubusercontent.com/17597852/221128250-714ab383-0698-47f6-b6ae-b4718bad81c6.png)

4. Preview the page

ℹ️ If you encounter the error, please 🙏  post a screenshot with the Console or a test instance.


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

