### PR TITLE
Fix missing submit messages for Form

### DIFF
--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -83,10 +83,11 @@ class Form_Data_Response {
 	 * @since 2.0.0
 	 */
 	public function __construct() {
-		$this->response['success']      = false;
-		$this->response['reasons']      = array();
-		$this->response['code']         = self::SUCCESS_EMAIL_SEND;
-		$this->response['displayError'] = 'Error. Please try again.';
+		$this->response['success']       = false;
+		$this->response['reasons']       = array();
+		$this->response['code']          = self::SUCCESS_EMAIL_SEND;
+		$this->response['displayError']  = 'Error. Please try again.';
+		$this->response['submitMessage'] = 'Success';
 	}
 
 	/**
@@ -145,6 +146,17 @@ class Form_Data_Response {
 	 */
 	public function set_reasons( $reasons ) {
 		$this->response['reasons'] = $reasons;
+		return $this;
+	}
+
+	/**
+	 * Set success message.
+	 * 
+	 * @param string $message The message.
+	 * @since 2.4
+	 */
+	public function set_success_message( $message ) {
+		$this->response['submitMessage'] = $message;
 		return $this;
 	}
 

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -278,20 +278,22 @@ class Form_Server {
 				do_action( 'otter_form_after_submit', $form_data );
 
 				if ( ! ( $form_data instanceof Form_Data_Request ) ) {
-					$res->set_code( Form_Data_Response::ERROR_RUNTIME_ERROR );
-					$res->add_reason( __( 'The form data class is not valid after performing provider actions! Some hook is corrupting the data.', 'otter-blocks' ) );
+					$res->set_code( Form_Data_Response::ERROR_RUNTIME_ERROR )
+						->add_reason( __( 'The form data class is not valid after performing provider actions! Some hook is corrupting the data.', 'otter-blocks' ) );
 				}
 
 				if ( $form_data->has_error() ) {
-					$res->set_code( $form_data->get_error_code() );
+					$res->set_code( $form_data->get_error_code() )
+						->set_display_error( $form_options->get_error_message() );
 				} else {
-					$res->set_code( Form_Data_Response::SUCCESS_EMAIL_SEND );
-					$res->mark_as_success();
+					$res->set_code( Form_Data_Response::SUCCESS_EMAIL_SEND )
+						->set_success_message( $form_options->get_submit_message() )
+						->mark_as_success();
 				}
 			}
 		} catch ( Exception $e ) {
-			$res->set_code( Form_Data_Response::ERROR_RUNTIME_ERROR );
-			$res->add_reason( $e->getMessage() );
+			$res->set_code( Form_Data_Response::ERROR_RUNTIME_ERROR )
+				->add_reason( $e->getMessage() );
 			$form_data->set_error( Form_Data_Response::ERROR_RUNTIME_ERROR, $e->getMessage() );
 			$this->send_error_email( $form_data );
 		} finally {

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -981,10 +981,10 @@ const Edit = ({
 										<Fragment>
 											<div>
 												<div className='o-form-server-response o-success' style={{ color: attributes.submitMessageColor }}>
-													{ formOptions.submitMessage || __( 'Success', 'otter-blocks' ) }
+													{ formOptions.submitMessage ?? __( 'Success', 'otter-blocks' ) }
 												</div>
 												<div className='o-form-server-response o-error' style={{ color: attributes.submitMessageErrorColor, margin: '0px' }}>
-													{ __( 'Error. Please try again.', 'otter-blocks' ) }
+													{ formOptions.errorMessage ?? __( 'Error. Please try again.', 'otter-blocks' ) }
 												</div>
 											</div>
 											{


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1804
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added missing submit messages handlers.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a Form and set custom submit messages for Succes and Error in block Inspector.
2. Test the success message.
3. Try to break the form to get the error message.

ℹ️ If you do not want to go through the process of installing the SMPT for mail. You can activate otter pro and use save in `Database` to test the success message, then switch to `Email` for error. (You will get an error if you do not have the SMPT set up)

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

