### PR TITLE
Fix Neve Custom Layout CSS

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -89,7 +89,8 @@ class Registration {
 					wp_enqueue_style( 'font-awesome-5' );
 					wp_enqueue_style( 'font-awesome-4-shims' );
 				}
-			}
+			},
+			11
 		);
 	}
 

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -329,6 +329,15 @@ class Registration {
 			}
 		}
 
+		add_filter(
+			'the_content',
+			function ( $content ) {
+				$this->enqueue_dependencies();
+
+				return $content;
+			}
+		);
+
 		add_action(
 			'wp_footer',
 			function() {

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -338,13 +338,6 @@ class Registration {
 			}
 		);
 
-		add_action(
-			'wp_footer',
-			function() {
-				$this->enqueue_dependencies();
-			}
-		);
-
 		$has_widgets = false;
 
 		foreach ( $wp_registered_sidebars as $key => $sidebar ) {

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -338,6 +338,13 @@ class Registration {
 			}
 		);
 
+		add_action(
+			'wp_footer',
+			function() {
+				$this->enqueue_dependencies();
+			}
+		);
+
 		$has_widgets = false;
 
 		foreach ( $wp_registered_sidebars as $key => $sidebar ) {

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -329,15 +329,6 @@ class Registration {
 			}
 		}
 
-		add_filter(
-			'the_content',
-			function ( $content ) {
-				$this->enqueue_dependencies();
-
-				return $content;
-			}
-		);
-
 		add_action(
 			'wp_footer',
 			function() {

--- a/inc/css/class-block-frontend.php
+++ b/inc/css/class-block-frontend.php
@@ -651,13 +651,30 @@ class Block_Frontend extends Base_CSS {
 		$posts = apply_filters( 'themeisle_gutenberg_blocks_enqueue_assets', array() );
 
 		$content_to_process = '';
+		$found_ids          = array();
 
 		add_filter(
 			'the_content',
-			function ( $content ) use ( &$content_to_process ) {
+			function ( $content ) use ( &$content_to_process, &$found_ids ) {
 				// Check if $content contains an Otter Block.
 				if ( strpos( $content, 'wp:themeisle-blocks' ) !== false ) {
-					$content_to_process .= $content;
+
+					// Extract all ids for Otter blocks.
+					preg_match_all( '/id="wp-block-themeisle-blocks-([a-z0-9-]+)"/', $content, $matches );
+
+					$add_to_content = false;
+
+					// Add to content if there is any id that has not been processed.
+					foreach ( $matches[1] as $id ) {
+						if ( ! in_array( $id, $found_ids, true ) ) {
+							$found_ids[]    = $id;
+							$add_to_content = true;
+						}
+					}
+
+					if ( $add_to_content ) {
+						$content_to_process .= $content;
+					}
 				}
 				return $content;
 			},


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1436 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Tweak the hooks that generate the dynamic CSS.

### Screenshots <!-- if applicable -->

Setup

![image](https://user-images.githubusercontent.com/17597852/227174610-f95d872d-6ec2-447d-97f7-c03fc840eb11.png)

Without fix

![image](https://user-images.githubusercontent.com/17597852/227175047-30c4e5ce-bf39-45bb-9b4f-2843c5ca37c8.png)


With fix

![image](https://user-images.githubusercontent.com/17597852/227174802-ac04f201-f5b4-4378-acfd-eb557c466098.png)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a Custom Neve Layout with Otter Blocks and add the option Global (so it can show up in any page)
2. Check the pages and see if the CSS is working.
3. Since this is a tweak in pipeline, it is recommended to check Widgets and FSE for regressions.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

