### PR TITLE
Regenerate saved style on theme change

### DIFF
--- a/inc/server/class-dashboard-server.php
+++ b/inc/server/class-dashboard-server.php
@@ -38,6 +38,7 @@ class Dashboard_Server {
 	 */
 	public function init() {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		add_action( 'after_switch_theme', array( $this, 'regenerate_styles' ) );
 	}
 
 	/**
@@ -65,7 +66,7 @@ class Dashboard_Server {
 	 * Regenerate styles.
 	 *
 	 * @param \WP_REST_Request $request The request.
-	 * 
+	 *
 	 * @return \WP_REST_Response
 	 * @since   2.0.9
 	 * @access  public

--- a/inc/server/class-dashboard-server.php
+++ b/inc/server/class-dashboard-server.php
@@ -38,7 +38,7 @@ class Dashboard_Server {
 	 */
 	public function init() {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-		add_action( 'after_switch_theme', array( $this, 'regenerate_styles' ) );
+		add_action( 'after_switch_theme', array( $this, 'regenerate_styles_on_theme_change' ) );
 	}
 
 	/**
@@ -73,6 +73,15 @@ class Dashboard_Server {
 	 */
 	public function rest_regenerate_styles( \WP_REST_Request $request ) {
 		return self::regenerate_styles();
+	}
+
+	/**
+	 * Regenerate styles on theme change.
+	 *
+	 * @since 2.3
+	 */
+	public function regenerate_styles_on_theme_change() {
+		self::regenerate_styles();
 	}
 
 	/**


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1673
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added the `regenerate_styles` function in the hook that triggers when the theme changes.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Import content from Template Cloud. Change some blocks on the Home page.
2. When you change to a FSE theme, check the Home page frontend.
3. All changes made before changing the theme should be visible in the Frontend

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

