### PR TITLE
Add PR checklist workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ new QueryQA().select('blocks').run()
 
 ### Checklist before the final review
 
+- [ ] Included E2E or unit tests for the changes in this PR.
 - [ ] Visual elements are not affected by independent changes.
 - [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
 - [ ] It loads additional script in frontend only if it is required.

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,26 @@
+name: Add labels to pull request based on checklist
+
+on:
+  pull_request:
+    types: [ opened, edited, synchronize, labeled, unlabeled ]
+    branches-ignore:
+      - 'master'
+      - 'update_dependencies'
+
+permissions: write-all
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    name: Label PR based on checklist
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    steps:
+      - name: Check if checklist items are completed
+        uses: Codeinwp/gha-pr-check-helper@master
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          requireChecklist: true
+          onlyCheckBody: true
+          completedLabel: "pr-checklist-complete"
+          incompleteLabel: "pr-checklist-incomplete"
+          skipLabel: "pr-checklist-skip"


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1666.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- Adds the PR checklist workflow from Neve.
- All checks from the PR description body should be checked for the workflow to show as passed.
- It can be skipped  with the `pr-checklist-skip`.

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

