### PR TITLE
Fix WP 6.2 RC issues

### DIFF
--- a/src/blocks/blocks/flip/edit.tsx
+++ b/src/blocks/blocks/flip/edit.tsx
@@ -199,21 +199,19 @@ const Edit = ({
 					</div>
 
 					<div className="o-flip-back">
-						<div className="o-flip-content">
-							<InnerBlocks
-								renderAppender={ isSelected ? InnerBlocks.DefaultBlockAppender : undefined }
-								template={[
-									[ 'core/heading', {
-										placeholder: __( 'Back title', 'otter-blocks' ),
-										level: 3
-									}],
-									[ 'core/paragraph', { placeholder: __( 'This is is just a placeholder to help you visualise how the content is displayed in the flip box. Feel free to edit this with your actual content.', 'otter-blocks' ) }],
-									[ 'core/buttons', {
-										layout: { type: 'flex', justifyContent: 'center' }
-									}, [[ 'core/button', { className: 'is-style-fill', placeholder: __( 'Button text', 'otter-blocks' ) }]]]
-								]}
-							/>
-						</div>
+						<InnerBlocks
+							renderAppender={ isSelected ? InnerBlocks.DefaultBlockAppender : undefined }
+							template={[
+								[ 'core/heading', {
+									placeholder: __( 'Back title', 'otter-blocks' ),
+									level: 3
+								}],
+								[ 'core/paragraph', { placeholder: __( 'This is is just a placeholder to help you visualise how the content is displayed in the flip box. Feel free to edit this with your actual content.', 'otter-blocks' ) }],
+								[ 'core/buttons', {
+									layout: { type: 'flex', justifyContent: 'center' }
+								}, [[ 'core/button', { className: 'is-style-fill', placeholder: __( 'Button text', 'otter-blocks' ) }]]]
+							]}
+						/>
 					</div>
 				</div>
 

--- a/src/blocks/blocks/google-map/components/marker-editor.js
+++ b/src/blocks/blocks/google-map/components/marker-editor.js
@@ -33,7 +33,7 @@ const MarkerEditor = ({
 
 		editor.on( 'change', () => onChange( editor.getContent() ) );
 
-		return () => window.wp.oldEditor.remove( editorRef.current.id );
+		return () => editorRef?.current?.id !== undefined ? wp.oldEditor.remove( editorRef.current.id ) : undefined;
 	}, []);
 
 	const id = `inspector-textarea-control-${ instanceId }`;

--- a/src/blocks/blocks/leaflet-map/components/marker-editor.js
+++ b/src/blocks/blocks/leaflet-map/components/marker-editor.js
@@ -33,7 +33,7 @@ const MarkerEditor = ({
 
 		editor.on( 'change', () => onChange( editor.getContent() ) );
 
-		return () => wp.oldEditor.remove( editorRef.current.id );
+		return () => editorRef?.current?.id !== undefined ? wp.oldEditor.remove( editorRef.current.id ) : undefined;
 	}, []);
 
 	const id = `inspector-textarea-control-${ instanceId }`;

--- a/src/blocks/blocks/slider/edit.js
+++ b/src/blocks/blocks/slider/edit.js
@@ -203,7 +203,7 @@ const Edit = ({
 		});
 
 		if ( null !== sliderRef.current ) {
-			sliderRef.current.destroy();
+			sliderRef.current.destroy?.();
 		}
 
 		initSlider();
@@ -211,14 +211,14 @@ const Edit = ({
 
 	const changePerView = value => {
 		setAttributes({ perView: Number( value ) });
-		sliderRef.current.update({ perView: Number( value ) });
+		sliderRef?.current?.update?.({ perView: Number( value ) });
 		if ( 1 === value ) {
 			setAttributes({
 				gap: 0,
 				peek: 0
 			});
 
-			sliderRef.current.update({
+			sliderRef?.current?.update?.({
 				gap: 0,
 				peek: 0
 			});


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1496.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

This PR solves the issues pointed out here: https://github.com/Codeinwp/otter-blocks/issues/1496#issuecomment-1466310096

Most issues were related to the use of undefined variables. The new version of React introduced is less forgiving of past mistakes.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Test for:
- Slider block changing of `Slides Per Page`
- Map blocks when closing and opening Markers in Sidebar
- Flip Back content alignment.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

