### PR TITLE
Fix missing redirect link on response

### DIFF
--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -241,6 +241,18 @@ class Form_Data_Response {
 	}
 
 	/**
+	 * Add new field to the response.
+	 *
+	 * @param string $key The key.
+	 * @param mixed  $value The value.
+	 * @return $this
+	 */
+	public function add_response_field( $key, $value ) {
+		$this->response[ $key ] = $value;
+		return $this;
+	}
+
+	/**
 	 * Add new data to the response.
 	 *
 	 * @param array $values The new data.

--- a/inc/integrations/class-form-settings-data.php
+++ b/inc/integrations/class-form-settings-data.php
@@ -199,7 +199,7 @@ class Form_Settings_Data {
 		$form_emails = get_option( 'themeisle_blocks_form_emails' );
 		$integration = new Form_Settings_Data( array() );
 		foreach ( $form_emails as $form ) {
-			if ( $form['form'] === $option_name ) {
+			if ( isset( $form['form'] ) && $form['form'] === $option_name ) {
 
 				if ( isset( $form['hasCaptcha'] ) ) {
 					$integration->set_captcha( $form['hasCaptcha'] );

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -259,6 +259,11 @@ class Form_Server {
 			if ( $res->has_error() || $form_data->has_error() ) {
 				$res->set_code( $form_data->get_error_code() );
 			} else {
+
+				if ( ! empty( $form_options->get_redirect_link() ) ) {
+					$res->add_response_field( 'redirectLink', $form_options->get_redirect_link() );
+				}
+
 				// Select the submit function based on the provider.
 				$provider_handlers = apply_filters( 'otter_select_form_provider', $form_data );
 

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -348,6 +348,10 @@ const collectAndSendInputFormData = async( form, btn, displayMsg ) => {
 
 					form?.querySelector( 'form' )?.reset();
 
+					if ( 0 < res?.redirectLink?.length ) {
+						form.setAttribute( 'data-redirect', res.redirectLink );
+					}
+
 					setTimeout( () => {
 						if ( 0 < res?.redirectLink?.length ) {
 							let a = document.createElement( 'a' );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1706.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The redirect link needed to be added to the response.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a Form and a redirect link. Save and bullish the post.
2. View the page and after completing the form with success, you should be redirected.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

