### PR TITLE
Fix: Additional classes behavior when deleting ticss class

### DIFF
--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -108,7 +108,8 @@ const CSSEditor = ({
 
 	useEffect( () => {
 		const regex = new RegExp( 'selector', 'g' );
-		const customCSS = editorValue?.replace( regex, `.${ getClassName().split( ' ' ).find( i => i.includes( 'ticss' ) ) }` );
+		const className = getClassName();
+		const customCSS = className ? editorValue?.replace( regex, `.${ className.split( ' ' ).find( i => i.includes( 'ticss' ) ) }` ) : editorValue;
 
 		if ( ( 'selector {\n}\n' ).replace( /\s+/g, '' ) === customCSS?.replace( /\s+/g, '' ) ) {
 			setAttributes({ customCSS: null });

--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -28,18 +28,22 @@ const CSSEditor = ({
 
 	const editorRef = useRef( null );
 	const [ errors, setErrors ] = useState([]);
-	const [ customCSS, setCustomCSS ] = useState( null );
 	const [ editorValue, setEditorValue ] = useState( null );
 
 	const getClassName = () => {
-		const uniqueId = clientId.substr( 0, 8 );
+		const uniqueId = clientId.substring( 0, 8 );
 
-		if ( customCSS?.replace( /\s+/g, '' ) === ( 'selector {\n}\n' ).replace( /\s+/g, '' ) ) {
+		if ( editorValue?.replace( /\s+/g, '' ) === ( 'selector {\n}\n' ).replace( /\s+/g, '' ) ) {
 			return attributes.className;
 		}
 
-		return  attributes.className ?
-			( ! attributes.className.includes( 'ticss-' ) ? [ ...attributes.className.split( ' ' ), `ticss-${ uniqueId }` ].join( ' ' ) : attributes.className ) :
+		const { className } = attributes;
+
+		return className ?
+			( ! className.includes( 'ticss-' ) ?
+				[ ...className.trim().split( ' ' ), `ticss-${ uniqueId }` ].join( ' ' ) :
+				className
+			) :
 			`ticss-${ uniqueId }`;
 	};
 
@@ -51,11 +55,12 @@ const CSSEditor = ({
 		}
 
 		editorErrors = editorErrors?.filter( error => ! window.otterCSSLintIgnored.includes( error ) );
-
 		setErrors( editorErrors );
+
 		if ( ! ignoreErrors && 0 < editorErrors?.length ) {
 			return;
 		}
+
 		setEditorValue( editor?.getValue() );
 	};
 
@@ -87,35 +92,37 @@ const CSSEditor = ({
 			}
 		});
 
-		editorRef.current.on( 'change', () => {
+		const onChange = () => {
 			clearTimeout( inputTimeout );
 			inputTimeout = setTimeout( () => {
 				checkInput( editorRef.current );
 			}, 500 );
-		});
+		};
+
+		editorRef.current.on( 'change', onChange );
+
+		return () => {
+			editorRef.current.off( 'change', onChange );
+		};
 	}, []);
 
 	useEffect( () => {
 		const regex = new RegExp( 'selector', 'g' );
-		setCustomCSS( editorValue?.replace( regex, `.${ getClassName().split( ' ' ).find( i => i.includes( 'ticss' ) ) }` ) );
-	}, [ editorValue ]);
+		const customCSS = editorValue?.replace( regex, `.${ getClassName().split( ' ' ).find( i => i.includes( 'ticss' ) ) }` );
 
-	useEffect( () => {
 		if ( ( 'selector {\n}\n' ).replace( /\s+/g, '' ) === customCSS?.replace( /\s+/g, '' ) ) {
 			setAttributes({ customCSS: null });
 			return;
 		}
-		if ( customCSS ) {
-			setAttributes({ customCSS });
-		}
-	}, [ customCSS ]);
 
-	useEffect( () => {
-		setAttributes({
-			hasCustomCSS: true,
-			className: getClassName()
-		});
-	}, [ attributes ]);
+		if ( customCSS ) {
+			setAttributes({
+				customCSS,
+				hasCustomCSS: true,
+				className: getClassName()
+			});
+		}
+	}, [ editorValue ]);
 
 	return (
 		<Fragment>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1507.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- When trying to delete the `ticss` class with backspace from the `Additional Classes`, the input is filled with `ticss` strings (see [here](https://www.loom.com/share/0bbaa6e047f44042811384bc7429e755)).
- This PR lets the user delete the class (meaning that the `Custom CSS` is no longer applied) until the `Custom CSS` is modified, which causes the `ticss` class to be added again.
- Also, made some changes to limit the re-renders of the component. They should not influence the behavior.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add Custom CSS to a block.
- From the Advance tab, try to remove the CSS class by pressing backspace.
- Modify the Custom CSS and the class should be added again.
- Make sure that besides this, everything else behaves the same.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

