### PR TITLE
Add File Field for Form Block

### DIFF
--- a/blocks.json
+++ b/blocks.json
@@ -96,6 +96,9 @@
 	"form-multiple-choice": {
 		"block": "blocks/blocks/form/multiple-choice/block.json"
 	},
+	"form-file": {
+		"block": "blocks/blocks/form/file/block.json"
+	},
 	"google-map": {
 		"block": "blocks/blocks/google-map/block.json",
 		"assets": {

--- a/inc/class-base-css.php
+++ b/inc/class-base-css.php
@@ -89,6 +89,7 @@ class Base_CSS {
 			'\ThemeIsle\GutenbergBlocks\CSS\Blocks\Form_Input_CSS',
 			'\ThemeIsle\GutenbergBlocks\CSS\Blocks\Form_Textarea_CSS',
 			'\ThemeIsle\GutenbergBlocks\CSS\Blocks\Form_Multiple_Choice_CSS',
+			'\ThemeIsle\GutenbergBlocks\CSS\Blocks\Form_File_CSS',
 			'\ThemeIsle\GutenbergBlocks\CSS\Blocks\Flip_CSS',
 			'\ThemeIsle\GutenbergBlocks\CSS\Blocks\Progress_Bar_CSS',
 			'\ThemeIsle\GutenbergBlocks\CSS\Blocks\Popup_CSS',

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -696,6 +696,7 @@ class Registration {
 			'sharing-icons'        => '\ThemeIsle\GutenbergBlocks\Render\Sharing_Icons_Block',
 			'stripe-checkout'      => '\ThemeIsle\GutenbergBlocks\Render\Stripe_Checkout_Block',
 			'form-multiple-choice' => '\ThemeIsle\GutenbergBlocks\Render\Form_Multiple_Choice_Block',
+			'form-file'            => '\ThemeIsle\GutenbergBlocks\Render\Form_File_Block',
 		);
 
 		$dynamic_blocks = apply_filters( 'otter_blocks_register_dynamic_blocks', $dynamic_blocks );
@@ -718,6 +719,7 @@ class Registration {
 			'form-nonce',
 			'form-textarea',
 			'form-multiple-choice',
+			'form-file',
 			'google-map',
 			'icon-list',
 			'icon-list-item',

--- a/inc/css/blocks/class-form-file.php
+++ b/inc/css/blocks/class-form-file.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Css handling logic for blocks.
+ *
+ * @package ThemeIsle\GutenbergBlocks\CSS\Blocks
+ */
+
+namespace ThemeIsle\GutenbergBlocks\CSS\Blocks;
+
+use ThemeIsle\GutenbergBlocks\Base_CSS;
+
+use ThemeIsle\GutenbergBlocks\CSS\CSS_Utility;
+
+/**
+ * Class Form_File_CSS
+ */
+class Form_File_CSS extends Base_CSS {
+	/**
+	 * The namespace under which the blocks are registered.
+	 *
+	 * @var string
+	 */
+	public $block_prefix = 'form-file';
+
+	/**
+	 * Generate Form Multiple Choice CSS
+	 *
+	 * @param mixed $block Block data.
+	 * @return string
+	 * @since   2.3.0
+	 * @access  public
+	 */
+	public function render_css( $block ) {
+		$css = new CSS_Utility( $block );
+
+		$css->add_item(
+			array(
+				'properties' => array(
+					array(
+						'property' => '--label-color',
+						'value'    => 'labelColor',
+					),
+				),
+			)
+		);
+
+		$style = $css->generate();
+
+		return $style;
+	}
+
+}

--- a/inc/render/class-form-file.php
+++ b/inc/render/class-form-file.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Form_File_Block
+ *
+ * @package ThemeIsle\GutenbergBlocks\Render
+ */
+
+namespace ThemeIsle\GutenbergBlocks\Render;
+
+use ThemeIsle\GutenbergBlocks\Pro;
+
+/**
+ * Form_File_Block
+ */
+class Form_File_Block {
+
+	/**
+	 * Block render function for server-side.
+	 *
+	 * This method will pe passed to the render_callback parameter and it will output
+	 * the server side output of the block.
+	 *
+	 * @param array $attributes Block attrs.
+	 * @return mixed|string
+	 */
+	public function render( $attributes ) {
+
+		if ( ! Pro::is_pro_installed() || ! Pro::is_pro_active() ) {
+			return '';
+		}
+
+		$class_names        = 'wp-block-themeisle-blocks-form-file ' . ( isset( $attributes['className'] ) ? $attributes['className'] : '' );
+		$id                 = isset( $attributes['id'] ) ? $attributes['id'] : '';
+		$label              = isset( $attributes['label'] ) ? $attributes['label'] : __( 'Select option', 'otter-blocks' );
+		$help_text          = isset( $attributes['helpText'] ) ? $attributes['helpText'] : '';
+		$is_required        = isset( $attributes['isRequired'] ) ? boolval( $attributes['isRequired'] ) : false;
+		$has_multiple_files = isset( $attributes['multipleFiles'] ) ? boolval( $attributes['multipleFiles'] ) : false;
+
+		$output = '<div class="' . $class_names . '" id="' . $id . '">';
+		
+		$output .= '<label class="otter-form-input-label" for="field-' . $id . '" >' . $label . $this->render_required_sign( $is_required ) . '</label>';
+
+		$output .= '<input type="file" class="otter-form-input" name="field-' 
+		. $id . '" ' 
+		. ( $is_required ? 'required' : '' ) . ' ' 
+		. ( $has_multiple_files ? 'multiple' : '' ) 
+		. ( isset( $attributes['allowedFileTypes'] ) ? ( 'accept="' . $attributes['allowedFileTypes'] ) . '"' : '' )
+		. ( isset( $attributes['maxFileSize'] ) ? ( 'data-max-file-size="' . $attributes['maxFileSize'] ) . '"' : '' )
+		. ' />';
+			
+		$output .= '<span class="o-form-help">' . $help_text . '</span>';
+
+		$output .= '</div>';
+		return $output;
+	}
+
+	/**
+	 * Render the required sign.
+	 * 
+	 * @param bool $is_required The required status of the field.
+	 * @return string
+	 */
+	public function render_required_sign( $is_required ) {
+		return $is_required ? '<span class="required">*</span>' : '';
+	}
+}

--- a/src/blocks/blocks/form/file/block.json
+++ b/src/blocks/blocks/form/file/block.json
@@ -1,0 +1,53 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "themeisle-blocks/form-file",
+	"title": "File Field",
+	"category": "themeisle-blocks",
+	"description": "Display a contact form for your clients.",
+	"keywords": [ "input", "file", "field" ],
+	"ancestor": [ "themeisle-blocks/form" ],
+	"textdomain": "otter-blocks",
+	"attributes": {
+		"id": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string",
+			"default": "file"
+		},
+		"label": {
+			"type": "string"
+		},
+		"placeholder": {
+			"type": "string"
+		},
+		"isRequired": {
+			"type": "boolean"
+		},
+		"mappedName": {
+			"type": "string"
+		},
+		"labelColor": {
+			"type": "string"
+		},
+		"inputWidth": {
+			"type": "number"
+		},
+		"helpText": {
+			"type": "string"
+		},
+		"maxFileSize": {
+			"type": "string"
+		},
+		"allowedFileTypes": {
+			"type": "string"
+		},
+		"multipleFiles": {
+			"type": "boolean"
+		}
+	},
+	"supports": {
+		"align": [ "wide", "full" ]
+	}
+}

--- a/src/blocks/blocks/form/file/edit.js
+++ b/src/blocks/blocks/form/file/edit.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import {
+	RichText,
+	useBlockProps
+} from '@wordpress/block-editor';
+
+import {
+	Fragment,
+	useEffect
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import { blockInit } from '../../../helpers/block-utility.js';
+import Inspector from './inspector.js';
+import { _cssBlock } from '../../../helpers/helper-functions';
+
+
+const { attributes: defaultAttributes } = metadata;
+
+/**
+ * Form Input component
+ * @param {import('./types').FormFileProps} props
+ * @returns
+ */
+const Edit = ({
+	attributes,
+	setAttributes,
+	clientId
+}) => {
+	useEffect( () => {
+		const unsubscribe = blockInit( clientId, defaultAttributes );
+		return () => unsubscribe( attributes.id );
+	}, [ attributes.id ]);
+
+	const blockProps = useBlockProps();
+
+	return (
+		<Fragment>
+			<Inspector
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				clientId={ clientId }
+			/>
+
+			<div { ...blockProps }>
+				<style>
+					{
+						`#block-${clientId}` + _cssBlock([
+							[ '--label-color', attributes.labelColor ]
+						])
+					}
+				</style>
+				<label
+					htmlFor={ attributes.id }
+					className="otter-form-input-label"
+				>
+					<RichText
+						placeholder={ __( 'Type here…', 'otter-blocks' ) }
+						className="otter-form-input-label__label"
+						value={ attributes.label }
+						onChange={ label => setAttributes({ label }) }
+						tagName="span"
+					/>
+
+					{ attributes.isRequired && (
+						<span className="required">*</span>
+					) }
+				</label>
+
+				<input
+					type={ 'file' }
+					name={ attributes.id }
+					id={ attributes.id }
+					required={ attributes.isRequired }
+					disabled
+					className="otter-form-input components-text-control__input"
+				/>
+				{
+					attributes.helpText && (
+						<span
+							className="o-form-help"
+						>
+							{ attributes.helpText }
+						</span>
+					)
+				}
+			</div>
+		</Fragment>
+	);
+};
+
+export default Edit;

--- a/src/blocks/blocks/form/file/index.js
+++ b/src/blocks/blocks/form/file/index.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import { registerBlockType } from '@wordpress/blocks';
+
+import { createBlock } from '@wordpress/blocks';
+
+import { omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import { formFieldIcon as icon } from '../../../helpers/icons.js';
+import edit from './edit.js';
+
+const { name } = metadata;
+
+if ( ! window.themeisleGutenberg.isAncestorTypeAvailable ) {
+	metadata.parent = [ 'themeisle-blocks/form' ];
+}
+
+registerBlockType( name, {
+	...metadata,
+	title: __( 'File Field', 'otter-blocks' ),
+	description: __( 'Display a file field for uploading.', 'otter-blocks' ),
+	icon,
+	keywords: [
+		'input',
+		'field',
+		'file'
+	],
+	edit,
+	save: () => null,
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'themeisle-blocks/form-input' ],
+				transform: ( attributes ) => {
+
+					return createBlock( 'themeisle-blocks/form-input', {
+						...attributes
+					});
+				}
+			},
+			{
+				type: 'block',
+				blocks: [ 'themeisle-blocks/form-textarea' ],
+				transform: ( attributes ) => {
+					const attrs = omit( attributes, [ 'type' ]);
+					return createBlock( 'themeisle-blocks/form-textarea', {
+						...attrs
+					});
+				}
+			},
+			{
+				type: 'block',
+				blocks: [ 'themeisle-blocks/form-multiple-choice' ],
+				transform: ( attributes ) => {
+					const attrs = omit( attributes, [ 'type' ]);
+					return createBlock( 'themeisle-blocks/form-multiple-choice', {
+						...attrs
+					});
+				}
+			}
+		]
+	}
+});

