### PR TITLE
Fix: error when adding the Add to Cart block

### DIFF
--- a/src/blocks/components/select-products-control/index.js
+++ b/src/blocks/components/select-products-control/index.js
@@ -4,8 +4,6 @@
  */
 import { __ } from '@wordpress/i18n';
 
-import { isEmpty } from 'lodash';
-
 import {
 	Placeholder,
 	SelectControl,
@@ -28,12 +26,12 @@ const SelectProducts = ({
 
 		const { COLLECTIONS_STORE_KEY } = window.wc.wcBlocksData;
 
-		const error = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products', { per_page: -1 });
+		const error = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products', { per_page: 0 });
 
 		if ( error ) {
 			status = 'error';
 		} else {
-			results = 'error' === status ? [] : ( select( COLLECTIONS_STORE_KEY ).getCollection?.( '/wc/store', 'products', { per_page: -1 }) ?? [])?.map( result => ({
+			results = 'error' === status ? [] : ( select( COLLECTIONS_STORE_KEY ).getCollection?.( '/wc/store', 'products', { per_page: 0 }) ?? [])?.map( result => ({
 				value: result.id,
 				label: decodeEntities( result.name )
 			}) );
@@ -51,7 +49,7 @@ const SelectProducts = ({
 		return {
 			results,
 			status,
-			isLoading: select( COLLECTIONS_STORE_KEY ).isResolving( 'getCollection', [ '/wc/store', 'products', { per_page: -1 }])
+			isLoading: select( COLLECTIONS_STORE_KEY ).isResolving( 'getCollection', [ '/wc/store', 'products', { per_page: 0 }])
 		};
 	}, []);
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1575.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Sets the `per_page` parameter to `0` to get all the products, since `-1` is invalid.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add an `Add to card` button
- There should be no error, and the product selector should display all products.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

