### PR TITLE
Fix Stripe Checkout Button when switching accounts

### DIFF
--- a/inc/render/class-stripe-checkout-block.php
+++ b/inc/render/class-stripe-checkout-block.php
@@ -53,7 +53,7 @@ class Stripe_Checkout_Block {
 			return sprintf(
 				'<div %1$s><div class="o-stripe-checkout">%2$s</div></div>',
 				get_block_wrapper_attributes(),
-				__( 'An error occurred! Could not retrieve product information!', 'otter-blocks' )
+				__( 'An error occurred! Could not retrieve product information!', 'otter-blocks' ) . $this->format_error( $product )
 			);
 		}
 
@@ -69,7 +69,7 @@ class Stripe_Checkout_Block {
 			return sprintf(
 				'<div %1$s><div class="o-stripe-checkout">%2$s</div></div>',
 				get_block_wrapper_attributes(),
-				__( 'An error occurred! Could not retrieve the price of the product!', 'otter-blocks' )
+				__( 'An error occurred! Could not retrieve the price of the product!', 'otter-blocks' ) . $this->format_error( $price )
 			);
 		}
 
@@ -107,7 +107,7 @@ class Stripe_Checkout_Block {
 		);
 
 		if ( is_wp_error( $session ) ) {
-			$button_markup = '<a>' . __( 'The product can not be purchased anymore.', 'otter-blocks' ) . '</a>';
+			$button_markup = '<a>' . __( 'The product can not be purchased anymore.', 'otter-blocks' ) . $this->format_error( $session ) . '</a>';
 		} else {
 			$button_markup = '<a href="' . esc_url( $session->url ) . '">' . __( 'Checkout', 'otter-blocks' ) . '</a>';
 		}
@@ -118,5 +118,17 @@ class Stripe_Checkout_Block {
 			$details_markup,
 			$button_markup
 		);
+	}
+
+	/**
+	 * Format the error message.
+	 *
+	 * @param \WP_Error $error The error.
+	 * @return string
+	 */
+	private function format_error( $error ) {
+		return defined( 'WP_DEBUG' ) && WP_DEBUG ? (
+			'<span><strong>' . __( 'Error message: ', 'otter-blocks' ) . '</strong> ' . $error->get_error_message() . '</span>'
+		) : '';
 	}
 }

--- a/inc/render/class-stripe-checkout-block.php
+++ b/inc/render/class-stripe-checkout-block.php
@@ -106,7 +106,11 @@ class Stripe_Checkout_Block {
 			)
 		);
 
-		$button_markup = '<a href="' . esc_url( $session->url ) . '">' . __( 'Checkout', 'otter-blocks' ) . '</a>';
+		if ( is_wp_error( $session ) ) {
+			$button_markup = '<a>' . __( 'The product can not be purchased anymore.', 'otter-blocks' ) . '</a>';
+		} else {
+			$button_markup = '<a href="' . esc_url( $session->url ) . '">' . __( 'Checkout', 'otter-blocks' ) . '</a>';
+		}
 
 		return sprintf(
 			'<div %1$s><div class="o-stripe-checkout">%2$s</div>%3$s</div>',

--- a/inc/render/class-stripe-checkout-block.php
+++ b/inc/render/class-stripe-checkout-block.php
@@ -49,6 +49,14 @@ class Stripe_Checkout_Block {
 
 		$product = $stripe->create_request( 'product', $attributes['product'] );
 
+		if ( is_wp_error( $product ) ) {
+			return sprintf(
+				'<div %1$s><div class="o-stripe-checkout">%2$s</div></div>',
+				get_block_wrapper_attributes(),
+				__( 'An error occurred! Could not retrieve product information!', 'otter-blocks' )
+			);
+		}
+
 		$details_markup = '';
 
 		if ( 0 < count( $product['images'] ) ) {
@@ -56,6 +64,14 @@ class Stripe_Checkout_Block {
 		}
 
 		$price = $stripe->create_request( 'price', $attributes['price'] );
+
+		if ( is_wp_error( $price ) ) {
+			return sprintf(
+				'<div %1$s><div class="o-stripe-checkout">%2$s</div></div>',
+				get_block_wrapper_attributes(),
+				__( 'An error occurred! Could not retrieve the price of the product!', 'otter-blocks' )
+			);
+		}
 
 		$currency = Review_Block::get_currency( $price['currency'] );
 		$amount   = number_format( $price['unit_amount'] / 100, 2, '.', ' ' );
@@ -72,7 +88,7 @@ class Stripe_Checkout_Block {
 				'stripe_session_id' => '{CHECKOUT_SESSION_ID}',
 				'product_id'        => $attributes['product'],
 			),
-			get_permalink() 
+			get_permalink()
 		);
 
 		$session = $stripe->create_request(


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1564 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

It seems that error handling was missing from Stripe Checkout Render when requesting product info and price.

Added a simple error handling that displays a message on the page.

### Screenshots <!-- if applicable -->

When something wrong happens, this message will appear.
 
![image](https://user-images.githubusercontent.com/17597852/228856218-2d6c9660-8e62-481b-afe9-dff25d70bbe8.png)

If the product is no longer valid to purchase: archived or deleted. 

![image](https://user-images.githubusercontent.com/17597852/229094877-d7e5d21a-86e6-422e-beda-65649e2402fb.png)
--- 

### Docs

The following explanation should be added in docs regarding the errors:

For errors `'An error occurred! Could not retrieve product information!'` and `'An error occurred! Could not retrieve product information!'`, you have the following causes:
- The Stripe API Key is no longer valid.
- Stripe Servies are no longer working. [Link](https://status.stripe.com) for users to check.
- The Stripe API is from a different account. Every product has its own id based on account. You can not use someone else account and expect to display his products/prices.
- The product/price no longer exists.

For error `'The product can not be purchased anymore.'`, you have:
- The product can no longer be purchased. The product was either deleted or archived.

In both cases, you should make the user review the block in Editor.
----

### Test instructions
<!-- Describe how this pull request can be tested. -->

ℹ️ You will need to have a Stripe account

1. Add a Stripe Checkout Button.
2. Select a product.
3. Publish the page and keep a tab open with it.
4. Switch the API Key to another account OR malformed the data from the block OR archive the product. 
5. A message like a Screenshot should be seen if an error occurs.

Video


https://user-images.githubusercontent.com/17597852/229098349-a0ff19ee-0fac-46af-9a91-834496fab04c.mp4



<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