--- a/src/blocks/blocks/form/file/inspector.js
+++ b/src/blocks/blocks/form/file/inspector.js
@@ -1,0 +1,167 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import {
+	InspectorControls,
+	PanelColorSettings
+} from '@wordpress/block-editor';
+
+import {
+	Button,
+	PanelBody,
+	SelectControl,
+	TextControl,
+	ToggleControl
+} from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
+import { useContext } from '@wordpress/element';
+
+import { HideFieldLabelToggle, switchFormFieldTo } from '../common';
+import { FormContext } from '../edit';
+import { Notice } from '../../../components';
+
+/**
+ *
+ * @param {import('./types').FormFileInspectorProps} props
+ * @returns {JSX.Element}
+ */
+const Inspector = ({
+	attributes,
+	setAttributes,
+	clientId
+}) => {
+
+	const {
+		selectForm
+	} = useContext( FormContext );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Field Settings', 'otter-blocks' ) }
+			>
+				<Button
+					isSecondary
+					variant="secondary"
+					onClick={ () => selectForm?.() }
+				>
+					{ __( 'Back to the Form', 'otter-blocks' ) }
+				</Button>
+
+				<SelectControl
+					label={ __( 'Field Type', 'otter-blocks' ) }
+					value={ attributes.type }
+					options={ [
+						{
+							label: __( 'Checkbox', 'otter-blocks' ),
+							value: 'checkbox'
+						},
+						{
+							label: __( 'Date', 'otter-blocks' ),
+							value: 'date'
+						},
+						{
+							label: __( 'Email', 'otter-blocks' ),
+							value: 'email'
+						},
+						{
+							label: __( 'Number', 'otter-blocks' ),
+							value: 'number'
+						},
+						{
+							label: __( 'Radio', 'otter-blocks' ),
+							value: 'radio'
+						},
+						{
+							label: __( 'Select', 'otter-blocks' ),
+							value: 'select'
+						},
+						{
+							label: __( 'Text', 'otter-blocks' ),
+							value: 'text'
+						},
+						{
+							label: __( 'Textarea', 'otter-blocks' ),
+							value: 'textarea'
+						},
+						{
+							label: __( 'Url', 'otter-blocks' ),
+							value: 'url'
+						}
+					] }
+					onChange={ type => {
+						if ( 'textarea' === type || 'radio' === type || 'checkbox' === type || 'select' === type ) {
+							switchFormFieldTo( type, clientId, attributes );
+							return;
+						}
+
+						setAttributes({ type });
+					}}
+				/>
+
+				<TextControl
+					label={ __( 'Label', 'otter-blocks' ) }
+					value={ attributes.label }
+					onChange={ label => setAttributes({ label }) }
+				/>
+
+				<HideFieldLabelToggle attributes={ attributes } setAttributes={ setAttributes } />
+
+				<TextControl
+					label={ __( 'Max File Size in MB', 'otter-blocks' ) }
+					type="number"
+					value={ attributes.maxFileSize }
+					onChange={ maxFileSize => setAttributes({ maxFileSize }) }
+					help={ __( 'You may need to contact your hosting provider to increase file sizes.', 'otter-blocks' ) }
+				/>
+
+				<TextControl
+					label={ __( 'Allowed File Types', 'otter-blocks' ) }
+					value={ attributes.allowedFileTypes }
+					onChange={ allowedFileTypes => setAttributes({ allowedFileTypes }) }
+					help={ __( 'Allowed file types separated by coma. E.g.: .png, .jpg, .pdf, .doc', 'otter-blocks' ) }
+				/>
+
+				<TextControl
+					label={ __( 'Help Text', 'otter-blocks' ) }
+					value={ attributes.helpText }
+					onChange={ helpText => setAttributes({ helpText }) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Required', 'otter-blocks' ) }
+					help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
+					checked={ attributes.isRequired }
+					onChange={ isRequired => setAttributes({ isRequired }) }
+				/>
+
+				{ ! Boolean( window.themeisleGutenberg?.hasPro ) && (
+					<Notice
+						notice={<ExternalLink href={setUtm( window.themeisleGutenberg.upgradeLink, 'formfilefieldfeature' )}>{__( 'Activate this field with Otter Pro.', 'otter-blocks' )}</ExternalLink>}
+						variant="upsell" instructions={undefined}				/>
+				) }
+
+				<div className="o-fp-wrap">
+					{ applyFilters( 'otter.feedback', '', 'sticky' ) }
+					{ applyFilters( 'otter.poweredBy', '' ) }
+				</div>
+			</PanelBody>
+
+			<PanelColorSettings
+				title={ __( 'Color', 'otter-blocks' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						value: attributes.labelColor,
+						onChange: labelColor => setAttributes({ labelColor }),
+						label: __( 'Label Color', 'otter-blocks' )
+					}
+				] }
+			/>
+		</InspectorControls>
+	);
+};
+
+export default Inspector;

