### PR TITLE
Attach Themeisle docs link on Mapped Name

### DIFF
--- a/src/blocks/blocks/form/common.tsx
+++ b/src/blocks/blocks/form/common.tsx
@@ -218,10 +218,8 @@ export const selectAllFieldsFromForm = ( children: any[]) : ({ parentClientId: s
 
 export const mappedNameInfo = (
 	<Fragment>
-		<Fragment>
-			{__( 'Allow easy identification of the field with features like: webhooks.', 'otter-blocks' )}
-			<ExternalLink href='https://docs.themeisle.com/article/1878-how-to-use-webhooks-in-otter-forms#mapped-name'> { __( 'Learn More', 'otter-blocks' ) } </ExternalLink>
-		</Fragment>
+		{__( 'Allow easy identification of the field.', 'otter-blocks' )}
+		<ExternalLink href='https://docs.themeisle.com/article/1878-how-to-use-webhooks-in-otter-forms#mapped-name'> { __( 'Learn More', 'otter-blocks' ) } </ExternalLink>
 	</Fragment>
 );
 

--- a/src/blocks/blocks/form/common.tsx
+++ b/src/blocks/blocks/form/common.tsx
@@ -2,7 +2,8 @@ import { __ } from '@wordpress/i18n';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	ToggleControl
+	ToggleControl,
+	ExternalLink
 } from '@wordpress/components';
 import { omit } from 'lodash';
 import { createBlock } from '@wordpress/blocks';
@@ -10,6 +11,7 @@ import { dispatch } from '@wordpress/data';
 
 import { BlockProps } from '../../helpers/blocks';
 import { changeActiveStyle, getActiveStyle, getChoice } from '../../helpers/helper-functions';
+import { Fragment } from '@wordpress/element';
 
 export const FieldInputWidth = ( props ) => {
 
@@ -213,5 +215,14 @@ export const selectAllFieldsFromForm = ( children: any[]) : ({ parentClientId: s
 		return undefined;
 	}).flat().filter( c => c !== undefined ) ?? []) as ({ parentClientId: string, inputField: any })[];
 };
+
+export const mappedNameInfo = (
+	<Fragment>
+		<Fragment>
+			{__( 'Allow easy identification of the field with features like: webhooks.', 'otter-blocks' )}
+			<ExternalLink href='https://docs.themeisle.com/article/1878-how-to-use-webhooks-in-otter-forms#mapped-name'> { __( 'Learn More', 'otter-blocks' ) } </ExternalLink>
+		</Fragment>
+	</Fragment>
+);
 
 export default { switchFormFieldTo, HideFieldLabelToggle, FieldInputWidth };

