### PR TITLE
Make Form field more fluid

### DIFF
--- a/src/blocks/blocks/form/common.tsx
+++ b/src/blocks/blocks/form/common.tsx
@@ -1,0 +1,54 @@
+// @ts-nocheck
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption
+} from '@wordpress/components';
+import { changeActiveStyle, getActiveStyle } from '../../helpers/helper-functions';
+
+export const FieldInputWidth = ( props ) => {
+
+	const options = props?.options ?? [
+		{ value: 'full', label: __( '100%', 'otter-blocks' ), isDefault: true },
+		{ value: 'o-c-three-quarters', label: __( '75%', 'otter-blocks' ) },
+		{ value: 'o-c-two-thirds', label: __( '66%', 'otter-blocks' ) },
+		{ value: 'o-c-half', label: __( '50%', 'otter-blocks' ) },
+		{ value: 'o-c-one-third', label: __( '33%', 'otter-blocks' ) },
+		{ value: 'o-c-one-quarter', label: __( '25%', 'otter-blocks' ) }
+	];
+
+	const value = props?.value ?? getActiveStyle( options, props?.attributes?.className );
+
+	const onChange = props?.onChange ?? ( ( value: string ) => {
+		let newStyle = value;
+		if ( 'full' === value ) {
+			newStyle = undefined;
+		}
+
+		const classes = changeActiveStyle( props?.attributes?.className, options, newStyle );
+		props?.setAttributes({ className: classes });
+	});
+
+	return (
+		<ToggleGroupControl
+			label={ props.label ?? __( 'Width', 'otter-blocks' ) }
+			value={ value  }
+			onChange={ onChange }
+			isBlock
+		>
+			{
+				options.map( ( option ) => {
+					return (
+						<ToggleGroupControlOption
+							key={ option.value }
+							value={ option.value }
+							label={ option.label }
+						/>
+					);
+				})
+			}
+		</ToggleGroupControl>
+	);
+};
+
+export default { FieldInputWidth };

--- a/src/blocks/blocks/form/editor.scss
+++ b/src/blocks/blocks/form/editor.scss
@@ -18,11 +18,10 @@
 
 	.otter-form__container > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
-		flex-direction: column;
-		gap: var(--inputs-gap);
+		flex-wrap: wrap;
 
-		&> div {
-			width: 100%;
+		&> * {
+			padding-left: var(--inputs-gap);
 		}
 	}
 }

--- a/src/blocks/blocks/form/editor.scss
+++ b/src/blocks/blocks/form/editor.scss
@@ -20,6 +20,11 @@
 		display: flex;
 		flex-wrap: wrap;
 		gap: var(--inputs-gap);
+
+		&> div {
+			width: 100%;
+			margin: 0px;
+		}
 	}
 }
 

--- a/src/blocks/blocks/form/editor.scss
+++ b/src/blocks/blocks/form/editor.scss
@@ -19,10 +19,7 @@
 	.otter-form__container > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
 		flex-wrap: wrap;
-
-		&> * {
-			padding-left: var(--inputs-gap);
-		}
+		column-gap: var(--inputs-gap);
 	}
 }
 

--- a/src/blocks/blocks/form/editor.scss
+++ b/src/blocks/blocks/form/editor.scss
@@ -19,7 +19,7 @@
 	.otter-form__container > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
 		flex-wrap: wrap;
-		column-gap: var(--inputs-gap);
+		gap: var(--inputs-gap);
 	}
 }
 

--- a/src/blocks/blocks/form/input/inspector.js
+++ b/src/blocks/blocks/form/input/inspector.js
@@ -15,6 +15,7 @@ import {
 	TextControl,
 	ToggleControl
 } from '@wordpress/components';
