### PR TITLE
Fix Form Marketing List ID fetch and improve error handling

### DIFF
--- a/inc/integrations/api/form-request-data.php
+++ b/inc/integrations/api/form-request-data.php
@@ -108,7 +108,7 @@ class Form_Data_Request {
 	 * Constructor.
 	 *
 	 * @access  public
-	 * @param \WP_REST_Request|mixed $request Request Data.
+	 * @param \WP_REST_Request $request Request Data.
 	 * @since 2.0.3
 	 */
 	public function __construct( $request = null ) {
@@ -118,11 +118,21 @@ class Form_Data_Request {
 		}
 
 		$this->request = $request;
-		$form_data     = $request->get_param( 'form_data' );
 
-		$form_data = json_decode( $form_data, true );
+		if ( ! empty( $request->get_param( 'form_data' ) ) ) {
+			$form_data          = $request->get_param( 'form_data' );
+			$form_data          = json_decode( $form_data, true );
+			$this->request_data = $this->sanitize_request_data( $form_data );
+		} else {
+			$body = json_decode( $request->get_body(), true );
+			if ( null !== $body ) {
+				$this->request_data = $this->sanitize_request_data( $body );
+			} else {
+				$this->error_code = Form_Data_Response::ERROR_MALFORMED_REQUEST;
+			}
+		}
 
-		$this->request_data = $this->sanitize_request_data( $form_data );
+
 		$this->form_options = new Form_Settings_Data( array() );
 	}
 

--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -30,6 +30,7 @@ class Form_Data_Response {
 	const ERROR_MISSING_FILE_FIELD_OPTION         = '16';
 	const ERROR_AUTORESPONDER_MISSING_EMAIL_FIELD = '17';
 	const ERROR_AUTORESPONDER_COULD_NOT_SEND      = '18';
+	const ERROR_MALFORMED_REQUEST                 = '19';
 
 	// Request validation errors.
 	const ERROR_MISSING_DATA          = '101';
@@ -151,7 +152,7 @@ class Form_Data_Response {
 
 	/**
 	 * Set success message.
-	 * 
+	 *
 	 * @param string $message The message.
 	 * @since 2.4
 	 */
@@ -356,6 +357,7 @@ class Form_Data_Response {
 			self::ERROR_AUTORESPONDER_MISSING_EMAIL_FIELD  => __( 'The email field is missing from the Form Block with Autoresponder activated.', 'otter-blocks' ),
 			self::ERROR_AUTORESPONDER_COULD_NOT_SEND       => __( 'The email from Autoresponder could not be sent.', 'otter-blocks' ),
 			self::ERROR_FILE_MISSING_BINARY                => __( 'The file data is missing.', 'otter-blocks' ),
+			self::ERROR_MALFORMED_REQUEST                  => __( 'The request is malformed.', 'otter-blocks' ),
 		);
 
 		if ( ! isset( $error_messages[ $error_code ] ) ) {

--- a/inc/integrations/class-form-utils.php
+++ b/inc/integrations/class-form-utils.php
@@ -40,9 +40,14 @@ class Form_Utils {
 			'eight',
 			'nine',
 			'ten',
+			'eleven',
+			'twelve',
+			'thirteen',
+			'fourteen',
+			'fifteen',
 		);
 
-		$name_1 = $words[ wp_rand( 0, count( $words ) ) ];
+		$name_1 = $words[ wp_rand( 0, count( $words ) - 1 ) ];
 		$name_2 = $words[ wp_rand( 2, count( $words ) ) - 1 ];
 
 		return "Otter-Form-successfully-connected.delete-on-confirmation.$name_1.$name_2@otter-blocks.com";

--- a/inc/integrations/interfaces/interface-form-subscribe-service.php
+++ b/inc/integrations/interfaces/interface-form-subscribe-service.php
@@ -51,10 +51,10 @@ interface FormSubscribeServiceInterface {
 	public static function validate_api_key( $api_key );
 
 	/**
-	 * Test if the service is set up by registering a random email address on the contact list.
+	 * Make a request that add the email to the contact list.
 	 *
-	 * @return mixed
-	 * @since 2.0.3
+	 * @param string $email The email address.
+	 * @return array|\WP_Error The response from Mailchimp.
 	 */
-	public function test_subscription();
+	public function make_subscribe_request( $email );
 }

--- a/inc/integrations/providers/class-mailchimp.php
+++ b/inc/integrations/providers/class-mailchimp.php
@@ -111,7 +111,7 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 	 * @param string $email The email address.
 	 * @return array|\WP_Error The response from Mailchimp.
 	 */
-	private function make_subscribe_request( $email ) {
+	public function make_subscribe_request( $email ) {
 		$user_status = $this->get_new_user_status_mailchimp( $this->list_id );
 
 		$url = 'https://' . $this->server_name . '.api.mailchimp.com/3.0/lists/' . $this->list_id . '/members/' . md5( strtolower( $email ) );
@@ -159,23 +159,6 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 		}
 
 		return $form_data;
-	}
-
-	/**
-	 * Test the subscription by registering a random generated email.
-	 *
-	 * @return Form_Data_Request
-	 * @since 2.0.3
-	 */
-	public function test_subscription() {
-		$req      = new Form_Data_Request();
-		$response = $this->make_subscribe_request( Form_Utils::generate_test_email() );
-
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$req->set_error( Form_Data_Response::get_error_code_message( Form_Data_Response::ERROR_PROVIDER_SUBSCRIBE_ERROR ) );
-		}
-
-		return $req;
 	}
 
 	/**

--- a/inc/integrations/providers/class-sendinblue.php
+++ b/inc/integrations/providers/class-sendinblue.php
@@ -155,22 +155,6 @@ class Sendinblue_Integration implements FormSubscribeServiceInterface {
 	}
 
 	/**
-	 * Test the subscription by registering a random generated email.
-	 *
-	 * @return Form_Data_Request
-	 */
-	public function test_subscription() {
-		$req      = new Form_Data_Request();
-		$response = $this->make_subscribe_request( Form_Utils::generate_test_email() );
-
-		if ( is_wp_error( $response ) || 400 === wp_remote_retrieve_response_code( $response ) ) {
-			$req->set_error( Form_Data_Response::get_error_code_message( Form_Data_Response::ERROR_PROVIDER_SUBSCRIBE_ERROR ) );
-		}
-
-		return $req;
-	}
-
-	/**
 	 * Set the API Key
 	 *
 	 * @param string $api_key The API Key of the provider.

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -655,7 +655,13 @@ class Form_Server {
 				if ( $valid_api_key['valid'] ) {
 					if ( $form_options->has_list_id() ) {
 						$service->set_api_key( $form_options->get_api_key() )->set_list_id( $form_options->get_list_id() );
-						$res = $service->test_subscription();
+						$response = $service->make_subscribe_request( Form_Utils::generate_test_email() );
+
+						if ( is_wp_error( $response ) ) {
+							$res->set_error( Form_Data_Response::ERROR_RUNTIME_ERROR, $response->get_error_message() );
+						} else {
+							$res->mark_as_success();
+						}
 					} else {
 						$res->set_error( __( 'Contact list ID is missing!', 'otter-blocks' ) );
 					}

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -199,7 +199,7 @@ class Form_Server {
 	 * @since 2.0.3
 	 */
 	public function editor( $request ) {
-		$data = new Form_Data_Request( json_decode( $request->get_body(), true ) );
+		$data = new Form_Data_Request( $request );
 		$res  = new Form_Data_Response();
 
 		$form_options = Form_Settings_Data::get_form_setting_from_wordpress_options( $data->get_payload_field( 'formOption' ) );
@@ -211,6 +211,10 @@ class Form_Server {
 			$provider = $data->get_payload_field( 'provider' );
 		}
 		$provider_handlers = Form_Providers::$instance->get_provider_handlers( $provider, 'editor' );
+
+		if ( $data->has_error() ) {
+			return $res->set_code( $data->get_error_code() )->build_response();
+		}
 
 		if ( $provider_handlers && Form_Providers::provider_has_handler( $provider_handlers, $data->get( 'handler' ) ) ) {
 			// Send the data to the provider.

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -553,7 +553,7 @@ const Edit = ({
 					} else {
 						createNotice(
 							'error',
-							res?.error,
+							res?.error ?? res?.reasons?.join( '. ' ) ?? __( 'An error has occurred.', 'otter-blocks' ),
 							{
 								isDismissible: true,
 								type: 'snackbar',

--- a/src/blocks/test/e2e/blocks/form.spec.js
+++ b/src/blocks/test/e2e/blocks/form.spec.js
@@ -273,4 +273,26 @@ test.describe( 'Form Block', () => {
 		// check for a element with the attribute data-redirect-url
 		await expect( await page.$( `[data-redirect="${REDIRECT_URL}"]` ) ).toBeTruthy();
 	});
+
+	test( 'errors on invalid API Key for Market Integration', async({ page, editor, browser }) => {
+
+		await editor.insertBlock({ name: 'themeisle-blocks/form' });
+
+		let formBlock = ( await editor.getBlocks() ).find( ( block ) => 'themeisle-blocks/form' === block.name );
+
+		expect( formBlock ).toBeTruthy();
+
+		const { clientId } = formBlock;
+
+		await page.click( `#block-${clientId} > div > fieldset > ul > li:nth-child(1) > button` );
+
+		await page.getByRole( 'button', { name: 'Marketing Integration' }).click();
+
+		// Select the Mailchimp option on the select with label Provider
+		await page.getByLabel( 'Provider' ).selectOption( 'mailchimp' );
+
+		await page.getByLabel( 'API Key' ).fill( 'invalid-api-key' );
+
+		await expect( page.getByLabel( 'Dismiss this notice' ) ).toBeVisible();
+	});
 });


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1835 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

ℹ️ From the last Form update, the internal structure was slightly modified. The relaxed type hint from PHPDocs made the problem invisible to PHPStan.

🔩  The type hint is now more strict.
🐛 Improved error display in Editor.
🔧 Test Provider feature has been simplified.

### Screenshots <!-- if applicable -->

#### Showcase the working API and error display.

https://github.com/Codeinwp/otter-blocks/assets/17597852/58e4e762-1b4e-4905-8b72-20c92a83cee4


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

⚠️ You will need a Mailchimp and Sendinblue API Key.

1. Insert a Form.
2. Go to marketing integration and use valid API Keys to check the functionality.
3. Try to use an invalid key format (like a random string) to see if errors appear as notices in the bottom-left corner.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

