### PR TITLE
Fix Otter options infinite loading

### DIFF
--- a/src/blocks/plugins/options/index.js
+++ b/src/blocks/plugins/options/index.js
@@ -136,6 +136,9 @@ const Options = () => {
 						setAPILoaded( true );
 					});
 				}
+			} else {
+				setCanUser( false );
+				setAPILoaded( true );
 			}
 		};
 
@@ -301,75 +304,81 @@ const Options = () => {
 							</PanelRow>
 						</PanelBody>
 
-						<PanelBody
-							title={__( 'Block Tools Defaults', 'otter-blocks' )}
-							initialOpen={true}
-						>
-							<p>
-								{
-									__( 'Make those features to be shown by default in Block Tools.', 'otter-blocks' )
-								}
-							</p>
+						{
+							canUser && (
+								<Fragment>
+									<PanelBody
+										title={__( 'Block Tools Defaults', 'otter-blocks' )}
+										initialOpen={true}
+									>
+										<p>
+											{
+												__( 'Make those features to be shown by default in Block Tools.', 'otter-blocks' )
+											}
+										</p>
 
-							{
-								'loading' === status && (
-									<p>
-										<Spinner />
-										{ __( 'Checking optional module...', 'otter-blocks' ) }
-									</p>
-								)
-							}
+										{
+											'loading' === status && (
+												<p>
+													<Spinner />
+													{ __( 'Checking optional module...', 'otter-blocks' ) }
+												</p>
+											)
+										}
 
-							{
-								enabledModules?.css && (
-									<PanelRow>
-										<ToggleControl
-											className="o-sidebar-toggle"
-											label={__( 'Custom CSS', 'otter-blocks' )}
-											checked={get?.( 'themeisle/otter-blocks', 'show-custom-css' )}
-											disabled={'loading' === preferenceStatus}
-											onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-custom-css', value ) )}
-										/>
-									</PanelRow>
-								)
-							}
+										{
+											enabledModules?.css && (
+												<PanelRow>
+													<ToggleControl
+														className="o-sidebar-toggle"
+														label={__( 'Custom CSS', 'otter-blocks' )}
+														checked={get?.( 'themeisle/otter-blocks', 'show-custom-css' )}
+														disabled={'loading' === preferenceStatus}
+														onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-custom-css', value ) )}
+													/>
+												</PanelRow>
+											)
+										}
 
-							{
-								enabledModules?.animation && (
-									<PanelRow>
-										<ToggleControl
-											className="o-sidebar-toggle"
-											label={__( 'Animation', 'otter-blocks' )}
-											checked={get?.( 'themeisle/otter-blocks', 'show-animations' ) ?? false}
-											disabled={'loading' === preferenceStatus}
-											onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-animations', value ) )}
-										/>
-									</PanelRow>
-								)
-							}
+										{
+											enabledModules?.animation && (
+												<PanelRow>
+													<ToggleControl
+														className="o-sidebar-toggle"
+														label={__( 'Animation', 'otter-blocks' )}
+														checked={get?.( 'themeisle/otter-blocks', 'show-animations' ) ?? false}
+														disabled={'loading' === preferenceStatus}
+														onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-animations', value ) )}
+													/>
+												</PanelRow>
+											)
+										}
 
-							{
-								enabledModules?.condition && (
-									<PanelRow>
-										<ToggleControl
-											className="o-sidebar-toggle"
-											label={__( 'Visibility Condition', 'otter-blocks' )}
-											checked={get?.( 'themeisle/otter-blocks', 'show-block-conditions' ) ?? false }
-											disabled={'loading' === preferenceStatus}
-											onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-block-conditions', value ) )}
-										/>
-									</PanelRow>
-								)
-							}
-						</PanelBody>
+										{
+											enabledModules?.condition && (
+												<PanelRow>
+													<ToggleControl
+														className="o-sidebar-toggle"
+														label={__( 'Visibility Condition', 'otter-blocks' )}
+														checked={get?.( 'themeisle/otter-blocks', 'show-block-conditions' ) ?? false }
+														disabled={'loading' === preferenceStatus}
+														onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-block-conditions', value ) )}
+													/>
+												</PanelRow>
+											)
+										}
+									</PanelBody>
 
-						<NavigatorButton
-							path="/block-settings"
-							icon={ chevronRightSmall }
-							className="o-navi-button"
-						>
-							{ __( 'Block Settings', 'otter-blocks' ) }
-						</NavigatorButton>
+									<NavigatorButton
+										path="/block-settings"
+										icon={ chevronRightSmall }
+										className="o-navi-button"
+									>
+										{ __( 'Block Settings', 'otter-blocks' ) }
+									</NavigatorButton>
+								</Fragment>
+							)
+						}
 
 						{ applyFilters( 'otter.feedback', '', 'otter-menu-editor', __( 'Help us improve Otter Blocks', 'otter-blocks' ) ) }
 					</NavigatorScreen>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1812
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The current handling of the case for the user who did not have the right to write to modify the options was very minimal.

🔧 Add conditional statements that hide the options from which the users do not have permission.



### Screenshots <!-- if applicable -->

#### Unauthorized users will see only the Onboarding modal and Feedback.

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/f47852e6-6d48-4fea-aae3-de26497f2c09)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Enter as a non-administrator user.
2. Create a new post and check the otter options in the top-right corner.
3. You should see only the onboarding Modal and Feedback.

⚠️ If you make a particular user with the rights to modify WP Options (like admin), then you should see the full options.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