+import { FieldInputWidth } from '../common';
 
 /**
  *
@@ -79,6 +80,8 @@ const Inspector = ({
 					value={ attributes.label }
 					onChange={ label => setAttributes({ label }) }
 				/>
+
+				<FieldInputWidth attributes={ attributes } setAttributes={ setAttributes } />
 
 				<TextControl
 					label={ __( 'Placeholder', 'otter-blocks' ) }

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -43,6 +43,10 @@
 			margin-bottom: 10px;
 		}
 
+		&> div {
+			width: 100%;
+		}
+
 		.wp-block-button {
 			display: flex;
 			align-items: baseline;

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -279,6 +279,7 @@
 			border-style: solid;
 			font-size: var(--input-font-size);
 			background: var(--input-bg-color);
+			box-sizing: border-box;
 		}
 
 		.o-form-help {

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -37,13 +37,7 @@
 	.otter-form__container {
 		display: flex;
 		flex-wrap: wrap;
-		
-		margin-left: calc(var(--inputs-gap) * -1);
-		width: calc(100% + var(--inputs-gap));
-
-		&> *:not(.block-editor-inner-blocks) {
-			padding-left: var(--inputs-gap);
-		}
+		column-gap: var(--inputs-gap);
 
 		p {
 			margin-bottom: 10px;
@@ -292,6 +286,8 @@
 		}
 
 		@media (min-width: 640px) {
+			flex-grow: 1;
+
 			&:is(.is-style-o-c-three-quarters, .is-style-o-c-two-thirds, .is-style-o-c-half, .is-style-o-c-one-third, .is-style-o-c-one-quarter) {
 				box-sizing: border-box;
 				margin-left: 0px;
@@ -299,23 +295,28 @@
 			}
 	
 			&.is-style-o-c-three-quarters {
-				flex-basis: 75%;
+				flex-basis: calc( 75% - var( --inputs-gap ) );
+				max-width: 75%;
 			}
 	
 			&.is-style-o-c-two-thirds {
-				flex-basis: 66.66666666666666%;
+				flex-basis: calc( 66.66666666666666% - var( --inputs-gap ) );
+				max-width: 66.66666666666666%;
 			}
 	
 			&.is-style-o-c-half {
-				flex-basis: 50%;
+				flex-basis: calc( 50% - var( --inputs-gap ) );
+				max-width: 50%;
 			}
 		
 			&.is-style-o-c-one-third {
-				flex-basis: 33.33333333333333%;
+				flex-basis: calc( 33.33333333333333% - var( --inputs-gap ) );
+				max-width: 33.33333333333333%;
 			}
 		
 			&.is-style-o-c-one-quarter {
-				flex-basis: 25%;
+				flex-basis: calc( 25% - var( --inputs-gap ) );
+				max-width: 25%;
 			}
 		}
 	}

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -37,7 +37,7 @@
 	.otter-form__container {
 		display: flex;
 		flex-wrap: wrap;
-		column-gap: var(--inputs-gap);
+		gap: var(--inputs-gap);
 
 		p {
 			margin-bottom: 10px;
@@ -254,7 +254,6 @@
 		width: 100%;
 		gap: var(--input-gap);
 		margin: 0px;
-		margin-bottom: var(--inputs-gap);
 
 		.otter-form-input-label, .otter-form-textarea-label {
 			width: 100%;

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -36,8 +36,14 @@
 
 	.otter-form__container {
 		display: flex;
-		flex-direction: column;
-		gap: var(--inputs-gap);
+		flex-wrap: wrap;
+		
+		margin-left: calc(var(--inputs-gap) * -1);
+		width: calc(100% + var(--inputs-gap));
+
+		&> *:not(.block-editor-inner-blocks) {
+			padding-left: var(--inputs-gap);
+		}
 
 		p {
 			margin-bottom: 10px;
@@ -254,6 +260,7 @@
 		width: 100%;
 		gap: var(--input-gap);
 		margin: 0px;
+		margin-bottom: var(--inputs-gap);
 
 		.otter-form-input-label, .otter-form-textarea-label {
 			width: 100%;
@@ -265,7 +272,7 @@
 			}
 		}
 
-		.otter-form-input,.otter-form-textarea-input {
+		.otter-form-input, .otter-form-textarea-input {
 			color: var(--input-color);
 			width: var(--input-width);
 			padding: var(--padding);
@@ -282,6 +289,32 @@
 			color: var(--help-label-color);
 			margin-bottom: 0px;
 			font-size: var(--help-font-size);
+		}
+
+		&:is(.is-style-o-c-three-quarters, .is-style-o-c-two-thirds, .is-style-o-c-half, .is-style-o-c-one-third, .is-style-o-c-one-quarter) {
+			box-sizing: border-box;
+			margin-left: 0px;
+			margin-right: 0px;
+		}
+
+		&.is-style-o-c-three-quarters {
+			flex-basis: 75%;
+		}
+
+		&.is-style-o-c-two-thirds {
+			flex-basis: 66.66666666666666%;
+		}
+
+		&.is-style-o-c-half {
+			flex-basis: 50%;
+		}
+	
+		&.is-style-o-c-one-third {
+			flex-basis: 33.33333333333333%;
+		}
+	
+		&.is-style-o-c-one-quarter {
+			flex-basis: 25%;
 		}
 	}
 

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -45,6 +45,7 @@
 
 		&> div {
 			width: 100%;
+			margin: 0px;
 		}
 
 		.wp-block-button {

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -291,30 +291,32 @@
 			font-size: var(--help-font-size);
 		}
 
-		&:is(.is-style-o-c-three-quarters, .is-style-o-c-two-thirds, .is-style-o-c-half, .is-style-o-c-one-third, .is-style-o-c-one-quarter) {
-			box-sizing: border-box;
-			margin-left: 0px;
-			margin-right: 0px;
-		}
-
-		&.is-style-o-c-three-quarters {
-			flex-basis: 75%;
-		}
-
-		&.is-style-o-c-two-thirds {
-			flex-basis: 66.66666666666666%;
-		}
-
-		&.is-style-o-c-half {
-			flex-basis: 50%;
-		}
+		@media (min-width: 640px) {
+			&:is(.is-style-o-c-three-quarters, .is-style-o-c-two-thirds, .is-style-o-c-half, .is-style-o-c-one-third, .is-style-o-c-one-quarter) {
+				box-sizing: border-box;
+				margin-left: 0px;
+				margin-right: 0px;
+			}
 	
-		&.is-style-o-c-one-third {
-			flex-basis: 33.33333333333333%;
-		}
+			&.is-style-o-c-three-quarters {
+				flex-basis: 75%;
+			}
 	
-		&.is-style-o-c-one-quarter {
-			flex-basis: 25%;
+			&.is-style-o-c-two-thirds {
+				flex-basis: 66.66666666666666%;
+			}
+	
+			&.is-style-o-c-half {
+				flex-basis: 50%;
+			}
+		
+			&.is-style-o-c-one-third {
+				flex-basis: 33.33333333333333%;
+			}
+		
+			&.is-style-o-c-one-quarter {
+				flex-basis: 25%;
+			}
 		}
 	}
 

--- a/src/blocks/blocks/form/textarea/inspector.js
+++ b/src/blocks/blocks/form/textarea/inspector.js
@@ -12,6 +12,7 @@ import {
 	TextControl,
 	ToggleControl
 } from '@wordpress/components';
+import { FieldInputWidth } from '../common';
 
 const Inspector = ({
 	attributes,
@@ -70,6 +71,8 @@ const Inspector = ({
 					value={ attributes.label }
 					onChange={ label => setAttributes({ label }) }
 				/>
+
+				<FieldInputWidth attributes={ attributes } setAttributes={ setAttributes } />
 
 				<TextControl
 					label={ __( 'Placeholder', 'otter-blocks' ) }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1513.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The form fields are not more fluid with the new Width setting. Some real CSS magic was used to achieve this.

### Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/17597852/230620136-383133a8-c9a7-4e1d-97fd-fc1b62afa9aa.mp4

#### Mobile
![image](https://user-images.githubusercontent.com/17597852/233396543-05992e59-7cd9-4a12-83bf-8b4d5648a4a9.png)
----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Play with the Width options of the Form fields like in the video above.

ℹ️ This is for Desktop and Tablets. On Mobile should look linear like the SS from above.

Things to look out for:
- Ensure the current Forms dimensions from the page stay consistent with the new update.
- No styling options from Form break.

### ⚠️ Mentions  

By default, every block with Form as the direct parent will have `width: 100%` and `margin: 0px`. Some Blocks can change those options ( like Image ). They can act like a column block and integrate into the flow by changing the options. 

ℹ️ Is the user's job to make sure that external blocks fit. Our settings are not strictly enforced.

Example with Image Block on `width` with `25%`

![image](https://user-images.githubusercontent.com/17597852/234251585-d27864d4-4be7-472c-91ee-4f922a6d87ff.png)


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

