### PR TITLE
Add height & font-size scaling for Progress Bar

### DIFF
--- a/src/blocks/blocks/progress-bar/style.scss
+++ b/src/blocks/blocks/progress-bar/style.scss
@@ -189,34 +189,20 @@ html[amp] {
 
 @media ( max-width: 600px ) {
 	.wp-block-themeisle-blocks-progress-bar {
-		.wp-block-themeisle-blocks-progress-bar__area {
-			font-size: 20px;
-			height: 30px;
+		:is(
+			.wp-block-themeisle-blocks-progress-bar__area,
+			.wp-block-themeisle-blocks-progress-bar__area__title,
+			.wp-block-themeisle-blocks-progress-bar__area__title span,
+			.wp-block-themeisle-blocks-progress-bar__progress,
+			.wp-block-themeisle-blocks-progress-bar__area__bar,
+			.wp-block-themeisle-blocks-progress-bar__progress__append 
+		) {
+				height: clamp(0px, var(--height), 45px);
+				font-size: clamp(0px, var(--font-size), 24px);
 		}
-
-		.wp-block-themeisle-blocks-progress-bar__area__title {
-			font-size: 20px;
-			height: 30px;
-			
-			span {
-				font-size: 20px;
-				height: 30px;
-			}
+	
+		:is(.wp-block-themeisle-blocks-progress-bar__outer__title, .wp-block-themeisle-blocks-progress-bar__outer__value) {
+			font-size: clamp(0px, var(--title-font-size), 24px);
 		}
-
-		.wp-block-themeisle-blocks-progress-bar__progress {
-			font-size: 20px;
-			height: 30px;
-		}
-
-		.wp-block-themeisle-blocks-progress-bar__area__bar {
-			font-size: 20px;
-			height: 30px;
-		}
-
-		.wp-block-themeisle-blocks-progress-bar__progress__append {
-			font-size: 20px;
-			height: 30px;
-		}
-	}
+	} 
 }

--- a/src/blocks/blocks/progress-bar/style.scss
+++ b/src/blocks/blocks/progress-bar/style.scss
@@ -90,7 +90,7 @@
 		border-radius: 2px;
 		line-height: 20px;
 		opacity: 0;
-		font-size: max( clamp(0px, var(--title-font-size), 1.25rem), 12px );
+		font-size: clamp(12px, var(--title-font-size), 26px );
 		text-align: center;
 
 		&.show {
@@ -197,12 +197,12 @@ html[amp] {
 			.wp-block-themeisle-blocks-progress-bar__area__bar,
 			.wp-block-themeisle-blocks-progress-bar__progress__append 
 		) {
-				height: clamp(0px, var(--height), 45px);
-				font-size: clamp(0px, var(--font-size), 24px);
+				height: min( var(--height), 64px);
+				font-size: min( var(--font-size), 64px);
 		}
 	
 		:is(.wp-block-themeisle-blocks-progress-bar__outer__title, .wp-block-themeisle-blocks-progress-bar__outer__value) {
-			font-size: clamp(0px, var(--title-font-size), 24px);
+			font-size: min( var(--title-font-size), 64px);
 		}
 	} 
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1776 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The Progress Bar can be tiny but not too big on Mobile.

For Mobile (viewport with less than 600px width), the `height` will be between `0px and 64px` instead of the fixed `30px`.


### Screenshots <!-- if applicable -->

#### Desktop

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/5336aaa3-e01e-40b3-935f-30e60bb383c1)


#### Mobile

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/c0fe3250-f299-4553-ae6e-7b4c66c3af0c)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a Progress Bar.
2. Add some colossal height.
3. On the Desktop should be the same size but on the Mobile should be smaller.
4. Now make a smaller Progress Bar (height less than 64px).
5. It should look the same on both Desktop and Mobile

ℹ️ Progress Bar does not have responsive options; thus, the constrain is implemented.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

