### PR TITLE
fix: remove ticss class if custom CSS is empty

### DIFF
--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -25,7 +25,6 @@ const CSSEditor = ({
 	setAttributes,
 	clientId
 }) => {
-
 	const editorRef = useRef( null );
 	const [ errors, setErrors ] = useState([]);
 	const [ editorValue, setEditorValue ] = useState( null );
@@ -112,18 +111,20 @@ const CSSEditor = ({
 	useEffect( () => {
 		const regex = new RegExp( 'selector', 'g' );
 		const className = getClassName();
-		const customCSS = className ? editorValue?.replace( regex, `.${ className.split( ' ' ).find( i => i.includes( 'ticss' ) ) }` ) : editorValue;
+
+		const customClass = className?.split( ' ' ).find( i => i.includes( 'ticss' ) );
+		const customCSS = customClass ? editorValue?.replace( regex, `.${ customClass }` ) : editorValue;
 
 		if ( ( 'selector {\n}\n' ).replace( /\s+/g, '' ) === customCSS?.replace( /\s+/g, '' ) ) {
-			setAttributes({ customCSS: null });
-			return;
-		}
-
-		if ( customCSS ) {
+			setAttributes({
+				customCSS: null,
+				className
+			});
+		} else if ( customCSS ) {
 			setAttributes({
 				customCSS,
 				hasCustomCSS: true,
-				className: getClassName()
+				className: className
 			});
 		}
 	}, [ editorValue ]);

--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -33,8 +33,11 @@ const CSSEditor = ({
 	const getClassName = () => {
 		const uniqueId = clientId.substring( 0, 8 );
 
+		// remove the ticss class if custom CSS is empty.
 		if ( editorValue?.replace( /\s+/g, '' ) === ( 'selector {\n}\n' ).replace( /\s+/g, '' ) ) {
-			return attributes.className;
+			return attributes.className ?
+				attributes.className.split( ' ' ).filter( className => ! className.includes( 'ticss-' ) ).join( ' ' ) :
+				attributes.className;
 		}
 
 		const { className } = attributes;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1544.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- If the custom CSS is empty there should be no `ticss` class.
- Fixes the last comment from https://wordpress.org/support/topic/problem-with-removing-unnecessary-classes/#post-16532550

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add custom CSS to a block and there should be the additional class `ticss-...`
- If the CSS gets removed that class should disappear.
- If there are other additional classes to that block, they should not be affected.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

