### PR TITLE
Wrong author in review block schema

### DIFF
--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -29,10 +29,12 @@ class Review_Block {
 		}
 
 		if ( isset( $attributes['title'] ) && ! empty( $attributes['title'] ) && isset( $attributes['features'] ) && count( $attributes['features'] ) > 0 && get_option( 'themeisle_blocks_settings_disable_review_schema', true ) ) {
+			$post_id = get_the_ID();
+
 			add_action(
 				'wp_footer',
-				function() use ( $attributes ) {
-					echo '<script type="application/ld+json">' . wp_json_encode( $this->get_json_ld( $attributes ) ) . '</script>';
+				function() use ( $attributes, $post_id ) {
+					echo '<script type="application/ld+json">' . wp_json_encode( $this->get_json_ld( $attributes, $post_id ) ) . '</script>';
 				}
 			);
 		}
@@ -246,10 +248,11 @@ class Review_Block {
 	 * Generate JSON-LD schema
 	 *
 	 * @param array $attributes Block attributes.
+	 * @param int   $post_id Post ID.
 	 *
 	 * @return array
 	 */
-	public function get_json_ld( $attributes ) {
+	public function get_json_ld( $attributes, $post_id ) {
 		$json = array(
 			'@context' => 'https://schema.org/',
 			'@type'    => 'Product',
@@ -273,7 +276,7 @@ class Review_Block {
 			),
 			'author'       => array(
 				'@type' => 'Person',
-				'name'  => get_the_author(),
+				'name'  => get_the_author_meta( 'display_name', get_post_field( 'post_author', $post_id ) ),
 			),
 		);
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1491.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Since `get_json_ld()` is hooked in the footer, it can sometimes get the wrong current post.
Passes the post ID to the function to get the author based on it.

### Test instructions
<!-- Describe how this pull request can be tested. -->

Hardeep found that in the user's case there must be a footer widget that uses `setup_postdata`, so he tested it and this fixes the issue. So, we only need a general testing of this and to make sure it works in places outside of Posts context, like widgets and FSE.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

