### PR TITLE
Fix infinite loop in Dynamic Content for Neve Custom Layout

### DIFF
--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -687,6 +687,8 @@ class Dynamic_Content {
 			}
 
 			if ( 'postContent' === $data['type'] ) {
+
+				// To do not trigger postContent action if the given content contains the postContent dynamic tag, because it will cause an infinite loop.
 				$content = get_the_content( $data['context'] );
 				if ( strpos( $content, 'data-type="postContent"' ) ) {
 					$key = $this->get_exception_key( $data, $post->ID );

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -685,6 +685,16 @@ class Dynamic_Content {
 					}
 				}
 			}
+
+			if ( 'postContent' === $data['type'] ) {
+				$content = get_the_content( $data['context'] );
+				if ( strpos( $content, 'data-type="postContent"' ) ) {
+					$key = $this->get_exception_key( $data, $post->ID );
+					if ( $key ) {
+						$data[ $key ] = true;
+					}
+				}
+			}
 		}
 
 		if ( has_filter( 'otter_blocks_dynamic_content_exception' ) ) {

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -371,7 +371,14 @@ class Dynamic_Content {
 	 * @return string
 	 */
 	public function get_content( $data ) {
-		$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( $data['context'] ) ) );
+		$content = get_the_content( $data['context'] );
+
+		// Remove internal calling of dynamic content to prevent creating an infinite loop (also known as 'Inception bug').
+		if ( strpos( $content, 'data-type="postContent"' ) ) {
+			$content = preg_replace( '/<o-dynamic.*?data-type="postContent".*?>.*?<\/o-dynamic>/', '', $content );
+		}
+
+		$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
 		return wp_kses_post( $content );
 	}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1600.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Sanitize the page's content when using Dynamic Content by removing references to dynamic content tags.

### Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/17597852/231764637-c975ebbb-ba15-4f3a-b23a-df3b094d065c.mp4

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a custom layout like it is mentioned in the issue.
2. When adding Dynamic Content, no error should appear in Editor.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

