### PR TITLE
Add Autoresponder to Stripe

### DIFF
--- a/inc/plugins/class-stripe-api.php
+++ b/inc/plugins/class-stripe-api.php
@@ -325,4 +325,22 @@ class Stripe_API {
 
 		return $bool;
 	}
+
+	/**
+	 * Get session email.
+	 *
+	 * @param string $session_id Stripe Session ID.
+	 *
+	 * @return  bool|string
+	 * @access  public
+	 */
+	public function get_session_email( $session_id ) {
+		$session = $this->create_request( 'get_session', $session_id );
+
+		if ( empty( $session['customer_details']['email'] ) ) {
+			return false;
+		}
+
+		return $session['customer_details']['email'];
+	}
 }

--- a/inc/render/class-stripe-checkout-block.php
+++ b/inc/render/class-stripe-checkout-block.php
@@ -39,6 +39,10 @@ class Stripe_Checkout_Block {
 			if ( false !== $status ) {
 				if ( 'success' === $status ) {
 					$message = isset( $attributes['successMessage'] ) ? wp_kses_post( $attributes['successMessage'] ) : __( 'Your payment was successful. If you have any questions, please email orders@example.com.', 'otter-blocks' );
+
+					if ( has_action( 'otter_blocks_stripe_checkout_success' ) ) {
+						do_action( 'otter_blocks_stripe_checkout_success', $attributes, $stripe, $session_id );
+					}
 				} else {
 					$message = isset( $attributes['cancelMessage'] ) ? wp_kses_post( $attributes['cancelMessage'] ) : __( 'Your payment was unsuccessful. If you have any questions, please email orders@example.com.', 'otter-blocks' );
 				}

--- a/plugins/otter-pro/inc/class-main.php
+++ b/plugins/otter-pro/inc/class-main.php
@@ -67,6 +67,7 @@ class Main {
 			'\ThemeIsle\OtterPro\Plugins\Posts_ACF_Integration',
 			'\ThemeIsle\OtterPro\Plugins\Review_Woo_Integration',
 			'\ThemeIsle\OtterPro\Plugins\WooCommerce_Builder',
+			'\ThemeIsle\OtterPro\Plugins\Stripe_Pro_Features',
 			'\ThemeIsle\OtterPro\Server\Dashboard_Server',
 			'\ThemeIsle\OtterPro\Server\Filter_Blocks_Server',
 			'\ThemeIsle\OtterPro\Server\Live_Search_Server',

--- a/plugins/otter-pro/inc/plugins/class-stripe-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-stripe-pro-features.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Stripe Pro Features.
+ *
+ * @package ThemeIsle\OtterPro\Plugins
+ */
+
+namespace ThemeIsle\OtterPro\Plugins;
+
+/**
+ * Class Live_Search
+ */
+class Stripe_Pro_Features {
+	/**
+	 * The main instance var.
+	 *
+	 * @var Live_Search
+	 */
+	public static $instance = null;
+
+	/**
+	 * Initialize the class
+	 */
+	public function init() {
+		if ( License::has_active_license() ) {
+			add_action( 'otter_blocks_stripe_checkout_success', array( $this, 'autoresponder' ), 10, 3 );
+		}
+	}
+
+	/**
+	 * Autoresponder.
+	 *
+	 * @param mixed                                         $attributes Block attributes.
+	 * @param \ThemeIsle\GutenbergBlocks\Plugins\Stripe_API $stripe Stripe API object.
+	 * @param string                                        $session_id Session ID.
+	 */
+	public function autoresponder( $attributes, $stripe, $session_id ) {
+
+		if ( ! isset( $attributes['autoresponder'] ) ) {
+			return;
+		}
+
+		if ( empty( $session_id ) || empty( $stripe ) ) {
+			return;
+		}
+
+		$transient_key = 'otter_stripe_checkout_' . $session_id;
+
+		$transient = get_transient( $transient_key );
+
+		if ( false !== $transient ) {
+			return;
+		}
+
+		$email = $stripe->get_session_email( $session_id );
+
+		if ( ! $email ) {
+			return;
+		}
+
+		$to        = $email;
+		$headers[] = 'Content-Type: text/html';
+		$headers[] = 'From: ' . get_bloginfo( 'name', 'display' );
+		$subject   = isset( $attributes['autoresponder']['subject'] ) ? $attributes['autoresponder']['subject'] : __( 'Thank you for your purchase', 'otter-blocks' );
+		$body      = isset( $attributes['autoresponder']['body'] ) ? $attributes['autoresponder']['body'] : __( 'Thank you for choosing our online store for your recent purchase. We greatly appreciate your business and trust in our products.', 'otter-blocks' );
+
+		// phpcs:ignore
+		if ( wp_mail( $to, $subject, $body, $headers ) ) {
+			set_transient( $transient_key, true, 60 * 24 * 7 );
+		}
+	}
+
+	/**
+	 * The instance method for the static class.
+	 * Defines and returns the instance of the static class.
+	 *
+	 * @static
+	 * @since 1.7.1
+	 * @access public
+	 * @return Live_Search
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+			self::$instance->init();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Throw error on object clone
+	 *
+	 * The whole idea of the singleton design pattern is that there is a single
+	 * object therefore, we don't want the object to be cloned.
+	 *
+	 * @access public
+	 * @since 1.7.1
+	 * @return void
+	 */
+	public function __clone() {
+		// Cloning instances of the class is forbidden.
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+	}
+
+	/**
+	 * Disable unserializing of the class
+	 *
+	 * @access public
+	 * @since 1.7.1
+	 * @return void
+	 */
+	public function __wakeup() {
+		// Unserializing instances of the class is forbidden.
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+	}
+}

--- a/src/blocks/blocks/stripe-checkout/block.json
+++ b/src/blocks/blocks/stripe-checkout/block.json
@@ -19,6 +19,9 @@
 		},
 		"cancelMessage": {
 			"type": "string"
+		},
+		"autoresponder": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/src/blocks/blocks/stripe-checkout/inspector.js
+++ b/src/blocks/blocks/stripe-checkout/inspector.js
@@ -13,14 +13,63 @@ import {
 	SelectControl,
 	Spinner,
 	TextControl,
-	TextareaControl
+	TextareaControl,
+	ExternalLink
 } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { ButtonToggleControl, RichTextEditor } from '../../components/index.js';
-import { useState } from '@wordpress/element';
+import { ButtonToggleControl, Notice, RichTextEditor } from '../../components/index.js';
+import { Fragment, useContext, useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+import { FormContext } from '../form/edit';
+import { setUtm } from '../../helpers/helper-functions';
+
+const ProFeatures = () => {
+	return (
+		<Fragment>
+			{ ! Boolean( window.themeisleGutenberg?.hasPro ) && (
+				<PanelBody
+					title={ __( 'Autoresponder (Pro)', 'otter-blocks' ) }
+				>
+					<TextControl
+						label={__( 'Autoresponder Subject', 'otter-blocks' )}
+						placeholder={__(
+							'Thank you for your purchase',
+							'otter-blocks'
+						)}
+						value={ undefined }
+						onChange={ () => {}}
+						help={__(
+							'Enter the subject of the autoresponder email.',
+							'otter-blocks'
+						)}
+					/>
+
+					<TextareaControl
+						label={ __( 'Autoresponder Body', 'otter-blocks' ) }
+						placeholder={ __( 'Thank you for choosing our online store for your recent purchase. We greatly appreciate your business and trust in our products.', 'otter-blocks' )}
+						rows={2}
+						value={ undefined }
+						onChange={ () => {} }
+						help={ __( 'Enter the body of the autoresponder email.', 'otter-blocks' ) }
+						disabled
+						className="o-disabled"
+					/>
+
+					<div>
+						<Notice
+							notice={ <ExternalLink href={ setUtm( window.themeisleGutenberg.upgradeLink, 'form-block' ) }>{ __( 'Unlock this with Otter Pro.', 'otter-blocks' ) }</ExternalLink> }
+							variant="upsell"
+						/>
+						<p className="description">{ __( 'Automatically send follow-up emails to your users with the Autoresponder feature.', 'otter-blocks' ) }</p>
+					</div>
+				</PanelBody>
+			)}
+		</Fragment>
+	);
+};
 
 const Inspector = ({
 	attributes,
@@ -160,6 +209,13 @@ const Inspector = ({
 					{ __( 'Save API Key', 'otter-blocks' ) }
 				</Button>
 			</PanelBody>
+
+			{ applyFilters(
+				'otter.stripe-checkout.inspector',
+				<ProFeatures />,
+				attributes,
+				setAttributes
+			) }
 		</InspectorControls>
 	);
 };

--- a/src/blocks/blocks/stripe-checkout/types.d.ts
+++ b/src/blocks/blocks/stripe-checkout/types.d.ts
@@ -5,6 +5,10 @@ type Attributes = {
 	price: string
 	successMessage: string
 	cancelMessage: string
+	autoresponder: {
+		subject: string
+		body: string
+	}
 }
 
 export type StripeCheckoutProps = BlockProps<Attributes>

--- a/src/pro/components/autoresponder/index.js
+++ b/src/pro/components/autoresponder/index.js
@@ -1,0 +1,36 @@
+import { useState } from '@wordpress/element';
+import { Button, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { RichTextEditor } from '../../../blocks/components';
+
+const AutoresponderBodyModal = ({ value, onChange }) => {
+	const [ isOpen, setOpen ] = useState( false );
+
+	return (
+		<>
+			{ isOpen && (
+				<Modal
+					title={ __( 'Autoresponder Body' ) }
+					onRequestClose={() => setOpen( false )}
+					shouldCloseOnClickOutside={ false }
+				>
+					<RichTextEditor
+						value={ value }
+						onChange={ onChange }
+						help={ __( 'Enter the body of the autoresponder email.', 'otter-blocks' ) }
+						allowRawHTML
+					/>
+				</Modal>
+			) }
+			<br/>
+			<Button
+				variant="secondary"
+				onClick={() => setOpen( true )}
+			>
+				{ __( 'Add Autoresponder Body', 'otter-blocks' ) }
+			</Button>
+		</>
+	);
+};
+
+export default AutoresponderBodyModal;

--- a/src/pro/plugins/form/index.js
+++ b/src/pro/plugins/form/index.js
@@ -21,40 +21,16 @@ import { Notice as OtterNotice } from '../../../blocks/components';
 import { RichTextEditor } from '../../../blocks/components';
 import { FieldInputWidth, HideFieldLabelToggle } from '../../../blocks/blocks/form/common';
 import { setSavedState } from '../../../blocks/helpers/helper-functions';
+import AutoreponderBodyModal from '../../components/autoresponder/index.js';
 
 // +-------------- Autoresponder --------------+
 
 const AutoresponderBody = ({ formOptions, setFormOption }) => {
-	const [ isOpen, setOpen ] = useState( false );
 	const onChange = body => {
 		setFormOption({ autoresponder: { ...formOptions.autoresponder, body }});
 	};
 
-	return (
-		<>
-			{ isOpen && (
-				<Modal
-					title={ __( 'Autoresponder Body' ) }
-					onRequestClose={() => setOpen( false )}
-					shouldCloseOnClickOutside={ false }
-				>
-					<RichTextEditor
-						value={ formOptions.autoresponder?.body }
-						onChange={ onChange }
-						help={ __( 'Enter the body of the autoresponder email.', 'otter-blocks' ) }
-						allowRawHTML
-					/>
-				</Modal>
-			) }
-			<br/>
-			<Button
-				variant="secondary"
-				onClick={() => setOpen( true )}
-			>
-				{ __( 'Add Autoresponder Body', 'otter-blocks' ) }
-			</Button>
-		</>
-	);
+	return <AutoresponderBodyModal value={formOptions.autoresponder?.body} onChange={onChange} />;
 };
 
 const helpMessages = {

--- a/src/pro/plugins/index.js
+++ b/src/pro/plugins/index.js
@@ -14,3 +14,4 @@ import './wc-integration/index.js';
 import './countdown/index';
 import './live-search/index.js';
 import './form/index.js';
+import './stripe-checkout/index.js';

--- a/src/pro/plugins/stripe-checkout/index.js
+++ b/src/pro/plugins/stripe-checkout/index.js
@@ -1,0 +1,50 @@
+import { Fragment } from '@wordpress/element';
+import { Notice, Notice as OtterNotice } from '../../../blocks/components';
+import { __ } from '@wordpress/i18n';
+import { ExternalLink, PanelBody, TextareaControl, TextControl } from '@wordpress/components';
+import { setUtm } from '../../../blocks/helpers/helper-functions';
+import { addFilter } from '@wordpress/hooks';
+import AutoresponderBodyModal from '../../components/autoresponder/index.js';
+
+const Autoresponder = ( Template, attributes, setAttributes ) => {
+
+	if ( ! Boolean( window?.otterPro?.isActive ) ) {
+		return (
+			<Fragment>
+				{ Template }
+				<OtterNotice
+					notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
+					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Stripe Checkout.', 'otter-blocks' ) }
+				/>
+			</Fragment>
+		);
+	}
+
+	return (
+		<Fragment>
+			<PanelBody
+				title={ __( 'Autoresponder', 'otter-blocks' ) }
+			>
+				<TextControl
+					label={__( 'Autoresponder Subject', 'otter-blocks' )}
+					placeholder={__(
+						'Thank you for your purchase',
+						'otter-blocks'
+					)}
+					value={ attributes.autoresponder?.subject }
+					onChange={ ( subject ) => setAttributes({ autoresponder: { ...attributes.autoresponder, subject }})}
+					help={__(
+						'Enter the subject of the autoresponder email.',
+						'otter-blocks'
+					)}
+				/>
+
+				<AutoresponderBodyModal
+					value={ attributes.autoresponder?.body ?? __( 'Thank you for choosing our online store for your recent purchase. We greatly appreciate your business and trust in our products.', 'otter-blocks' ) }
+					onChange={ ( body ) => setAttributes({ autoresponder: { ...attributes.autoresponder, body }}) } />
+			</PanelBody>
+		</Fragment>
+	);
+};
+
+addFilter( 'otter.stripe-checkout.inspector', 'themeisle-gutenberg/stripe-checkout-inspector', Autoresponder );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1661.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

