### PR TITLE
Remove redundant border on closed tabs in Dashboard

### DIFF
--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -155,11 +155,13 @@
 			border: 1px solid #e2e4e7;
 			border-radius: 10px;
 
-			.components-panel__body-toggle {
-				border-bottom: 1px solid #d6e2ed;
+			&.is-opened {
+				.components-panel__body-toggle {
+					border-bottom: 1px solid #d6e2ed;
 
-				&:hover {
-					border-bottom: 1px solid #d6e2ed !important;
+					&:hover {
+						border-bottom: 1px solid #d6e2ed !important;
+					}
 				}
 			}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1541 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

Before

![image](https://user-images.githubusercontent.com/17597852/224051098-41190869-882d-4c29-a889-597a8489a4ff.png)

After

![image](https://user-images.githubusercontent.com/17597852/224050746-4e3f1a5a-ec2c-44bb-9dc5-fd81f023e883.png)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Go to Otter Dashboard.
2. Close the tabs like in the above picture.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

