### PR TITLE
Add CSS var conversion to hex for Section & Column Block shadow color

### DIFF
--- a/inc/css/blocks/class-shared-css.php
+++ b/inc/css/blocks/class-shared-css.php
@@ -275,6 +275,14 @@ class Shared_CSS {
 						'value'   => 'boxShadowColor',
 						'default' => '#000',
 						'format'  => function( $value, $attrs ) {
+							if ( ! isset( $attrs['boxShadowColorOpacity'] ) ) {
+								return $value;
+							}
+
+							if ( 100 === $attrs['boxShadowColorOpacity'] ) {
+								return $value;
+							}
+
 							$opacity = ( isset( $attrs['boxShadowColorOpacity'] ) ? $attrs['boxShadowColorOpacity'] : 50 ) / 100;
 							return Base_CSS::hex2rgba( $value, $opacity );
 						},

--- a/src/blocks/blocks/flip/inspector.js
+++ b/src/blocks/blocks/flip/inspector.js
@@ -112,7 +112,7 @@ const Inspector = ({
 
 	const changeBoxShadowColor = value => {
 		setAttributes({
-			boxShadowColor: ( 100 > attributes.boxShadowColorOpacity && attributes.boxShadowColor?.includes( 'var(' ) ) ?
+			boxShadowColor: ( 100 > attributes.boxShadowColorOpacity && value?.includes( 'var(' ) ) ?
 				getComputedStyle( document.documentElement, null ).getPropertyValue( value?.replace( 'var(', '' )?.replace( ')', '' ) ) :
 				value
 		});

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -254,7 +254,7 @@ const Edit = ({
 
 	if ( true === attributes.boxShadow ) {
 		boxShadowStyle = {
-			boxShadow: `${ attributes.boxShadowHorizontal }px ${ attributes.boxShadowVertical }px ${ attributes.boxShadowBlur }px ${ attributes.boxShadowSpread }px ${  hexToRgba( ( attributes.boxShadowColor ? attributes.boxShadowColor : '#000000' ), attributes.boxShadowColorOpacity ) }`
+			boxShadow: `${ attributes.boxShadowHorizontal }px ${ attributes.boxShadowVertical }px ${ attributes.boxShadowBlur }px ${ attributes.boxShadowSpread }px ${ attributes.boxShadowColor.includes( 'var(' ) && ( attributes.boxShadowColorOpacity === undefined || 100 === attributes.boxShadowColorOpacity ) ? attributes.boxShadowColor : hexToRgba( ( attributes.boxShadowColor ? attributes.boxShadowColor : '#000000' ), attributes.boxShadowColorOpacity ) }`
 		};
 	}
 

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -472,13 +472,29 @@ const Inspector = ({
 								<ColorGradientControl
 									label={ __( 'Shadow Color', 'otter-blocks' ) }
 									colorValue={ attributes.boxShadowColor }
-									onColorChange={ value => setAttributes({ boxShadowColor: value }) }
+									onColorChange={ value => setAttributes({
+										boxShadowColor: ( 100 > attributes.boxShadowColorOpacity && value?.includes( 'var(' ) ) ?
+											getComputedStyle( document.documentElement, null ).getPropertyValue( value?.replace( 'var(', '' )?.replace( ')', '' ) ) :
+											value
+									}) }
 								/>
 
 								<RangeControl
 									label={ __( 'Opacity', 'otter-blocks' ) }
 									value={ attributes.boxShadowColorOpacity }
-									onChange={ value => setAttributes({ boxShadowColorOpacity: value }) }
+									onChange={ value => {
+										const changes = { boxShadowColorOpacity: value };
+
+										/**
+										 * If the value is less than 100 and the color is CSS a variable, then replace the CSS variable with the computed value.
+										 * This is needed because the way calculate the opacity of the color is by using the HEX value since we are doing in the server side.
+										 */
+										if ( 100 > value && attributes.boxShadowColor?.includes( 'var(' ) ) {
+											changes.boxShadowColor = getComputedStyle( document.documentElement, null ).getPropertyValue( attributes.boxShadowColor.replace( 'var(', '' ).replace( ')', '' ) );
+										}
+
+										setAttributes( changes );
+									} }
 									min={ 0 }
 									max={ 100 }
 								/>

--- a/src/blocks/blocks/section/columns/edit.js
+++ b/src/blocks/blocks/section/columns/edit.js
@@ -308,7 +308,7 @@ const Edit = ({
 
 	if ( true === attributes.boxShadow ) {
 		boxShadowStyle = {
-			boxShadow: `${ attributes.boxShadowHorizontal }px ${ attributes.boxShadowVertical }px ${ attributes.boxShadowBlur }px ${ attributes.boxShadowSpread }px ${  hexToRgba( ( attributes.boxShadowColor ? attributes.boxShadowColor : '#000000' ), attributes.boxShadowColorOpacity ) }`
+			boxShadow: `${ attributes.boxShadowHorizontal }px ${ attributes.boxShadowVertical }px ${ attributes.boxShadowBlur }px ${ attributes.boxShadowSpread }px ${ attributes.boxShadowColor.includes( 'var(' ) && ( attributes.boxShadowColorOpacity === undefined || 100 === attributes.boxShadowColorOpacity ) ? attributes.boxShadowColor : hexToRgba( ( attributes.boxShadowColor ? attributes.boxShadowColor : '#000000' ), attributes.boxShadowColorOpacity ) }`
 		};
 	}
 

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -917,13 +917,30 @@ const Inspector = ({
 									<ColorGradientControl
 										label={ __( 'Shadow Color', 'otter-blocks' ) }
 										colorValue={ attributes.boxShadowColor }
-										onColorChange={ value => setAttributes({ boxShadowColor: value }) }
+										onColorChange={ value => setAttributes({
+											boxShadowColor: ( 100 > attributes.boxShadowColorOpacity && value?.includes( 'var(' ) ) ?
+												getComputedStyle( document.documentElement, null ).getPropertyValue( value?.replace( 'var(', '' )?.replace( ')', '' ) ) :
+												value
+										}) }
 									/>
 
 									<RangeControl
 										label={ __( 'Opacity', 'otter-blocks' ) }
 										value={ attributes.boxShadowColorOpacity }
-										onChange={ value => setAttributes({ boxShadowColorOpacity: value }) }
+										onChange={ value => {
+
+											const changes = { boxShadowColorOpacity: value };
+
+											/**
+											 * If the value is less than 100 and the color is CSS a variable, then replace the CSS variable with the computed value.
+											 * This is needed because the way calculate the opacity of the color is by using the HEX value since we are doing in the server side.
+											 */
+											if ( 100 > value && attributes.boxShadowColor?.includes( 'var(' ) ) {
+												changes.boxShadowColor = getComputedStyle( document.documentElement, null ).getPropertyValue( attributes.boxShadowColor.replace( 'var(', '' ).replace( ')', '' ) );
+											}
+
+											setAttributes( changes );
+										} }
 										min={ 0 }
 										max={ 100 }
 									/>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1723
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Added color extraction to Section Block & Column Block for Shadow Color from CSS vars when opacity is lower than 100%.
- Minor fix for Flip Shadow Color: it did not consider the new color when processing. 


### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/otter-blocks/assets/17597852/2b61b8f6-5f97-4f7f-8fb7-53ea5ec115d8



----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Section block with one Column Block.
2. Test the shadow in both blocks, like in the video above.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

