### PR TITLE
Fix Form options toggle

### DIFF
--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -91,7 +91,7 @@ const Edit = ({
 	const { responsiveGetAttributes } = useResponsiveAttributes( setAttributes );
 
 	const [ loadingState, setLoadingState ] = useState({
-		formOptions: 'done',
+		formOptions: 'loading',
 		formIntegration: 'done',
 		listId: 'init',
 		captcha: 'init',
@@ -314,9 +314,10 @@ const Edit = ({
 		let controller = new AbortController();
 		const t = setTimeout( () => {
 			setLoading({ formOptions: 'done', formIntegration: 'done' });
-		}, 3000 );
+		}, 20000 );
 
 		if ( attributes.optionName ) {
+			setLoading({ formOptions: 'loading', formIntegration: 'loading' });
 			try {
 				api.loadPromise.then( () => {
 					setLoading({ formOptions: 'loading', formIntegration: 'loading' });

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -123,7 +123,7 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 			</ToolsPanelItem>
 
 			<ToolsPanelItem
-				hasValue={ () => undefined !== formOptions.cc }
+				hasValue={ () => Boolean( formOptions.cc ) }
 				label={ __( 'CC', 'otter-blocks' ) }
 				onDeselect={ () => setFormOption({ cc: '' }) }
 				isShownByDefault={ false }
@@ -139,7 +139,7 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 			</ToolsPanelItem>
 
 			<ToolsPanelItem
-				hasValue={ () => undefined !== formOptions.bcc }
+				hasValue={ () => Boolean( formOptions.bcc ) }
 				label={ __( 'BCC', 'otter-blocks' ) }
 				onDeselect={ () => setFormOption({ bcc: '' }) }
 				isShownByDefault={ false }
@@ -169,9 +169,9 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 			</ToolsPanelItem>
 
 			<ToolsPanelItem
-				hasValue={ () => undefined !== formOptions.fromEmail }
+				hasValue={ () => Boolean( formOptions.fromName ) }
 				label={ __( 'From Name', 'otter-blocks' ) }
-				onDeselect={ () => setFormOption({ fromEmail: '' }) }
+				onDeselect={ () => setFormOption({ fromName: '' }) }
 				isShownByDefault={ false }
 			>
 				<TextControl
@@ -183,7 +183,7 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 			</ToolsPanelItem>
 
 			<ToolsPanelItem
-				hasValue={ () => undefined !== formOptions.redirectLink }
+				hasValue={ () => Boolean( formOptions.redirectLink ) }
 				label={ __( 'Redirect on Submit', 'otter-blocks' ) }
 				onDeselect={ () => setFormOption({ redirectLink: '' }) }
 				isShownByDefault={ false }
@@ -427,18 +427,24 @@ const Inspector = ({
 								</div>
 							) }
 
-							{ applyFilters(
-								'otter.formBlock.options',
-								<FormOptions
-									formOptions={formOptions}
-									setFormOption={setFormOption}
-									attributes={attributes}
-									setAttributes={setAttributes}
-								/>,
-								formOptions,
-								setFormOption,
-								useContext( FormContext )
-							) }
+							{
+								'loading' !== loadingState?.formOptions && (
+									<Fragment>
+										{ applyFilters(
+											'otter.formBlock.options',
+											<FormOptions
+												formOptions={formOptions}
+												setFormOption={setFormOption}
+												attributes={attributes}
+												setAttributes={setAttributes}
+											/>,
+											formOptions,
+											setFormOption,
+											useContext( FormContext )
+										) }
+									</Fragment>
+								)
+							}
 						</ToolsPanel>
 
 						<PanelBody


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1702.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Fixed the condition for checking the values.
- Now the Options will not show during the loading.
- Fixed a wrong field name (very subtle bug -- introduced in https://github.com/Codeinwp/otter-blocks/commit/320052caecb5218b8378f77e3d6efd65139b1885 ): `fromEmail` instead of `fromName`

### Screenshots <!-- if applicable -->


https://github.com/Codeinwp/otter-blocks/assets/17597852/f8345e99-e226-4157-816f-cabb2e2dea8b


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Check the toggle for the first four options like it is described in the issue.

ℹ️ If you enable one of the top four fields and do not make any changes when you refresh the page, you will not see them enabled -- this is the default behavior. Unchanged fields should not be shown. 

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

