### PR TITLE
CSS not rendering on dynamic value for post content

### DIFF
--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -84,7 +84,7 @@ class Dynamic_Content {
 		if ( ! isset( $data['default'] ) ) {
 			$data['default'] = '';
 		}
-	
+
 		$data = $this->apply_data( $data, true );
 
 		return $data;
@@ -97,7 +97,7 @@ class Dynamic_Content {
 	 *
 	 * @return string
 	 */
-	public function apply_dynamic_link( $content ) { 
+	public function apply_dynamic_link( $content ) {
 		if ( false === strpos( $content, '<o-dynamic-link' ) ) {
 			return $content;
 		}
@@ -371,7 +371,7 @@ class Dynamic_Content {
 	 * @return string
 	 */
 	public function get_content( $data ) {
-		$content = get_the_content( $data['context'] );
+		$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( $data['context'] ) ) );
 		return wp_kses_post( $content );
 	}
 
@@ -598,7 +598,7 @@ class Dynamic_Content {
 
 		$data = explode( '#otterDynamicLink', $data[0] );
 		$data = self::query_string_to_array( $data[1] );
-	
+
 		$link = $this->get_link( $data );
 
 		if ( empty( $link ) ) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1508 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Applies `the_content` filter on the dynamic value for post content.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Using a FSE theme, add a dynamic value with `Post content` for a post in the Homepage, as seen below:

<img width="500" alt="Screenshot 2023-03-01 at 12 23 15" src="https://user-images.githubusercontent.com/39873395/222112102-d86ef524-b795-487c-a125-d01914fe6580.png">

- Add some blocks on the specific post and they should look as expected in the frontent:

<img width="500" alt="Screenshot 2023-03-01 at 12 28 23" src="https://user-images.githubusercontent.com/39873395/222113371-7f4951e9-ad4c-4b09-9e6b-b1ac79deac9d.png">

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

