### PR TITLE
Fix/hover and link styles minor issues

### DIFF
--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -1,5 +1,9 @@
 @import "../blocks/plugins/feedback/editor.scss";
 
+:root {
+	--main-link-color: #2271b1;
+  }
+
 * {
 	box-sizing: inherit;
 }
@@ -32,6 +36,10 @@
 			--wp-admin-theme-color: #ed6f57;
 			--wp-admin-theme-color-darker-20: #d5654f;
 			--wp-admin-theme-color-darker-10: #dd6851;
+		}
+
+		&.is-link {
+			color: var(--main-link-color);
 		}
 	}
 
@@ -262,8 +270,8 @@
 				}
 
 				&:focus {
-					border-color: #00a0d2;
-					box-shadow: 0 0 0 1px #00a0d2;
+					border-color: var(--main-link-color);
+					box-shadow: 0 0 0 1px var(--main-link-color);
 					outline: 2px solid transparent;
 					outline-offset: -2px;
 				}
@@ -305,6 +313,8 @@
 									padding: 2px 20px;
 									font-size: 14px;
 									margin-right: 10px;
+									color: var(--main-link-color);
+									box-shadow: inset 0 0 0 1px var(--main-link-color);
 								}
 
 								.components-external-link {
@@ -357,6 +367,8 @@
 					.is-secondary {
 						padding: 2px 20px;
 						font-size: 14px;
+						color: var(--main-link-color);
+						box-shadow: inset 0 0 0 1px var(--main-link-color);
 
 						&:not(:last-child) {
 							margin-right: 15px;
@@ -498,6 +510,15 @@
 		.components-placeholder__fieldset {
 			justify-content: center;
 		}
+	}
+
+	.components-form-toggle.is-checked .components-form-toggle__track {
+		background-color: var(--main-link-color);
+	}
+
+	.components-textarea-control__input:focus,
+	.components-text-control__input:focus {
+		border-color: var(--main-link-color);
 	}
 }
 

--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -315,6 +315,10 @@
 									margin-right: 10px;
 									color: var(--main-link-color);
 									box-shadow: inset 0 0 0 1px var(--main-link-color);
+
+									&:focus {
+										box-shadow: inset 0 0 0 1.5px var(--main-link-color);
+									}
 								}
 
 								.components-external-link {
@@ -372,6 +376,10 @@
 
 						&:not(:last-child) {
 							margin-right: 15px;
+						}
+
+						&:focus {
+							box-shadow: inset 0 0 0 1.5px var(--main-link-color);
 						}
 					}
 				}
@@ -519,6 +527,7 @@
 	.components-textarea-control__input:focus,
 	.components-text-control__input:focus {
 		border-color: var(--main-link-color);
+		box-shadow: 0 0 0 1px var(--main-link-color);
 	}
 }
 

--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -1,9 +1,5 @@
 @import "../blocks/plugins/feedback/editor.scss";
 
-:root {
-	--main-link-color: #2271b1;
-  }
-
 * {
 	box-sizing: inherit;
 }
@@ -31,6 +27,8 @@
 }
 
 #otter {
+	--main-link-color: #2271b1;
+	
 	.components-button {
 		&.is-primary {
 			--wp-admin-theme-color: #ed6f57;
@@ -524,8 +522,16 @@
 		background-color: var(--main-link-color);
 	}
 
-	.components-textarea-control__input:focus,
-	.components-text-control__input:focus {
+	#o-feedback {
+		box-shadow: inset 0 0 0 1px var(--main-link-color);
+    	color: var(--main-link-color);
+
+		&:focus {
+			box-shadow: inset 0 0 0 1.5px var(--main-link-color);
+		}
+	}
+
+	:is(.components-textarea-control__input, .components-text-control__input):focus {
 		border-color: var(--main-link-color);
 		box-shadow: 0 0 0 1px var(--main-link-color);
 	}

--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -161,7 +161,14 @@
 
 					&:hover {
 						border-bottom: 1px solid #d6e2ed !important;
+						background: #E8E8E8;
 					}
+				}
+			}
+
+			.components-panel__body-toggle {
+				&:hover {
+					background: #E8E8E8;
 				}
 			}
 

--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -89,9 +89,17 @@
 					margin: 0;
 					border: 0;
 					cursor: pointer;
+					margin-right: 8px;
+
+					&:hover {
+						span {
+							color: #282828;
+						}
+						border-bottom: 3px solid #e5e5e5;
+					}
 
 					&.is-active {
-						border-bottom: 4px solid #1E7DB2;
+						border-bottom: 3px solid #1E7DB2;
 
 						span {
 							color: #282828;
@@ -100,7 +108,7 @@
 
 						@media ( max-width: 960px ) {
 							border-bottom: 0;
-							border-left: 4px solid #1E7DB2;
+							border-left: 3px solid #1E7DB2;
 						}
 					}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1843 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Minor styles changes for hover, focus, links and primary accent colors.

### 1. Added hover state for the Navigation panels, since we didn't had one


https://github.com/Codeinwp/otter-blocks/assets/52494172/9f9d0854-ab53-46aa-8d5f-3d498c90f576


### 2. Improved the hover state for the Accordion Panels, to increase the contrast. 
<img width="1098" alt="image" src="https://github.com/Codeinwp/otter-blocks/assets/52494172/6aff71e1-5e49-4b5f-8ade-8ab6be8e040d">

### 3. Made the toggles, Secondary buttons and link - to use 1 single color. In the current live version, those colors change when changing the theme, which creates inconsistent results (attached below): 
<img width="1189" alt="Screenshot 2023-09-01 at 15 21 04" src="https://github.com/Codeinwp/otter-blocks/assets/52494172/fde3c91b-365c-4d64-b6b5-7224ee297205">




----

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. The secondary buttons, link, toggles -> should use the same accent color
2. Test the top navigation, that it has hover state now
3. Test the Accordion hover state, which should also have more contrast now

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

