### PR TITLE
Make Reusable Review Block visible to Review Comparison Block

### DIFF
--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -16,6 +16,10 @@ import {
 	select
 } from '@wordpress/data';
 
+import {
+	parse
+} from '@wordpress/blocks';
+
 /**
  * Internal dependencies.
  */
@@ -443,3 +447,25 @@ export const buildGetSyncValue = ( name, attributes, defaultAttributes ) => {
 		return attributes?.[field];
 	};
 };
+
+/**
+ * Get the reusable block content by id.
+ *
+ * @param {string} id The id of the reusable block.
+ * @returns {BlockInstance[]|*[]} The reusable block content.
+ */
+export function pullReusableBlockContentById( id ) {
+	const reusableBlocks = select( 'core' ).getEntityRecords( 'postType', 'wp_block' );
+
+	if ( ! reusableBlocks ) {
+		return [];
+	}
+
+	const reusableBlock = reusableBlocks.find( block => block.id === id );
+
+	if ( ! reusableBlock || undefined === reusableBlock.content ) {
+		return [];
+	}
+
+	return parse( reusableBlock.content.raw ?? reusableBlock.content );
+}

--- a/src/blocks/plugins/css-handler/index.js
+++ b/src/blocks/plugins/css-handler/index.js
@@ -12,6 +12,7 @@ import {
 	select,
 	subscribe
 } from '@wordpress/data';
+import { pullReusableBlockContentById } from '../../helpers/block-utility';
 
 let isSavingCSS = false;
 
@@ -80,7 +81,10 @@ const checkReviewBlock = blocks => {
 			return true;
 		}
 
-		if ( 0 < block?.innerBlocks?.length ) {
+		if ( block.attributes?.ref && 'core/block' === block?.name ) {
+			const blocks = pullReusableBlockContentById( block.attributes.ref );
+			return checkReviewBlock( blocks );
+		} else if ( 0 < block?.innerBlocks?.length ) {
 			return checkReviewBlock( block.innerBlocks );
 		}
 	});


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1622 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.

