### PR TITLE
Remove extra nodes when sorting the images in Slider with drag-and-drop.

### DIFF
--- a/src/blocks/components/image-grid/GridList.js
+++ b/src/blocks/components/image-grid/GridList.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,6 +23,7 @@ const GridList = ({
 	const [ selectedItems, setSelectedItems ] = useState([]);
 	const [ isSorting, setIsSorting ] = useState( false );
 	const [ sortingItemKey, setSortingItemKey ] = useState( null );
+	const containerRef = useRef( null );
 
 	const handleUpdateBeforeSortStart = ({ index }) => {
 		return new Promise( resolve => {
@@ -50,6 +51,20 @@ const GridList = ({
 		setSortingItemKey( null );
 		setSelectedItems([]);
 		onSelectImages( newItems );
+
+		// Remove all extra nodes that react-sortable-hoc adds to the DOM but doesn't remove after sorting is done.
+		document.querySelectorAll( '.o-images-grid-component__image' ).forEach( node => {
+			if ( ! containerRef.current?.container.contains?.( node ) ) {
+
+				// Hide the node until it can be removed to prevent a flash of unstyled content.
+				node.style.display = 'none';
+				setTimeout( () => {
+
+					// Remove the node after a short delay to allow the transition to finish.
+					node.remove();
+				}, 250 );
+			}
+		});
 	};
 
 	const handleItemSelect = item => {
@@ -96,6 +111,7 @@ const GridList = ({
 			onSortEnd={ onSortEnd }
 			distance={ 3 }
 			axis="xy"
+			ref={ containerRef }
 		/>
 	);
 };

--- a/src/blocks/components/image-grid/SortableList.js
+++ b/src/blocks/components/image-grid/SortableList.js
@@ -27,12 +27,14 @@ const SortableList = SortableContainer( ({
 	selectedItems,
 	isSorting,
 	sortingItemKey,
-	open
+	open,
+	ref
 }) => {
 	return (
 		<div
 			className={ className }
 			tabIndex="0"
+			ref={ ref }
 		>
 			{ items.map( ( item, index ) => {
 				const isSelected = selectedItems.includes( item );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1820 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

🔴 I could not find how to fix this by tweaking the props of the HOC component.

🔧 The working solution was a manual cleaning of the extra nodes. It is a little hack, but it works.


### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/otter-blocks/assets/17597852/13213723-9892-4993-952d-d046d4afb93a




----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a Slider Block
2. Add images.
3. Sort the images using the Drag and Drop feature like in the video above.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

