### PR TITLE
Add Popup Variations

### DIFF
--- a/src/blocks/blocks/popup/index.js
+++ b/src/blocks/blocks/popup/index.js
@@ -9,9 +9,9 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import metadata from './block.json';
-import { popupIcon as icon } from '../../helpers/icons.js';
 import edit from './edit.js';
 import save from './save.js';
+import { popupIcon as icon, popupScratch, popupWithForm, popupWithImageAndText } from '../../helpers/icons';
 
 const { name } = metadata;
 
@@ -29,5 +29,452 @@ registerBlockType( name, {
 	save,
 	example: {
 		attributes: {}
-	}
+	},
+	variations: [
+		{
+			'name': 'themeisle-blocks/popup-scratch',
+			'title': __( 'Start from scratch', 'otter-blocks' ),
+			'description': __( 'Simple Popup with default settings.', 'otter-blocks' ),
+			'icon': popupScratch,
+			'scope': [ 'block' ],
+			'attributes': {},
+			'innerBlocks': [
+				{
+					'name': 'core/paragraph',
+					'attributes': {
+						'content': 'Add your content.',
+						'dropCap': false,
+						'style': {
+							'typography': {
+								'fontSize': '16px'
+							}
+						}
+					}
+				}
+			]
+		},
+		{
+			'name': 'themeisle-blocks/popup-with-text-and-image',
+			'title': __( 'Text and Image', 'otter-blocks' ),
+			'description': __( 'Popup with Text and Image.', 'otter-blocks' ),
+			'icon': popupWithImageAndText,
+			'scope': [ 'block' ],
+			'attributes': {
+				'minWidth': 900,
+				'trigger': 'onLoad',
+				'wait': 3,
+				'scroll': 75,
+				'showClose': false,
+				'outsideClose': true,
+				'anchorClose': false,
+				'recurringClose': false,
+				'backgroundColor': 'var(--nv-site-bg)',
+				'closeColor': 'var(--nv-text-color)',
+				'overlayColor': 'var(--nv-dark-bg)',
+				'overlayOpacity': 95,
+				'paddingMobile': {
+					'top': '8px',
+					'bottom': '8px',
+					'left': '8px',
+					'right': '8px'
+				},
+				'width': '860px',
+				'height': '500px',
+				'heightTablet': '400px',
+				'heightMobile': '320px',
+				'boxShadow': {
+					'active': false,
+					'colorOpacity': 50,
+					'blur': 5,
+					'spread': 1,
+					'horizontal': 0,
+					'vertical': 0
+				}
+			},
+			'innerBlocks': [
+				{
+					'name': 'themeisle-blocks/advanced-columns',
+					'attributes': {
+						'columns': 2,
+						'layout': 'equal',
+						'layoutTablet': 'equal',
+						'layoutMobile': 'collapsedRows',
+						'padding': {
+							'top': '0px',
+							'right': '0px',
+							'bottom': '0px',
+							'left': '0px'
+						},
+						'paddingTablet': {
+							'top': '40px',
+							'right': '20px',
+							'bottom': '40px',
+							'left': '20px'
+						},
+						'paddingMobile': {
+							'top': '20px',
+							'right': '20px',
+							'bottom': '20px',
+							'left': '20px'
+						},
+						'columnsWidth': '100%',
+						'horizontalAlign': 'center',
+						'columnsHeight': 'auto',
+						'verticalAlign': 'center',
+						'backgroundType': 'color',
+						'backgroundAttachment': 'scroll',
+						'backgroundRepeat': 'repeat',
+						'backgroundSize': 'auto',
+						'backgroundGradient': 'linear-gradient(90deg,rgba(54,209,220,1) 0%,rgba(91,134,229,1) 100%)',
+						'backgroundOverlayOpacity': 50,
+						'backgroundOverlayType': 'color',
+						'backgroundOverlayAttachment': 'scroll',
+						'backgroundOverlayRepeat': 'repeat',
+						'backgroundOverlaySize': 'auto',
+						'backgroundOverlayGradient': 'linear-gradient(90deg,rgba(54,209,220,1) 0%,rgba(91,134,229,1) 100%)',
+						'backgroundOverlayFilterBlur': 0,
+						'backgroundOverlayFilterBrightness': 10,
+						'backgroundOverlayFilterContrast': 10,
+						'backgroundOverlayFilterGrayscale': 0,
+						'backgroundOverlayFilterHue': 0,
+						'backgroundOverlayFilterSaturate': 10,
+						'backgroundOverlayBlend': 'normal',
+						'boxShadow': false,
+						'boxShadowColor': '#000000',
+						'boxShadowColorOpacity': 50,
+						'boxShadowBlur': 5,
+						'boxShadowSpread': 0,
+						'boxShadowHorizontal': 0,
+						'boxShadowVertical': 0,
+						'dividerTopType': 'none',
+						'dividerTopColor': '#000000',
+						'dividerTopInvert': false,
+						'dividerBottomType': 'none',
+						'dividerBottomColor': '#000000',
+						'dividerBottomInvert': false,
+						'hide': false,
+						'hideTablet': false,
+						'hideMobile': false,
+						'reverseColumnsTablet': false,
+						'reverseColumnsMobile': true,
+						'columnsHTMLTag': 'div'
+					},
+					'innerBlocks': [
+						{
+							'name': 'themeisle-blocks/advanced-column',
+							'attributes': {
+								'padding': {
+									'top': '20px',
+									'right': '20px',
+									'bottom': '20px',
+									'left': '20px'
+								},
+								'paddingTablet': {
+									'top': '20px',
+									'right': '20px',
+									'bottom': '20px',
+									'left': '20px'
+								},
+								'paddingMobile': {
+									'top': '20px',
+									'right': '20px',
+									'bottom': '20px',
+									'left': '20px'
+								},
+								'backgroundType': 'color',
+								'backgroundAttachment': 'scroll',
+								'backgroundRepeat': 'repeat',
+								'backgroundSize': 'auto',
+								'backgroundGradient': 'linear-gradient(90deg,rgba(54,209,220,1) 0%,rgba(91,134,229,1) 100%)',
+								'backgroundOverlayOpacity': 50,
+								'backgroundOverlayType': 'color',
+								'backgroundOverlayAttachment': 'scroll',
+								'backgroundOverlayRepeat': 'repeat',
+								'backgroundOverlaySize': 'auto',
+								'backgroundOverlayGradient': 'linear-gradient(90deg,rgba(54,209,220,1) 0%,rgba(91,134,229,1) 100%)',
+								'backgroundOverlayFilterBlur': 0,
+								'backgroundOverlayFilterBrightness': 10,
+								'backgroundOverlayFilterContrast': 10,
+								'backgroundOverlayFilterGrayscale': 0,
+								'backgroundOverlayFilterHue': 0,
+								'backgroundOverlayFilterSaturate': 10,
+								'backgroundOverlayBlend': 'normal',
+								'boxShadow': false,
+								'boxShadowColor': '#000000',
+								'boxShadowColorOpacity': 50,
+								'boxShadowBlur': 5,
+								'boxShadowSpread': 0,
+								'boxShadowHorizontal': 0,
+								'boxShadowVertical': 0,
+								'columnsHTMLTag': 'div',
+								'columnWidth': '50',
+								'verticalAlign': 'center'
+							},
+							'innerBlocks': [
+								{
+									'name': 'themeisle-blocks/advanced-heading',
+									'attributes': {
+										'content': '<strong>Explore COURSES</strong>',
+										'tag': 'p',
+										'alignTablet': 'left',
+										'alignMobile': 'left',
+										'headingColor': 'var(--nv-primary-accent)',
+										'fontSize': '12px',
+										'fontSizeTablet': 16,
+										'fontSizeMobile': 16,
+										'textTransform': 'uppercase',
+										'lineHeight': 1.4,
+										'textShadow': false,
+										'textShadowColor': '#000000',
+										'textShadowColorOpacity': 50,
+										'textShadowBlur': 5,
+										'textShadowHorizontal': 0,
+										'textShadowVertical': 0,
+										'paddingTop': 0,
+										'hasCustomCSS': false,
+										'customCSS': null
+									}
+								},
+								{
+									'name': 'themeisle-blocks/advanced-heading',
+									'attributes': {
+										'content': 'Illustration Skills',
+										'tag': 'h2',
+										'textShadow': false,
+										'textShadowColor': '#000000',
+										'textShadowColorOpacity': 50,
+										'textShadowBlur': 5,
+										'textShadowHorizontal': 0,
+										'textShadowVertical': 0,
+										'paddingTop': 0,
+										'margin': {
+											'top': '0px',
+											'bottom': '8px'
+										}
+									}
+								},
+								{
+									'name': 'core/paragraph',
+									'attributes': {
+										'content': 'Through the years I have created downloadable resources that you can download and improve your skills.',
+										'dropCap': false
+									}
+								},
+								{
+									'name': 'core/buttons',
+									'attributes': {
+										'layout': {
+											'type': 'flex',
+											'justifyContent': 'left'
+										}
+									},
+									'innerBlocks': [
+										{
+											'name': 'core/button',
+											'isValid': true,
+											'attributes': {
+												'text': 'Learn More',
+												'className': 'is-style-primary'
+											}
+										}
+									]
+								}
+							]
+						},
+						{
+							'name': 'themeisle-blocks/advanced-column',
+							'attributes': {
+								'padding': {
+									'top': '20px',
+									'right': '20px',
+									'bottom': '20px',
+									'left': '20px'
+								},
+								'paddingTablet': {
+									'top': '20px',
+									'right': '20px',
+									'bottom': '20px',
+									'left': '20px'
+								},
+								'paddingMobile': {
+									'top': '20px',
+									'right': '20px',
+									'bottom': '20px',
+									'left': '20px'
+								},
+								'backgroundType': 'color',
+								'backgroundAttachment': 'scroll',
+								'backgroundRepeat': 'repeat',
+								'backgroundSize': 'auto',
+								'backgroundGradient': 'linear-gradient(90deg,rgba(54,209,220,1) 0%,rgba(91,134,229,1) 100%)',
+								'backgroundOverlayOpacity': 50,
+								'backgroundOverlayType': 'color',
+								'backgroundOverlayAttachment': 'scroll',
+								'backgroundOverlayRepeat': 'repeat',
+								'backgroundOverlaySize': 'auto',
+								'backgroundOverlayGradient': 'linear-gradient(90deg,rgba(54,209,220,1) 0%,rgba(91,134,229,1) 100%)',
+								'backgroundOverlayFilterBlur': 0,
+								'backgroundOverlayFilterBrightness': 10,
+								'backgroundOverlayFilterContrast': 10,
+								'backgroundOverlayFilterGrayscale': 0,
+								'backgroundOverlayFilterHue': 0,
+								'backgroundOverlayFilterSaturate': 10,
+								'backgroundOverlayBlend': 'normal',
+								'boxShadow': false,
+								'boxShadowColor': '#000000',
+								'boxShadowColorOpacity': 50,
+								'boxShadowBlur': 5,
+								'boxShadowSpread': 0,
+								'boxShadowHorizontal': 0,
+								'boxShadowVertical': 0,
+								'columnsHTMLTag': 'div',
+								'columnWidth': '50'
+							},
+							'innerBlocks': [
+								{
+									'name': 'core/image',
+									'attributes': {
+										'url': 'https://demosites.io/otter/wp-content/uploads/sites/664/2022/11/otter-demo-8.png',
+										'alt': '',
+										'caption': '',
+										'sizeSlug': 'full',
+										'linkDestination': 'none',
+										'boxShadow': false,
+										'boxShadowColor': '#000000',
+										'boxShadowColorOpacity': 50,
+										'boxShadowBlur': 5,
+										'boxShadowHorizontal': 0,
+										'boxShadowVertical': 0
+									}
+
+								}
+							]
+
+						}
+					]
+				}
+			]
+		},
+		{
+			'name': 'themeisle-blocks/popup-with-form',
+			'title': __( 'Popup with Form', 'otter-blocks' ),
+			'description': __( 'Popup with Form that appears on page load.', 'otter-blocks' ),
+			'icon': popupWithForm,
+			'scope': [ 'block' ],
+			'attributes': {
+				'trigger': 'onLoad',
+				'wait': 3,
+				'showClose': true,
+				'outsideClose': true,
+				'anchorClose': false,
+				'recurringClose': false,
+				'backgroundColor': 'var(--nv-light-bg)',
+				'closeColor': 'var(--nv-text-color)',
+				'lockScrolling': false,
+				'padding': {
+					'top': '32px',
+					'bottom': '32px',
+					'left': '32px',
+					'right': '32px'
+				},
+				'borderWidth': {
+					'top': '8px'
+				},
+				'borderRadius': {
+					'top': '5px',
+					'bottom': '5px',
+					'left': '5px',
+					'right': '5px'
+				},
+				'borderColor': 'var(--nv-primary-accent)',
+				'width': '540px',
+				'closeButtonType': 'outside',
+				'boxShadow': {
+					'active': false,
+					'colorOpacity': 50,
+					'blur': 5,
+					'spread': 1,
+					'horizontal': 0,
+					'vertical': 0
+				},
+				'disableOn': 'mobile'
+			},
+			'innerBlocks': [
+				{
+					'name': 'themeisle-blocks/advanced-heading',
+					'attributes': {
+						'content': 'Find the perfect course',
+						'tag': 'h2',
+						'textShadow': false,
+						'textShadowColor': '#000000',
+						'textShadowColorOpacity': 50,
+						'textShadowBlur': 5,
+						'textShadowHorizontal': 0,
+						'textShadowVertical': 0,
+						'paddingTop': 0,
+						'margin': {
+							'top': '0px',
+							'bottom': '16px'
+						}
+					}
+				},
+				{
+					'name': 'core/paragraph',
+					'attributes': {
+						'content': 'All of our courses are designed to help you learn the fundamentals of writing and other related topics.',
+						'dropCap': false,
+						'style': {
+							'typography': {
+								'fontSize': '16px'
+							}
+						},
+						'textColor': 'neve-text-color'
+					}
+				},
+				{
+					'name': 'themeisle-blocks/form',
+					'attributes': {
+						'provider': '',
+						'action': 'subscribe',
+						'submitLabel': 'Send me the survey',
+						'submitMessageColor': 'var(--nv-c-1)',
+						'submitMessageErrorColor': 'var(--nv-c-2)',
+						'submitBackgroundColor': 'var(--nv-primary-accent)',
+						'submitColor': 'var(--nv-text-dark-bg)',
+						'submitStyle': 'full'
+					},
+					'innerBlocks': [
+						{
+							'name': 'themeisle-blocks/form-input',
+							'attributes': {
+								'type': 'text',
+								'label': 'Name',
+								'isRequired': true,
+								'labelColor': 'var(--nv-text-color)'
+							}
+						},
+						{
+							'name': 'themeisle-blocks/form-input',
+							'attributes': {
+								'type': 'email',
+								'label': 'Email',
+								'isRequired': true,
+								'labelColor': 'var(--nv-text-color)'
+							}
+						},
+						{
+							'name': 'core/paragraph',
+							'attributes': {
+								'align': 'left',
+								'content': 'You agree to privacy and terms.',
+								'dropCap': false,
+								'textColor': 'neve-text-color',
+								'fontSize': 'small'
+							}
+						}
+					]
+				}
+			]
+		}
+	]
 });

