### PR TITLE
Update SDK and add About Us page

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb35ab55d758cdd3e0cb3f75edaf1847",
+    "content-hash": "60fffd630dc8f1393372f8533c20b01a",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.40",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "d719fff89cb6643e555f5e3daa4ebd627ccb4fd7"
+                "reference": "68dc5d11c1d7a20a13f3ae730183f61ff309d574"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/d719fff89cb6643e555f5e3daa4ebd627ccb4fd7",
-                "reference": "d719fff89cb6643e555f5e3daa4ebd627ccb4fd7",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/68dc5d11c1d7a20a13f3ae730183f61ff309d574",
+                "reference": "68dc5d11c1d7a20a13f3ae730183f61ff309d574",
                 "shasum": ""
             },
             "require-dev": {
@@ -42,9 +42,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.40"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.0"
             },
-            "time": "2023-03-30T09:29:30+00:00"
+            "time": "2023-05-30T08:55:06+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -2423,5 +2423,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -43,6 +43,7 @@ class Main {
 			add_filter( 'wp_generate_attachment_metadata', array( $this, 'generate_svg_attachment_metadata' ), PHP_INT_MAX, 3 );
 		}
 
+		add_filter( 'otter_blocks_about_us_metadata', array( $this, 'about_page' ) );
 	}
 
 	/**
@@ -466,6 +467,23 @@ class Main {
 		}
 
 		return update_option( 'themeisle_blocks_db_version', OTTER_BLOCKS_VERSION );
+	}
+
+	/**
+	 * About page SDK
+	 *
+	 * @return array
+	 * @since  2.3.1
+	 * @access public
+	 */
+	public function about_page() {
+		return array(
+			'location'         => 'otter',
+			'logo'             => 'https://ps.w.org/otter-blocks/assets/icon-256x256.png?rev=2019293',
+			'has_upgrade_menu' => ! DEFINED( 'OTTER_PRO_VERSION' ),
+			'upgrade_link'     => tsdk_utmify( Pro::get_url(), 'editor', Pro::get_reference() ),
+			'upgrade_text'     => __( 'Upgrade to Otter Pro', 'otter-blocks' ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1680.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Themeisle SDK update to latest version: 2.3
- Added About Us page registration via hook

### Screenshots <!-- if applicable -->


![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/969a0e95-42a4-49b2-90b8-70dd757a7a04)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Check if the About Us page is visible.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