--- a/src/blocks/blocks/form/file/inspector.js
+++ b/src/blocks/blocks/form/file/inspector.js
@@ -21,7 +21,7 @@ import {
 import { applyFilters } from '@wordpress/hooks';
 import { Fragment, useContext } from '@wordpress/element';
 
-import { fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
+import { fieldTypesOptions, HideFieldLabelToggle, mappedNameInfo, switchFormFieldTo } from '../common';
 import { FormContext } from '../edit';
 import { setUtm } from '../../../helpers/helper-functions';
 import { HTMLAnchorControl, Notice } from '../../../components';
@@ -70,7 +70,7 @@ const ProPreview = ({ attributes }) => {
 
 				<TextControl
 					label={ __( 'Mapped Name', 'otter-blocks' ) }
-					help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+					help={ mappedNameInfo }
 					value={ attributes.mappedName }
 					onChange={ () => {} }
 					placeholder={ __( 'photos', 'otter-blocks' ) }

--- a/src/blocks/blocks/form/hidden-field/inspector.js
+++ b/src/blocks/blocks/form/hidden-field/inspector.js
@@ -24,7 +24,7 @@ import { useContext } from '@wordpress/element';
 import { FormContext } from '../edit';
 import { Notice } from '../../../components';
 import { setUtm } from '../../../helpers/helper-functions';
-import { fieldTypesOptions, switchFormFieldTo } from '../common';
+import { fieldTypesOptions, mappedNameInfo, switchFormFieldTo } from '../common';
 
 
 /**
@@ -81,6 +81,14 @@ const Inspector = ({
 					help={ __( 'The query parameter name that is used in URL. If the param is present, its value will be extracted and send with the Form.', 'otter-blocks' ) }
 					placeholder={ __( 'e.g. utm_source', 'otter-blocks' ) }
 					disabled={true}
+				/>
+
+				<TextControl
+					label={ __( 'Mapped Name', 'otter-blocks' ) }
+					help={ mappedNameInfo }
+					value={ attributes.mappedName }
+					onChange={ () => {} }
+					placeholder={ __( 'photos', 'otter-blocks' ) }
 				/>
 
 				<Notice

--- a/src/blocks/blocks/form/input/inspector.js
+++ b/src/blocks/blocks/form/input/inspector.js
@@ -10,6 +10,7 @@ import {
 
 import {
 	Button,
+	ExternalLink,
 	PanelBody,
 	SelectControl,
 	TextControl,
@@ -20,7 +21,7 @@ import { Fragment, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
+import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, mappedNameInfo, switchFormFieldTo } from '../common';
 import { FormContext } from '../edit';
 import { HTMLAnchorControl } from '../../../components';
 
@@ -102,7 +103,7 @@ const Inspector = ({
 
 					<TextControl
 						label={ __( 'Mapped Name', 'otter-blocks' ) }
-						help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+						help={ mappedNameInfo }
 						value={ attributes.mappedName }
 						onChange={ mappedName => setAttributes({ mappedName }) }
 						placeholder={ __( 'first_name', 'otter-blocks' ) }

--- a/src/blocks/blocks/form/multiple-choice/inspector.js
+++ b/src/blocks/blocks/form/multiple-choice/inspector.js
@@ -22,7 +22,7 @@ import { Fragment, useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { getActiveStyle, changeActiveStyle } from '../../../helpers/helper-functions.js';
-import { fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
+import { fieldTypesOptions, HideFieldLabelToggle, mappedNameInfo, switchFormFieldTo } from '../common';
 import { FormContext } from '../edit.js';
 import { HTMLAnchorControl } from '../../../components';
 
@@ -128,7 +128,7 @@ const Inspector = ({
 
 					<TextControl
 						label={ __( 'Mapped Name', 'otter-blocks' ) }
-						help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+						help={ mappedNameInfo }
 						value={ attributes.mappedName }
 						onChange={ mappedName => setAttributes({ mappedName }) }
 						placeholder={ __( 'car_type', 'otter-blocks' ) }

--- a/src/blocks/blocks/form/textarea/inspector.js
+++ b/src/blocks/blocks/form/textarea/inspector.js
@@ -17,7 +17,7 @@ import { Fragment, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../common';
+import { FieldInputWidth, fieldTypesOptions, HideFieldLabelToggle, mappedNameInfo, switchFormFieldTo } from '../common';
 import { FormContext } from '../edit';
 import { HTMLAnchorControl } from '../../../components';
 
@@ -88,7 +88,7 @@ const Inspector = ({
 
 					<TextControl
 						label={ __( 'Mapped Name', 'otter-blocks' ) }
-						help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+						help={ mappedNameInfo }
 						value={ attributes.mappedName }
 						onChange={ mappedName => setAttributes({ mappedName }) }
 						placeholder={ __( 'message', 'otter-blocks' ) }

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -98,6 +98,7 @@ const extractFormFields = async( form ) => {
 				fieldType = 'multiple-choice';
 			} else if ( hiddenInput ) {
 				const paramName = hiddenInput?.dataset?.paramName;
+				mappedName = hiddenInput?.name;
 
 				if ( paramName ) {
 					const urlParams = new URLSearchParams( window.location.search );

--- a/src/pro/blocks/file/inspector.js
+++ b/src/pro/blocks/file/inspector.js
@@ -25,7 +25,7 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { fieldTypesOptions, HideFieldLabelToggle, switchFormFieldTo } from '../../../blocks/blocks/form/common';
+import { fieldTypesOptions, HideFieldLabelToggle, mappedNameInfo, switchFormFieldTo } from '../../../blocks/blocks/form/common';
 import { Notice } from '../../../blocks/components';
 import { setUtm } from '../../../blocks/helpers/helper-functions';
 
@@ -80,7 +80,7 @@ const ProPreview = ({ attributes }) => {
 
 				<TextControl
 					label={ __( 'Mapped Name', 'otter-blocks' ) }
-					help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+					help={ mappedNameInfo }
 					value={ attributes.mappedName }
 					onChange={ () => {} }
 					placeholder={ __( 'photos', 'otter-blocks' ) }

--- a/src/pro/blocks/form-hidden-field/inspector.js
+++ b/src/pro/blocks/form-hidden-field/inspector.js
@@ -22,7 +22,7 @@ import { dispatch } from '@wordpress/data';
  */
 
 import { Notice as OtterNotice } from '../../../blocks/components';
-import { fieldTypesOptions, switchFormFieldTo } from '../../../blocks/blocks/form/common';
+import { fieldTypesOptions, mappedNameInfo, switchFormFieldTo } from '../../../blocks/blocks/form/common';
 
 
 /**
@@ -80,6 +80,15 @@ const Inspector = ({
 					onChange={ paramName => setAttributes({ paramName }) }
 					help={ __( 'The query parameter name that is used in URL. If the param is present, its value will be extracted and send with the Form.', 'otter-blocks' ) }
 					placeholder={ __( 'e.g. utm_source', 'otter-blocks' ) }
+					disabled={! Boolean( window?.otterPro?.isActive )}
+				/>
+
+				<TextControl
+					label={ __( 'Mapped Name', 'otter-blocks' ) }
+					help={ mappedNameInfo }
+					value={ attributes.mappedName }
+					onChange={ mappedName => setAttributes({ mappedName }) }
+					placeholder={ __( 'car_type', 'otter-blocks' ) }
 					disabled={! Boolean( window?.otterPro?.isActive )}
 				/>
 

--- a/src/pro/plugins/form/index.js
+++ b/src/pro/plugins/form/index.js
@@ -16,7 +16,7 @@ import { Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import { Notice as OtterNotice } from '../../../blocks/components';
-import { FieldInputWidth, HideFieldLabelToggle } from '../../../blocks/blocks/form/common';
+import { FieldInputWidth, HideFieldLabelToggle, mappedNameInfo } from '../../../blocks/blocks/form/common';
 import { setSavedState } from '../../../blocks/helpers/helper-functions';
 import AutoresponderBodyModal from '../../components/autoresponder/index.js';
 import WebhookEditor from '../../components/webhook-editor';
@@ -305,7 +305,7 @@ const FormFileInspector = ( Template, {
 
 			<TextControl
 				label={ __( 'Mapped Name', 'otter-blocks' ) }
-				help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+				help={ mappedNameInfo }
 				value={ attributes.mappedName }
 				onChange={ mappedName => setAttributes({ mappedName }) }
 				placeholder={ __( 'photos', 'otter-blocks' ) }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Attach docs link to the Mapped Name field in Fields Blocks.

Enable the change of the mapped name in Hidden Input.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/b21cfbbf-b117-47ca-96f0-402f1a04d9ea)


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

