### PR TITLE
Allow anchor open & close based on ID

### DIFF
--- a/src/blocks/frontend/popup/popup.ts
+++ b/src/blocks/frontend/popup/popup.ts
@@ -13,7 +13,7 @@ class PopupBlock {
 		const { dismiss, anchor } = element.dataset;
 
 		if ( this.isItemDismissed() && dismiss && ! anchor && ! Boolean( window.themeisleGutenberg?.isPreview ) ) {
-			return ;
+			return;
 		}
 
 		this.canLock = Boolean( this.element.dataset.lockScrolling );
@@ -32,11 +32,7 @@ class PopupBlock {
 	isDisabled() {
 		const { disableOn } = this.element.dataset;
 
-		if ( 'mobile' === disableOn && window.matchMedia( '(max-width: 600px)' ).matches ) {
-			return true;
-		}
-
-		return false;
+		return 'mobile' === disableOn && window.matchMedia( '(max-width: 600px)' ).matches;
 	}
 
 	openModal() {
@@ -44,7 +40,6 @@ class PopupBlock {
 		this.happened = true;
 
 		this.lockScrolling();
-
 	}
 
 	closeModal() {
@@ -136,11 +131,16 @@ class PopupBlock {
 			return false;
 		}
 
-		const buttons = document.querySelectorAll( `a[href='#${ anchor }']` );
+		const buttons = document.querySelectorAll( `a[href='#${ anchor }'], a#${ anchor }` );
 
 		buttons.forEach( ( button ) => {
 			button.addEventListener( 'click', ( e ) => {
-				e.preventDefault();
+
+				// do not prevent default if href is a URL
+				if ( ( e.target as HTMLAnchorElement )?.href === `#${ anchor }` ) {
+					e.preventDefault();
+				}
+
 				this.openModal();
 			});
 		});
@@ -208,11 +208,16 @@ class PopupBlock {
 			return false;
 		}
 
-		const buttons = document.querySelectorAll( `a[href='#${ anchorclose }']` );
+		const buttons = document.querySelectorAll( `a[href='#${ anchorclose }'], a#${ anchorclose }` );
 
 		buttons.forEach( ( button ) => {
 			button.addEventListener( 'click', ( e ) => {
-				e.preventDefault();
+
+				// do not prevent default if href is a URL
+				if ( ( e.target as HTMLAnchorElement )?.href === `#${ anchorclose }` ) {
+					e.preventDefault();
+				}
+
 				this.closeModal();
 			});
 		});

--- a/src/blocks/global.d.ts
+++ b/src/blocks/global.d.ts
@@ -41,6 +41,7 @@ declare global {
 			blocksIDs: string[]
 			isAncestorTypeAvailable: boolean
 			highlightDynamicText: boolean
+			isPreview: boolean
 		}
 		otterPro?: Readonly<{
 			isActive: boolean


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1539 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

