### PR TITLE
Make Z index consistent for Section Dividers

### DIFF
--- a/src/blocks/blocks/section/components/separators/editor.scss
+++ b/src/blocks/blocks/section/components/separators/editor.scss
@@ -3,6 +3,7 @@
 	left: 0;
 	width: 100%;
 	overflow-x: clip;
+	z-index: 2;
 
 	&.top {
 		top: 0;

--- a/src/blocks/blocks/section/components/separators/style.scss
+++ b/src/blocks/blocks/section/components/separators/style.scss
@@ -3,6 +3,7 @@
 	left: 0;
 	width: 100%;
 	overflow-x: clip;
+	z-index: 2;
 
 	&.top {
 		top: 0;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1597.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Make the top and bottom dividers on top of common things more consistent with Z positioning.

### Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/17597852/231155043-79462a8e-0fb8-4259-b117-8b239f4510b6.png)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add a Section block.
2. Add some content and dividers (you can find them in the Style tab).
3. The dividers must be on the top of the content, with exceptions*

⚠️ *Some blocks are built to be on top of others, like Maps (image below) or Sticky blocks. Dividers act like decorators and not blockers. For those kinds of Blocks, there will be no issue if they are blocked or not. It is up to he user to use them correctly. 

![image](https://user-images.githubusercontent.com/17597852/231153944-1fb27347-c84f-4b2c-b649-08baf4935f06.png)


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

