### PR TITLE
Fix undefined checking for stripe store in Stripe Checkout Block

### DIFF
--- a/src/blocks/blocks/stripe-checkout/edit.tsx
+++ b/src/blocks/blocks/stripe-checkout/edit.tsx
@@ -91,9 +91,9 @@ const Edit = ({
 					value: product?.id
 				};
 			}) : [],
-			hasProductsRequestFailed: Boolean( getResolutionError( 'getStripeProducts' ) ),
-			productsError: getResolutionError( 'getStripeProducts' ),
-			isLoadingProducts: isResolving( 'getStripeProducts' )
+			hasProductsRequestFailed: Boolean( getResolutionError?.( 'getStripeProducts' ) ),
+			productsError: getResolutionError?.( 'getStripeProducts' ),
+			isLoadingProducts: isResolving?.( 'getStripeProducts' )
 		};
 	}, [ canRetrieveProducts, status ]);
 
@@ -119,7 +119,7 @@ const Edit = ({
 			isResolving: Function
 		} = select( 'themeisle-gutenberg/data' );
 
-		const prices = attributes.product ? getStripeProductPrices( attributes.product ) : [];
+		const prices = attributes.product ? getStripeProductPrices?.( attributes.product ) : [];
 
 		return {
 			prices,
@@ -129,9 +129,9 @@ const Edit = ({
 					value: prices?.id
 				};
 			}) : [],
-			hasPricesRequestFailed: Boolean( getResolutionError( 'getStripeProductPrices', [ attributes.product ]) ),
-			pricesError: getResolutionError( 'getStripeProductPrices', [ attributes.product ]),
-			isLoadingPrices: isResolving( 'getStripeProductPrices', [ attributes.product ])
+			hasPricesRequestFailed: Boolean( getResolutionError?.( 'getStripeProductPrices', [ attributes.product ]) ),
+			pricesError: getResolutionError?.( 'getStripeProductPrices', [ attributes.product ]),
+			isLoadingPrices: isResolving?.( 'getStripeProductPrices', [ attributes.product ])
 		};
 	}, [ attributes.product, canRetrieveProducts ]);
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1815
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added `?.` as a guard against undefined values when functions are not yet initialized.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

ℹ️ You need to test on WP5.9. Make sure to have a Stripe API Key for testing.

1. Insert a Stripe Checkout Block
2. It should work as expected.


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

