### PR TITLE
fix: color section dropdown alignment selector

### DIFF
--- a/src/blocks/components/button-dropdown-control/editor.scss
+++ b/src/blocks/components/button-dropdown-control/editor.scss
@@ -49,7 +49,7 @@
     }
 }
 
-body:not( .branch-6-1 ) {
+body:is( [class*="branch-5-"], [class*="version-6-0"] ) {
     .o-button-dropdown-control-content {
         .components-popover__content {
             @media (min-width: 782px) {

--- a/src/blocks/components/color-dropdown-control/editor.scss
+++ b/src/blocks/components/color-dropdown-control/editor.scss
@@ -56,7 +56,7 @@
     }
 }
 
-body:not( .branch-6-1 ) {
+body:is( [class*="branch-5-"], [class*="version-6-0"] ) {
     .o-color-dropdown-control-content {
         .components-popover__content {
             @media (min-width: 782px) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1711
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Updated the Section Color Dropdown Component selector regarding the alignment fix in Inspector for the Dropdown component.

Not the selector targets 5.x and 6.0 WP versions. ^6.1 will not be affected.

### Screenshots

#### Before in WP 6.3

![](https://user-images.githubusercontent.com/2649903/245942580-9b7ac394-9628-4419-89f2-3987db57cbbe.png)

#### After in WP 6.3

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/955709ce-0bfb-49e9-9e54-b9db2e4885cf)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

⚠️ We need to test backward compatibility with 5.9, 6.0, 6.1, 6.1

1. Insert a Section Block
2. Go to its color picker in Background & Content on the Style tab, and when pressing the change color, the Popover will be beside the Inspector. Not too further and not inside.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

