### PR TITLE
Fix: dynamic value preview breaking the block

### DIFF
--- a/src/blocks/plugins/dynamic-content/value/fields.js
+++ b/src/blocks/plugins/dynamic-content/value/fields.js
@@ -70,10 +70,10 @@ const Fields = ({
 	const [ isLoading, setLoading ] = useState( false );
 
 	useEffect( () => {
-		const context = select( 'core/editor' ).getCurrentPostId();
+		const context = select( 'core/editor' )?.getCurrentPostId();
 		const { type } = attributes;
 
-		if ( !! attributes.type && 'none' !== attributes.type ) {
+		if ( !! attributes.type && 'none' !== attributes.type && !! context ) {
 			setLoading( true );
 			apiFetch({ path: 'otter/v1/dynamic/preview/?' + getQueryStringFromObject({ context, type }) })
 				.then( data => {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1652.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
As described in the issue, the dynamic value preview doesn't work in widgets, such as sidebar. 
This PR makes the preview appear only in the editor, since it doesn't make much sense in the widgets (for example 'Post Title' cannot be previewed because the post that will contain that widget is unknown in that moment)

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Go to Appearance -> Widgets
- Add a dynamic value
- It should not throw any error in the console and the preview will not appear.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

