### PR TITLE
fix: replace otter page path to admin

### DIFF
--- a/development.php
+++ b/development.php
@@ -31,7 +31,7 @@ if ( ENABLE_OTTER_PRO_DEV && defined( 'WPINC' ) && class_exists( '\ThemeIsle\Ott
 	add_filter(
 		'otter_pro_lc_no_valid_string',
 		function ( $message ) {
-			return str_replace( '<a href="%s">', '<a href="' . admin_url( 'options-general.php?page=otter' ) . '">', $message );
+			return str_replace( '<a href="%s">', '<a href="' . admin_url( 'admin.php?page=otter' ) . '">', $message );
 		}
 	);
 

--- a/inc/class-pro.php
+++ b/inc/class-pro.php
@@ -248,7 +248,7 @@ class Pro {
 		<div class="clear">
 			<p><?php _e( 'Unlock the full power of WooCommerce Builder by activating Otter Pro license.', 'otter-blocks' ); ?></p>
 
-			<a href="<?php echo esc_url( admin_url( 'options-general.php?page=otter' ) ); ?>" target="_blank" class="button button-primary">
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=otter' ) ); ?>" target="_blank" class="button button-primary">
 				<?php _e( 'Activate License', 'otter-blocks' ); ?>
 			</a>
 		</div>

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -246,7 +246,7 @@ class Registration {
 				'should_show_upsell'      => Pro::should_show_upsell(),
 				'assetsPath'              => OTTER_BLOCKS_URL . 'assets',
 				'updatePath'              => admin_url( 'update-core.php' ),
-				'optionsPath'             => admin_url( 'options-general.php?page=otter' ),
+				'optionsPath'             => admin_url( 'admin.php?page=otter' ),
 				'mapsAPI'                 => $api,
 				'hasStripeAPI'            => Stripe_API::has_keys(),
 				'globalDefaults'          => json_decode( get_option( 'themeisle_blocks_settings_global_defaults', '{}' ) ),

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -195,7 +195,7 @@ class Dashboard {
 		}
 
 		update_option( 'themeisle_blocks_settings_redirect', false );
-		wp_safe_redirect( admin_url( 'options-general.php?page=otter' ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=otter' ) );
 		exit;
 	}
 

--- a/otter-blocks.php
+++ b/otter-blocks.php
@@ -66,7 +66,7 @@ add_action(
 	function( $links ) {
 		array_unshift(
 			$links,
-			sprintf( '<a href="%s">%s</a>', admin_url( 'options-general.php?page=otter' ), __( 'Settings', 'otter-blocks' ) )
+			sprintf( '<a href="%s">%s</a>', admin_url( 'admin.php?page=otter' ), __( 'Settings', 'otter-blocks' ) )
 		);
 		return $links;
 	}

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -54,7 +54,7 @@ add_filter(
 add_filter(
 	'otter_pro_lc_no_valid_string',
 	function ( $message ) {
-		return str_replace( '<a href="%s">', '<a href="' . admin_url( 'options-general.php?page=otter' ) . '">', $message );
+		return str_replace( '<a href="%s">', '<a href="' . admin_url( 'admin.php?page=otter' ) . '">', $message );
 	}
 );
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1712.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The Otter page is now in the Admin panel and not Options.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Check the instruction from the issue.
2. Create a new Post and open the Console (F12 - on some browsers) then run this command: `window.location = themeisleGutenberg.optionsPath` -- this command should take you to the Otter menu page.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

