### PR TITLE
Fix wrong otter page menu hook fix

### DIFF
--- a/plugins/otter-pro/inc/class-main.php
+++ b/plugins/otter-pro/inc/class-main.php
@@ -41,7 +41,7 @@ class Main {
 			add_filter( 'otter_blocks_register_blocks', array( $this, 'register_blocks' ) );
 			add_filter( 'otter_blocks_register_dynamic_blocks', array( $this, 'register_dynamic_blocks' ) );
 			add_filter( 'otter_blocks_register_css', array( $this, 'register_blocks_css' ) );
-			add_action( 'admin_print_scripts-settings_page_otter', array( $this, 'enqueue_options_assets' ) );
+			add_action( 'admin_print_scripts-toplevel_page_otter', array( $this, 'enqueue_options_assets' ) );
 		}
 	}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1703.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

We moved the Otter menu page to the top level and the Pro handler was not updated.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Same as in the [issue](https://github.com/Codeinwp/otter-blocks/issues/1703#issue-1747638463):link:.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

