### PR TITLE
Open in new tab for Review Block links

### DIFF
--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -193,7 +193,7 @@ class Review_Block {
 
 			foreach ( $attributes['links'] as $link ) {
 				$rel   = ( isset( $link['isSponsored'] ) && true === $link['isSponsored'] ) ? 'sponsored' : 'nofollow';
-				$html .= '	<a href="' . esc_url( $link['href'] ) . '" rel="' . $rel . '" target="' . $link['target'] . '">' . esc_html( $link['label'] ) . '</a>';
+				$html .= '	<a href="' . esc_url( $link['href'] ) . '" rel="' . $rel . '" target="' . ( empty( $link['target'] ) ? '_blank' : $link['target'] ) . '">' . esc_html( $link['label'] ) . '</a>';
 			}
 			$html .= '		</div>';
 			$html .= '	</div>';

--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -193,7 +193,7 @@ class Review_Block {
 
 			foreach ( $attributes['links'] as $link ) {
 				$rel   = ( isset( $link['isSponsored'] ) && true === $link['isSponsored'] ) ? 'sponsored' : 'nofollow';
-				$html .= '	<a href="' . esc_url( $link['href'] ) . '" rel="' . $rel . '" target="_blank">' . esc_html( $link['label'] ) . '</a>';
+				$html .= '	<a href="' . esc_url( $link['href'] ) . '" rel="' . $rel . '" target="' . $link['target'] . '">' . esc_html( $link['label'] ) . '</a>';
 			}
 			$html .= '		</div>';
 			$html .= '	</div>';

--- a/src/blocks/blocks/review/block.json
+++ b/src/blocks/blocks/review/block.json
@@ -70,18 +70,18 @@
 		"links": {
 			"type": "array",
 			"default": [
-			{
-				"label": "Buy on Amazon",
-				"href": "",
-				"isSponsored": false,
-				"target": "_blank"
-			},
-			{
-				"label": "Buy on eBay",
-				"href": "",
-				"isSponsored": false,
-				"target": "_blank"
-			}
+				{
+					"label": "Buy on Amazon",
+					"href": "",
+					"isSponsored": false,
+					"target": "_blank"
+				},
+				{
+					"label": "Buy on eBay",
+					"href": "",
+					"isSponsored": false,
+					"target": "_blank"
+				}
 			]
 		},
 		"prosLabel": {

--- a/src/blocks/blocks/review/block.json
+++ b/src/blocks/blocks/review/block.json
@@ -73,12 +73,14 @@
 			{
 				"label": "Buy on Amazon",
 				"href": "",
-				"isSponsored": false
+				"isSponsored": false,
+				"target": "_blank"
 			},
 			{
 				"label": "Buy on eBay",
 				"href": "",
-				"isSponsored": false
+				"isSponsored": false,
+				"target": "_blank"
 			}
 			]
 		},

--- a/src/blocks/blocks/review/inspector.js
+++ b/src/blocks/blocks/review/inspector.js
@@ -598,6 +598,12 @@ const Inspector = ({
 									checked={ link.isSponsored }
 									disabled={ attributes.product }
 								/>
+
+								<ToggleControl
+									label={ __( 'Open in New Tab', 'otter-blocks' ) }
+									checked={ '_blank' === link.target }
+									disabled={ attributes.product }
+								/>
 							</PanelItem>
 						) ) }
 
@@ -629,6 +635,12 @@ const Inspector = ({
 											label={ __( 'Is this Sponsored?', 'otter-blocks' ) }
 											checked={ link.isSponsored }
 											onChange={ () => onChangeLink({ action: 'update', index, value: { isSponsored: ! link.isSponsored }}) }
+										/>
+
+										<ToggleControl
+											label={ __( 'Open in New Tab', 'otter-blocks' ) }
+											checked={ '_blank' === link.target }
+											onChange={ () => onChangeLink({ action: 'update', index, value: { target: '_blank' === link.target ? '_self' : '_blank' }}) }
 										/>
 									</PanelItem>
 								) ) }

--- a/src/blocks/blocks/review/inspector.js
+++ b/src/blocks/blocks/review/inspector.js
@@ -639,8 +639,8 @@ const Inspector = ({
 
 										<ToggleControl
 											label={ __( 'Open in New Tab', 'otter-blocks' ) }
-											checked={ '_blank' === link.target }
-											onChange={ () => onChangeLink({ action: 'update', index, value: { target: '_blank' === link.target ? '_self' : '_blank' }}) }
+											checked={ undefined === link.target || '_blank' === link.target }
+											onChange={ () => onChangeLink({ action: 'update', index, value: { target: '_blank' === link.target || undefined === link.target ? '_self' : '_blank' }}) }
 										/>
 									</PanelItem>
 								) ) }

--- a/src/blocks/test/e2e/blocks/product-review.spec.js
+++ b/src/blocks/test/e2e/blocks/product-review.spec.js
@@ -81,5 +81,26 @@ test.describe( 'Product Review Block', () => {
 		await expect( await page.getByRole( 'document', { name: 'Block: Product Review' }).getByText( FEATURE_DESCRIPTION, { exact: true }) ).toBeVisible();
 	});
 
+	test( 'open in new tab', async({ editor, page }) => {
+		await editor.insertBlock({ name: 'themeisle-blocks/review' });
 
+		await page.getByRole( 'button', { name: 'Buttons' }).click({ clickCount: 1 });
+
+		await page.getByRole( 'button', { name: 'Add Links' }).click();
+
+		await page.getByRole( 'button', { name: 'Buy Now' }).click();
+
+		await page.getByPlaceholder( 'Button label' ).fill( 'Buy Now in same tab' );
+		await page.getByLabel( 'Open in New Tab' ).click();
+
+		await page.getByRole( 'button', { name: 'Add Links' }).click();
+
+		const postId = await editor.publishPost();
+
+		await page.goto( `/?p=${postId}` );
+
+		await expect( page.getByRole( 'link', { name: 'Buy Now in same tab' }) ).toHaveAttribute( 'target', '_self' );
+		await expect( page.getByRole( 'link', { name: 'Buy Now', exact: true }) ).toHaveAttribute( 'target', '_blank' );
+
+	});
 });


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1840
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

🔩 Added the option to open the links in the same tab.
ℹ️ Default behavior opens in the new tab to preserve the current status.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/b21fc9a1-3b59-43ec-b11f-ca853c1748bd)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a Product Review Block
2. Check the options that allow you to open the link in the same or a new tab (Inspector > Settings > Buttons)

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

