### PR TITLE
Hide "Add New" btn in Submission Dashboard 

### DIFF
--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -253,6 +253,11 @@ class Dashboard {
 			.otter-banner__version {
 				align-self: center;
 			}
+
+			/* Hide the "Add New" button for Multisite WP */
+			a.page-title-action {
+				display: none;
+			}
 		</style>
 		<div class="otter-banner">
 			<div class="otter-banner__image">

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -254,8 +254,8 @@ class Dashboard {
 				align-self: center;
 			}
 
-			/* Hide the "Add New" button for Multisite WP */
-			a.page-title-action {
+			/* Hide the "Add New" button for Multisite WP. Second part is for Elementor */
+			a.page-title-action:first-of-type, #e-admin-top-bar-root:not(.e-admin-top-bar--active)~#wpbody .wrap a.page-title-action:first-of-type {
 				display: none;
 			}
 		</style>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1810 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add CSS to hide the "Add New" button. This way it will prevent the user from accidentally creating a submission.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install Otter Pro on a WordPress multisite installation.
- Create multiple sites and visit one of them while being logged in using the super admin user of the network
- Visit Otter Blocks > Form Submissions -> There is should NO "Add New" button.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

