### PR TITLE
chore: remove extra wording in form

### DIFF
--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -497,7 +497,7 @@ const Inspector = ({
 						) }
 
 						<BoxControl
-							label={ __( 'Border Radius', 'otter-blocks' ) }
+							label={ __( 'Radius', 'otter-blocks' ) }
 							values={
 								mergeBoxDefaultValues(
 									attributes.borderRadiusBox,

--- a/src/blocks/blocks/flip/inspector.js
+++ b/src/blocks/blocks/flip/inspector.js
@@ -290,7 +290,7 @@ const Inspector = ({
 								( 'front' === currentSide && ! Boolean( attributes.isInverted ) ) || ( 'back' === currentSide && Boolean( attributes.isInverted ) ) ? (
 									<Fragment>
 										<BaseControl
-											label={ __( 'Vertical Alignment', 'otter-blocks' ) }
+											label={ __( 'Vertical', 'otter-blocks' ) }
 										>
 											<ToogleGroupControl
 
@@ -314,7 +314,7 @@ const Inspector = ({
 										</BaseControl>
 
 										<BaseControl
-											label={ __( 'Horizontal Alignment', 'otter-blocks' ) }
+											label={ __( 'Horizontal', 'otter-blocks' ) }
 										>
 											<ToogleGroupControl
 												options={[
@@ -339,7 +339,7 @@ const Inspector = ({
 									</Fragment>
 								) : (
 									<BaseControl
-										label={ __( 'Vertical Alignment', 'otter-blocks' ) }
+										label={ __( 'Vertical', 'otter-blocks' ) }
 									>
 										<ToogleGroupControl
 
@@ -544,19 +544,19 @@ const Inspector = ({
 								{
 									value: attributes.borderColor,
 									onChange: borderColor => setAttributes({ borderColor }),
-									label: __( 'Border Color', 'otter-blocks' ),
+									label: __( 'Border', 'otter-blocks' ),
 									isShownByDefault: false
 								},
 								{
 									value: attributes.titleColor,
 									onChange: titleColor => setAttributes({ titleColor }),
-									label: __( 'Title Color', 'otter-blocks' ),
+									label: __( 'Title', 'otter-blocks' ),
 									isShownByDefault: false
 								},
 								{
 									value: attributes.descriptionColor,
 									onChange: descriptionColor => setAttributes({ descriptionColor }),
-									label: __( 'Description Color', 'otter-blocks' ),
+									label: __( 'Description', 'otter-blocks' ),
 									isShownByDefault: false
 								}
 							] }
@@ -567,7 +567,7 @@ const Inspector = ({
 							initialOpen={ false }
 						>
 							<BoxControl
-								label={ __( 'Border Width', 'otter-blocks' ) }
+								label={ __( 'Width', 'otter-blocks' ) }
 								values={
 									mergeBoxDefaultValues(
 										numberToBox( attributes.borderWidth ),
@@ -584,7 +584,7 @@ const Inspector = ({
 
 							<BoxControl
 								id="o-border-raduis-box"
-								label={ __( 'Border Radius', 'otter-blocks' ) }
+								label={ __( 'Radius', 'otter-blocks' ) }
 								values={
 									mergeBoxDefaultValues(
 										numberToBox( attributes.borderRadius ),

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -1021,7 +1021,7 @@ const Inspector = ({
 
 							<AutoDisableSyncAttr attributes={ attributes } attr={ 'helpFontSize' }>
 								<BaseControl
-									label={ __( 'Helper Text Size', 'otter-blocks' ) }
+									label={ __( 'Helper Text', 'otter-blocks' ) }
 								>
 									<FontSizePicker
 										fontSizes={ defaultFontSizes }
@@ -1034,7 +1034,7 @@ const Inspector = ({
 
 							<AutoDisableSyncAttr attributes={ attributes } attr={ 'messageFontSize' }>
 								<BaseControl
-									label={ __( 'Success/Error Message Size', 'otter-blocks' ) }
+									label={ __( 'Success/Error Message', 'otter-blocks' ) }
 								>
 									<FontSizePicker
 										fontSizes={ defaultFontSizes }

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -984,7 +984,7 @@ const Inspector = ({
 
 							<AutoDisableSyncAttr attributes={ attributes } attr={'inputBorderRadius'}>
 								<BoxControl
-									label={ __( 'Border Radius', 'otter-blocks' ) }
+									label={ __( 'Radius', 'otter-blocks' ) }
 									values={ ! isObjectLike( attributes.inputBorderRadius ) ? makeBox( _px( attributes.inputBorderRadius ?? 4 ) ) : attributes.inputBorderRadius }
 									onChange={ inputBorderRadius  => setAttributes({ inputBorderRadius }) }
 									id="o-border-raduis-box"
@@ -993,7 +993,7 @@ const Inspector = ({
 
 							<AutoDisableSyncAttr attributes={ attributes } attr={'inputBorderWidth'}>
 								<BoxControl
-									label={ __( 'Border Width', 'otter-blocks' ) }
+									label={ __( 'Width', 'otter-blocks' ) }
 									values={ ! isObjectLike( attributes.inputBorderWidth ) ? makeBox( _px( attributes.inputBorderWidth ?? 1 ) ) : attributes.inputBorderWidth }
 									onChange={ inputBorderWidth  => setAttributes({ inputBorderWidth }) }
 								/>

--- a/src/blocks/blocks/icon-list/inspector.js
+++ b/src/blocks/blocks/icon-list/inspector.js
@@ -221,7 +221,7 @@ const Inspector = ({
 							initialOpen={ false }
 						>
 							<BaseControl
-								label={ __( 'Font Size', 'otter-blocks' ) }
+								label={ __( 'Font', 'otter-blocks' ) }
 								__nextHasNoMarginBottom={ true }
 
 								// help={ __( 'The size of the font size of the content and icon.', 'otter-blocks' ) }
@@ -256,7 +256,7 @@ const Inspector = ({
 							</BaseControl>
 
 							<BaseControl
-								label={ __( 'Icon Size', 'otter-blocks' ) }
+								label={ __( 'Icon', 'otter-blocks' ) }
 								__nextHasNoMarginBottom={ true }
 
 								//help={ __( 'The size of the font size of the content and icon.', 'otter-blocks' ) }

--- a/src/blocks/blocks/icon-list/item/inspector.js
+++ b/src/blocks/blocks/icon-list/item/inspector.js
@@ -71,14 +71,14 @@ const Inspector = ({
 					{
 						value: attributes.contentColor,
 						onChange: contentColor => setAttributes({ contentColor }),
-						label: __( 'Content Color', 'otter-blocks' ),
+						label: __( 'Content', 'otter-blocks' ),
 						isShownByDefault: true
 					},
 					...( 'image' !== attributes.library ? [
 						{
 							value: attributes.iconColor,
 							onChange: iconColor => setAttributes({ iconColor }),
-							label: __( 'Icon Color', 'otter-blocks' ),
+							label: __( 'Icon', 'otter-blocks' ),
 							isShownByDefault: true
 						}
 					] : [])

--- a/src/blocks/blocks/popup/inspector.js
+++ b/src/blocks/blocks/popup/inspector.js
@@ -394,7 +394,7 @@ const Inspector = ({
 
 							<BoxControl
 								id="o-border-raduis-box"
-								label={ __( 'Border Radius', 'otter-blocks' ) }
+								label={ __( 'Radius', 'otter-blocks' ) }
 								values={ attributes.borderRadius ?? { top: '0px', bottom: '0px', left: '0px', right: '0px' } }
 								onChange={ value => {
 									setAttributes({

--- a/src/blocks/blocks/review/inspector.js
+++ b/src/blocks/blocks/review/inspector.js
@@ -704,7 +704,7 @@ const Inspector = ({
 						/>
 
 						<BaseControl
-							label={ __( 'Content Font Size', 'otter-blocks' ) }
+							label={ __( 'Content', 'otter-blocks' ) }
 						>
 							<FontSizePicker
 								fontSizes={ defaultFontSizes }

--- a/src/blocks/blocks/tabs/group/inspector.js
+++ b/src/blocks/blocks/tabs/group/inspector.js
@@ -331,22 +331,22 @@ const Inspector = ({
 									},
 									{
 										value: attributes.activeTitleBackgroundColor,
-										label: __( 'Active Title Tackground', 'otter-blocks' ),
+										label: __( 'Active Title Background', 'otter-blocks' ),
 										slug: 'activeTitleBackgroundColor'
 									},
 									{
 										value: attributes.titleColor ?? attributes.tabColor ?? 'white',
-										label: __( 'Title Color', 'otter-blocks' ),
+										label: __( 'Title', 'otter-blocks' ),
 										slug: 'titleColor'
 									},
 									{
 										value: attributes.activeTitleColor,
-										label: __( 'Active Title Color', 'otter-blocks' ),
+										label: __( 'Active Title', 'otter-blocks' ),
 										slug: 'activeTitleColor'
 									},
 									{
 										value: attributes.contentTextColor,
-										label: __( 'Content Text Color', 'otter-blocks' ),
+										label: __( 'Content Text', 'otter-blocks' ),
 										slug: 'contentTextColor'
 									},
 									{


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1781 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Removed extra words.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/a65a0a8a-89df-4c7b-94ee-08dfed625b2c)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a Form Block
2. In Inspector/Sidebar, go to Style -> Helper & Submit Messages

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

