### PR TITLE
Dynamic Content Fallback sanitization.

### DIFF
--- a/inc/server/class-dynamic-content-server.php
+++ b/inc/server/class-dynamic-content-server.php
@@ -163,8 +163,14 @@ class Dynamic_Content_Server {
 		$fallback = $request->get_param( 'fallback' );
 		$path     = OTTER_BLOCKS_PATH . '/assets/images/placeholder.jpg';
 
-		if ( ! empty( $fallback ) && @getimagesize( $fallback ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-			$path = $fallback;
+		if ( ! empty( $fallback ) ) {
+
+			$fallback           = sanitize_text_field( $fallback );
+			$feedback_full_path = realpath( $fallback );
+
+			if ( false !== $feedback_full_path && @getimagesize( $fallback ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				$path = $feedback_full_path;
+			}
 		}
 
 		$default = $path;
@@ -191,7 +197,7 @@ class Dynamic_Content_Server {
 
 		if ( 'logo' === $type ) {
 			$custom_logo_id = get_theme_mod( 'custom_logo' );
- 
+
 			if ( $custom_logo_id ) {
 				$path = wp_get_original_image_path( $custom_logo_id );
 			}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The fallback path is now sanitized and checked for validity in Dynamic Content API Endpoint.


### Screenshots <!-- if applicable -->

Example of usage

https://user-images.githubusercontent.com/17597852/234552081-39d82a3e-fe82-416f-9b06-015e8216d787.mp4




----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

