### PR TITLE
Fix image box shadow

### DIFF
--- a/src/blocks/plugins/image-extension/edit.js
+++ b/src/blocks/plugins/image-extension/edit.js
@@ -103,20 +103,17 @@ const Edit = ({
 	const [ cssNodeName, setNodeCSS ] = useCSSNode();
 	useEffect( () => {
 		setNodeCSS([
-			`img {
+			attributes.boxShadow ? `img {
 				box-shadow: ${ attributes.boxShadowHorizontal }px ${ attributes.boxShadowVertical }px ${ attributes.boxShadowBlur }px ${ getShadowColor() }
 			}
-			` ]);
-	}, [ attributes.boxShadowHorizontal, attributes.boxShadowVertical, attributes.boxShadowBlur, attributes.boxShadowColor, attributes.boxShadowColorOpacity ]);
+			` : '' ]);
+	}, [ attributes.boxShadowHorizontal, attributes.boxShadowVertical, attributes.boxShadowBlur, attributes.boxShadowColor, attributes.boxShadowColorOpacity, attributes.boxShadow ]);
 
 
 	return (
 		<Fragment>
-			{ attributes.boxShadow ? (
-				<BlockEdit {...props } className={ props.className + ` ${cssNodeName};` } />
-			) : (
-				<BlockEdit {...props } className={ props.className + ` ${cssNodeName};` } />
-			) }
+
+			<BlockEdit {...props } className={ props.className + ` ${cssNodeName}` } />
 
 			<InspectorControls>
 				<PanelBody


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1720 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix the Box Shadow image extension in Editor for Core Image.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/0b48f811-1cfc-41e3-a6fd-7e7540fbaeed)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a core Image Block
2. In Inspector, activate the shadow in Box Shadow tab.
3. You should see the shadow in Editor.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

