### PR TITLE
Adjust z-index for section dividers

### DIFF
--- a/src/blocks/blocks/section/components/separators/editor.scss
+++ b/src/blocks/blocks/section/components/separators/editor.scss
@@ -3,7 +3,6 @@
 	left: 0;
 	width: 100%;
 	overflow-x: clip;
-	z-index: 2;
 
 	&.top {
 		top: 0;
@@ -17,7 +16,7 @@
 			bottom: 0;
 		}
 	}
-	
+
 	.rotate {
 		transform: rotate(180deg);
 	}

--- a/src/blocks/blocks/section/components/separators/style.scss
+++ b/src/blocks/blocks/section/components/separators/style.scss
@@ -3,7 +3,6 @@
 	left: 0;
 	width: 100%;
 	overflow-x: clip;
-	z-index: 2;
 
 	&.top {
 		top: 0;

--- a/src/blocks/blocks/section/editor.scss
+++ b/src/blocks/blocks/section/editor.scss
@@ -32,6 +32,10 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 		word-break: keep-all;
 		max-width: var( --columns-width );
 
+		&:not(:first-child, :last-child) {
+			z-index: 1; // If dividers are present, make sure they are behind the columns.
+		}
+
 		> .block-editor-inner-blocks > .block-editor-block-list__layout {
 			display: flex;
 			flex-wrap: nowrap;

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -141,6 +141,10 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 	&.has-light-bg {
 		color: var( --text-color, var( --nv-text-color , #000 ) );
 	}
+
+	&> .innerblocks-wrap:not(:first-child, :last-child) {
+			z-index: 1; // If dividers are present, make sure they are behind the columns.
+	}
 }
 
 @media ( min-width: 960px ) {
@@ -155,10 +159,6 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 			flex-basis: 100%;
 			word-break: keep-all;
 			max-width: var( --columns-width );
-
-			&:not(:first-child, :last-child) {
-				z-index: 1; // If dividers are present, make sure they are behind the columns.
-			}
 
 			.wp-block-themeisle-blocks-advanced-column {
 				position: relative;

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -156,6 +156,10 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 			word-break: keep-all;
 			max-width: var( --columns-width );
 
+			&:not(:first-child, :last-child) {
+				z-index: 1; // If dividers are present, make sure they are behind the columns.
+			}
+
 			.wp-block-themeisle-blocks-advanced-column {
 				position: relative;
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1751.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Adjust section dividers so they can be behind the content but in front of the background.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/00d41813-9f15-4bba-8849-1f2ef2ff07fb)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a section block with content.
2. Insert the dividers.
3. Ensure the dividers are behind the content but in front of the Section background.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

