### PR TITLE
Add Rich Text Editor for Stripe Checkout block

### DIFF
--- a/inc/render/class-stripe-checkout-block.php
+++ b/inc/render/class-stripe-checkout-block.php
@@ -38,9 +38,9 @@ class Stripe_Checkout_Block {
 
 			if ( false !== $status ) {
 				if ( 'success' === $status ) {
-					$message = isset( $attributes['successMessage'] ) ? $attributes['successMessage'] : __( 'Your payment was successful. If you have any questions, please email orders@example.com.', 'otter-blocks' );
+					$message = isset( $attributes['successMessage'] ) ? wp_kses_post( $attributes['successMessage'] ) : __( 'Your payment was successful. If you have any questions, please email orders@example.com.', 'otter-blocks' );
 				} else {
-					$message = isset( $attributes['cancelMessage'] ) ? $attributes['cancelMessage'] : __( 'Your payment was unsuccessful. If you have any questions, please email orders@example.com.', 'otter-blocks' );
+					$message = isset( $attributes['cancelMessage'] ) ? wp_kses_post( $attributes['cancelMessage'] ) : __( 'Your payment was unsuccessful. If you have any questions, please email orders@example.com.', 'otter-blocks' );
 				}
 
 				return sprintf( '<p class="o-stripe-message-%2$s">%1$s</p>', $message, $status );

--- a/src/blocks/blocks/stripe-checkout/inspector.js
+++ b/src/blocks/blocks/stripe-checkout/inspector.js
@@ -6,6 +6,8 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 
 import {
+	Button,
+	Modal,
 	PanelBody,
 	Placeholder,
 	SelectControl,
@@ -16,7 +18,8 @@ import {
 /**
  * Internal dependencies
  */
-import { ButtonToggleControl } from '../../components/index.js';
+import { ButtonToggleControl, RichTextEditor } from '../../components/index.js';
+import { useState } from '@wordpress/element';
 
 const Inspector = ({
 	attributes,
@@ -28,6 +31,9 @@ const Inspector = ({
 	isLoadingPrices,
 	pricesList
 }) => {
+
+	const [ isOpen, setOpen ] = useState( false );
+
 	return (
 		<InspectorControls>
 			<PanelBody
@@ -95,19 +101,34 @@ const Inspector = ({
 					onChange={ setView }
 				/>
 
-				<TextareaControl
-					label={ __( 'Success Message', 'otter-blocks' ) }
-					value={ attributes.successMessage }
-					placeholder={ __( 'Your payment was successful. If you have any questions, please email orders@example.com.', 'otter-blocks' ) }
-					onChange={ successMessage => setAttributes({ successMessage }) }
-				/>
+				{ isOpen && (
+					<Modal
+						title={ __( 'Stripe Messages' ) }
+						onRequestClose={() => setOpen( false )}
+						shouldCloseOnClickOutside={ false }
+					>
+						<RichTextEditor
+							label={ __( 'Success Message', 'otter-blocks' ) }
+							value={ attributes.successMessage ?? __( 'Your payment was successful. If you have any questions, please email orders@example.com.', 'otter-blocks' ) }
+							onChange={ successMessage => setAttributes({ successMessage }) }
+							allowRawHTML
+						/>
 
-				<TextareaControl
-					label={ __( 'Cancel Message', 'otter-blocks' ) }
-					value={ attributes.cancelMessage }
-					placeholder={ __( 'Your payment was unsuccessful. If you have any questions, please email orders@example.com.', 'otter-blocks' ) }
-					onChange={ cancelMessage => setAttributes({ cancelMessage }) }
-				/>
+						<RichTextEditor
+							label={ __( 'Cancel Message', 'otter-blocks' ) }
+							value={ attributes.cancelMessage ?? __( 'Your payment was unsuccessful. If you have any questions, please email orders@example.com.', 'otter-blocks' ) }
+							onChange={ cancelMessage => setAttributes({ cancelMessage }) }
+							allowRawHTML
+						/>
+					</Modal>
+				) }
+
+				<Button
+					variant="secondary"
+					onClick={() => setOpen( true )}
+				>
+					{ __( 'Open Editor', 'otter-blocks' ) }
+				</Button>
 			</PanelBody>
 		</InspectorControls>
 	);


### PR DESCRIPTION

<!-- Issues that this pull request closes. -->
Closes #1563.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add rich text editor for Stripe Checkout messages. This will alow the usage of images and links.

ℹ️ A Modal was used (same as Autoresponder) since it offers more space which prevents some weird glitches (mostly related to Add Link pop-up)


### Screenshots <!-- if applicable -->

<img width="256" src="https://user-images.githubusercontent.com/17597852/234595698-a3603897-4538-49bd-9c3e-eb92979254b4.png">

<img width="512" src="https://user-images.githubusercontent.com/17597852/234595779-98b5a3b2-50fa-48d4-9105-5d187da08779.png">


https://user-images.githubusercontent.com/17597852/234594934-c9e908d0-7a3f-4803-a425-a564feddde67.mp4


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

⚠️ Make sure to have a Stripe account (Testing Mode) and some products.

1. Insert a Stripe Checkout
2. Edit the messages like in the video
3. Make sure that they are displayed.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

