### PR TITLE
Add Webhook to Form

### DIFF
--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -57,6 +57,7 @@ class Form_Data_Response {
 	const ERROR_PROVIDER_INVALID_EMAIL             = '207';
 	const ERROR_PROVIDER_DUPLICATED_EMAIL          = '208';
 	const ERROR_PROVIDER_CREDENTIAL_ERROR          = '209';
+	const ERROR_WEBHOOK_COULD_NOT_TRIGGER          = '210';
 
 
 	/**
@@ -332,6 +333,7 @@ class Form_Data_Response {
 			self::ERROR_AUTORESPONDER_MISSING_EMAIL_FIELD  => __( 'The email field is missing from the Form Block with Autoresponder activated.', 'otter-blocks' ),
 			self::ERROR_AUTORESPONDER_COULD_NOT_SEND       => __( 'The email from Autoresponder could not be sent.', 'otter-blocks' ),
 			self::ERROR_FILE_MISSING_BINARY                => __( 'The file data is missing.', 'otter-blocks' ),
+			self::ERROR_WEBHOOK_COULD_NOT_TRIGGER          => __( 'The webhook could not be triggered.', 'otter-blocks' ),
 		);
 
 		if ( ! isset( $error_messages[ $error_code ] ) ) {

--- a/inc/integrations/class-form-settings-data.php
+++ b/inc/integrations/class-form-settings-data.php
@@ -122,6 +122,13 @@ class Form_Settings_Data {
 	private $submissions_save_location = '';
 
 	/**
+	 * The webhook ID.
+	 *
+	 * @var string
+	 */
+	private $webhook_id = '';
+
+	/**
 	 * The default constructor.
 	 *
 	 * @param array $integration_data The integration data.
@@ -241,6 +248,9 @@ class Form_Settings_Data {
 					$integration->set_submissions_save_location( 'database-email' );
 				}
 				$integration->set_meta( $form );
+				if ( isset( $form['webhookId'] ) ) {
+					$integration->set_webhook_id( $form['webhookId'] );
+				}
 			}
 		}
 		return $integration;
@@ -645,6 +655,15 @@ class Form_Settings_Data {
 	}
 
 	/**
+	 * Get the webhook id.
+	 *
+	 * @return string
+	 */
+	public function get_webhook_id() {
+		return $this->webhook_id;
+	}
+
+	/**
 	 * Set the autoresponder.
 	 *
 	 * @param array $autoresponder The email bcc.
@@ -673,6 +692,19 @@ class Form_Settings_Data {
 	 */
 	public function set_submissions_save_location( $submissions_save_location ) {
 		$this->submissions_save_location = $submissions_save_location;
+		return $this;
+	}
+
+	/**
+	 * Set the webhook ID.
+	 *
+	 * @param string $webhook_id The webhook ID.
+	 * @return $this
+	 */
+	private function set_webhook_id( $webhook_id ) {
+		if ( ! empty( $webhook_id ) ) {
+			$this->webhook_id = $webhook_id;
+		}
 		return $this;
 	}
 }

--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -536,9 +536,10 @@ class Options_Settings {
 							if ( isset( $item['method'] ) ) {
 								$item['method'] = sanitize_text_field( $item['method'] );
 							}
-							if ( isset( $item['headers'] ) && is_array( $item['headers'] ) && count( array_keys( $item['headers'] ) ) > 0 ) {
-								foreach ( $item['headers'] as $key => $value ) {
-									$item['headers'][ $key ] = sanitize_text_field( $value );
+							if ( isset( $item['headers'] ) && is_array( $item['headers'] ) ) {
+								foreach ( $item['headers'] as &$header ) {
+									$header['key']   = sanitize_text_field( $header['key'] );
+									$header['value'] = sanitize_text_field( $header['value'] );
 								}
 							} else {
 								$item['headers'] = array();

--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -394,6 +394,9 @@ class Options_Settings {
 								'submissionsSaveLocation' => array(
 									'type' => 'string',
 								),
+								'webhookId'               => array(
+									'type' => 'string',
+								),
 							),
 						),
 					),
@@ -508,6 +511,78 @@ class Options_Settings {
 				),
 				'default'           => array(
 					'editor_upsell' => false,
+				),
+			)
+		);
+
+		register_setting(
+			'themeisle_blocks_settings',
+			'themeisle_webhooks_options',
+			array(
+				'type'              => 'array',
+				'description'       => __( 'Otter Registered Webhooks.', 'otter-blocks' ),
+				'sanitize_callback' => function ( $array ) {
+					return array_map(
+						function ( $item ) {
+							if ( isset( $item['id'] ) ) {
+								$item['id'] = sanitize_text_field( $item['id'] );
+							}
+							if ( isset( $item['url'] ) ) {
+								$item['url'] = esc_url_raw( $item['url'] );
+							}
+							if ( isset( $item['name'] ) ) {
+								$item['name'] = sanitize_text_field( $item['name'] );
+							}
+							if ( isset( $item['method'] ) ) {
+								$item['method'] = sanitize_text_field( $item['method'] );
+							}
+							if ( isset( $item['headers'] ) && is_array( $item['headers'] ) && count( array_keys( $item['headers'] ) ) > 0 ) {
+								foreach ( $item['headers'] as $key => $value ) {
+									$item['headers'][ $key ] = sanitize_text_field( $value );
+								}
+							} else {
+								$item['headers'] = array();
+							}
+							return $item;
+						},
+						$array
+					);
+				},
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'      => array(
+									'type' => 'string',
+								),
+								'url'     => array(
+									'type' => 'string',
+								),
+								'headers' => array(
+									'type'  => 'array',
+									'items' => array(
+										'type'       => 'object',
+										'properties' => array(
+											'key'   => array(
+												'type' => 'string',
+											),
+											'value' => array(
+												'type' => 'string',
+											),
+										),
+									),
+								),
+								'name'    => array(
+									'type' => 'string',
+								),
+								'method'  => array(
+									'type' => 'string',
+								),
+							),
+						),
+					),
 				),
 			)
 		);

