### PR TITLE
Adding requestAnimationFrame() to scroll sniffing for better perf

### DIFF
--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -208,24 +208,26 @@ window.addEventListener( 'load', () => {
 	}
 
 	window.addEventListener( 'scroll', () => {
-		for ( const element of elements ) {
-			if (
-				element.getBoundingClientRect().top <=
-					window.innerHeight * 0.95 &&
-				0 < element.getBoundingClientRect().top
-			) {
+		requestAnimationFrame( () => {
+			for ( const element of elements ) {
 				if (
-					element.animationClasses &&
-					0 < element.animationClasses.length
+					element.getBoundingClientRect().top <=
+						window.innerHeight * 0.95 &&
+					0 < element.getBoundingClientRect().top
 				) {
-					const classes = element.animationClasses;
-					classes.forEach( ( i ) => element.classList.add( i ) );
+					if (
+						element.animationClasses &&
+						0 < element.animationClasses.length
+					) {
+						const classes = element.animationClasses;
+						classes.forEach( ( i ) => element.classList.add( i ) );
 
-					element.classList.remove( 'hidden-animated' );
-					delete element.animationClasses;
+						element.classList.remove( 'hidden-animated' );
+						delete element.animationClasses;
+					}
 				}
 			}
-		}
+		});
 	});
 });
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes Issue: (n/a)
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
Added `requestAnimationFrame()` API to scroll sniffing for better performance. Source: https://css-tricks.com/using-requestanimationframe/

_Edit by Hardeep:_ Details: https://wordpress.org/support/topic/performance-feature-request/#post-16998512

### Screenshots <!-- if applicable -->

----

### Test instructions
1. Add an animation to a black that is out of viewport `onLoad`.
2. Load the page with the animation. 
3. Ensure the animation fires appropriately

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

See [WordPress.org Support Thread](https://wordpress.org/support/topic/performance-feature-request/#post-16993761) for full context.

Please let me know if there are 