### PR TITLE
WP Version Bump

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,6 +5,7 @@
 .jshintrc
 Gruntfile.js
 phpcs.xml
+phpstan.neon
 .eslintrc
 .gitattributes
 .releaserc.yml

--- a/plugins/blocks-animation/readme.md
+++ b/plugins/blocks-animation/readme.md
@@ -2,7 +2,7 @@
 **Contributors:** [themeisle](https://profiles.wordpress.org/themeisle/), [hardeepasrani](https://profiles.wordpress.org/hardeepasrani/), [mariamunteanu1](https://profiles.wordpress.org/mariamunteanu1/)  
 **Tags:** gutenberg, block, block editor, editor, animation, animations, animate, styles, block animations  
 **Requires at least:** 5.9  
-**Tested up to:** 6.2  
+**Tested up to:** 6.3  
 **Requires PHP:** 5.4  
 **Stable tag:** trunk  
 **License:** GPLv3  

--- a/plugins/blocks-animation/readme.txt
+++ b/plugins/blocks-animation/readme.txt
@@ -2,7 +2,7 @@
 Contributors: themeisle, hardeepasrani, mariamunteanu1
 Tags: gutenberg, block, block editor, editor, animation, animations, animate, styles, block animations
 Requires at least: 5.9
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.4
 Stable tag: trunk
 License: GPLv3

--- a/plugins/blocks-css/readme.md
+++ b/plugins/blocks-css/readme.md
@@ -2,7 +2,7 @@
 **Contributors:** [themeisle](https://profiles.wordpress.org/themeisle/), [hardeepasrani](https://profiles.wordpress.org/hardeepasrani/)  
 **Tags:** gutenberg, block, css, css editor, blocks css  
 **Requires at least:** 5.9      
-**Tested up to:** 6.2  
+**Tested up to:** 6.3  
 **Requires PHP:** 5.4    
 **Stable tag:** trunk  
 **License:** GPLv3    

--- a/plugins/blocks-css/readme.txt
+++ b/plugins/blocks-css/readme.txt
@@ -2,7 +2,7 @@
 Contributors: themeisle, hardeepasrani
 Tags: gutenberg, block, css, css editor, blocks css
 Requires at least: 5.9    
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.4  
 Stable tag: trunk
 License: GPLv3  

--- a/plugins/blocks-export-import/readme.md
+++ b/plugins/blocks-export-import/readme.md
@@ -2,7 +2,7 @@
 **Contributors:** [themeisle](https://profiles.wordpress.org/themeisle/), [hardeepasrani](https://profiles.wordpress.org/hardeepasrani/)  
 **Tags:** gutenberg, block, blocks, export, import, exporter, importer, block exporter, block export, block import, block importer  
 **Requires at least:** 5.9      
-**Tested up to:** 6.2  
+**Tested up to:** 6.3  
 **Requires PHP:** 5.4    
 **Stable tag:** trunk  
 **License:** GPLv3    

--- a/plugins/blocks-export-import/readme.txt
+++ b/plugins/blocks-export-import/readme.txt
@@ -2,7 +2,7 @@
 Contributors: themeisle, hardeepasrani
 Tags: gutenberg, block, blocks, export, import, exporter, importer, block exporter, block export, block import, block importer
 Requires at least: 5.9    
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.4  
 Stable tag: trunk
 License: GPLv3  

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 **Contributors:** [themeisle](https://profiles.wordpress.org/themeisle/), [hardeepasrani](https://profiles.wordpress.org/hardeepasrani/), [soarerobertdaniel7](https://profiles.wordpress.org/soarerobertdaniel7/), [mariamunteanu1](https://profiles.wordpress.org/mariamunteanu1/), [arinat](https://profiles.wordpress.org/arinat/), [uriahs-victor](https://profiles.wordpress.org/uriahs-victor/), [john_pixle](https://profiles.wordpress.org/john_pixle/), [wildmisha](https://profiles.wordpress.org/wildmisha/), [irinelenache](https://profiles.wordpress.org/irinelenache/)  
 **Tags:** block, blocks, gutenberg, gutenberg blocks, wordPress blocks, editor, block Editor, page Builder, post blocks, post grids  
 **Requires at least:** 5.9  
-**Tested up to:** 6.2  
+**Tested up to:** 6.3  
 **Requires PHP:** 5.6  
 **Stable tag:** trunk  
 **License:** GPLv3  


### PR DESCRIPTION
This updates WordPress compatibility version as updating through readme.txt wasn't possible due to changes made to readme.md.