### PR TITLE
Fix blocks-css with FSE themes

### DIFF
--- a/inc/class-base-css.php
+++ b/inc/class-base-css.php
@@ -352,10 +352,10 @@ class Base_CSS {
 			} else {
 				$parser = new Parser( file_get_contents( OTTER_BLOCKS_PATH . '/build/animation/index.css' ) ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 			}
-	
+
 			$content = $parser->parse()->getContents();
 
-			set_transient( 'otter_animations_parsed', $content, MONTH_IN_SECONDS ); 
+			set_transient( 'otter_animations_parsed', $content, MONTH_IN_SECONDS );
 		}
 
 		$format = OutputFormat::createCompact();
@@ -369,7 +369,7 @@ class Base_CSS {
 				}
 				continue;
 			}
-		
+
 			/*
 			 * This is used to get the reduced-motion animation styles.
 			 */
@@ -377,7 +377,7 @@ class Base_CSS {
 				if ( false === in_array( $rule->atRuleArgs(), array( '(prefers-reduced-motion:reduce),print', 'screen' ) ) ) {
 					continue;
 				}
-		
+
 				$style .= $rule->render( $format );
 				continue;
 			}

--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -49,8 +49,8 @@ class Blocks_CSS {
 
 		wp_enqueue_code_editor( array( 'type' => 'text/css' ) );
 
-		wp_add_inline_script( 
-			'wp-codemirror', 
+		wp_add_inline_script(
+			'wp-codemirror',
 			'window.CodeMirror = wp.CodeMirror;'
 		);
 
@@ -88,7 +88,7 @@ class Blocks_CSS {
 
 	/**
 	 * Render server-side CSS
-	 * 
+	 *
 	 * @since   1.0.0
 	 * @access  public
 	 */
@@ -100,7 +100,12 @@ class Blocks_CSS {
 				return;
 			}
 
-			$blocks = parse_blocks( $post->post_content );
+			if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() && current_theme_supports( 'block-templates' ) ) {
+				global $_wp_current_template_content;
+				$blocks = parse_blocks( $_wp_current_template_content );
+			} else {
+				$blocks = parse_blocks( $post->post_content );
+			}
 
 			if ( ! is_array( $blocks ) || empty( $blocks ) ) {
 				return;
@@ -125,7 +130,7 @@ class Blocks_CSS {
 	 *
 	 * @param array $inner_blocks Array of blocks.
 	 * @param int   $id Post ID.
-	 * 
+	 *
 	 * @since   1.0.0
 	 * @access  public
 	 */
@@ -188,9 +193,9 @@ class Blocks_CSS {
 	}
 
 	/**
-	 * Append Block CSS to Otter's CSS file..
+	 * Append Block CSS to Otter's CSS file.
 	 *
-	 * @param int $block Block.
+	 * @param array $block Block.
 	 *
 	 * @since   1.1.4
 	 * @access  public

--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -100,7 +100,13 @@ class Blocks_CSS {
 				return;
 			}
 
-			if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() && current_theme_supports( 'block-templates' ) ) {
+			if (
+				! defined( 'OTTER_BLOCKS_VERSION' ) &&
+				get_queried_object() === null &&
+				function_exists( 'wp_is_block_theme' ) &&
+				wp_is_block_theme() &&
+				current_theme_supports( 'block-templates' )
+			) {
 				global $_wp_current_template_content;
 				$blocks = parse_blocks( $_wp_current_template_content );
 			} else {

--- a/src/css/inject-css.js
+++ b/src/css/inject-css.js
@@ -64,7 +64,7 @@ const getCustomCssFromBlocks = ( blocks, reusableBlocks ) => {
 			if ( reBlocks && reBlocks.content ) {
 				const content = reBlocks.content.hasOwnProperty( 'raw' ) ? reBlocks.content.raw : reBlocks.content;
 				children.push(  parse( content ).map( ( child ) => [ child, getChildrenFromBlock( child ) ])  );
-			};
+			}
 		}
 
 		if ( undefined !== block.innerBlocks && 0 < ( block.innerBlocks ).length ) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1542.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- In the context of the issue (FSE theme, home page), the `$post` will be the first post from the query, not the actual page, so the correct blocks were not considered. 
- This PR adds an additional check to select the correct blocks and add their custom CSS.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Use only the blocks-css plugin
- Add custom CSS on a block from a home page using an FSE theme
- The custom CSS should load just the same as in usual contexts.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

