### PR TITLE
Feat: Add preview for dynamic value

### DIFF
--- a/src/blocks/plugins/dynamic-content/editor.scss
+++ b/src/blocks/plugins/dynamic-content/editor.scss
@@ -84,6 +84,23 @@ o-dynamic-link {
 		padding: 0 24px;
 		margin: 0;
 	}
+
+	&__preview {
+		&__content {
+			padding: 15px;
+			background-color: #F3F3F3;
+			border-radius: 4px;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			overflow: hidden;
+		}
+
+		&__description {
+			font-style: italic;
+			font-size: 11px;
+			margin-top: 5px;
+		}
+	}
 }
 
 .o-dynamic-popover {

--- a/src/blocks/plugins/dynamic-content/editor.scss
+++ b/src/blocks/plugins/dynamic-content/editor.scss
@@ -93,6 +93,15 @@ o-dynamic-link {
 			white-space: nowrap;
 			text-overflow: ellipsis;
 			overflow: hidden;
+
+			&.is-loading {
+				display: flex;
+				justify-content: center;
+			}
+
+			.components-spinner {
+				margin: 0;
+			}
 		}
 
 		&__description {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1504 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Adds a small preview for the Dynamic Value in the popup.

### Screenshots <!-- if applicable -->

<img width="500" alt="Screenshot 2023-03-12 at 21 34 59" src="https://user-images.githubusercontent.com/39873395/224568919-2606a7a2-3fef-420e-930f-c4410473e6ca.png">

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add a dynamic value
- After selecting the type of the value, a preview should appear below

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