--- a/src/blocks/blocks/popup/index.js
+++ b/src/blocks/blocks/popup/index.js
@@ -62,15 +62,15 @@ registerBlockType( name, {
 			'attributes': {
 				'minWidth': 900,
 				'trigger': 'onLoad',
-				'wait': 3,
+				'wait': 1,
 				'scroll': 75,
 				'showClose': false,
 				'outsideClose': true,
 				'anchorClose': false,
 				'recurringClose': false,
-				'backgroundColor': 'var(--nv-site-bg)',
+				'backgroundColor': '#ffffff',
 				'closeColor': 'var(--nv-text-color)',
-				'overlayColor': 'var(--nv-dark-bg)',
+				'overlayColor': '#000000',
 				'overlayOpacity': 95,
 				'paddingMobile': {
 					'top': '8px',
@@ -218,7 +218,6 @@ registerBlockType( name, {
 										'tag': 'p',
 										'alignTablet': 'left',
 										'alignMobile': 'left',
-										'headingColor': 'var(--nv-primary-accent)',
 										'fontSize': '12px',
 										'fontSizeTablet': 16,
 										'fontSizeMobile': 16,
@@ -230,9 +229,7 @@ registerBlockType( name, {
 										'textShadowBlur': 5,
 										'textShadowHorizontal': 0,
 										'textShadowVertical': 0,
-										'paddingTop': 0,
-										'hasCustomCSS': false,
-										'customCSS': null
+										'paddingTop': 0
 									}
 								},
 								{
@@ -363,12 +360,12 @@ registerBlockType( name, {
 			'scope': [ 'block' ],
 			'attributes': {
 				'trigger': 'onLoad',
-				'wait': 3,
+				'wait': 1,
 				'showClose': true,
 				'outsideClose': true,
 				'anchorClose': false,
 				'recurringClose': false,
-				'backgroundColor': 'var(--nv-light-bg)',
+				'backgroundColor': '#ffffff',
 				'closeColor': 'var(--nv-text-color)',
 				'lockScrolling': false,
 				'padding': {
@@ -386,7 +383,7 @@ registerBlockType( name, {
 					'left': '5px',
 					'right': '5px'
 				},
-				'borderColor': 'var(--nv-primary-accent)',
+				'borderColor': '#ed6f57',
 				'width': '540px',
 				'closeButtonType': 'outside',
 				'boxShadow': {
@@ -439,8 +436,6 @@ registerBlockType( name, {
 						'submitLabel': 'Send me the survey',
 						'submitMessageColor': 'var(--nv-c-1)',
 						'submitMessageErrorColor': 'var(--nv-c-2)',
-						'submitBackgroundColor': 'var(--nv-primary-accent)',
-						'submitColor': 'var(--nv-text-dark-bg)',
 						'submitStyle': 'full'
 					},
 					'innerBlocks': [

--- a/src/blocks/blocks/popup/style.scss
+++ b/src/blocks/blocks/popup/style.scss
@@ -170,6 +170,10 @@ $base-index: 99999 !default;
 		}
 	}
 
+	&> .block-editor-block-variation-picker .block-editor-block-variation-picker__variations .components-button {
+		box-shadow: unset;
+		margin-bottom: 0px;
+	}
 }
 
 .o-lock-body {

--- a/src/blocks/helpers/icons.js
+++ b/src/blocks/helpers/icons.js
@@ -13,6 +13,7 @@ import {
 	Rect,
 	SVG
 } from '@wordpress/primitives';
+import { Circle } from '@wordpress/components';
 
 export const otterIcon = ({ className }) => {
 	return (
@@ -616,4 +617,41 @@ export const alignTop = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M9 20h6V9H9v11zM4 4v1.5h16V4H4z" />
 	</SVG>
+);
+
+export const popupScratch = (
+	<SVG width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#2271B1" fill="none"/>
+		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#2271B1"/>
+	</SVG>
+);
+
+export const popupWithForm = (
+	<SVG width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#2271B1" fill="none"/>
+		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#2271B1"/>
+		<Rect x="16.5" y="14.5" width="15" height="19" rx="0.5" stroke="#2271B1" fill="none"/>
+		<Rect x="18.5" y="16.5" width="11" height="3" rx="0.5" stroke="#2271B1" fill="none"/>
+		<Rect x="18.5" y="22.5" width="11" height="2" rx="0.5" stroke="#2271B1" fill="none"/>
+		<Rect x="18.5" y="26.5" width="11" height="5" rx="0.5" stroke="#2271B1" fill="none"/>
+	</SVG>
+
+);
+
+export const popupWithImageAndText = (
+	<SVG width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" fill="none">
+		<Circle cx="37.5" cy="21.5" r="2" stroke="#2271B1"/>
+		<Path d="M29 28.9V19.2261C29 19.1392 29.103 19.0937 29.1673 19.1521L34.5 24L39.8086 28.826C39.8762 28.8875 39.8327 29 39.7413 29H34.5H29.1C29.0448 29 29 28.9552 29 28.9Z" stroke="#2271B1" fill="none"/>
+		<mask id="path-3-inside-1_3034_34948" fill="white">
+			<Path d="M25 16C25 15.4477 25.4477 15 26 15H42C42.5523 15 43 15.4477 43 16V32C43 32.5523 42.5523 33 42 33H26C25.4477 33 25 32.5523 25 32V16Z"/>
+		</mask>
+		<Path d="M24 16C24 14.8954 24.8954 14 26 14H42C43.1046 14 44 14.8954 44 16H42H26H24ZM44 32C44 33.1046 43.1046 34 42 34H26C24.8954 34 24 33.1046 24 32H26H42H44ZM26 34C24.8954 34 24 33.1046 24 32V16C24 14.8954 24.8954 14 26 14V16V32V34ZM42 14C43.1046 14 44 14.8954 44 16V32C44 33.1046 43.1046 34 42 34V32V16V14Z" fill="#2271B1" mask="url(#path-3-inside-1_3034_34948)"/>
+		<Path d="M5 18H21" stroke="#2271B1" stroke-linecap="round" fill="none"/>
+		<Path d="M5 22H21" stroke="#2271B1" stroke-linecap="round" fill="none"/>
+		<Path d="M5 26H21" stroke="#2271B1" stroke-linecap="round" fill="none"/>
+		<Path d="M5 30H13.8889" stroke="#2271B1" stroke-linecap="round" fill="none"/>
+		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#2271B1" fill="none"/>
+		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#2271B1"/>
+	</SVG>
+
 );

--- a/src/blocks/helpers/icons.js
+++ b/src/blocks/helpers/icons.js
@@ -621,37 +621,37 @@ export const alignTop = (
 
 export const popupScratch = (
 	<SVG width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#2271B1" fill="none"/>
-		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#2271B1"/>
+		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#ED6F57" fill="none"/>
+		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#ED6F57"/>
 	</SVG>
 );
 
 export const popupWithForm = (
 	<SVG width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#2271B1" fill="none"/>
-		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#2271B1"/>
-		<Rect x="16.5" y="14.5" width="15" height="19" rx="0.5" stroke="#2271B1" fill="none"/>
-		<Rect x="18.5" y="16.5" width="11" height="3" rx="0.5" stroke="#2271B1" fill="none"/>
-		<Rect x="18.5" y="22.5" width="11" height="2" rx="0.5" stroke="#2271B1" fill="none"/>
-		<Rect x="18.5" y="26.5" width="11" height="5" rx="0.5" stroke="#2271B1" fill="none"/>
+		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#ED6F57" fill="none"/>
+		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#ED6F57"/>
+		<Rect x="16.5" y="14.5" width="15" height="19" rx="0.5" stroke="#ED6F57" fill="none"/>
+		<Rect x="18.5" y="16.5" width="11" height="3" rx="0.5" stroke="#ED6F57" fill="none"/>
+		<Rect x="18.5" y="22.5" width="11" height="2" rx="0.5" stroke="#ED6F57" fill="none"/>
+		<Rect x="18.5" y="26.5" width="11" height="5" rx="0.5" stroke="#ED6F57" fill="none"/>
 	</SVG>
 
 );
 
 export const popupWithImageAndText = (
 	<SVG width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" fill="none">
-		<Circle cx="37.5" cy="21.5" r="2" stroke="#2271B1"/>
-		<Path d="M29 28.9V19.2261C29 19.1392 29.103 19.0937 29.1673 19.1521L34.5 24L39.8086 28.826C39.8762 28.8875 39.8327 29 39.7413 29H34.5H29.1C29.0448 29 29 28.9552 29 28.9Z" stroke="#2271B1" fill="none"/>
+		<Circle cx="37.5" cy="21.5" r="2" stroke="#ED6F57" fill="none"/>
+		<Path d="M29 28.9V19.2261C29 19.1392 29.103 19.0937 29.1673 19.1521L34.5 24L39.8086 28.826C39.8762 28.8875 39.8327 29 39.7413 29H34.5H29.1C29.0448 29 29 28.9552 29 28.9Z" stroke="#ED6F57" fill="none"/>
 		<mask id="path-3-inside-1_3034_34948" fill="white">
 			<Path d="M25 16C25 15.4477 25.4477 15 26 15H42C42.5523 15 43 15.4477 43 16V32C43 32.5523 42.5523 33 42 33H26C25.4477 33 25 32.5523 25 32V16Z"/>
 		</mask>
-		<Path d="M24 16C24 14.8954 24.8954 14 26 14H42C43.1046 14 44 14.8954 44 16H42H26H24ZM44 32C44 33.1046 43.1046 34 42 34H26C24.8954 34 24 33.1046 24 32H26H42H44ZM26 34C24.8954 34 24 33.1046 24 32V16C24 14.8954 24.8954 14 26 14V16V32V34ZM42 14C43.1046 14 44 14.8954 44 16V32C44 33.1046 43.1046 34 42 34V32V16V14Z" fill="#2271B1" mask="url(#path-3-inside-1_3034_34948)"/>
-		<Path d="M5 18H21" stroke="#2271B1" stroke-linecap="round" fill="none"/>
-		<Path d="M5 22H21" stroke="#2271B1" stroke-linecap="round" fill="none"/>
-		<Path d="M5 26H21" stroke="#2271B1" stroke-linecap="round" fill="none"/>
-		<Path d="M5 30H13.8889" stroke="#2271B1" stroke-linecap="round" fill="none"/>
-		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#2271B1" fill="none"/>
-		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#2271B1"/>
+		<Path d="M24 16C24 14.8954 24.8954 14 26 14H42C43.1046 14 44 14.8954 44 16H42H26H24ZM44 32C44 33.1046 43.1046 34 42 34H26C24.8954 34 24 33.1046 24 32H26H42H44ZM26 34C24.8954 34 24 33.1046 24 32V16C24 14.8954 24.8954 14 26 14V16V32V34ZM42 14C43.1046 14 44 14.8954 44 16V32C44 33.1046 43.1046 34 42 34V32V16V14Z" fill="#ED6F57" mask="url(#path-3-inside-1_3034_34948)"/>
+		<Path d="M5 18H21" stroke="#ED6F57" stroke-linecap="round" fill="none"/>
+		<Path d="M5 22H21" stroke="#ED6F57" stroke-linecap="round" fill="none"/>
+		<Path d="M5 26H21" stroke="#ED6F57" stroke-linecap="round" fill="none"/>
+		<Path d="M5 30H13.8889" stroke="#ED6F57" stroke-linecap="round" fill="none"/>
+		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#ED6F57" fill="none"/>
+		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#ED6F57"/>
 	</SVG>
 
 );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1495.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add two popups variations for free users:
- Popup with Image and Text
- Popup with Form

### Screenshots <!-- if applicable -->

[Updated]
![image](https://user-images.githubusercontent.com/17597852/224997069-a0c1ff9b-a5a2-4185-a51e-eb8fa316ea37.png)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Popup.
2. Test each variation.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

