### PR TITLE
Fix SVG crop in Neve

### DIFF
--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -38,7 +38,7 @@ class Main {
 		add_action( 'init', array( $this, 'after_update_migration' ) );
 
 		if ( ! function_exists( 'is_wpcom_vip' ) ) {
-			add_filter( 'upload_mimes', array( $this, 'allow_meme_types' ) ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
+			add_filter( 'upload_mimes', array( $this, 'allow_meme_types' ), PHP_INT_MAX ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
 			add_filter( 'wp_check_filetype_and_ext', array( $this, 'fix_mime_type_json_svg' ), 75, 4 );
 		}
 	}
@@ -368,9 +368,22 @@ class Main {
 	 * @access public
 	 */
 	public function allow_meme_types( $mimes ) {
-		$mimes['json']   = 'application/json';
-		$mimes['lottie'] = 'application/zip';
-		$mimes['svg']    = 'image/svg+xml';
+		if ( ! isset( $mimes['json'] ) ) {
+			$mimes['json'] = 'application/json';
+		}
+
+		if ( ! isset( $mimes['lottie'] ) ) {
+			$mimes['lottie'] = 'application/zip';
+		}
+
+		if ( ! isset( $mimes['svg'] ) ) {
+			$mimes['svg'] = 'image/svg+xml';
+		}
+
+		if ( ! isset( $mimes['svgz'] ) ) {
+			$mimes['svgz'] = 'image/svg+xml';
+		}
+
 		return $mimes;
 	}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1594 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Our filter will load the mime types & metadata only if no other filter adds them.

ℹ️ Tested with SVG Support, and we do not accidentally override the data generated 👍 

### Screenshots <!-- if applicable -->

Before: Load SVG has no details about the size. When trying to edit, the window shows empty. When using in Customizer for Website Logo, the Skip crop button does not exist, and Select & Crop does not give any feedback.

https://user-images.githubusercontent.com/17597852/230579406-3eb65a07-e036-4a1b-81d0-baf3cc20d599.mp4

After: SVG has details about the size, the edit window is no longer empty, and you can see the dimensions in the right corner. On Customizer, all buttons are working. 

https://user-images.githubusercontent.com/17597852/230579658-4adfd890-d56a-4a07-b857-851113e5f7e9.mp4

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Load an SVG. You can get plenty from [here ](https://themeisle.com/illustrations/).
2. Check if it has details about the size when you select it in Media Libary (can be seen in the video)
3. When you use it in Customizer for Logo & Site Identity, the buttons are functional when you press them.

ℹ️ You can NOT crop SVG, so when you press the Select & Crop, it should give you an error (seen in the second video). 

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

