### PR TITLE
Do not enqueue dependancy for inactive widgets

### DIFF
--- a/inc/class-base-css.php
+++ b/inc/class-base-css.php
@@ -230,19 +230,12 @@ class Base_CSS {
 	 */
 	public function get_widgets_css() {
 		if ( function_exists( 'has_blocks' ) ) {
-			$content = '';
-			$widgets = get_option( 'widget_block', array() );
-
-			foreach ( $widgets as $widget ) {
-				if ( is_array( $widget ) && isset( $widget['content'] ) ) {
-					$content .= $widget['content'];
-				}
-			}
+			$content = Registration::get_active_widgets_content();
 
 			$blocks = parse_blocks( $content );
 
 			if ( ! is_array( $blocks ) || empty( $blocks ) ) {
-				return;
+				return '';
 			}
 
 			$animations = boolval( preg_match( '/\banimated\b/', $content ) );

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -368,28 +368,7 @@ class Registration {
 		$content = '';
 
 		if ( 'widgets' === $post ) {
-			global $wp_registered_widgets;
-			$valid_widgets = array();
-			$widget_data   = get_option( 'widget_block' );
-
-			// Loop through all widgets, and add any that are active.
-			foreach ( $wp_registered_widgets as $widget_name => $widget ) {
-				// Get the active sidebar the widget is located in.
-				$sidebar = is_active_widget( $widget['callback'], $widget['id'], false, false );
-				
-				if ( $sidebar && 'wp_inactive_widgets' !== $sidebar ) {
-					$key             = $widget['params'][0]['number'];
-					$valid_widgets[] = (object) $widget_data[ $key ];
-				}
-			}
-		
-			foreach ( $valid_widgets as $widget ) {
-				if ( isset( $widget->content ) ) {
-					$content .= $widget->content;
-				}
-			}
-
-			$post = $content;
+			$post = self::get_active_widgets_content();
 		} elseif ( 'block-templates' === $post ) {
 			global $_wp_current_template_content;
 
@@ -976,6 +955,37 @@ class Registration {
 	 */
 	public static function sticky_style() {
 		echo '<style id="o-sticky-inline-css">.o-sticky.o-sticky-float { height: 0px; } </style>';
+	}
+
+	/**
+	 * Get the content of all active widgets.
+	 *
+	 * @return string
+	 */
+	public static function get_active_widgets_content() {
+		global $wp_registered_widgets;
+		$content       = '';
+		$valid_widgets = array();
+		$widget_data   = get_option( 'widget_block', array() );
+
+		// Loop through all widgets, and add any that are active.
+		foreach ( $wp_registered_widgets as $widget_name => $widget ) {
+			// Get the active sidebar the widget is located in.
+			$sidebar = is_active_widget( $widget['callback'], $widget['id'] );
+
+			if ( $sidebar && 'wp_inactive_widgets' !== $sidebar ) {
+				$key             = $widget['params'][0]['number'];
+				$valid_widgets[] = (object) $widget_data[ $key ];
+			}
+		}
+
+		foreach ( $valid_widgets as $widget ) {
+			if ( isset( $widget->content ) ) {
+				$content .= $widget->content;
+			}
+		}
+
+		return $content;
 	}
 
 	/**

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -368,9 +368,22 @@ class Registration {
 		$content = '';
 
 		if ( 'widgets' === $post ) {
-			$widgets = get_option( 'widget_block', array() );
+			global $wp_registered_widgets;
+			$valid_widgets = array();
+			$widget_data   = get_option( 'widget_block' );
 
-			foreach ( $widgets as $widget ) {
+			// Loop through all widgets, and add any that are active.
+			foreach ( $wp_registered_widgets as $widget_name => $widget ) {
+				// Get the active sidebar the widget is located in.
+				$sidebar = is_active_widget( $widget['callback'], $widget['id'], false, false );
+				
+				if ( $sidebar && 'wp_inactive_widgets' !== $sidebar ) {
+					$key             = $widget['params'][0]['number'];
+					$valid_widgets[] = (object) $widget_data[ $key ];
+				}
+			}
+		
+			foreach ( $valid_widgets as $widget ) {
 				if ( is_array( $widget ) && isset( $widget['content'] ) ) {
 					$content .= $widget['content'];
 				}

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -384,8 +384,8 @@ class Registration {
 			}
 		
 			foreach ( $valid_widgets as $widget ) {
-				if ( is_array( $widget ) && isset( $widget['content'] ) ) {
-					$content .= $widget['content'];
+				if ( isset( $widget->content ) ) {
+					$content .= $widget->content;
 				}
 			}
 


### PR DESCRIPTION

<!-- Issues that this pull request closes. -->
Closes #1656 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Since we were getting the content from all the widgets, some inactive widgets were activating our deps without being on the page.

When you delete a block from a widget, the widget goes to Inactive widgets and they are not displayed on the page. Our dependency verification did not count for this case and thus the problem. 

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/b4b9c509-3603-492e-9865-5b740cdfd642)

Many thanks to @preda-bogdan for helping out.

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/otter-blocks/assets/17597852/07e2ce7e-bbd1-4d1d-8e09-505c7a6a855f

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the instruction from the issue to reproduce the error. After applying the fix, there should be no extra dependencies loaded on the page, like in the video above.

Note from Hardeep: It will be interesting to test it with various widgets and see to confirm it works properly all the time.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

