### PR TITLE
Improve taxonomy detection for Posts Block

### DIFF
--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -35,7 +35,15 @@ class Posts_Grid_Block {
 		}
 
 		$get_custom_post_types_posts = function ( $post_type ) use ( $attributes, $categories ) {
-			return get_posts(
+
+			if ( 'product' === $post_type ) {
+				$categories = array();
+				foreach ( $attributes['categories'] as $category ) {
+					array_push( $categories, $category['slug'] );
+				}
+			}
+
+			return $this->get_posts(
 				apply_filters(
 					'themeisle_gutenberg_posts_block_query',
 					array(
@@ -53,7 +61,7 @@ class Posts_Grid_Block {
 			);
 		};
 
-		$recent_posts = ( isset( $attributes['postTypes'] ) && 0 < count( $attributes['postTypes'] ) ) ? array_merge( ...array_map( $get_custom_post_types_posts, $attributes['postTypes'] ) ) : get_posts(
+		$recent_posts = ( isset( $attributes['postTypes'] ) && 0 < count( $attributes['postTypes'] ) ) ? array_merge( ...array_map( $get_custom_post_types_posts, $attributes['postTypes'] ) ) : $this->get_posts(
 			apply_filters(
 				'themeisle_gutenberg_posts_block_query',
 				array(
@@ -80,20 +88,20 @@ class Posts_Grid_Block {
 						return in_array( $x instanceof WP_Post ? $x->ID : $x, $sticky_posts_id );
 					}
 				);
-		
+
 				$non_sticky_posts = array_filter(
 					$recent_posts,
 					function ( $x ) use ( $sticky_posts_id ) {
 						return ! in_array( $x instanceof WP_Post ? $x->ID : $x, $sticky_posts_id );
 					}
 				);
-		
+
 				$recent_posts = array_merge( $sticky_posts, $non_sticky_posts );
 			}
 		}
 
 		$list_items_markup = '';
-	
+
 		foreach ( array_slice( $recent_posts, isset( $attributes['enableFeaturedPost'] ) && $attributes['enableFeaturedPost'] && isset( $recent_posts[0] ) ? 1 : 0 ) as $post ) {
 
 			$id = $post instanceof WP_Post ? $post->ID : $post;
@@ -339,5 +347,31 @@ class Posts_Grid_Block {
 		$html .= $this->get_post_fields( $id, $attributes );
 		$html .= '</div>';
 		return sprintf( '<div class="o-featured-container"><div class="o-featured-post">%1$s</div></div>', $html );
+	}
+
+	/**
+	 * Get posts to display.
+	 *
+	 * @param array $args Query args.
+	 * @return array|array[]|int[]|null[]|\WP_Post[] Posts.
+	 */
+	protected function get_posts( $args ) {
+		if ( isset( $args['post_type'] ) && 'product' === $args['post_type'] && function_exists( 'wc_get_products' ) ) {
+
+			// drop the post_type arg, as wc_get_products() doesn't support it.
+			unset( $args['post_type'] );
+
+			$products = wc_get_products( $args );
+
+			// convert to array of post objects since the rest of the code expects that.
+			return array_map(
+				function( $product ) {
+					return get_post( $product->get_id() );
+				},
+				$products
+			);
+		}
+
+		return get_posts( $args );
 	}
 }

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -39,7 +39,9 @@ class Posts_Grid_Block {
 			if ( 'product' === $post_type ) {
 				$categories = array();
 				foreach ( $attributes['categories'] as $category ) {
-					array_push( $categories, $category['slug'] );
+					if ( isset( $category['slug'] ) ) {
+						array_push( $categories, $category['slug'] );
+					}
 				}
 			}
 

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -36,7 +36,7 @@ class Posts_Grid_Block {
 
 		$get_custom_post_types_posts = function ( $post_type ) use ( $attributes, $categories ) {
 
-			if ( 'product' === $post_type ) {
+			if ( 'product' === $post_type && isset( $attributes['categories'] ) ) {
 				$categories = array();
 				foreach ( $attributes['categories'] as $category ) {
 					if ( isset( $category['slug'] ) ) {

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -368,7 +368,7 @@ class Posts_Grid_Block {
 			// convert to array of post objects since the rest of the code expects that.
 			return array_map(
 				function( $product ) {
-					return get_post( $product->get_id() );
+					return $product->get_id();
 				},
 				$products
 			);

--- a/src/blocks/blocks/posts/components/layout/featured.js
+++ b/src/blocks/blocks/posts/components/layout/featured.js
@@ -27,12 +27,13 @@ const FeaturedPost = ({
 	post,
 	attributes,
 	author,
-	category,
 	categoriesList
 }) => {
 	if ( ! post  ) {
 		return '';
 	}
+
+	const category = categoriesList && 0 < post?.categories?.length ? categoriesList.find( item => item.id === post.categories[0]) : undefined;
 
 	return (
 		<div className="o-featured-container">

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -18,6 +18,7 @@ import { applyFilters } from '@wordpress/hooks';
  */
 import Thumbnail from './thumbnail.js';
 import { unescapeHTML, formatDate } from '../../../../helpers/helper-functions.js';
+import { Placeholder } from '@wordpress/components';
 
 const Layout = ({
 	attributes,
@@ -25,6 +26,16 @@ const Layout = ({
 	categoriesList,
 	authors
 }) => {
+
+	const postsToDisplay = posts
+		.filter( post => post )
+		.filter( post => {
+			if ( 'product' === post?.type && attributes?.categories?.length  ) {
+				return post?.['product_cat']?.some( cat => attributes.categories?.some( item => item.id === cat ) );
+			}
+			return true;
+		});
+
 	return (
 		<div
 			className={
@@ -44,14 +55,7 @@ const Layout = ({
 					)
 			}
 		>
-			{ posts
-				.filter( post => post )
-				.filter( post => {
-					if ( 'product' === post?.type && attributes?.categories?.length  ) {
-						return post?.['product_cat']?.some( cat => attributes.categories?.some( item => item.id === cat ) );
-					}
-					return true;
-				})
+			{ postsToDisplay
 				.slice( attributes.enableFeaturedPost ? 1 : 0 )
 				.map( post => {
 					const category = categoriesList && 0 < post?.categories?.length ? categoriesList.find( item => item.id === post.categories[0]) : undefined;

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -46,6 +46,12 @@ const Layout = ({
 		>
 			{ posts
 				.filter( post => post )
+				.filter( post => {
+					if ( 'product' === post?.type && categoriesList ) {
+						return post?.['product_cat']?.some( cat => attributes.categories?.some( item => item.id === cat ) );
+					}
+					return true;
+				})
 				.slice( attributes.enableFeaturedPost ? 1 : 0 )
 				.map( post => {
 					const category = categoriesList && 0 < post?.categories?.length ? categoriesList.find( item => item.id === post.categories[0]) : undefined;

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -28,13 +28,7 @@ const Layout = ({
 }) => {
 
 	const postsToDisplay = posts
-		.filter( post => post )
-		.filter( post => {
-			if ( 'product' === post?.type && attributes?.categories?.length  ) {
-				return post?.['product_cat']?.some( cat => attributes.categories?.some( item => item.id === cat ) );
-			}
-			return true;
-		});
+		.filter( post => post );
 
 	return (
 		<div

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -47,7 +47,7 @@ const Layout = ({
 			{ posts
 				.filter( post => post )
 				.filter( post => {
-					if ( 'product' === post?.type && categoriesList ) {
+					if ( 'product' === post?.type && attributes?.categories?.length  ) {
 						return post?.['product_cat']?.some( cat => attributes.categories?.some( item => item.id === cat ) );
 					}
 					return true;

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -285,7 +285,6 @@ const Edit = ({
 						<FeaturedPost
 							attributes={ attributes }
 							post={ posts?.[0] }
-							category={ categoriesList[0] }
 							categoriesList={ categoriesList }
 							author={ authors[0] }
 						/>

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -88,9 +88,9 @@ const Edit = ({
 			context: 'view'
 		}, ( value ) => ! isUndefined( value ) );
 
-		const slugs = attributes.postTypes;
-		let posts = ( 0 < slugs.length ) ? (
-			slugs.map( slug => select( 'core' ).getEntityRecords( 'postType', slug, latestPostsQuery ) ).flat()
+		const postTypeSlugs = attributes.postTypes;
+		let posts = ( 0 < postTypeSlugs.length ) ? (
+			postTypeSlugs.map( slug => select( 'core' ).getEntityRecords( 'postType', slug, latestPostsQuery ) ).flat()
 		) : select( 'core' ).getEntityRecords( 'postType', 'post', latestPostsQuery );
 
 		if ( attributes.featuredPostOrder && 0 < posts?.length ) {
@@ -100,10 +100,22 @@ const Edit = ({
 			];
 		}
 
+		const taxonomies = select( 'core' )?.getTaxonomies()
+			?.map( ({ slug }) => slug )
+			?.filter( ( slug ) => postTypeSlugs.some( postTypeSlug => slug === `${postTypeSlug}_cat` ) ) ?? [];
+
+		if ( 0 === taxonomies.length ) {
+			taxonomies.push( 'category' );
+		}
+
+		const categoriesList = taxonomies
+			// eslint-disable-next-line camelcase
+			.map( taxonomy => select( 'core' ).getEntityRecords( 'taxonomy', taxonomy, { per_page: -1 }) ?? [])
+			.flat();
+
 		return {
 			posts,
-			// eslint-disable-next-line camelcase
-			categoriesList: select( 'core' ).getEntityRecords( 'taxonomy', 'category', { per_page: -1, context: 'view' }),
+			categoriesList: categoriesList,
 			authors: select( 'core' ).getUsers({ who: 'authors', context: 'view' })
 		};
 	}, [ attributes.categories, attributes.order, attributes.orderBy, attributes.postsToShow, attributes.offset, attributes.postTypes, attributes.featuredPostOrder ]);

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -140,7 +140,7 @@ const Edit = ({
 	useEffect( () => {
 
 		/**
-		 * Stop loading message after 5 seconds if no posts are found.
+		 * Stop loading message after 30 seconds if no posts are found.
 		 * When switching between post types for first time we need to wait for the posts to load.
 		 * Since the hook for getting posts has no status we do not know when it is done,
 		 * because when it is loading is returning `[]` and we can not know if it did not find any posts, or it is still loading.
@@ -148,7 +148,7 @@ const Edit = ({
 		if ( autoStopLoadingTimeout && 0 < posts?.length ) {
 			clearTimeout( autoStopLoadingTimeout );
 		} else if ( ! autoStopLoadingTimeout && isLoading ) {
-			autoStopLoadingTimeout = setTimeout( () => toggleLoading( false ), 5000 );
+			autoStopLoadingTimeout = setTimeout( () => toggleLoading( false ), 30000 );
 		}
 
 	}, [ isLoading, posts ]);
@@ -258,6 +258,7 @@ const Edit = ({
 					setAttributes={ setAttributes }
 					categoriesList={ categoriesList }
 					toggleLoading={ toggleLoading }
+					isLoading={ isLoading }
 				/>
 			) }
 

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -123,15 +123,17 @@ const Edit = ({
 					};
 				}
 
+				const productIds = products.map( ({ id }) => id );
+
 				return {
-					posts: products.map( ({ id }) => select( 'core' ).getEntityRecord( 'postType', postType, id ) ).filter( Boolean ) ?? [],
-					isLoading: products.reduce( ( acc, { id }) => acc || select( 'core' ).isResolving( 'core', 'getEntityRecord', [ 'postType', postType, id ]), false )
+					posts: select( 'core' ).getEntityRecords( 'postType', postType, { include: productIds }) ?? [],
+					isLoading: select( 'core' ).isResolving( 'getEntityRecords', [ 'postType', postType, { include: productIds }])
 				};
 			}
 
 			return {
 				posts: select( 'core' ).getEntityRecords( 'postType', postType, latestPostsQuery ),
-				isLoading: select( 'core' ).isResolving( 'core', 'getEntityRecords', [ 'postType', postType, latestPostsQuery ])
+				isLoading: select( 'core' ).isResolving( 'getEntityRecords', [ 'postType', postType, latestPostsQuery ])
 			};
 		};
 
@@ -157,7 +159,7 @@ const Edit = ({
 			isLoading = loadingCheck;
 		} else {
 			posts = select( 'core' ).getEntityRecords( 'postType', 'post', latestPostsQuery );
-			isLoading = select( 'core' ).isResolving( 'core', 'getEntityRecords', [ 'postType', 'post', latestPostsQuery ]);
+			isLoading = select( 'core' ).isResolving( 'getEntityRecords', [ 'postType', 'post', latestPostsQuery ]);
 		}
 
 		if ( attributes.featuredPostOrder && 0 < posts?.length ) {
@@ -167,7 +169,7 @@ const Edit = ({
 			];
 		}
 
-		posts = posts.filter( Boolean );
+		posts = posts?.filter( Boolean ) ?? [];
 
 		const taxonomies = select( 'core' )?.getTaxonomies()
 			?.map( ({ slug }) => slug )
@@ -261,6 +263,16 @@ const Edit = ({
 					<Placeholder>
 						<Spinner />
 						{ __( 'Loading Posts', 'otter-blocks' ) }
+					</Placeholder>
+				</div>
+			);
+		}
+
+		if ( 0 === posts.length ) {
+			return (
+				<div { ...blockProps }>
+					<Placeholder>
+						{ __( 'No Posts', 'otter-blocks' ) }
 					</Placeholder>
 				</div>
 			);

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -98,7 +98,8 @@ const defaultFontSizes = [
 const Inspector = ({
 	attributes,
 	setAttributes,
-	categoriesList
+	categoriesList,
+	toggleLoading
 }) => {
 	const [ tab, setTab ] = useState( 'settings' );
 
@@ -127,7 +128,7 @@ const Inspector = ({
 		const cat = categoriesList.find( cat => cat.id === Number( category.id ) );
 		return {
 			id: category.id,
-			name: cat?.name || cat?.slug || '',
+			name: cat?.name ?? cat?.slug ?? ( category?.name + ' (' + __( 'Invalid', 'otter-blocks' ) + ')' ),
 			slug: cat?.slug || ''
 		};
 	}) : [];
@@ -142,15 +143,11 @@ const Inspector = ({
 		if ( 'object' === typeof value ) {
 			if ( 0 < value.length ) {
 				categories = value.map( name => {
-					if ( 'object' === typeof name ) {
-						return name;
-					}
-
-					const category = categoriesList.find( e => e.name === name );
+					const category = categoriesList.find( e => e.name === name || e.name === name?.value );
 					if ( category ) {
 						return {
 							id: category.id,
-							name,
+							name: name?.value ?? name,
 							slug: category?.slug ?? ''
 						};
 					}
@@ -165,6 +162,7 @@ const Inspector = ({
 		}
 
 		setAttributes({ categories });
+		toggleLoading( true );
 	};
 
 	const changeStyle = value => {
@@ -207,7 +205,12 @@ const Inspector = ({
 							label={ __( 'Post Type', 'otter-blocks' ) }
 							help={ __( 'WordPress contains different types of content and they are divided into collections called "Post types". By default there are a few different ones such as blog posts and pages, but plugins could add more.', 'otter-blocks' ) }
 							value={ attributes.postTypes[0] || null }
-							onChange={ ( value ) => value && setAttributes({ postTypes: [ value ] }) }
+							onChange={ ( value ) => {
+								if ( value ) {
+									setAttributes({ postTypes: [ value ] });
+									toggleLoading( true );
+								}
+							} }
 							options={
 								slugs.map( slug => ({ label: convertToTitleCase( slug ), value: slug }) )
 							}

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -127,7 +127,8 @@ const Inspector = ({
 		const cat = categoriesList.find( cat => cat.id === Number( category.id ) );
 		return {
 			id: category.id,
-			name: cat?.name || cat?.slug || ''
+			name: cat?.name || cat?.slug || '',
+			slug: cat?.slug || ''
 		};
 	}) : [];
 
@@ -149,7 +150,8 @@ const Inspector = ({
 					if ( category ) {
 						return {
 							id: category.id,
-							name
+							name,
+							slug: category?.slug ?? ''
 						};
 					}
 				}).filter( e => undefined !== e );
@@ -157,7 +159,8 @@ const Inspector = ({
 		} else if ( '' !== value ) {
 			categories = [{
 				id: value,
-				name: categoriesList.find( e => e.id === Number( value ) ).name
+				name: categoriesList.find( e => e.id === Number( value ) ).name,
+				slug: categoriesList.find( e => e.id === Number( value ) )?.slug ?? ''
 			}];
 		}
 

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -99,7 +99,6 @@ const Inspector = ({
 	attributes,
 	setAttributes,
 	categoriesList,
-	toggleLoading,
 	isLoading
 }) => {
 	const [ tab, setTab ] = useState( 'settings' );
@@ -166,7 +165,6 @@ const Inspector = ({
 		}
 
 		setAttributes({ categories });
-		toggleLoading( true );
 	};
 
 	const changeStyle = value => {
@@ -212,7 +210,6 @@ const Inspector = ({
 							onChange={ ( value ) => {
 								if ( value ) {
 									setAttributes({ postTypes: [ value ] });
-									toggleLoading( true );
 								}
 							} }
 							options={

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -99,7 +99,8 @@ const Inspector = ({
 	attributes,
 	setAttributes,
 	categoriesList,
-	toggleLoading
+	toggleLoading,
+	isLoading
 }) => {
 	const [ tab, setTab ] = useState( 'settings' );
 
@@ -126,10 +127,13 @@ const Inspector = ({
 
 	const selectedCategories = attributes.categories ? attributes.categories.map( category => {
 		const cat = categoriesList.find( cat => cat.id === Number( category.id ) );
+		const isInvalid = ! isLoading && categoriesList?.length && ! cat;
+
 		return {
 			id: category.id,
-			name: cat?.name ?? cat?.slug ?? ( category?.name + ' (' + __( 'Invalid', 'otter-blocks' ) + ')' ),
-			slug: cat?.slug || ''
+			name: ( category?.name ?? cat?.name ?? cat?.slug ) +
+				( isInvalid ? ' (' + __( 'Invalid', 'otter-blocks' ) + ')' : '' ),
+			slug: category?.slug ?? cat?.slug ?? ''
 		};
 	}) : [];
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1572.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The categories list used only `category` taxonomy. Now it will detect based on the `postType` slug.

E.g.: `product` post type will have `product_cat` as the taxonomy slug.

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/otter-blocks/assets/17597852/0aae6972-4dea-4f1a-a67c-2fbad0a482f7


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add WooComerce and import the samples 
2. Make a new post page and add a Posts Block
3. In the Settings > Categories check if you have category related to Woo.

ℹ️ When loading the Product for the first time, you see a loading status then `No Posts` for a short period, and a loading status again like in the video. This is caused by the way the loading is done.

ℹ️ When switching between post types, the categories will be marked as `Invalid` if they are not found. When clicking on it should remove them -- like in the video.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

