### PR TITLE
Fix: automatic detection of background darkness

### DIFF
--- a/inc/css/blocks/class-shared-css.php
+++ b/inc/css/blocks/class-shared-css.php
@@ -20,7 +20,7 @@ class Shared_CSS {
 	public static function section_shared() {
 		$css = array(
 			array(
-				'property' => '--content-color',
+				'property' => '--text-color',
 				'value'    => 'color',
 			),
 			array(
@@ -154,7 +154,7 @@ class Shared_CSS {
 			),
 			array(
 				'property'  => 'color',
-				'default'   => 'var( --content-color )',
+				'default'   => 'var( --text-color )',
 				'condition' => function( $attrs ) {
 					return isset( $attrs['color'] );
 				},

--- a/src/blocks/blocks/accordion/editor.scss
+++ b/src/blocks/blocks/accordion/editor.scss
@@ -4,6 +4,24 @@
 	$block: &;
 	border: none;
 
+	&.has-dark-active-title-bg &-item.is-open &-item__title {
+		--title-color: #FFF;
+	}
+
+	&.has-light-active-title-bg &-item.is-open &-item__title {
+		--title-color: #000;
+	}
+
+	/* wrote this for specificity because neve
+	overwrote the paragraph color */
+	&.has-dark-content-bg &-item__content p {
+		color: #FFF;
+	}
+
+	&.has-light-content-bg &-item__content p {
+		color: #000;
+	}
+
 	&-item {
 		border: none;
 		margin: var(--gap) 0;

--- a/src/blocks/blocks/accordion/editor.scss
+++ b/src/blocks/blocks/accordion/editor.scss
@@ -6,22 +6,20 @@
 
 	&.has-dark-title-bg > * > * > &-item > &-item__title,
 	&.has-dark-active-title-bg > * > * > &-item.is-open > &-item__title {
-		--title-color: #FFF;
+		color: var( --title-color, #FFF );
 	}
 
 	&.has-light-title-bg > * > * > &-item > &-item__title,
 	&.has-light-active-title-bg > * > * > &-item.is-open > &-item__title {
-		--title-color: #000;
+		color: var( --title-color, #000 );
 	}
 
-	/* wrote this for specificity because neve
-	overwrote the paragraph color */
-	&.has-dark-content-bg &-item__content p {
-		color: #FFF;
+	&.has-dark-content-bg &-item__content, &.has-dark-content-bg &-item__content p {
+		color: var( --text-color, #FFF );
 	}
 
-	&.has-light-content-bg &-item__content p {
-		color: #000;
+	&.has-light-content-bg &-item__content, &.has-dark-content-bg &-item__content p {
+		color: var( --text-color, #000 );
 	}
 
 	&-item {

--- a/src/blocks/blocks/accordion/editor.scss
+++ b/src/blocks/blocks/accordion/editor.scss
@@ -4,11 +4,13 @@
 	$block: &;
 	border: none;
 
-	&.has-dark-active-title-bg &-item.is-open &-item__title {
+	&.has-dark-title-bg > * > * > &-item > &-item__title,
+	&.has-dark-active-title-bg > * > * > &-item.is-open > &-item__title {
 		--title-color: #FFF;
 	}
 
-	&.has-light-active-title-bg &-item.is-open &-item__title {
+	&.has-light-title-bg > * > * > &-item > &-item__title,
+	&.has-light-active-title-bg > * > * > &-item.is-open > &-item__title {
 		--title-color: #000;
 	}
 

--- a/src/blocks/blocks/accordion/editor.scss
+++ b/src/blocks/blocks/accordion/editor.scss
@@ -4,22 +4,27 @@
 	$block: &;
 	border: none;
 
+	/* Add this to override Neve styles */
+	&[class*="has-dark-"] p, &[class*="has-light-"] p {
+		color: unset;
+	}
+
 	&.has-dark-title-bg > * > * > &-item > &-item__title,
 	&.has-dark-active-title-bg > * > * > &-item.is-open > &-item__title {
-		color: var( --title-color, #FFF );
+		color: var( --title-color, var( --nv-text-dark-bg , #fff ) );
 	}
 
 	&.has-light-title-bg > * > * > &-item > &-item__title,
 	&.has-light-active-title-bg > * > * > &-item.is-open > &-item__title {
-		color: var( --title-color, #000 );
+		color: var( --title-color, var( --nv-text-color , #000 ) );
 	}
 
-	&.has-dark-content-bg &-item__content, &.has-dark-content-bg &-item__content p {
-		color: var( --text-color, #FFF );
+	&.has-dark-content-bg &-item__content {
+		color: var( --text-color, var( --nv-text-dark-bg , #fff ) );
 	}
 
-	&.has-light-content-bg &-item__content, &.has-dark-content-bg &-item__content p {
-		color: var( --text-color, #000 );
+	&.has-light-content-bg &-item__content {
+		color: var( --text-color, var( --nv-text-color , #000 ) );
 	}
 
 	&-item {

--- a/src/blocks/blocks/accordion/group/edit.js
+++ b/src/blocks/blocks/accordion/group/edit.js
@@ -140,9 +140,9 @@ const Edit = ({
 		}
 	}, [ attributes.fontFamily ]);
 
-	useDarkBackground( getValue( 'titleBackground' ), attributes, setAttributes, 'has-dark-title-bg' );
-	useDarkBackground( getValue( 'activeTitleBackground' ), attributes, setAttributes, 'has-dark-active-title-bg' );
-	useDarkBackground( getValue( 'contentBackground' ), attributes, setAttributes, 'has-dark-content-bg' );
+	useDarkBackground( getValue( 'titleBackground' ), attributes, setAttributes, 'has-dark-title-bg', 'has-light-title-bg' );
+	useDarkBackground( getValue( 'activeTitleBackground' ), attributes, setAttributes, 'has-dark-active-title-bg', 'has-light-active-title-bg' );
+	useDarkBackground( getValue( 'contentBackground' ), attributes, setAttributes, 'has-dark-content-bg', 'has-light-content-bg' );
 
 	const blockProps = useBlockProps({
 		id: attributes.id,

--- a/src/blocks/blocks/accordion/style.scss
+++ b/src/blocks/blocks/accordion/style.scss
@@ -15,28 +15,22 @@
 	--padding-tablet: var( --padding );
 	--padding-mobile: var( --padding-tablet );
 
-	&.has-dark-title-bg > &-item > &-item__title {
-		--title-color: #FFF;
-	}
-
-	&.has-light-title-bg > &-item > &-item__title {
-		--title-color: #000;
-	}
-
+	&.has-dark-title-bg > &-item > &-item__title,
 	&.has-dark-active-title-bg > &-item[open] > &-item__title {
-		--title-color: #FFF;
+		color: var( --title-color, #FFF );
 	}
 
+	&.has-light-title-bg > &-item > &-item__title,
 	&.has-light-active-title-bg > &-item[open] > &-item__title {
-		--title-color: #000;
+		color: var( --title-color, #000 );
 	}
 
 	&.has-dark-content-bg &-item__content {
-		color: #FFF;
+		color: var( --text-color, #FFF );
 	}
 
 	&.has-light-content-bg &-item__content {
-		color: #000;
+		color: var( --text-color, #000 );
 	}
 
 	&-item {

--- a/src/blocks/blocks/accordion/style.scss
+++ b/src/blocks/blocks/accordion/style.scss
@@ -17,20 +17,20 @@
 
 	&.has-dark-title-bg > &-item > &-item__title,
 	&.has-dark-active-title-bg > &-item[open] > &-item__title {
-		color: var( --title-color, #FFF );
+		color: var( --title-color, var( --nv-text-dark-bg , #fff ) );
 	}
 
 	&.has-light-title-bg > &-item > &-item__title,
 	&.has-light-active-title-bg > &-item[open] > &-item__title {
-		color: var( --title-color, #000 );
+		color: var( --title-color, var( --nv-text-color , #000 ) );
 	}
 
 	&.has-dark-content-bg &-item__content {
-		color: var( --text-color, #FFF );
+		color: var( --text-color, var( --nv-text-dark-bg , #fff ) );
 	}
 
 	&.has-light-content-bg &-item__content {
-		color: var( --text-color, #000 );
+		color: var( --text-color, var( --nv-text-color , #000 ) );
 	}
 
 	&-item {

--- a/src/blocks/blocks/accordion/style.scss
+++ b/src/blocks/blocks/accordion/style.scss
@@ -19,12 +19,24 @@
 		--title-color: #FFF;
 	}
 
-	&.has-dark-active-title-bg {
+	&.has-light-title-bg {
+		--title-color: #000;
+	}
+
+	&.has-dark-active-title-bg &-item[open] {
 		--title-color: #FFF;
+	}
+
+	&.has-light-active-title-bg &-item[open] {
+		--title-color: #000;
 	}
 
 	&.has-dark-content-bg {
 		color: #FFF;
+	}
+
+	&.has-light-content-bg {
+		color: #000;
 	}
 
 	&-item {

--- a/src/blocks/blocks/accordion/style.scss
+++ b/src/blocks/blocks/accordion/style.scss
@@ -15,27 +15,27 @@
 	--padding-tablet: var( --padding );
 	--padding-mobile: var( --padding-tablet );
 
-	&.has-dark-title-bg {
+	&.has-dark-title-bg > &-item > &-item__title {
 		--title-color: #FFF;
 	}
 
-	&.has-light-title-bg {
+	&.has-light-title-bg > &-item > &-item__title {
 		--title-color: #000;
 	}
 
-	&.has-dark-active-title-bg &-item[open] {
+	&.has-dark-active-title-bg > &-item[open] > &-item__title {
 		--title-color: #FFF;
 	}
 
-	&.has-light-active-title-bg &-item[open] {
+	&.has-light-active-title-bg > &-item[open] > &-item__title {
 		--title-color: #000;
 	}
 
-	&.has-dark-content-bg {
+	&.has-dark-content-bg &-item__content {
 		color: #FFF;
 	}
 
-	&.has-light-content-bg {
+	&.has-light-content-bg &-item__content {
 		color: #000;
 	}
 

--- a/src/blocks/blocks/flip/edit.tsx
+++ b/src/blocks/blocks/flip/edit.tsx
@@ -122,11 +122,11 @@ const Edit = ({
 				transform: ${ 'back' === currentSide ? 'var( --flip-anim )' : 'unset' };
 			}`,
 			`.o-flip-front .o-flip-content h3 {
-				color: ${ attributes.titleColor };
+				${ attributes.titleColor && `color: ${ attributes.titleColor }` };
 				${ attributes.titleFontSize && `font-size: ${ _px( attributes.titleFontSize ) }` }
 			}`,
 			`.o-flip-front .o-flip-content p {
-				color: ${ attributes.descriptionColor };
+				${ attributes.descriptionColor && `color: ${ attributes.descriptionColor }` };
 				${ attributes.descriptionFontSize && `font-size: ${ _px( attributes.descriptionFontSize ) }` }
 			}`
 		]);

--- a/src/blocks/blocks/flip/edit.tsx
+++ b/src/blocks/blocks/flip/edit.tsx
@@ -60,8 +60,8 @@ const Edit = ({
 		return () => unsubscribe( attributes.id );
 	}, [ attributes.id ]);
 
-	useDarkBackground( 'color' === attributes.frontBackgroundType && attributes.frontBackgroundColor, attributes, setAttributes, 'has-dark-front-bg' );
-	useDarkBackground( 'color' === attributes.backBackgroundType && attributes.backBackgroundColor, attributes, setAttributes, 'has-dark-back-bg' );
+	useDarkBackground( 'color' === attributes.frontBackgroundType && attributes.frontBackgroundColor, attributes, setAttributes, 'has-dark-front-bg', 'has-light-front-bg' );
+	useDarkBackground( 'color' === attributes.backBackgroundType && attributes.backBackgroundColor, attributes, setAttributes, 'has-dark-back-bg', 'has-light-back-bg' );
 
 	const [ currentSide, setSide ] = useState( 'front' );
 

--- a/src/blocks/blocks/flip/editor.scss
+++ b/src/blocks/blocks/flip/editor.scss
@@ -1,7 +1,6 @@
 @import 'style';
 
 .wp-block-themeisle-blocks-flip {
-
 	--height-tablet: var(--height);
 	--height-mobile: var(--height-tablet);
 
@@ -13,22 +12,9 @@
 
 	border: none;
 
-	/* wrote this for specificity because neve
-	overwrote the paragraph color */
-	&.has-dark-front-bg .o-flip-front p {
-		color: #fff;
-	}
-
-	&.has-light-front-bg .o-flip-front p {
-		color: #000;
-	}
-
-	&.has-dark-back-bg .o-flip-back p {
-		color: #fff;
-	}
-
-	&.has-light-back-bg .o-flip-back p {
-		color: #000;
+	/* Add this to override Neve styles */
+	&[class*="has-dark-"] p, &[class*="has-light-"] p {
+		color: unset;
 	}
 
 	.o-switcher {

--- a/src/blocks/blocks/flip/editor.scss
+++ b/src/blocks/blocks/flip/editor.scss
@@ -13,6 +13,24 @@
 
 	border: none;
 
+	/* wrote this for specificity because neve
+	overwrote the paragraph color */
+	&.has-dark-front-bg .o-flip-front p {
+		color: #fff;
+	}
+
+	&.has-light-front-bg .o-flip-front p {
+		color: #000;
+	}
+
+	&.has-dark-back-bg .o-flip-back p {
+		color: #fff;
+	}
+
+	&.has-light-back-bg .o-flip-back p {
+		color: #000;
+	}
+
 	.o-switcher {
 		margin-top: 30px;
 		width: 100%;
@@ -26,7 +44,7 @@
 	}
 
 	@media ( max-width: 960px ) {
-		
+
 		height: var( --height-tablet );
 
 		&.is-selected {
@@ -41,9 +59,9 @@
 			padding: var(--padding-tablet);
 		}
 	}
-	
+
 	@media ( max-width: 600px ) {
-		
+
 		height: var( --height-mobile );
 
 		&.is-selected {

--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -25,12 +25,20 @@
 	height: var( --height );
 	perspective: 1000px; /* Remove this if you don't want the 3D effect */
 
-	&.has-dark-front-bg {
+	&.has-dark-front-bg .o-flip-front {
 		color: #fff;
 	}
 
-	&.has-dark-back-bg {
+	&.has-light-front-bg .o-flip-front {
+		color: #000;
+	}
+
+	&.has-dark-back-bg .o-flip-back {
 		color: #fff;
+	}
+
+	&.has-light-back-bg .o-flip-back {
+		color: #000;
 	}
 
 	// &[class^="block-editor"] {

--- a/src/blocks/blocks/flip/style.scss
+++ b/src/blocks/blocks/flip/style.scss
@@ -26,19 +26,19 @@
 	perspective: 1000px; /* Remove this if you don't want the 3D effect */
 
 	&.has-dark-front-bg .o-flip-front {
-		color: #fff;
+		color: var( --nv-text-dark-bg , #fff );
 	}
 
 	&.has-light-front-bg .o-flip-front {
-		color: #000;
+		color: var( --nv-text-color , #000 );
 	}
 
 	&.has-dark-back-bg .o-flip-back {
-		color: #fff;
+		color: var( --nv-text-dark-bg , #fff );
 	}
 
 	&.has-light-back-bg .o-flip-back {
-		color: #000;
+		color: var( --nv-text-color , #000 );
 	}
 
 	// &[class^="block-editor"] {

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -322,13 +322,13 @@ const Edit = ({
 		<Fragment>
 			<style>
 				{
-					`#block-${ clientId } > *, #block-${ clientId } p ` + _cssBlock([
-						[ 'color', attributes.color ]
+					`#block-${ clientId } > * ` + _cssBlock([
+						[ '--text-color', attributes.color ]
 					])
 				}
 				{
-					`#block-${ clientId }:hover > *, #block-${ clientId }:hover p ` + _cssBlock([
-						[ 'color', attributes.colorHover ]
+					`#block-${ clientId }:hover > * ` + _cssBlock([
+						[ '--text-color', attributes.colorHover ]
 					])
 				}
 			</style>

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -322,12 +322,12 @@ const Edit = ({
 		<Fragment>
 			<style>
 				{
-					`#block-${ clientId } > * ` + _cssBlock([
+					`#block-${ clientId }` + _cssBlock([
 						[ '--text-color', attributes.color ]
 					])
 				}
 				{
-					`#block-${ clientId }:hover > * ` + _cssBlock([
+					`#block-${ clientId }:hover` + _cssBlock([
 						[ '--text-color', attributes.colorHover ]
 					])
 				}

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -322,12 +322,12 @@ const Edit = ({
 		<Fragment>
 			<style>
 				{
-					`#block-${ clientId } ` + _cssBlock([
+					`#block-${ clientId } > *, #block-${ clientId } p ` + _cssBlock([
 						[ 'color', attributes.color ]
 					])
 				}
 				{
-					`#block-${ clientId }:hover ` + _cssBlock([
+					`#block-${ clientId }:hover > *, #block-${ clientId }:hover p ` + _cssBlock([
 						[ 'color', attributes.colorHover ]
 					])
 				}

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -425,12 +425,12 @@ const Edit = ({
 			<style>
 				{
 					`#block-${ clientId } ` + _cssBlock([
-						[ 'color', attributes.color ]
+						[ '--text-color', attributes.color ]
 					])
 				}
 				{
 					`#block-${ clientId }:hover ` + _cssBlock([
-						[ 'color', attributes.colorHover ]
+						[ '--text-color', attributes.colorHover ]
 					])
 				}
 			</style>

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -13,12 +13,17 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	display: flex;
 	transition: 0.3s;
 
-	&.has-dark-bg, &.has-dark-bg p {
-		color: var( --text-color, #fff );
+	/* Add this to override Neve styles */
+	&[class*="has-dark-"] p, &[class*="has-light-"] p {
+		color: unset;
 	}
 
-	&.has-light-bg, &.has-light-bg p {
-		color: var( --text-color, #000 );
+	&.has-dark-bg {
+		color: var( --text-color, var( --nv-text-dark-bg , #fff ) );
+	}
+
+	&.has-light-bg {
+		color: var( --text-color, var( --nv-text-color , #000 ) );
 	}
 
 	> .innerblocks-wrap {
@@ -45,12 +50,12 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 					max-width: unset;
 				}
 
-				&.has-dark-bg, &.has-dark-bg p {
-					color: var( --text-color, #fff );
+				&.has-dark-bg {
+					color: var( --text-color, var( --nv-text-dark-bg , #fff ) );
 				}
 
-				&.has-light-bg, &.has-light-bg p {
-					color: var( --text-color, #000 );
+				&.has-light-bg {
+					color: var( --text-color, var( --nv-text-color , #000 ) );
 				}
 			}
 		}

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -14,11 +14,11 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	transition: 0.3s;
 
 	&.has-dark-bg, &.has-dark-bg p {
-		color: #fff;
+		color: var( --text-color, #fff );
 	}
 
 	&.has-light-bg, &.has-light-bg p {
-		color: #000;
+		color: var( --text-color, #000 );
 	}
 
 	> .innerblocks-wrap {
@@ -46,11 +46,11 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 				}
 
 				&.has-dark-bg, &.has-dark-bg p {
-					color: #fff;
+					color: var( --text-color, #fff );
 				}
 
 				&.has-light-bg, &.has-light-bg p {
-					color: #000;
+					color: var( --text-color, #000 );
 				}
 			}
 		}

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -13,8 +13,12 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	display: flex;
 	transition: 0.3s;
 
-	&.has-dark-bg {
+	&.has-dark-bg, &.has-dark-bg p {
 		color: #fff;
+	}
+
+	&.has-light-bg, &.has-light-bg p {
+		color: #000;
 	}
 
 	> .innerblocks-wrap {
@@ -41,8 +45,12 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 					max-width: unset;
 				}
 
-				&.has-dark-bg {
+				&.has-dark-bg, &.has-dark-bg p {
 					color: #fff;
+				}
+
+				&.has-light-bg, &.has-light-bg p {
+					color: #000;
 				}
 			}
 		}
@@ -71,7 +79,7 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 		> * {
 			position: relative;
 		}
-	
+
 		a:not( .wp-block-button__link ):not( .social-icon ) {
 			color: var( --link-color );
 		}

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -42,6 +42,11 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 				margin: inherit;
 				flex: 1;
 
+				/* Add this to override Neve styles */
+				&[class*="has-dark-"] p, &[class*="has-light-"] p {
+					color: unset;
+				}
+
 				> .block-editor-inner-blocks {
 					flex: 1;
 				}

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -86,6 +86,10 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 		&.has-dark-bg {
 			color: #fff;
 		}
+
+		&.has-light-bg {
+			color: #000;
+		}
 	}
 
 	&.has-default-gap {
@@ -132,6 +136,10 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 
 	&.has-dark-bg {
 		color: #fff;
+	}
+
+	&.has-light-bg {
+		color: #000;
 	}
 }
 

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -84,11 +84,11 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 		}
 
 		&.has-dark-bg {
-			color: #fff;
+			color: var( --text-color, #fff );
 		}
 
 		&.has-light-bg {
-			color: #000;
+			color: var( --text-color, #000 );
 		}
 	}
 
@@ -135,11 +135,11 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	}
 
 	&.has-dark-bg {
-		color: #fff;
+		color: var( --text-color, #fff );
 	}
 
 	&.has-light-bg {
-		color: #000;
+		color: var( --text-color, #000 );
 	}
 }
 

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -84,11 +84,11 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 		}
 
 		&.has-dark-bg {
-			color: var( --text-color, #fff );
+			color: var( --text-color, var( --nv-text-dark-bg , #fff ) );
 		}
 
 		&.has-light-bg {
-			color: var( --text-color, #000 );
+			color: var( --text-color, var( --nv-text-color , #000 ) );
 		}
 	}
 
@@ -135,11 +135,11 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	}
 
 	&.has-dark-bg {
-		color: var( --text-color, #fff );
+		color: var( --text-color, var( --nv-text-dark-bg , #fff ) );
 	}
 
 	&.has-light-bg {
-		color: var( --text-color, #000 );
+		color: var( --text-color, var( --nv-text-color , #000 ) );
 	}
 }
 

--- a/src/blocks/helpers/blocks.d.ts
+++ b/src/blocks/helpers/blocks.d.ts
@@ -51,7 +51,7 @@ export type OtterNodeCSSOptions = {
 	selector: string
 }
 
-export type OtterSetNodeCSS = ( css: string[], media: string[]) => void;
+export type OtterSetNodeCSS = ( css: string[], media?: string[]) => void;
 
 export type OtterNodeCSSReturn = [
 	string,

--- a/src/blocks/helpers/helper-functions.js
+++ b/src/blocks/helpers/helper-functions.js
@@ -329,9 +329,9 @@ export const hex2rgba = ( color, alpha = 100 ) => {
  * Check if color is a dark.
  *
  * @param color
- * @returns {boolean}
+ * @returns {string|boolean}
  */
-export const isColorDark = color => {
+export const lightnessFromColor = color => {
 	if ( ! color ) {
 		return false;
 	}
@@ -358,7 +358,7 @@ export const isColorDark = color => {
 	const brightness = ( 0.299 * r ) + ( 0.587 * g ) + ( 0.114 * b );
 
 	// Compare the brightness to a threshold
-	return 128 > brightness;
+	return 128 > brightness ? 'dark' : 'light';
 };
 
 /**

--- a/src/blocks/helpers/utility-hooks.js
+++ b/src/blocks/helpers/utility-hooks.js
@@ -8,7 +8,7 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { buildResponsiveGetAttributes, buildResponsiveSetAttributes, isColorDark } from './helper-functions.js';
+import { buildResponsiveGetAttributes, buildResponsiveSetAttributes, lightnessFromColor } from './helper-functions.js';
 
 /**
  * Utiliy hook to get/set responsive attributes.
@@ -29,25 +29,41 @@ export const useResponsiveAttributes = ( setAttributes = () => {}) => useSelect(
 /**
  * Utility hook to get/set dark background class.
  *
- * @param {string} backgroundColor - The background color.
+ * @param {string|false|undefined} backgroundColor - The background color.
  * @param {Object} attributes - The block attributes.
  * @param {Function} setAttributes - The setAttributes function from the block.
- * @param {string} className - The class name to add/remove.
+ * @param {string} darkClassName - The dark-bg class name to add/remove.
+ * @param {string} lightClassName - The light-bg class name to add/remove.
  */
-export const useDarkBackground = ( backgroundColor, attributes, setAttributes, className = 'has-dark-bg' ) => {
+export const useDarkBackground = ( backgroundColor, attributes, setAttributes, darkClassName = 'has-dark-bg', lightClassName = 'has-light-bg' ) => {
 	useEffect( () => {
-		const isDark = isColorDark( backgroundColor );
+		const isDark = 'dark' === lightnessFromColor( backgroundColor );
+		const isLight = 'light' === lightnessFromColor( backgroundColor );
 
-		if ( isDark && ! attributes?.className?.includes( className ) ) {
-			let classes = attributes.className || '';
+		let classes = attributes.className || '';
+
+		const addClass = ( className ) => {
 			classes = classes.split( ' ' );
 			classes.push( className );
 			classes = classes.join( ' ' ).trim();
-			setAttributes({ className: classes });
+		};
+
+		const removeClass = ( className ) => {
+			classes = classes.replace( className, '' ).trim();
+		};
+
+		if ( isDark && ! attributes?.className?.includes( darkClassName ) ) {
+			addClass( darkClassName );
+		} else if ( ! isDark && attributes?.className?.includes( darkClassName ) ) {
+			removeClass( darkClassName );
 		}
 
-		if ( ! isDark && attributes?.className?.includes( className ) ) {
-			setAttributes({ className: attributes.className.replace( className, '' ).trim() });
+		if ( isLight && ! attributes?.className?.includes( lightClassName ) ) {
+			addClass( lightClassName );
+		} else if ( ! isLight && attributes?.className?.includes( lightClassName ) ) {
+			removeClass( lightClassName );
 		}
+
+		setAttributes({ className: classes });
 	}, [ backgroundColor ]);
 };


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1595.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- Besides the `has-dark-bg`, this PR adds also `has-light-bg` to make it work in nested blocks (i.e. accordion inside a column). This shoud fix the bug described in the issue.

Other fixes:

- The automatic text color didn't work properly for the Flip Card because the CSS from the `has-dark-front-bg` and `has-dark-back-bg` was applied to the whole flip block, not the specific parts (front/back).

- For the Accordion Block, as in Flip Card, the `has-dark-active-title-bg` was applied to all titles, not just active ones.

- When using Neve, the `has-dark-bg` had no effect on paragraphs in the editor because Neve's selector was more specific, so this PR adds a more specific selector to avoid this.

The affected blocks are Flip Card, Section Block, Column Block, and Accordion.

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add one of the mentioned blocks
- Switch between dark and light background colors
- Make sure to test with nested blocks like sections inside sections, accordion/flip card inside sections, etc.
- Make sure that setting a specific color for an element (for example a paragraph) inside the blocks specified above still works

For example, in the screenshot below, only background colors are set, and the text colors are automatically set such as they are in contrast:

<p align="center">
<img width="450" alt="Screenshot 2023-04-11 at 15 46 38" src="https://user-images.githubusercontent.com/39873395/231166602-c60aa167-f77d-4541-94fe-24444b8d3e1b.png">
</p>

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

