### PR TITLE
Fix slider error on Block creation

### DIFF
--- a/src/blocks/blocks/slider/edit.js
+++ b/src/blocks/blocks/slider/edit.js
@@ -94,7 +94,7 @@ const Edit = ({
 			initObserver.current = new IntersectionObserver( ( entries ) => {
 				entries.forEach( entry => {
 					if ( entry.isIntersecting && 0 <= entry.intersectionRect.height ) {
-						if ( attributes.images.length ) {
+						if ( attributes.images && 0 < attributes.images.length ) {
 							initSlider();
 							initObserver.current?.unobserve( containerRef.current );
 						}
@@ -114,7 +114,7 @@ const Edit = ({
 	}, [ attributes.id ]);
 
 	useEffect( () => {
-		if ( attributes.images.length ) {
+		if ( attributes.images && 0 < attributes.images.length && attributes.id ) {
 			setSelectedImage( null );
 
 			initSlider();
@@ -158,6 +158,11 @@ const Edit = ({
 				}
 			}
 		};
+
+		// This will prevent the slider from initializing if the block is not in the DOM that it can reach (like Inserter block preview)
+		if ( ! Boolean( document.querySelector( `#${ attributes.id }` ) ?? iframe?.contentDocument?.querySelector( `#${ attributes.id }` ) ) ) {
+			return;
+		}
 
 		/**
 		 * Init the Slider inside the iframe.

--- a/src/blocks/blocks/slider/edit.js
+++ b/src/blocks/blocks/slider/edit.js
@@ -117,9 +117,7 @@ const Edit = ({
 		if ( attributes.images.length ) {
 			setSelectedImage( null );
 
-			if ( null !== sliderRef.current && attributes.id ) {
-				initSlider();
-			}
+			initSlider();
 		}
 	}, [ isSelected, attributes.id, sliderRef.current, attributes.images, attributes.width ]);
 
@@ -164,22 +162,29 @@ const Edit = ({
 		/**
 		 * Init the Slider inside the iframe.
 		 */
-		if ( Boolean( iframe ) ) {
-			const initFrame = () => {
-				if ( iframe?.contentWindow?.Glide ) {
-					sliderRef.current = new iframe.contentWindow.Glide( containerRef.current, config ).mount();
+		try {
+			if ( Boolean( iframe ) ) {
+				const initFrame = () => {
+					if ( iframe?.contentWindow?.Glide ) {
+						sliderRef.current = new iframe.contentWindow.Glide( containerRef.current, config ).mount();
+					}
+				};
+
+				if ( ! Boolean( iframe.contentDocument?.querySelector( '#glidejs-js' ) ) ) {
+
+					// Load the JS file into the iframe.
+					copyScriptAssetToIframe( '#glidejs-js', initFrame );
+				} else {
+					initFrame();
 				}
-			};
-
-			if ( ! Boolean( iframe.contentDocument?.querySelector( '#glidejs-js' ) ) ) {
-
-				// Load the JS file into the iframe.
-				copyScriptAssetToIframe( '#glidejs-js', initFrame );
 			} else {
-				initFrame();
+				sliderRef.current = new window.Glide( containerRef.current, config ).mount();
 			}
-		} else {
-			sliderRef.current = new window.Glide( containerRef.current, config ).mount();
+		} catch ( e ) {
+
+			// We don't want to break the block if the slider fails to init.
+			// The main cause is when the block runs inside an iFrame and can not access the root node.
+			console.warn( e );
 		}
 	};
 
@@ -201,15 +206,6 @@ const Edit = ({
 			peek: 1 === value ? 0 : attributes.peek
 		});
 	};
-
-	useEffect( () => {
-
-		if ( ! attributes.images.length ) {
-			return;
-		}
-
-		initSlider();
-	}, [ attributes.images ]);
 
 	useEffect( () => {
 		if ( Boolean( sliderRef?.current?.update ) ) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1710 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Tweaked the hook that re-initializes the Glide instance when the num of images changes. 
- Used a React Ref for getting the container for the Glide instance instead of making use of `querySelector`. This is working nicely in FSE and Widgets. But I still need the `querySelector` to check if the root is reachable by Glide -- e.g.: Inserter Block Review is not reachable.
- Solved another error related to the observer when deleting the block.

### Screenshots <!-- if applicable -->


https://github.com/Codeinwp/otter-blocks/assets/17597852/f12770c2-695d-411d-9085-875ac2cbf6b7



----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a new Slider Block.
2. Add some images.
3. The arrows that change the image position should work.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

