### PR TITLE
Add support for more ACF fields in Dynamic Content

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-dynamic-content.php
+++ b/plugins/otter-pro/inc/plugins/class-dynamic-content.php
@@ -239,6 +239,10 @@ class Dynamic_Content {
 
 				$meta = implode( ', ', $display );
 			}
+
+			if ( isset( $meta['label'] ) ) {
+				$meta = $meta['label'];
+			}
 		}
 
 		if ( false === $meta || true === $meta ) {

--- a/plugins/otter-pro/inc/plugins/class-dynamic-content.php
+++ b/plugins/otter-pro/inc/plugins/class-dynamic-content.php
@@ -223,6 +223,28 @@ class Dynamic_Content {
 			$meta = get_field( esc_html( $data['metaKey'] ), $data['context'], true );
 		}
 
+		if ( is_array( $meta ) ) {
+			if ( isset( $meta[0] ) ) {
+				$display = array();
+
+				if ( is_string( $meta[0] ) ) {
+					$display = $meta;
+				} elseif ( isset( $meta[0]['label'] ) ) {
+					foreach ( $meta as $item ) {
+						if ( isset( $item['label'] ) ) {
+							$display[] = $item['label'];
+						}
+					}
+				}
+
+				$meta = implode( ', ', $display );
+			}
+		}
+
+		if ( false === $meta || true === $meta ) {
+			$meta = $meta ? __( 'True', 'otter-blocks' ) : __( 'False', 'otter-blocks' );
+		}
+
 		if ( empty( $meta ) || ! is_string( $meta ) ) {
 			$meta = $default;
 		}
@@ -437,7 +459,7 @@ class Dynamic_Content {
 		if ( 'product' === $type && class_exists( 'WooCommerce' ) && ! empty( $id ) ) {
 			$product = wc_get_product( $id );
 			$image   = $product->get_image_id();
-			
+
 			if ( $image ) {
 				$path = wp_get_original_image_path( $image );
 			} else {
@@ -497,7 +519,7 @@ class Dynamic_Content {
 		if ( 'product' === $data['type'] && class_exists( 'WooCommerce' ) && isset( $data['id'] ) && ! empty( $data['id'] ) ) {
 			$product = wc_get_product( $data['id'] );
 			$image   = $product->get_image_id();
-			
+
 			if ( $image ) {
 				$value = wp_get_attachment_image_url( $image, 'full' );
 			} else {

--- a/plugins/otter-pro/inc/plugins/class-dynamic-content.php
+++ b/plugins/otter-pro/inc/plugins/class-dynamic-content.php
@@ -246,7 +246,7 @@ class Dynamic_Content {
 		}
 
 		if ( false === $meta || true === $meta ) {
-			$meta = $meta ? __( 'True', 'otter-blocks' ) : __( 'False', 'otter-blocks' );
+			$meta = $meta ? __( 'Yes', 'otter-blocks' ) : __( 'No', 'otter-blocks' );
 		}
 
 		if ( empty( $meta ) || ! is_string( $meta ) ) {

--- a/src/pro/plugins/dynamic-content/value-edit.js
+++ b/src/pro/plugins/dynamic-content/value-edit.js
@@ -21,7 +21,7 @@ const ALLOWED_ACF_TYPES = [
 	'button_group',
 	'checkbox',
 	'color_picker',
-	'data_time_picker',
+	'date_time_picker',
 	'date_picker',
 	'email',
 	'number',

--- a/src/pro/plugins/dynamic-content/value-edit.js
+++ b/src/pro/plugins/dynamic-content/value-edit.js
@@ -18,13 +18,22 @@ import { useSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 
 const ALLOWED_ACF_TYPES = [
+	'button_group',
+	'checkbox',
+	'color_picker',
+	'data_time_picker',
+	'date_picker',
+	'email',
+	'number',
+	'password',
+	'radio',
+	'range',
+	'select',
 	'text',
 	'textarea',
-	'range',
-	'number',
-	'url',
-	'email',
-	'password'
+	'time_picker',
+	'true_false',
+	'url'
 ];
 
 const Edit = ({


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/83
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added support for the following types:

	'button_group',
	'checkbox',
	'color_picker',
	'data_time_picker',
	'date_picker',
	'radio',
	'range',
	'select',
	'time_picker',
	'true_false',


### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/ce0504cb-3169-4aa4-9df4-2368b8c96cac)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

🧪 Here are some ACF fields example. You can import them by going to the Tools tab in ACF menu.
[acf-export-2023-05-25.json.zip](https://github.com/Codeinwp/otter-blocks/files/11566554/acf-export-2023-05-25.json.zip)

Things to test:
- Dynamic to do break. We do not want any side effects.
- New ACF options do not break the page.

ℹ️ For most fields, we display the value ACF gives: email, URL, time, etc. But some areas are of type array like the Choice section, and they have the same option to display: value, label, or both. In the case of `both` options, we will use only the Label. That means `label` and `both` will have the same output.

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/7edfc314-1523-43e2-940e-4a698a117b9d)

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/4023edb7-d8b2-4597-94c7-68c3f9d3ada1)

ℹ️ In case of values that are type array, each value will be displayed separated by a comma `,`

⚠️ If you do not have a value for the ACF field, the Dynamic Content `default` value will be used which is the text `Advanced Custom Fields`.

⚠️ If you have a field that it is inconsistent with `label` and `value`. Example: 

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/4595f1c8-3ad8-4696-a56c-5e3b33b926b0)

▶️  ACF will give us the following.

```php
Array
(
    [0] => Array
        (
            [value] => dog: Dg
            [label] => dog: Dg
        )

    [1] => Array
        (
            [value] => cat
            [label] => cat
        )

    [2] => Array
        (
            [value] => bird
            [label] => bird
        )

)
```

And the result will be:

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/6fbd263b-31fb-48e6-9608-6c41a5770e6e)

ℹ️ This will be the user's responsibility. We do not assume which is the correct way since other plugins can manipulate those values. We display what is given to us.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

