### PR TITLE
Add Otter Free & Pro compatibility to SDK

### DIFF
--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -47,8 +47,8 @@ class Main {
 			function ( $compatibilities ) {
 				$compatibilities['OtterBlocksPRO'] = array(
 					'basefile'  => defined( 'OTTER_PRO_BASEFILE' ) ? OTTER_PRO_BASEFILE : '',
-					'required'  => '2.2.3',
-					'tested_up' => '2.2.3',
+					'required'  => '2.2',
+					'tested_up' => '2.2',
 				);
 				return $compatibilities;
 			}

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -48,7 +48,7 @@ class Main {
 				$compatibilities['OtterBlocksPRO'] = array(
 					'basefile'  => defined( 'OTTER_PRO_BASEFILE' ) ? OTTER_PRO_BASEFILE : '',
 					'required'  => '2.0',
-					'tested_up' => '2.2',
+					'tested_up' => OTTER_PRO_VERSION,
 				);
 				return $compatibilities;
 			}

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -47,7 +47,7 @@ class Main {
 			function ( $compatibilities ) {
 				$compatibilities['OtterBlocksPRO'] = array(
 					'basefile'  => defined( 'OTTER_PRO_BASEFILE' ) ? OTTER_PRO_BASEFILE : '',
-					'required'  => '2.2',
+					'required'  => '2.0',
 					'tested_up' => '2.2',
 				);
 				return $compatibilities;

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -41,6 +41,18 @@ class Main {
 			add_filter( 'upload_mimes', array( $this, 'allow_meme_types' ) ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
 			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_json_svg' ), 75, 4 );
 		}
+
+		add_filter(
+			'themeisle_sdk_compatibilities/' . OTTER_BLOCKS_BASEFILE,
+			function ( $compatibilities ) {
+				$compatibilities['OtterBlocksPRO'] = array(
+					'basefile'  => defined( 'OTTER_PRO_BASEFILE' ) ? OTTER_PRO_BASEFILE : '',
+					'required'  => '2.2.3',
+					'tested_up' => '2.2.3',
+				);
+				return $compatibilities;
+			}
+		);
 	}
 
 	/**

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -42,17 +42,6 @@ class Main {
 			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_json_svg' ), 75, 4 );
 		}
 
-		add_filter(
-			'themeisle_sdk_compatibilities/' . OTTER_BLOCKS_BASEFILE,
-			function ( $compatibilities ) {
-				$compatibilities['OtterBlocksPRO'] = array(
-					'basefile'  => defined( 'OTTER_PRO_BASEFILE' ) ? OTTER_PRO_BASEFILE : '',
-					'required'  => '2.0',
-					'tested_up' => OTTER_PRO_VERSION,
-				);
-				return $compatibilities;
-			}
-		);
 	}
 
 	/**

--- a/otter-blocks.php
+++ b/otter-blocks.php
@@ -49,6 +49,18 @@ add_filter(
 	}
 );
 
+add_filter(
+	'themeisle_sdk_compatibilities/' . basename( OTTER_BLOCKS_PATH ),
+	function ( $compatibilities ) {
+		$compatibilities['OtterBlocksPRO'] = array(
+			'basefile'  => defined( 'OTTER_PRO_BASEFILE' ) ? OTTER_PRO_BASEFILE : '',
+			'required'  => '2.0',
+			'tested_up' => OTTER_BLOCKS_VERSION,
+		);
+		return $compatibilities;
+	}
+);
+
 add_action(
 	'plugin_action_links_' . plugin_basename( __FILE__ ),
 	function( $links ) {

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -120,7 +120,7 @@ add_filter(
 		$compatibilities['OtterBlocks'] = array(
 			'basefile'  => defined( 'OTTER_BLOCKS_BASEFILE' ) ? OTTER_BLOCKS_BASEFILE : '',
 			'required'  => '2.0',
-			'tested_up' => '2.2',
+			'tested_up' => OTTER_BLOCKS_VERSION,
 		);
 		return $compatibilities;
 	}

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -119,7 +119,7 @@ add_filter(
 	function ( $compatibilities ) {
 		$compatibilities['OtterBlocks'] = array(
 			'basefile'  => defined( 'OTTER_BLOCKS_BASEFILE' ) ? OTTER_BLOCKS_BASEFILE : '',
-			'required'  => '2.2',
+			'required'  => '2.0',
 			'tested_up' => '2.2',
 		);
 		return $compatibilities;

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -113,3 +113,15 @@ add_action(
 		}
 	}
 );
+
+add_filter(
+	'themeisle_sdk_compatibilities/' . OTTER_PRO_BASEFILE,
+	function ( $compatibilities ) {
+		$compatibilities['OtterBlocks'] = array(
+			'basefile'  => defined( 'OTTER_BLOCKS_BASEFILE' ) ? OTTER_BLOCKS_BASEFILE : '',
+			'required'  => '2.2.3',
+			'tested_up' => '2.2.3',
+		);
+		return $compatibilities;
+	}
+);

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -115,12 +115,12 @@ add_action(
 );
 
 add_filter(
-	'themeisle_sdk_compatibilities/' . OTTER_PRO_BASEFILE,
+	'themeisle_sdk_compatibilities/' . basename( OTTER_PRO_PATH ),
 	function ( $compatibilities ) {
 		$compatibilities['OtterBlocks'] = array(
 			'basefile'  => defined( 'OTTER_BLOCKS_BASEFILE' ) ? OTTER_BLOCKS_BASEFILE : '',
 			'required'  => '2.0',
-			'tested_up' => OTTER_BLOCKS_VERSION,
+			'tested_up' => OTTER_PRO_VERSION,
 		);
 		return $compatibilities;
 	}

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -119,8 +119,8 @@ add_filter(
 	function ( $compatibilities ) {
 		$compatibilities['OtterBlocks'] = array(
 			'basefile'  => defined( 'OTTER_BLOCKS_BASEFILE' ) ? OTTER_BLOCKS_BASEFILE : '',
-			'required'  => '2.2.3',
-			'tested_up' => '2.2.3',
+			'required'  => '2.2',
+			'tested_up' => '2.2',
 		);
 		return $compatibilities;
 	}


### PR DESCRIPTION
Register Otter Free & Pro to SDK for compatibility check

<!-- Issues that this pull request closes. -->
Closes #1460.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add filters for registering Otter Free & Pro to Themeisle SDK for compatibility.

### Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/17597852/228471314-2bdebb14-821e-47f6-8b03-f8ccca28140c.png)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Install an editing file plugin like [WPIDE](https://wordpress.org/plugins/wpide/) in your instance.
2. Install both Otter Free & Pro
3. Edit the version (something lower than 2.0) in `otter-blocks.php` in the Otter Blocks folder.
4. Check if you see a notice in Dashboard.
5. Redo the step 3 & 4 for Otter Pro in  `otter-pro.php`

You can also download the older Otter Free version from [here](https://wordpress.org/plugins/otter-blocks/advanced/) and check if the Otter Pro shows a notice for upgrading.

Video

https://user-images.githubusercontent.com/17597852/228480275-4460f30d-a543-4376-966c-99c094f3b719.mp4


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

