### PR TITLE
Fix: accordion schema

### DIFF
--- a/src/blocks/frontend/accordion/index.js
+++ b/src/blocks/frontend/accordion/index.js
@@ -30,7 +30,7 @@ domReady( () => {
 	};
 
 	const addFAQSchema = accordion => {
-		if ( ! accordion.dataset.hasSchema ) {
+		if ( ! accordion.dataset.hasSchema || 'false' === accordion.dataset.hasSchema ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1617 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
The `hasSchema` data attribute is `false` when the FAQ Schema is disabled, but the check only checked if it existed. So, it was added anyway.

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add an Accordion block
- Set the FAQ Schema to true and the schema should be added in the frontend
- Set the FAQ Schema to false and the schema should be removed.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

