### PR TITLE
Add patterns structure checking.

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-patterns.php
+++ b/plugins/otter-pro/inc/plugins/class-patterns.php
@@ -40,7 +40,7 @@ class Patterns {
 	 * @access  public
 	 */
 	public function maybe_sync_patterns() {
-		if ( ! get_transient( 'otter_pro_patterns' ) ) {
+		if ( ! get_transient( 'otter_pro_patterns' ) && ! get_transient( 'otter_pro_patterns_refetch' ) ) {
 			$this->sync_patterns();
 		}
 	}
@@ -72,11 +72,19 @@ class Patterns {
 		$response = json_decode( $response, true );
 
 		if ( ! is_array( $response ) || isset( $response['message'] ) || 0 === count( $response ) ) {
+			if ( ! get_transient( 'otter_pro_patterns_refetch' ) ) {
+				set_transient( 'otter_pro_patterns_refetch', true, HOUR_IN_SECONDS );
+			}
 			return;
 		}
 
 		foreach ( $response as $pattern_block ) {
 			if ( ! $this->check_pattern_structure( $pattern_block ) ) {
+
+				if ( ! get_transient( 'otter_pro_patterns_refetch' ) ) {
+					set_transient( 'otter_pro_patterns_refetch', true, HOUR_IN_SECONDS );
+				}
+
 				return;
 			}
 		}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/93#event-9527021938
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add structure checking when fetching the patterns and fast checking when using it. The transient will be invalid if the quick check fails.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a new instance and add Otter Pro
2. Check if the Pro patterns are working -- they are visible and you can insert them in editor.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