--- a/src/blocks/blocks/form/file/save.js
+++ b/src/blocks/blocks/form/file/save.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import {
+	RichText,
+	useBlockProps
+} from '@wordpress/block-editor';
+
+const Save = ({
+	attributes
+}) => {
+	const blockProps = useBlockProps.save({
+		id: attributes.id
+	});
+
+	return (
+		<div { ...blockProps }>
+			<label
+				htmlFor={ attributes.id ? attributes.id + '-input' : '' }
+				className="otter-form-input-label"
+			>
+				<RichText.Content
+					value={ attributes.label }
+					className="otter-form-input-label__label"
+					tagName="span"
+				/>
+
+				{ attributes.isRequired && (
+					<span className="required">*</span>
+				) }
+			</label>
+
+			<input
+				type={ attributes.type }
+				name={ attributes.mappedName }
+				id={ attributes.id ? attributes.id + '-input' : '' }
+				required={ attributes.isRequired }
+				placeholder={ attributes.placeholder }
+				className="otter-form-input"
+			/>
+			{
+				attributes.helpText && (
+					<span className="o-form-help">
+						{ attributes.helpText }
+					</span>
+				)
+			}
+		</div>
+	);
+};
+
+export default Save;

--- a/src/blocks/blocks/form/file/types.d.ts
+++ b/src/blocks/blocks/form/file/types.d.ts
@@ -1,0 +1,17 @@
+import {
+	BlockProps,
+	InspectorProps
+} from '../../../helpers/blocks';
+import { FormInputCommonProps } from '../common';
+
+type Attributes = FormInputCommonProps & {
+	type: string
+	inputWidth: number
+	maxFileSize: string
+	allowedFileTypes: string
+	multipleFiles: boolean
+}
+
+export type FormFileProps = BlockProps<Attributes>
+export interface FormFileInspectorProps extends InspectorProps<Attributes> {}
+

--- a/src/blocks/blocks/form/index.js
+++ b/src/blocks/blocks/form/index.js
@@ -17,6 +17,7 @@ import './input/index.js';
 import './nonce/index.js';
 import './textarea/index.js';
 import './multiple-choice/index.js';
+import './file/index.js';
 
 const { name } = metadata;
 

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -252,7 +252,7 @@
 	}
 
 
-	.wp-block-themeisle-blocks-form-input, .wp-block-themeisle-blocks-form-textarea, .wp-block-themeisle-blocks-form-multiple-choice {
+	.wp-block-themeisle-blocks-form-input, .wp-block-themeisle-blocks-form-textarea, .wp-block-themeisle-blocks-form-multiple-choice, .wp-block-themeisle-blocks-form-file {
 		display: flex;
 		flex-direction: column;
 		width: 100%;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1466 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add File Field as Pro feature for Form Block

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

