### PR TITLE
Fix: use a generic name for the title & change default storing location

### DIFF
--- a/inc/integrations/class-form-settings-data.php
+++ b/inc/integrations/class-form-settings-data.php
@@ -233,7 +233,7 @@ class Form_Settings_Data {
 				}
 				if ( isset( $form['submissionsSaveLocation'] ) ) {
 					if ( '' === $form['submissionsSaveLocation'] && Pro::is_pro_active() ) {
-						$integration->set_submissions_save_location( 'database' );
+						$integration->set_submissions_save_location( 'database-email' );
 					} else {
 						$integration->set_submissions_save_location( $form['submissionsSaveLocation'] );
 					}

--- a/src/pro/plugins/form/index.js
+++ b/src/pro/plugins/form/index.js
@@ -65,6 +65,7 @@ const helpMessages = {
 
 
 const FormOptions = ( Options, formOptions, setFormOption, config ) => {
+
 	return (
 		<>
 			{Options}
@@ -78,7 +79,7 @@ const FormOptions = ( Options, formOptions, setFormOption, config ) => {
 				{Boolean( window.otterPro.isActive ) ? (
 					<SelectControl
 						label={ __( 'Save Location', 'otter-blocks' ) }
-						value={ formOptions.submissionsSaveLocation }
+						value={ formOptions.submissionsSaveLocation ?? 'database-email' }
 						onChange={ submissionsSaveLocation => setFormOption({ submissionsSaveLocation }) }
 						options={
 							[


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1676, https://github.com/Codeinwp/otter-internals/issues/88.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- Change the column name from `Email` to `Title`
- Change the default option save location to `database & email` for pro users.
- Use a generic name for the `otter_form_record` post: `Submission #<post_id>`
- Set `show_in_rest` to `false` for otter_form_record

### Screenshots <!-- if applicable -->
<img width="936" alt="Screenshot 2023-05-29 at 17 52 20" src="https://github.com/Codeinwp/otter-blocks/assets/39873395/530411c0-c5a4-44e7-9bc8-063beea3b873">

### Test instructions
<!-- Describe how this pull request can be tested. -->
- When activating Otter pro, the default option for `Save Location` should be `Database and Email`.
- The saved submissions should be named `Submission #<post_id>` and the emails should be visible only in the post meta, visible when editing the submission data.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