--- a/inc/render/class-form-multiple-choice.php
+++ b/inc/render/class-form-multiple-choice.php
@@ -32,11 +32,12 @@ class Form_Multiple_Choice_Block {
 		$options_array          = explode( "\n", $options );
 		$is_required            = isset( $attributes['isRequired'] ) ? boolval( $attributes['isRequired'] ) : false;
 		$has_multiple_selection = isset( $attributes['multipleSelection'] ) ? boolval( $attributes['multipleSelection'] ) : false;
+		$mapped_name            = isset( $attributes['mappedName'] ) ? $attributes['mappedName'] : $id;
 
 		$output = '<div class="' . $class_names . '" id="' . $id . '">';
 
 		if ( 'select' === $field_type ) {
-			$output .= $this->render_select_field( $label, $options_array, $id, $has_multiple_selection, $is_required );
+			$output .= $this->render_select_field( $label, $options_array, $id, $mapped_name, $has_multiple_selection, $is_required );
 		} else {
 			$output .= '<label class="otter-form-input-label" >' . $label . $this->render_required_sign( $is_required ) . '</label>';
 
@@ -50,7 +51,7 @@ class Form_Multiple_Choice_Block {
 				$field_value = implode( '_', explode( ' ', sanitize_title( $field_label ) ) );
 				$field_id    = 'field-' . $field_value;
 
-				$output .= $this->render_field( $field_type, $field_label, $field_value, $id, $field_id, $is_required );
+				$output .= $this->render_field( $field_type, $field_label, $field_value, $mapped_name, $field_id, $is_required );
 			}
 
 			$output .= '</div>';
@@ -90,13 +91,14 @@ class Form_Multiple_Choice_Block {
 	 * @param string $label The label of the field.
 	 * @param array  $options_array The options of the field.
 	 * @param string $id The id of the field.
+	 * @param string $name The name of the field.
 	 * @param bool   $is_multiple The multiple status of the field.
 	 * @param bool   $is_required The required status of the field.
 	 * @return string
 	 */
-	public function render_select_field( $label, $options_array, $id, $is_multiple, $is_required ) {
+	public function render_select_field( $label, $options_array, $id, $name, $is_multiple, $is_required ) {
 		$output  = '<label class="otter-form-input-label" for="' . $id . '" >' . $label . $this->render_required_sign( $is_required ) . '</label>';
-		$output .= '<select id="' . $id . '" ' . ( $is_multiple ? ' multiple ' : '' ) . ( $is_required ? ' required ' : '' ) . '>';
+		$output .= '<select id="' . $id . '" ' . ( $is_multiple ? ' multiple ' : '' ) . ( $is_required ? ' required ' : '' ) . ' name="' . $name . '">';
 
 		foreach ( $options_array as $field_label ) {
 
@@ -114,7 +116,7 @@ class Form_Multiple_Choice_Block {
 
 	/**
 	 * Render the required sign.
-	 * 
+	 *
 	 * @param bool $is_required The required status of the field.
 	 * @return string
 	 */

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -35,7 +35,6 @@ class Form_Pro_Features {
 			add_action( 'otter_form_after_submit', array( $this, 'clean_files_from_uploads' ) );
 			add_action( 'otter_form_after_submit', array( $this, 'send_autoresponder' ), 99 );
 			add_action( 'otter_form_after_submit', array( $this, 'trigger_webhook' ) );
-			add_filter( 'themeisle_blocks_form_webhook_payload', array( $this, 'prepare_webhook_payload' ), 10, 3 );
 		}
 	}
 
@@ -398,7 +397,8 @@ class Form_Pro_Features {
 					$headers[] = $pair['key'] . ': ' . $pair['value'];
 				}
 
-				$payload = apply_filters( 'themeisle_blocks_form_webhook_payload', array(), $form_data, $webhook );
+				$payload = $this->prepare_webhook_payload( array(), $form_data, $webhook );
+				$payload = apply_filters( 'themeisle_blocks_form_webhook_payload', $payload, $form_data, $webhook );
 				$payload = wp_json_encode( $payload );
 
 				$response = wp_remote_request(

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -398,7 +398,7 @@ class Form_Pro_Features {
 				}
 
 				$payload = $this->prepare_webhook_payload( array(), $form_data, $webhook );
-				$payload = apply_filters( 'themeisle_blocks_form_webhook_payload', $payload, $form_data, $webhook );
+				$payload = apply_filters( 'otter_form_webhook_payload', $payload, $form_data, $webhook );
 				$payload = wp_json_encode( $payload );
 
 				$response = wp_remote_request(

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -35,6 +35,7 @@ class Form_Pro_Features {
 			add_action( 'otter_form_after_submit', array( $this, 'clean_files_from_uploads' ) );
 			add_action( 'otter_form_after_submit', array( $this, 'send_autoresponder' ), 99 );
 			add_action( 'otter_form_after_submit', array( $this, 'trigger_webhook' ) );
+			add_filter( 'themeisle_blocks_form_webhook_payload', array( $this, 'prepare_webhook_payload' ), 10, 2 );
 		}
 	}
 
@@ -397,58 +398,7 @@ class Form_Pro_Features {
 					$headers[] = $pair['key'] . ': ' . $pair['value'];
 				}
 
-				$payload = array();
-
-				$inputs         = $form_data->get_form_inputs();
-				$uploaded_files = $form_data->get_uploaded_files_path();
-
-				foreach ( $inputs as $input ) {
-					if ( isset( $input['id'] ) && isset( $input['value'] ) ) {
-						$key   = str_replace( 'wp-block-themeisle-blocks-form-', '', $input['id'] );
-						$value = $input['value'];
-
-						if ( ! empty( $input['metadata']['mappedName'] ) ) {
-							$key = $input['metadata']['mappedName'];
-						}
-
-						$is_file_field = ! empty( $input['type'] ) && 'file' === $input['type'];
-
-						if ( $is_file_field && ! empty( $input['metadata']['data'] ) ) {
-							$file_data_key = $input['metadata']['data'];
-
-							if ( ! empty( $uploaded_files[ $file_data_key ] ) ) {
-								$value = $uploaded_files[ $file_data_key ]['file_path'];
-
-								/**
-								 * If the file was uploaded to the media library, we use the URL instead of the path.
-								 */
-								if ( ! empty( $uploaded_files[ $file_data_key ]['file_url'] ) ) {
-									$value = $uploaded_files[ $file_data_key ]['file_url'];
-								}
-							}
-						}
-
-
-						if ( array_key_exists( $key, $payload ) ) {
-							if ( is_array( $payload[ $key ] ) ) {
-								$payload[ $key ][] = $value;
-							} else {
-								/**
-								 * Overwrite the value if it's not an array.
-								 */
-								$payload[ $key ] = $value;
-							}
-						} elseif ( $is_file_field ) {
-							/**
-							 * If the field is a file field, we need to make sure the value is an array.
-							 */
-							$payload[ $key ] = array( $value );
-						} else {
-							$payload[ $key ] = $value;
-						}
-					}
-				}
-
+				$payload = apply_filters( 'themeisle_blocks_form_webhook_payload', array(), $form_data );
 				$payload = wp_json_encode( $payload );
 
 				$response = wp_remote_request(
@@ -475,6 +425,71 @@ class Form_Pro_Features {
 		} finally {
 			return $form_data;
 		}
+	}
+
+	/**
+	 * Prepare webhook payload with form data.
+	 *
+	 * @param mixed             $payload The payload.
+	 * @param Form_Data_Request $form_data The form data.
+	 * @return mixed
+	 */
+	public function prepare_webhook_payload( $payload, $form_data ) {
+
+		if ( ! is_array( $payload ) ) {
+			return $payload;
+		}
+
+		$inputs         = $form_data->get_form_inputs();
+		$uploaded_files = $form_data->get_uploaded_files_path();
+
+		foreach ( $inputs as $input ) {
+			if ( isset( $input['id'] ) && isset( $input['value'] ) ) {
+				$key   = str_replace( 'wp-block-themeisle-blocks-form-', '', $input['id'] );
+				$value = $input['value'];
+
+				if ( ! empty( $input['metadata']['mappedName'] ) ) {
+					$key = $input['metadata']['mappedName'];
+				}
+
+				$is_file_field = ! empty( $input['type'] ) && 'file' === $input['type'];
+
+				if ( $is_file_field && ! empty( $input['metadata']['data'] ) ) {
+					$file_data_key = $input['metadata']['data'];
+
+					if ( ! empty( $uploaded_files[ $file_data_key ] ) ) {
+						$value = $uploaded_files[ $file_data_key ]['file_path'];
+
+						/**
+						 * If the file was uploaded to the media library, we use the URL instead of the path.
+						 */
+						if ( ! empty( $uploaded_files[ $file_data_key ]['file_url'] ) ) {
+							$value = $uploaded_files[ $file_data_key ]['file_url'];
+						}
+					}
+				}
+
+				if ( array_key_exists( $key, $payload ) ) {
+					if ( is_array( $payload[ $key ] ) ) {
+						$payload[ $key ][] = $value;
+					} else {
+						/**
+						 * Overwrite the value if it's not an array.
+						 */
+						$payload[ $key ] = $value;
+					}
+				} elseif ( $is_file_field ) {
+					/**
+					 * If the field is a file field, we need to make sure the value is an array.
+					 */
+					$payload[ $key ] = array( $value );
+				} else {
+					$payload[ $key ] = $value;
+				}
+			}
+		}
+
+		return $payload;
 	}
 
 	/**

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -393,14 +393,14 @@ class Form_Pro_Features {
 					if ( empty( $pair['key'] ) || empty( $pair['value'] ) ) {
 						continue;
 					}
-					$headers[ $pair['key'] ] = $pair['value'];
+
+					$headers[] = $pair['key'] . ': ' . $pair['value'];
 				}
 
 				$payload = array();
 
 				$inputs         = $form_data->get_form_inputs();
 				$uploaded_files = $form_data->get_uploaded_files_path();
-				$media_files    = $form_data->get_files_loaded_to_media_library();
 
 				foreach ( $inputs as $input ) {
 					if ( isset( $input['id'] ) && isset( $input['value'] ) ) {

--- a/plugins/otter-pro/inc/render/class-form-file-block.php
+++ b/plugins/otter-pro/inc/render/class-form-file-block.php
@@ -37,12 +37,13 @@ class Form_File_Block {
 		$has_multiple_files = isset( $attributes['multipleFiles'] ) && boolval( $attributes['multipleFiles'] ) && ( ! isset( $attributes['maxFilesNumber'] ) || intval( $attributes['maxFilesNumber'] ) > 1 );
 		$allowed_files      = isset( $attributes['allowedFileTypes'] ) ? implode( ',', $attributes['allowedFileTypes'] ) : '';
 
-		$output = '<div class="' . $class_names . '" id="' . $id . '">';
+		$output      = '<div class="' . $class_names . '" id="' . $id . '">';
+		$mapped_name = isset( $attributes['mappedName'] ) ? $attributes['mappedName'] : 'field-' . $id;
 
-		$output .= '<label class="otter-form-input-label" for="field-' . $id . '" >' . $label . $this->render_required_sign( $is_required ) . '</label>';
+		$output .= '<label class="otter-form-input-label" for="' . $mapped_name . '" >' . $label . $this->render_required_sign( $is_required ) . '</label>';
 
-		$output .= '<input type="file" class="otter-form-input" name="field-'
-		. $id . '" '
+		$output .= '<input type="file" class="otter-form-input" name="'
+		. $mapped_name . '" '
 		. ( $is_required ? 'required ' : '' ) . ' '
 		. ( $has_multiple_files ? 'multiple ' : '' )
 		. ( isset( $attributes['allowedFileTypes'] ) ? ( ' accept="' . $allowed_files ) . '"' : '' )

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -69,7 +69,8 @@ const formOptionsMap = {
 	cc: 'cc',
 	bcc: 'bcc',
 	autoresponder: 'autoresponder',
-	submissionsSaveLocation: 'submissionsSaveLocation'
+	submissionsSaveLocation: 'submissionsSaveLocation',
+	webhookId: 'webhookId'
 };
 
 /**
@@ -303,7 +304,8 @@ const Edit = ({
 			hasCaptcha: wpOptions?.hasCaptcha,
 			autoresponder: wpOptions?.autoresponder,
 			autoresponderSubject: wpOptions?.autoresponderSubject,
-			submissionsSaveLocation: wpOptions?.submissionsSaveLocation
+			submissionsSaveLocation: wpOptions?.submissionsSaveLocation,
+			webhookId: wpOptions?.webhookId
 		});
 	};
 

--- a/src/blocks/blocks/form/file/inspector.js
+++ b/src/blocks/blocks/form/file/inspector.js
@@ -24,7 +24,7 @@ import { Fragment, useContext } from '@wordpress/element';
 import { fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
 import { FormContext } from '../edit';
 import { setUtm } from '../../../helpers/helper-functions';
-import { Notice } from '../../../components';
+import { HTMLAnchorControl, Notice } from '../../../components';
 
 const ProPreview = ({ attributes }) => {
 
@@ -66,6 +66,14 @@ const ProPreview = ({ attributes }) => {
 					help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
 					checked={ attributes.isRequired }
 					onChange={ () => {} }
+				/>
+
+				<TextControl
+					label={ __( 'Mapped Name', 'otter-blocks' ) }
+					help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+					value={ attributes.mappedName }
+					onChange={ () => {} }
+					placeholder={ __( 'photos', 'otter-blocks' ) }
 				/>
 
 				<ToggleControl
@@ -118,45 +126,52 @@ const Inspector = ({
 	} = useContext( FormContext );
 
 	return (
-		<InspectorControls>
-			<PanelBody
-				title={ __( 'Field Settings', 'otter-blocks' ) }
-			>
-				<Button
-					isSecondary
-					variant="secondary"
-					onClick={ () => selectForm?.() }
+		<Fragment>
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Field Settings', 'otter-blocks' ) }
 				>
-					{ __( 'Back to the Form', 'otter-blocks' ) }
-				</Button>
+					<Button
+						isSecondary
+						variant="secondary"
+						onClick={ () => selectForm?.() }
+					>
+						{ __( 'Back to the Form', 'otter-blocks' ) }
+					</Button>
 
-				<SelectControl
-					label={ __( 'Field Type', 'otter-blocks' ) }
-					value={ attributes.type }
-					options={ fieldTypesOptions() }
-					onChange={ type => {
-						if ( 'file' !== type ) {
-							switchFormFieldTo( type, clientId, attributes );
+					<SelectControl
+						label={ __( 'Field Type', 'otter-blocks' ) }
+						value={ attributes.type }
+						options={ fieldTypesOptions() }
+						onChange={ type => {
+							if ( 'file' !== type ) {
+								switchFormFieldTo( type, clientId, attributes );
+							}
+						}}
+					/>
+
+					<ProPreview attributes={ attributes } />
+
+				</PanelBody>
+
+				<PanelColorSettings
+					title={ __( 'Color', 'otter-blocks' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: attributes.labelColor,
+							onChange: () => {},
+							label: __( 'Label Color', 'otter-blocks' )
 						}
-					}}
+					] }
 				/>
-
-				<ProPreview attributes={ attributes } />
-
-			</PanelBody>
-
-			<PanelColorSettings
-				title={ __( 'Color', 'otter-blocks' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						value: attributes.labelColor,
-						onChange: () => {},
-						label: __( 'Label Color', 'otter-blocks' )
-					}
-				] }
+			</InspectorControls>
+			<HTMLAnchorControl
+				value={ attributes.id }
+				onChange={ value => setAttributes({ id: value }) }
 			/>
-		</InspectorControls>
+		</Fragment>
+
 	);
 };
 

--- a/src/blocks/blocks/form/input/inspector.js
+++ b/src/blocks/blocks/form/input/inspector.js
@@ -15,8 +15,12 @@ import {
 	TextControl,
 	ToggleControl
 } from '@wordpress/components';
-import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
 import { Fragment, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
 import { FormContext } from '../edit';
 import { HTMLAnchorControl } from '../../../components';
 

--- a/src/blocks/blocks/form/input/inspector.js
+++ b/src/blocks/blocks/form/input/inspector.js
@@ -16,8 +16,9 @@ import {
 	ToggleControl
 } from '@wordpress/components';
 import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
-import { useContext } from '@wordpress/element';
+import { Fragment, useContext } from '@wordpress/element';
 import { FormContext } from '../edit';
+import { HTMLAnchorControl } from '../../../components';
 
 /**
  *
@@ -35,78 +36,92 @@ const Inspector = ({
 	} = useContext( FormContext );
 
 	return (
-		<InspectorControls>
-			<PanelBody
-				title={ __( 'Field Settings', 'otter-blocks' ) }
-			>
-				<Button
-					isSecondary
-					variant="secondary"
-					onClick={ () => selectForm?.() }
+		<Fragment>
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Field Settings', 'otter-blocks' ) }
 				>
-					{ __( 'Back to the Form', 'otter-blocks' ) }
-				</Button>
+					<Button
+						isSecondary
+						variant="secondary"
+						onClick={ () => selectForm?.() }
+					>
+						{ __( 'Back to the Form', 'otter-blocks' ) }
+					</Button>
 
-				<SelectControl
-					label={ __( 'Field Type', 'otter-blocks' ) }
-					value={ attributes.type }
-					options={ fieldTypesOptions() }
-					onChange={ type => {
-						if ( 'textarea' === type || 'radio' === type || 'checkbox' === type || 'select' === type || 'file' === type ) {
-							switchFormFieldTo( type, clientId, attributes );
-							return;
-						}
+					<SelectControl
+						label={ __( 'Field Type', 'otter-blocks' ) }
+						value={ attributes.type }
+						options={ fieldTypesOptions() }
+						onChange={ type => {
+							if ( 'textarea' === type || 'radio' === type || 'checkbox' === type || 'select' === type || 'file' === type ) {
+								switchFormFieldTo( type, clientId, attributes );
+								return;
+							}
 
-						setAttributes({ type });
-					}}
-				/>
+							setAttributes({ type });
+						}}
+					/>
 
-				<TextControl
-					label={ __( 'Label', 'otter-blocks' ) }
-					value={ attributes.label }
-					onChange={ label => setAttributes({ label }) }
-				/>
+					<TextControl
+						label={ __( 'Label', 'otter-blocks' ) }
+						value={ attributes.label }
+						onChange={ label => setAttributes({ label }) }
+					/>
 
-				<HideFieldLabelToggle attributes={ attributes } setAttributes={ setAttributes } />
+					<HideFieldLabelToggle attributes={ attributes } setAttributes={ setAttributes } />
 
-				<FieldInputWidth attributes={ attributes } setAttributes={ setAttributes } />
+					<FieldInputWidth attributes={ attributes } setAttributes={ setAttributes } />
 
-				{
-					( 'date' !== attributes.type || undefined === attributes.type ) && (
-						<TextControl
-							label={ __( 'Placeholder', 'otter-blocks' ) }
-							value={ attributes.placeholder }
-							onChange={ placeholder => setAttributes({ placeholder }) }
-						/>
-					)
-				}
-
-				<TextControl
-					label={ __( 'Help Text', 'otter-blocks' ) }
-					value={ attributes.helpText }
-					onChange={ helpText => setAttributes({ helpText }) }
-				/>
-
-				<ToggleControl
-					label={ __( 'Required', 'otter-blocks' ) }
-					help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
-					checked={ attributes.isRequired }
-					onChange={ isRequired => setAttributes({ isRequired }) }
-				/>
-			</PanelBody>
-
-			<PanelColorSettings
-				title={ __( 'Color', 'otter-blocks' ) }
-				initialOpen={ false }
-				colorSettings={ [
 					{
-						value: attributes.labelColor,
-						onChange: labelColor => setAttributes({ labelColor }),
-						label: __( 'Label Color', 'otter-blocks' )
+						( 'date' !== attributes.type || undefined === attributes.type ) && (
+							<TextControl
+								label={ __( 'Placeholder', 'otter-blocks' ) }
+								value={ attributes.placeholder }
+								onChange={ placeholder => setAttributes({ placeholder }) }
+							/>
+						)
 					}
-				] }
+
+					<TextControl
+						label={ __( 'Help Text', 'otter-blocks' ) }
+						value={ attributes.helpText }
+						onChange={ helpText => setAttributes({ helpText }) }
+					/>
+
+					<ToggleControl
+						label={ __( 'Required', 'otter-blocks' ) }
+						help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
+						checked={ attributes.isRequired }
+						onChange={ isRequired => setAttributes({ isRequired }) }
+					/>
+
+					<TextControl
+						label={ __( 'Mapped Name', 'otter-blocks' ) }
+						help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+						value={ attributes.mappedName }
+						onChange={ mappedName => setAttributes({ mappedName }) }
+						placeholder={ __( 'first_name', 'otter-blocks' ) }
+					/>
+				</PanelBody>
+
+				<PanelColorSettings
+					title={ __( 'Color', 'otter-blocks' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: attributes.labelColor,
+							onChange: labelColor => setAttributes({ labelColor }),
+							label: __( 'Label Color', 'otter-blocks' )
+						}
+					] }
+				/>
+			</InspectorControls>
+			<HTMLAnchorControl
+				value={ attributes.id }
+				onChange={ value => setAttributes({ id: value }) }
 			/>
-		</InspectorControls>
+		</Fragment>
 	);
 };
 

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -294,6 +294,44 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 						</div>
 
 					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => undefined !== formOptions.webhookId }
+						label={ __( 'Webhook', 'otter-blocks' ) }
+						onDeselect={ () => setFormOption({ webhookId: undefined }) }
+						isShownByDefault={ true }
+					>
+						<SelectControl
+							label={ __( 'Webhook', 'otter-blocks' ) }
+							disabled
+							value={ undefined }
+							options={
+								[
+									{
+										label: __( 'Select Webhook', 'otter-blocks' ),
+										value: ''
+									}
+								]
+
+							}
+							onChange={ props.onChange }
+						/>
+						< br />
+						<Button
+							variant="secondary"
+							onClick={undefined}
+							disabled
+						>
+							{ __( 'Edit Webhooks', 'otter-blocks' ) }
+						</Button>
+
+						<div>
+							<Notice
+								notice={ <ExternalLink href={ setUtm( window.themeisleGutenberg.upgradeLink, 'form-block' ) }>{ __( 'Unlock this with Otter Pro.', 'otter-blocks' ) }</ExternalLink> }
+								variant="upsell"
+							/>
+							<p className="description">{ __( 'Trigger webhooks on Form submit action.', 'otter-blocks' ) }</p>
+						</div>
+					</ToolsPanelItem>
 				</Fragment>
 			) }
 		</Fragment>

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -313,16 +313,22 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 								]
 
 							}
-							onChange={ props.onChange }
+							onChange={ undefined }
 						/>
 						< br />
 						<Button
 							variant="secondary"
 							onClick={undefined}
 							disabled
+							className="wp-block-themeisle-blocks-tabs-inspector-add-tab"
 						>
 							{ __( 'Edit Webhooks', 'otter-blocks' ) }
 						</Button>
+
+						< br />
+						<ExternalLink href="https://docs.themeisle.com/article/1550-otter-pro-documentation">
+							{ __( 'Learn more about webhooks.', 'otter-blocks' ) }
+						</ExternalLink>
 
 						<div>
 							<Notice

--- a/src/blocks/blocks/form/multiple-choice/inspector.js
+++ b/src/blocks/blocks/form/multiple-choice/inspector.js
@@ -16,10 +16,13 @@ import {
 	TextControl,
 	ToggleControl
 } from '@wordpress/components';
+import { Fragment, useContext } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
 import { getActiveStyle, changeActiveStyle } from '../../../helpers/helper-functions.js';
 import { fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
-import { Fragment, useContext } from '@wordpress/element';
 import { FormContext } from '../edit.js';
 import { HTMLAnchorControl } from '../../../components';
 

--- a/src/blocks/blocks/form/multiple-choice/inspector.js
+++ b/src/blocks/blocks/form/multiple-choice/inspector.js
@@ -19,8 +19,9 @@ import {
 
 import { getActiveStyle, changeActiveStyle } from '../../../helpers/helper-functions.js';
 import { fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
-import { useContext } from '@wordpress/element';
+import { Fragment, useContext } from '@wordpress/element';
 import { FormContext } from '../edit.js';
+import { HTMLAnchorControl } from '../../../components';
 
 const styles = [
 	{
@@ -45,95 +46,109 @@ const Inspector = ({
 	} = useContext( FormContext );
 
 	return (
-		<InspectorControls>
-			<PanelBody
-				title={ __( 'Field Settings', 'otter-blocks' ) }
-			>
-				<Button
-					isSecondary
-					variant="secondary"
-					onClick={ () => selectForm?.() }
+		<Fragment>
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Field Settings', 'otter-blocks' ) }
 				>
-					{ __( 'Back to the Form', 'otter-blocks' ) }
-				</Button>
+					<Button
+						isSecondary
+						variant="secondary"
+						onClick={ () => selectForm?.() }
+					>
+						{ __( 'Back to the Form', 'otter-blocks' ) }
+					</Button>
 
-				<SelectControl
-					label={ __( 'Field Type', 'otter-blocks' ) }
-					value={ attributes.type }
-					options={ fieldTypesOptions() }
-					onChange={ type => {
-						if ( 'radio' === type || 'checkbox' === type || 'select' === type ) {
-							setAttributes({ type });
-							return;
-						}
-						switchFormFieldTo( type, clientId, attributes );
-					}}
-				/>
+					<SelectControl
+						label={ __( 'Field Type', 'otter-blocks' ) }
+						value={ attributes.type }
+						options={ fieldTypesOptions() }
+						onChange={ type => {
+							if ( 'radio' === type || 'checkbox' === type || 'select' === type ) {
+								setAttributes({ type });
+								return;
+							}
+							switchFormFieldTo( type, clientId, attributes );
+						}}
+					/>
 
-				<TextControl
-					label={ __( 'Label', 'otter-blocks' ) }
-					value={ attributes.label }
-					onChange={ label => setAttributes({ label }) }
-				/>
+					<TextControl
+						label={ __( 'Label', 'otter-blocks' ) }
+						value={ attributes.label }
+						onChange={ label => setAttributes({ label }) }
+					/>
 
-				<HideFieldLabelToggle attributes={ attributes } setAttributes={ setAttributes } />
+					<HideFieldLabelToggle attributes={ attributes } setAttributes={ setAttributes } />
 
-				<TextareaControl
-					label={ __( 'Options', 'otter-blocks' ) }
-					help={ __( 'Enter each option in a different line.', 'otter-blocks' ) }
-					value={ attributes.options }
-					onChange={ ( options ) => setAttributes({ options }) }
-				/>
+					<TextareaControl
+						label={ __( 'Options', 'otter-blocks' ) }
+						help={ __( 'Enter each option in a different line.', 'otter-blocks' ) }
+						value={ attributes.options }
+						onChange={ ( options ) => setAttributes({ options }) }
+					/>
 
-				<TextControl
-					label={ __( 'Help Text', 'otter-blocks' ) }
-					value={ attributes.helpText }
-					onChange={ helpText => setAttributes({ helpText }) }
-				/>
+					<TextControl
+						label={ __( 'Help Text', 'otter-blocks' ) }
+						value={ attributes.helpText }
+						onChange={ helpText => setAttributes({ helpText }) }
+					/>
 
-				{
-					'select' !== attributes?.type && (
-						<ToggleControl
-							label={ __( 'Inline list', 'otter-blocks' ) }
-							checked={ Boolean( getActiveStyle( styles, attributes.className ) ) }
-							onChange={ value => {
-								const classes = changeActiveStyle( attributes.className, styles, value ? 'inline-list' : undefined );
-								setAttributes({ className: classes });
-							} }
-						/>
-					)
-				}
-
-				{
-					'select' === attributes?.type && (
-						<ToggleControl
-							label={ __( 'Multiple selection', 'otter-blocks' ) }
-							checked={ attributes.multipleSelection }
-							onChange={ multipleSelection => setAttributes({ multipleSelection }) }
-						/>
-					)
-				}
-
-				<ToggleControl
-					label={ __( 'Required', 'otter-blocks' ) }
-					help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
-					checked={ attributes.isRequired }
-					onChange={ isRequired => setAttributes({ isRequired }) }
-				/>
-			</PanelBody>
-
-			<PanelColorSettings
-				title={ __( 'Color', 'otter-blocks' ) }
-				initialOpen={ false }
-				colorSettings={ [
 					{
-						value: attributes.labelColor,
-						onChange: labelColor => setAttributes({ labelColor }),
-						label: __( 'Label Color', 'otter-blocks' )
+						'select' !== attributes?.type && (
+							<ToggleControl
+								label={ __( 'Inline list', 'otter-blocks' ) }
+								checked={ Boolean( getActiveStyle( styles, attributes.className ) ) }
+								onChange={ value => {
+									const classes = changeActiveStyle( attributes.className, styles, value ? 'inline-list' : undefined );
+									setAttributes({ className: classes });
+								} }
+							/>
+						)
 					}
-				] }
+
+					{
+						'select' === attributes?.type && (
+							<ToggleControl
+								label={ __( 'Multiple selection', 'otter-blocks' ) }
+								checked={ attributes.multipleSelection }
+								onChange={ multipleSelection => setAttributes({ multipleSelection }) }
+							/>
+						)
+					}
+
+					<ToggleControl
+						label={ __( 'Required', 'otter-blocks' ) }
+						help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
+						checked={ attributes.isRequired }
+						onChange={ isRequired => setAttributes({ isRequired }) }
+					/>
+
+					<TextControl
+						label={ __( 'Mapped Name', 'otter-blocks' ) }
+						help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+						value={ attributes.mappedName }
+						onChange={ mappedName => setAttributes({ mappedName }) }
+						placeholder={ __( 'car_type', 'otter-blocks' ) }
+					/>
+				</PanelBody>
+
+				<PanelColorSettings
+					title={ __( 'Color', 'otter-blocks' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: attributes.labelColor,
+							onChange: () => {},
+							label: __( 'Label Color', 'otter-blocks' )
+						}
+					] }
+				/>
+			</InspectorControls>
+			<HTMLAnchorControl
+				value={ attributes.id }
+				onChange={ value => setAttributes({ id: value }) }
 			/>
-		</InspectorControls>
+		</Fragment>
 	);
 };
 

--- a/src/blocks/blocks/form/textarea/inspector.js
+++ b/src/blocks/blocks/form/textarea/inspector.js
@@ -14,7 +14,8 @@ import {
 } from '@wordpress/components';
 import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
 import { FormContext } from '../edit';
-import { useContext } from '@wordpress/element';
+import { Fragment, useContext } from '@wordpress/element';
+import { HTMLAnchorControl } from '../../../components';
 
 const Inspector = ({
 	attributes,
@@ -27,60 +28,75 @@ const Inspector = ({
 	} = useContext( FormContext );
 
 	return (
-		<InspectorControls>
-			<PanelBody
-				title={ __( 'Field Settings', 'otter-blocks' ) }
-			>
-				<Button
-					isSecondary
-					variant="secondary"
-					onClick={ () => selectForm?.() }
+		<Fragment>
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Field Settings', 'otter-blocks' ) }
 				>
-					{ __( 'Back to the Form', 'otter-blocks' ) }
-				</Button>
+					<Button
+						isSecondary
+						variant="secondary"
+						onClick={ () => selectForm?.() }
+					>
+						{ __( 'Back to the Form', 'otter-blocks' ) }
+					</Button>
 
-				<SelectControl
-					label={ __( 'Field Type', 'otter-blocks' ) }
-					value={ 'textarea' }
-					options={ fieldTypesOptions() }
-					onChange={ type => {
-						if ( 'textarea' === type ) {
-							return;
-						}
-						switchFormFieldTo( type, clientId, attributes );
-					}}
-				/>
+					<SelectControl
+						label={ __( 'Field Type', 'otter-blocks' ) }
+						value={ 'textarea' }
+						options={ fieldTypesOptions() }
+						onChange={ type => {
+							if ( 'textarea' === type ) {
+								return;
+							}
+							switchFormFieldTo( type, clientId, attributes );
+						}}
+					/>
 
-				<TextControl
-					label={ __( 'Label', 'otter-blocks' ) }
-					value={ attributes.label }
-					onChange={ label => setAttributes({ label }) }
-				/>
+					<TextControl
+						label={ __( 'Label', 'otter-blocks' ) }
+						value={ attributes.label }
+						onChange={ label => setAttributes({ label }) }
+					/>
 
-				<HideFieldLabelToggle attributes={ attributes } setAttributes={ setAttributes } />
+					<HideFieldLabelToggle attributes={ attributes } setAttributes={ setAttributes } />
 
-				<FieldInputWidth attributes={ attributes } setAttributes={ setAttributes } />
+					<FieldInputWidth attributes={ attributes } setAttributes={ setAttributes } />
 
-				<TextControl
-					label={ __( 'Placeholder', 'otter-blocks' ) }
-					value={ attributes.placeholder }
-					onChange={ placeholder => setAttributes({ placeholder }) }
-				/>
+					<TextControl
+						label={ __( 'Placeholder', 'otter-blocks' ) }
+						value={ attributes.placeholder }
+						onChange={ placeholder => setAttributes({ placeholder }) }
+					/>
 
-				<TextControl
-					label={ __( 'Help Text', 'otter-blocks' ) }
-					value={ attributes.helpText }
-					onChange={ helpText => setAttributes({ helpText }) }
-				/>
+					<TextControl
+						label={ __( 'Help Text', 'otter-blocks' ) }
+						value={ attributes.helpText }
+						onChange={ helpText => setAttributes({ helpText }) }
+					/>
 
-				<ToggleControl
-					label={ __( 'Required', 'otter-blocks' ) }
-					help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
-					checked={ attributes.isRequired }
-					onChange={ isRequired => setAttributes({ isRequired }) }
-				/>
-			</PanelBody>
-		</InspectorControls>
+					<ToggleControl
+						label={ __( 'Required', 'otter-blocks' ) }
+						help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
+						checked={ attributes.isRequired }
+						onChange={ isRequired => setAttributes({ isRequired }) }
+					/>
+
+					<TextControl
+						label={ __( 'Mapped Name', 'otter-blocks' ) }
+						help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+						value={ attributes.mappedName }
+						onChange={ mappedName => setAttributes({ mappedName }) }
+						placeholder={ __( 'message', 'otter-blocks' ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<HTMLAnchorControl
+				value={ attributes.id }
+				onChange={ value => setAttributes({ id: value }) }
+			/>
+		</Fragment>
+
 	);
 };
 

--- a/src/blocks/blocks/form/textarea/inspector.js
+++ b/src/blocks/blocks/form/textarea/inspector.js
@@ -12,9 +12,13 @@ import {
 	TextControl,
 	ToggleControl
 } from '@wordpress/components';
+import { Fragment, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
 import { FormContext } from '../edit';
-import { Fragment, useContext } from '@wordpress/element';
 import { HTMLAnchorControl } from '../../../components';
 
 const Inspector = ({

--- a/src/blocks/blocks/form/type.d.ts
+++ b/src/blocks/blocks/form/type.d.ts
@@ -63,7 +63,8 @@ export type FormOptions = {
 		subject?: string
 		body?: string
 	}
-	submissionSaveLocation?: string
+	submissionsSaveLocation?: string
+	webhookId?: string
 }
 
 export type FormAttrs = Partial<Attributes>

--- a/src/blocks/editor.scss
+++ b/src/blocks/editor.scss
@@ -180,3 +180,24 @@ svg.o-block-icon {
 	}
 }
 
+.o-webhooks {
+	display: flex;
+	flex-direction: column;
+
+	&> .o-options-global-defaults {
+		max-height: 500px;
+		overflow-y: auto;
+
+		.o-options-block-item .o-options-block-item-label {
+			margin-left: 10px;
+			flex-grow: 1;
+		}
+	}
+
+	.o-webhook-add {
+		display: flex;
+		justify-content: center;
+		margin-top: 10px;
+	}
+}
+

--- a/src/blocks/editor.scss
+++ b/src/blocks/editor.scss
@@ -145,3 +145,38 @@ svg.o-block-icon {
 		}
 	}
 }
+
+.o-webhook-headers {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+
+	.o-webhook-header {
+		display: grid;
+		grid-template-columns: 1fr 1fr 35px;
+		gap: 10px;
+		align-items: center;
+
+		.components-base-control__field {
+			margin: 0;
+		}
+	}
+
+	button {
+		display: flex;
+		justify-content: center;
+	}
+}
+
+.o-webhook-actions {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+
+	.o-webhook-actions__left {
+		display: flex;
+		flex-direction: row;
+		gap: 10px;
+	}
+}
+

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -55,20 +55,25 @@ const extractFormFields = async( form ) => {
 
 		let value = undefined;
 		let fieldType = undefined;
+		let mappedName = undefined;
 		const { id } = input;
 
 		const valueElem = input.querySelector( '.otter-form-input:not([type="checkbox"], [type="radio"], [type="file"]), .otter-form-textarea-input' );
 		if ( null !== valueElem ) {
 			value = valueElem?.value;
 			fieldType = valueElem?.type;
+			mappedName = valueElem?.name;
 		} else {
 			const select = input.querySelector( 'select' );
+			mappedName = select?.name;
 
 			/** @type{HTMLInputElement} */
 			const fileInput = input.querySelector( 'input[type="file"]' );
 
+
 			if ( fileInput ) {
 				const files = fileInput?.files;
+				const mappedName = fileInput?.name;
 
 				for ( let i = 0; i < files.length; i++ ) {
 					formFieldsData.push({
@@ -82,7 +87,8 @@ const extractFormFields = async( form ) => {
 							size: files[i].size,
 							file: files[i],
 							fieldOptionName: fileInput?.dataset?.fieldOptionName,
-							position: index + 1
+							position: index + 1,
+							mappedName: mappedName
 						}
 					});
 				}
@@ -92,6 +98,7 @@ const extractFormFields = async( form ) => {
 			} else {
 				const labels = input.querySelectorAll( '.o-form-multiple-choice-field > label' );
 				const valuesElem = input.querySelectorAll( '.o-form-multiple-choice-field > input' );
+				mappedName = valuesElem[0]?.name;
 				value = [ ...labels ].filter( ( label, index ) => valuesElem[index]?.checked ).map( label => label.innerHTML ).join( ', ' );
 				fieldType = 'multiple-choice';
 			}
@@ -105,7 +112,8 @@ const extractFormFields = async( form ) => {
 				id: id,
 				metadata: {
 					version: METADATA_VERSION,
-					position: index + 1
+					position: index + 1,
+					mappedName: mappedName
 				}
 			});
 		}

--- a/src/blocks/helpers/use-settings.js
+++ b/src/blocks/helpers/use-settings.js
@@ -105,8 +105,8 @@ const useSettings = () => {
 					}
 				);
 			}
-			onSuccess?.();
 			getSettings();
+			onSuccess?.( response );
 		});
 
 		save.error( ( response ) => {

--- a/src/pro/blocks/file/inspector.js
+++ b/src/pro/blocks/file/inspector.js
@@ -20,10 +20,14 @@ import {
 } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 import { Fragment } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import { fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../../../blocks/blocks/form/common';
 import { Notice } from '../../../blocks/components';
 import { setUtm } from '../../../blocks/helpers/helper-functions';
-import { dispatch } from '@wordpress/data';
 
 
 const ProPreview = ({ attributes }) => {
@@ -72,6 +76,14 @@ const ProPreview = ({ attributes }) => {
 					label={ __( 'Allow multiple file uploads', 'otter-blocks' ) }
 					checked={ attributes.multipleFiles }
 					onChange={ () => {} }
+				/>
+
+				<TextControl
+					label={ __( 'Mapped Name', 'otter-blocks' ) }
+					help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+					value={ attributes.mappedName }
+					onChange={ () => {} }
+					placeholder={ __( 'photos', 'otter-blocks' ) }
 				/>
 
 				{

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -63,7 +63,6 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 
 	const [ webhooks, setWebhooks ] = useState<Webhook[]>([]);
 
-
 	const [ initWebhooks, setInitWebhooks ] = useState( true );
 	useEffect( () => {
 		if ( 'loaded' === status && initWebhooks ) {
@@ -107,6 +106,19 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 			setWebhooks( response?.['themeisle_webhooks_options'] ?? []);
 		});
 	};
+
+	useEffect( () => {
+		if ( isOpen && 0 < webhooks?.length && props.webhookId && id !== props.webhookId ) {
+			const webhook = webhooks.find( ( hook: Webhook ) => hook.id === props.webhookId );
+			if ( webhook ) {
+				setId( webhook.id );
+				setName( webhook.name );
+				setUrl( webhook.url );
+				setMethod( webhook.method );
+				setHeaders( webhook.headers );
+			}
+		}
+	}, [ isOpen, webhooks, props.webhookId ]);
 
 	return (
 		<Fragment>

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -103,7 +103,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 		}
 
 		// Save to wp options
-		setOption?.( 'themeisle_webhooks_options', [ ...webhooksToSave ], __( 'Webhooks saved!', 'otter-blocks' ), 'webhook', ( response ) => {
+		setOption?.( 'themeisle_webhooks_options', [ ...webhooksToSave ], __( 'Webhooks saved.', 'otter-blocks' ), 'webhook', ( response ) => {
 			setWebhooks( response?.['themeisle_webhooks_options'] ?? []);
 		});
 	};

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
  */
 import {
 	BaseControl,
-	Button,
+	Button, ExternalLink,
 	Icon,
 	Modal,
 	Notice,
@@ -378,6 +378,10 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 			>
 				{ __( 'Edit Webhooks', 'otter-blocks' ) }
 			</Button>
+			< br />
+			<ExternalLink href="https://docs.themeisle.com/article/1550-otter-pro-documentation">
+				{ __( 'Learn more about webhooks.', 'otter-blocks' ) }
+			</ExternalLink>
 		</Fragment>
 	);
 };

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -217,7 +217,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 											variant={ 'tertiary' }
 											isDestructive
 											onClick={() => {
-												setWebhooks( webhooks.filter( ( webhook ) => webhook.id !== id ) );
+												saveWebhooks( webhooks.filter( ( webhook ) => webhook.id !== id ) );
 												setId( '' );
 											}}
 										>

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -1,0 +1,362 @@
+import { Fragment } from 'react';
+import {
+	BaseControl,
+	Button,
+	Icon,
+	Modal,
+	Notice,
+	SelectControl,
+	Spinner,
+	TabPanel,
+	TextControl
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+import { arrowRight, closeSmall, trash } from '@wordpress/icons';
+import { v4 as uuidv4 } from 'uuid';
+import useSettings from '../../../blocks/helpers/use-settings';
+
+
+type WebhookEditorProps = {
+	webhookId: string,
+	onChange: ( webhookId: string ) => void,
+}
+
+type Webhook = {
+	id: string,
+	name: string,
+	url: string,
+	method: string,
+	headers: {key?: string, value?: string}[],
+}
+
+const WebhookEditor = ( props: WebhookEditorProps ) => {
+
+	const [ isOpen, setOpen ] = useState( false );
+	const [ error, setError ] = useState( '' );
+
+	const [ id, setId ] = useState( '' );
+
+	const [ url, setUrl ] = useState( '' );
+	const [ name, setName ] = useState( '' );
+	const [ method, setMethod ] = useState( 'GET' );
+	const [ headers, setHeaders ] = useState<{key?: string, value?: string}[]>([]);
+
+	const [ getOption, setOption, status ] = useSettings();
+
+	const fetchWebhook = () => {
+		const hooksOptions = getOption?.( 'themeisle_webhooks_options' );
+		console.log( hooksOptions );
+
+		if ( hooksOptions ) {
+			setWebhooks( hooksOptions );
+		}
+	};
+
+	const [ webhooks, setWebhooks ] = useState<Webhook[]>([]);
+
+
+	const [ initWebhooks, setInitWebhooks ] = useState( true );
+	useEffect( () => {
+		if ( 'loaded' === status && initWebhooks ) {
+			fetchWebhook();
+			setInitWebhooks( false );
+		}
+	}, [ status, initWebhooks ]);
+
+	const checkWebhook = ( webhook: Webhook ) => {
+		if ( ! webhook.name ) {
+			return  __( 'Please enter a webhook name.', 'otter-blocks' );
+		}
+
+		if ( ! webhook.url ) {
+			return __( 'Please enter a webhook URL.', 'otter-blocks' );
+		}
+
+		if ( 0 < webhook.headers.length ) {
+			for ( const header of webhook.headers ) {
+				if ( ! header.key || ! header.value ) {
+					return __( 'Please enter a key and value for all headers.', 'otter-blocks' );
+				}
+			}
+		}
+
+		return true;
+	};
+
+	const saveWebhooks = ( webhooksToSave: Webhook[]) => {
+		for ( const webhook of webhooksToSave ) {
+			const check = checkWebhook( webhook );
+			if ( true !== check ) {
+				const msg = __( 'There was an error saving the webhook: ', 'otter-blocks' ) + webhook?.name + '\n';
+				setError( msg + check );
+				return;
+			}
+		}
+
+		// Save to wp options
+		setOption?.( 'themeisle_webhooks_options', [ ...webhooksToSave ], __( 'Webhooks saved!', 'otter-blocks' ), 'webhook', ( response ) => {
+			setWebhooks( response?.['themeisle_webhooks_options'] ?? []);
+		});
+	};
+
+	return (
+		<Fragment>
+			{ isOpen && (
+				<Modal
+					title={ id ?  __( 'Webhook Editor' ) : __( 'Webhook List' ) }
+					onRequestClose={() => setOpen( false )}
+					shouldCloseOnClickOutside={ false }
+				>
+					{
+						id ? (
+							<Fragment>
+								<TextControl
+									label={ __( 'Webhook Name', 'otter-blocks' ) }
+									help={ __( 'Enter the URL to send the data to.', 'otter-blocks' )}
+									value={name}
+									onChange={setName}
+								/>
+								<TextControl
+									label={ __( 'URL', 'otter-blocks' ) }
+									help={ __( 'Enter the URL to send the data to.', 'otter-blocks' )}
+									value={url}
+									onChange={setUrl}
+								/>
+								<SelectControl
+									label={ __( 'Method', 'otter-blocks' ) }
+									value={method}
+									onChange={setMethod}
+									options={[
+										{ label: 'GET', value: 'GET' },
+										{ label: 'POST', value: 'POST' },
+										{ label: 'PUT', value: 'PUT' }
+									]}
+								/>
+								<BaseControl
+									id="otter-blocks-webhook-headers"
+									label={ __( 'Headers', 'otter-blocks' ) }
+									help={ __( 'Enter the HTTP headers to send with the request.', 'otter-blocks' )}
+								>
+									<div className="o-webhook-headers">
+										{
+											headers?.map( ( header, index ) => {
+												return (
+													<div className="o-webhook-header" key={index}>
+														<TextControl
+															value={header?.key ?? ''}
+															placeholder={ __( 'Content-Type', 'otter-blocks' )}
+															onChange={( value ) => {
+																const newHeaders = [ ...headers ];
+																newHeaders[ index ] = {
+																	...newHeaders[ index ],
+																	key: value
+																};
+																setHeaders( newHeaders );
+															}}
+														/>
+														<TextControl
+															value={header?.value ?? ''}
+															placeholder={ __( 'application/json', 'otter-blocks' )}
+															onChange={( value ) => {
+																const newHeaders = [ ...headers ];
+																newHeaders[ index ] = {
+																	...newHeaders[ index ],
+																	value
+																};
+																setHeaders( newHeaders );
+															}}
+														/>
+														<Button
+															variant={ 'tertiary' }
+															icon={ <Icon icon={closeSmall} /> }
+															onClick={() => {
+																const newHeaders = [ ...headers ];
+																newHeaders.splice( index, 1 );
+																setHeaders( newHeaders );
+															}}
+														/>
+													</div>
+												);
+											})
+										}
+										<Button
+											variant={ 'secondary' }
+											onClick={() => {
+												setHeaders([
+													...headers,
+													{ key: '', value: '' }
+												]);
+											}}
+										>
+											{ __( 'Add New Header', 'otter-blocks' ) }
+										</Button>
+									</div>
+								</BaseControl>
+								<div className="o-webhook-actions">
+									<div className="o-webhook-actions__left">
+										<Button
+											variant={ 'secondary' }
+											onClick={() => {
+												setId( '' );
+											}}
+										>
+											{ __( 'Back', 'otter-blocks' ) }
+										</Button>
+										<Button
+											variant={ 'tertiary' }
+											isDestructive
+											onClick={() => {
+												setWebhooks( webhooks.filter( ( webhook ) => webhook.id !== id ) );
+												setId( '' );
+											}}
+										>
+											{ __( 'Delete', 'otter-blocks' ) }
+										</Button>
+									</div>
+
+									<Button
+										variant={ 'primary' }
+										isBusy={ 'saving' === status || 'loading' === status }
+										onClick={() => {
+
+											const webhook = {
+												id,
+												name,
+												url,
+												method,
+												headers
+											};
+
+											const err = checkWebhook( webhook );
+
+											if ( true !== err ) {
+												setError( err );
+												return;
+											}
+
+											const newWebhooks = [ ...webhooks ];
+											const index = newWebhooks.findIndex( ( webhook ) => webhook.id === id );
+
+											if ( -1 === index ) {
+												newWebhooks.push( webhook );
+											} else {
+												newWebhooks[ index ] = webhook;
+											}
+
+											saveWebhooks( newWebhooks );
+										}}
+									>
+										{ __( 'Save', 'otter-blocks' ) }
+									</Button>
+								</div>
+							</Fragment>
+						) : (
+							<Fragment>
+								<div className="o-options-global-defaults" style={{ maxHeight: '500px', overflowY: 'auto' }}>
+									{
+										webhooks?.map( ( webhook ) => {
+											return (
+												<div className="o-options-block-item">
+
+													<div className="o-options-block-item-label" style={{ marginLeft: '10px', flexGrow: '1' }}>
+														{ webhook.name }
+													</div>
+													<Button
+														icon={ <Icon icon={arrowRight} /> }
+
+														className="o-options-block-item-button"
+														onClick={ () => {
+															setId( webhook.id );
+															setName( webhook.name );
+															setUrl( webhook.url );
+															setMethod( webhook.method );
+															setHeaders( webhook.headers );
+														} }
+													/>
+												</div>
+											);
+										})
+									}
+
+								</div>
+
+								<div className="o-webhook-actions" style={{ justifyContent: 'center' }}>
+									<Button
+										variant={ 'primary' }
+										onClick={() => {
+											setId( `w-${uuidv4()}` );
+											setName( 'New Webhook' );
+											setUrl( 'example.com' );
+											setMethod( 'GET' );
+											setHeaders([]);
+										}}>
+										{ __( 'Add New Webhook', 'otter-blocks' ) }
+									</Button>
+								</div>
+							</Fragment>
+						)
+					}
+
+					{
+						error && (
+							<Notice
+								key="webhook"
+								status="error"
+								isDismissible={true}
+								onRemove={() => {
+									setError( '' );
+								}}>
+								{ error }
+							</Notice>
+						)
+					}
+				</Modal>
+			) }
+
+			{
+				'loading' === status && (
+					<Fragment>
+						<br/>
+						<span>
+							<Spinner />
+							{ __( 'Loading Webhooks', 'otter-blocks' ) }
+						</span>
+					</Fragment>
+				)
+			}
+
+			<SelectControl
+				label={ __( 'Webhook', 'otter-blocks' ) }
+				value={ props.webhookId }
+				options={
+					[
+						{
+							label: __( 'Select Webhook', 'otter-blocks' ),
+							value: ''
+						},
+						...(
+							webhooks?.map?.( ( webhook ) => {
+								return {
+									value: webhook.id,
+									label: webhook.name
+								};
+							}) ?? []
+						)
+					]
+
+				}
+				onChange={ props.onChange }
+			/>
+			< br />
+			<Button
+				variant="secondary"
+				onClick={() => setOpen( true )}
+			>
+				{ __( 'Edit Webhooks', 'otter-blocks' ) }
+			</Button>
+		</Fragment>
+	);
+};
+
+export default WebhookEditor;

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -254,14 +254,14 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 								</div>
 							</Fragment>
 						) : (
-							<Fragment>
-								<div className="o-options-global-defaults" style={{ maxHeight: '500px', overflowY: 'auto' }}>
+							<div className="o-webhooks">
+								<div className="o-options-global-defaults">
 									{
 										webhooks?.map( ( webhook ) => {
 											return (
 												<div className="o-options-block-item">
 
-													<div className="o-options-block-item-label" style={{ marginLeft: '10px', flexGrow: '1' }}>
+													<div className="o-options-block-item-label">
 														{ webhook.name }
 													</div>
 													<Button
@@ -283,7 +283,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 
 								</div>
 
-								<div className="o-webhook-actions" style={{ justifyContent: 'center', marginTop: '10px' }}>
+								<div className="o-webhook-add">
 									<Button
 										variant={ 'primary' }
 										onClick={() => {
@@ -296,7 +296,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 										{ __( 'Add New Webhook', 'otter-blocks' ) }
 									</Button>
 								</div>
-							</Fragment>
+							</div>
 						)
 					}
 
@@ -354,6 +354,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 			<Button
 				variant="secondary"
 				onClick={() => setOpen( true )}
+				className="wp-block-themeisle-blocks-tabs-inspector-add-tab"
 			>
 				{ __( 'Edit Webhooks', 'otter-blocks' ) }
 			</Button>

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -116,12 +116,14 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 									help={ __( 'Enter the URL to send the data to.', 'otter-blocks' )}
 									value={name}
 									onChange={setName}
+									placeholder={ __( 'My Webhook', 'otter-blocks' )}
 								/>
 								<TextControl
 									label={ __( 'URL', 'otter-blocks' ) }
 									help={ __( 'Enter the URL to send the data to.', 'otter-blocks' )}
 									value={url}
 									onChange={setUrl}
+									placeholder={ __( 'https://example.com', 'otter-blocks' )}
 								/>
 								<SelectControl
 									label={ __( 'Method', 'otter-blocks' ) }
@@ -281,14 +283,14 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 
 								</div>
 
-								<div className="o-webhook-actions" style={{ justifyContent: 'center' }}>
+								<div className="o-webhook-actions" style={{ justifyContent: 'center', marginTop: '10px' }}>
 									<Button
 										variant={ 'primary' }
 										onClick={() => {
 											setId( `w-${uuidv4()}` );
-											setName( 'New Webhook' );
-											setUrl( 'example.com' );
-											setMethod( 'GET' );
+											setName( '' );
+											setUrl( '' );
+											setMethod( 'POST' );
 											setHeaders([]);
 										}}>
 										{ __( 'Add New Webhook', 'otter-blocks' ) }

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -1,4 +1,11 @@
-import { Fragment } from 'react';
+/**
+ * External dependencies
+ */
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * WordPress dependencies
+ */
 import {
 	BaseControl,
 	Button,
@@ -7,13 +14,15 @@ import {
 	Notice,
 	SelectControl,
 	Spinner,
-	TabPanel,
 	TextControl
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
-import { arrowRight, closeSmall, trash } from '@wordpress/icons';
-import { v4 as uuidv4 } from 'uuid';
+import { useEffect, useState, Fragment } from '@wordpress/element';
+import { arrowRight, closeSmall } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
 import useSettings from '../../../blocks/helpers/use-settings';
 
 
@@ -46,7 +55,6 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 
 	const fetchWebhook = () => {
 		const hooksOptions = getOption?.( 'themeisle_webhooks_options' );
-		console.log( hooksOptions );
 
 		if ( hooksOptions ) {
 			setWebhooks( hooksOptions );

--- a/src/pro/plugins/form/index.js
+++ b/src/pro/plugins/form/index.js
@@ -21,6 +21,7 @@ import { Notice as OtterNotice } from '../../../blocks/components';
 import { RichTextEditor } from '../../../blocks/components';
 import { FieldInputWidth, HideFieldLabelToggle } from '../../../blocks/blocks/form/common';
 import { setSavedState } from '../../../blocks/helpers/helper-functions';
+import WebhookEditor from '../../components/webhook-editor';
 
 // +-------------- Autoresponder --------------+
 
@@ -63,7 +64,15 @@ const helpMessages = {
 	'database-email': __( 'Save the submissions to the database and notify also via email.', 'otter-blocks' )
 };
 
-
+/**
+ * Form Options
+ *
+ * @param {React.ReactNode} Options The children of the FormOptions component.
+ * @param {import('../../../blocks/blocks/form/type').FormOptions} formOptions The form options.
+ * @param { (options: import('../../../blocks/blocks/form/type').FormOptions) => void } setFormOption The function to set the form options.
+ * @param {any} config The form config.
+ * @returns {JSX.Element}
+ */
 const FormOptions = ( Options, formOptions, setFormOption, config ) => {
 
 	return (
@@ -151,6 +160,37 @@ const FormOptions = ( Options, formOptions, setFormOption, config ) => {
 							)
 						}
 
+					</>
+				) : (
+					<div>
+						<OtterNotice
+							notice={__(
+								'You need to activate Otter Pro.',
+								'otter-blocks'
+							)}
+							instructions={__(
+								'You need to activate your Otter Pro license to use Pro features of Form Block.',
+								'otter-blocks'
+							)}
+						/>
+					</div>
+				)}
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={() => formOptions.webhookId }
+				label={__( 'Webhook', 'otter-blocks' )}
+				onDeselect={() => setFormOption({ webhookId: undefined })}
+			>
+				{Boolean( window.otterPro.isActive ) ? (
+					<>
+						<WebhookEditor
+							webhookId={formOptions.webhookId}
+							onChange={( webhookId ) => {
+								setFormOption({
+									webhookId: webhookId
+								});
+							}}
+						/>
 					</>
 				) : (
 					<div>

--- a/src/pro/plugins/form/index.js
+++ b/src/pro/plugins/form/index.js
@@ -330,6 +330,14 @@ const FormFileInspector = ( Template, {
 				onChange={ isRequired => setAttributes({ isRequired }) }
 			/>
 
+			<TextControl
+				label={ __( 'Mapped Name', 'otter-blocks' ) }
+				help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+				value={ attributes.mappedName }
+				onChange={ mappedName => setAttributes({ mappedName }) }
+				placeholder={ __( 'photos', 'otter-blocks' ) }
+			/>
+
 			<ToggleControl
 				label={ __( 'Allow multiple file uploads', 'otter-blocks' ) }
 				checked={ Boolean( attributes.multipleFiles ) }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add Webhook triggers to Form.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/91fc6a73-6e16-4e06-a1c0-8799b0080eae)

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/c79296f5-e1f6-4f9e-aa7b-dfe3272a521f)

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/48bb734d-6e52-467e-84c7-0defa68e2a6a)


----

### Workflow Explanation

The idea of the webhook is that after a form has been submitted, it will ping a given URL which will trigger an external action/workflow (e.g.: send an SMS, email, a Slack message).

In this feature, we will support Zappier and IFTTT. The way they function is the same regarding the API call. (which means we do not need separate codes for them).

For the features to work, we need three parts:
- the URL of the webhook
- the method: GET, POST,  PATCH
- the headers.

Those settings will be managed in the Webhook editor available in Form at Form Options > Webhook (check screenshots from above).

When a user submits a form, the data of the form will be prepared in a payload with the structure (in JSON format): `key: value`. The `value` will be the field values (⚠️ for File Input the values will be the URI of the saved file (given always as an `array`) - if they are saved on Media Library the URL will be provided. Otherwise, the location on the disk will be given). 

The `key` should be confused with the label. By default, the key will a unique id that resembles the following structure `input-1234234` (this is not enforced). The key is generated using the field unique internal id.

ℹ️ Each field now has a new option named `Mapped Name` which is used as a `key` instead of the default one if present.

#### Example with default keys:

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/0d118166-d15e-4df5-82ab-814483aac330)

#### Example with Mapped Name

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/7f39c0c5-6451-4130-b49a-bffc9f76637f)
 
ℹ️ The main role of Mapped Name is to offer a uniform way of reusing the webhook. Suppose you have three different forms with different types and numbers of fields. And a webhook that takes a phone number and sends an SMS. So for each form, you create the field for the user to introduce the phone number then you set the Mapped Name as `phone_number`, then in the webhook provider, you set a rule to extract the `phone_number` from the request.

#### In Zappier you have something like this
<img width="630" alt="Screenshot 2023-06-30 at 16 14 26" src="https://github.com/Codeinwp/otter-blocks/assets/17597852/9cc8b037-7fdd-40e1-a4f6-eb639d351570">

⚠️ Both Zappier and IFTTT have some cumbersome documentation and website. I strongly suggested some tutorials before starting to document/test this feature.

### Zapier

Zapier is one of the biggest services for integrating things with many services. Workflows in Zapier are called Zaps. When you create a Zap, it shows a drag-and-drop editor in which you put different Apps to connect. To integrate with Form, you need to insert the `Catch Hook in Webhooks by Zapier` (this is a premium feature) it will be marked with a `Trigger` label.

When you press on it, on the right side, a sidebar will open, and the Test tab will appear, which has a section named `Your webhook URL` with a URL that you need to introduce in the Form Webhook feature (see pictures above) on URL field in Webhook Editor.

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/451b2fa3-dc54-4703-972c-84309a0c282e)


You will need the URL from Zapier to connect, and you are ready to go. When you submit a form, all its data will be sent to the webhook (you can check the pictures above).

Regarding the usage of the data that we send, it will be more on the user side on how to configure it. For this, let's put references for tutorials. 

To test this, you can attach a Gmail workflow named `Gmail` with `Create Draft` event in App & event. Then you can set up the values in the Action tab.

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/471ad713-12eb-46fb-a311-588b5f1a0cac)

:information: After you send some submissions and return to the Zapier interface, you will notice that after you press on the field, it will show some suggestions about the values. Zapier parses the fields and offers autocompletion so it can be easier to set up the app.

### IFTTT

🔥 [Video Guide](https://github.com/Codeinwp/otter-internals/issues/96#issuecomment-1630333367)

IFTTT is a Zapier alternative but with an ugly desktop interface (personal opinion). The setup is the same with the differences that workflow is named Applets and the Webhook App is called  `Webhooks`. Unlike Zapier, getting the URL is more cumbersome. To get the URL, you need to go to [this page](https://ifttt.com/maker_webhooks) and press Documentation (you need to be logged in), and the page you are going to see it will contain all the details.

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/c3b1b14e-803e-447d-b257-df236d405ef8)


ℹ️  When you first insert that Webhooks in your Applet, it will ask you to introduce an `Event Name`; this name will be used to identify the webhook.

In the documentation, you will find an URL like this: `https://maker.ifttt.com/trigger/{event}/json/with/key/c1kinRqHROD2Ds...`, in which you replace the `{event}` with your webhook name. If you set the webhook name as `test_1`, the link will be: `https://maker.ifttt.com/trigger/test_1/json/with/key/c1kinRqHROD2Ds...`

You take this URL and put it in the URL field in the Webhook Editor of the Form Block. As you can see, is the same thing as Zapier.

ℹ️ Do not forget to add the Header: `Content-Type: application/json`

To this up, I recommend connecting your account with Google and adding the `Send yourself an email` via Gmail, which practically will send an email with data with JSON payload.

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/116bb89d-cd3e-4ced-815a-bf9e030ec32f)


ℹ️  Even if IFTTT does the same thing as Zapier, it does not have the same features regarding the UX. In Zapier, things are in the same Editor, while in IFTTT, you will have multiple navigations to check things.

### Change the payload data with PHP Hooks

Using PHP, users can change the data of the payload that will be sent to the webhook.

The name of the filter is `themeisle_blocks_form_webhook_payload`. It takes the three parameters: the current content as `array`, the form data of type `Form_Data_Request` ([definition](https://github.com/Codeinwp/otter-blocks/blob/master/inc/integrations/api/form-request-data.php)), and the current used webhook data, which have `method, url, headers` as `array keys`.

Example:

```php

         /**
	 * Add extra data to the payload that marks the IFTTT webhook provider.
	 *
	 * @param mixed $payload The payload.
	 * @param Form_Data_Request $form_data The form data.
	 * @param mixed $webhook The webhook.
	 * @return mixed
	 */
	function mark_ifttt_provider( $payload, $form_data, $webhook ) {
		if ( str_contains( $webhook['url'], 'maker.ifttt.com' ) ) {
			$payload['webhook_provider'] = 'ifttt';
		}

		return $payload;
	}

        add_filter( 'otter_form_webhook_payload', 'mark_ifttt_provider', 10, 3 );
```

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a form with some fields.
2. Create a webhook (Zappier or IFTTT) and make the setup via Webhook Editor.
3. Test if the data has been received (check the webhook provider)
4. Go back to the fields and set a `Mapped Name` to set a special name for the field --- you can read more about this above.
5. Test again.

⚠️ The job of the Form is to call the webhook and trigger a workflow. The payload will be served like the description above. For this version, we do not aim to have special integration (like preparing the payload in a way to work with X service from Zappier).  

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

