### PR TITLE
Add email failover for Form Block

### DIFF
--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -63,7 +63,7 @@ class Form_Server {
 	/**
 	 * Autoresponder Email Error Expiration Time
 	 */
-	const AUTO_RESPONDER_ERROR_EXPIRATION_TIME = 7 * 24 * 60; // 1 week
+	const AUTO_RESPONDER_ERROR_EXPIRATION_TIME = WEEK_IN_SECONDS;
 
 	/**
 	 * Initialize the class
@@ -366,7 +366,13 @@ class Form_Server {
 			// phpcs:ignore
 			$email_was_send = wp_mail( $to, $email_subject, $email_body, $headers, $attachments );
 			if ( ! $email_was_send ) {
-				$form_data->set_error( Form_Data_Response::ERROR_EMAIL_NOT_SEND );
+				$is_warning = Pro::is_pro_active() && strstr( $form_options->get_submissions_save_location(), 'database' );
+
+				if ( $is_warning ) {
+					$form_data->add_warning( Form_Data_Response::ERROR_EMAIL_NOT_SEND );
+				} else {
+					$form_data->set_error( Form_Data_Response::ERROR_EMAIL_NOT_SEND );
+				}
 			}
 		} catch ( Exception  $e ) {
 			$form_data->set_error( Form_Data_Response::ERROR_RUNTIME_ERROR, array( $e->getMessage() ) );
@@ -412,7 +418,7 @@ class Form_Server {
 			) {
 				$key = $form_data->get_form_option_id() . '_autoresponder_error';
 
-				if ( ! get_transient( $key ) ) {
+				if ( false === get_transient( $key ) ) {
 					$send_email = true;
 					set_transient( $key, true, self::AUTO_RESPONDER_ERROR_EXPIRATION_TIME );
 				}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1677 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

If you have the option to save set as `database-email` and the Email service is not working, the error from email not sent will be considered as a warning and thus will be non-blocking.

ℹ️ I was considering notifying the admin via email about this problem then I realized that I could not send the email if the Email service is not working 🤦 

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Make an instance where Email SMTP is not set-up. Set the options to save the data as `Database & Email` in a Form. Fill the form and submit then check if it was saved in the Submissions.  

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

