### PR TITLE
Add missing stripe info link

### DIFF
--- a/src/dashboard/components/pages/Integrations.js
+++ b/src/dashboard/components/pages/Integrations.js
@@ -201,7 +201,7 @@ const Integrations = () => {
 							</ExternalLink>
 
 							<ExternalLink
-								href="#"
+								href="https://docs.themeisle.com/article/1688-integrations-related-blocks#stripe-checkout"
 							>
 								{ __( 'More Info', 'otter-blocks' ) }
 							</ExternalLink>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1722 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add missing stripe info.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Go to Admin > Otter Blocks > Integrations > Stripe and click `More Info`.  It should open a docs page.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

