### PR TITLE
Add AI Block consent toggle

### DIFF
--- a/inc/server/class-prompt-server.php
+++ b/inc/server/class-prompt-server.php
@@ -287,6 +287,7 @@ class Prompt_Server {
 				'site_url'   => get_site_url(),
 				'license_id' => apply_filters( 'product_otter_license_key', 'free' ),
 				'cache'      => gmdate( 'u' ),
+				'isValid'    => boolval( get_option( 'themeisle_open_ai_api_key', false ) ),
 			),
 			'https://api.themeisle.com/templates-cloud/otter-prompts'
 		);

--- a/src/blocks/blocks/content-generator/editor.scss
+++ b/src/blocks/blocks/content-generator/editor.scss
@@ -18,7 +18,7 @@
 		&> div:not(.prompt-input__container):last-child {
 			padding: 10px;
 		}
-	} 
+	}
 
 	.o-actions {
 		display: flex;
@@ -29,5 +29,33 @@
 		padding: 10px;
 		border: 1px dashed #1E1E1E;
 		border-radius: 3px;
-	} 
+	}
+}
+
+.o-tracking-consent-toggle {
+	display: flex;
+	flex-direction: row;
+	gap: 5px;
+	align-items: center;
+	padding: 4px;
+	border-radius: 2px;
+	background-color: #f7f7f7;
+	font-size: 12px;
+	margin-top: 8px;
+
+	&__label {
+		flex-grow: 1;
+	}
+
+	&__close {
+		height: 24px;
+		&> button.components-button.is-tertiary.has-icon  {
+			padding: 0;
+			height: 24px;
+
+			svg {
+				fill: #1E1E1E;
+			}
+		}
+	}
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added consent toggle for AI Block. The consent uses the already present value of `'otter_blocks_logger_flag'`

Behaviour:
- Toggle will not appear for people who have already accepted.
- If the button close is used, we will use the browser storage to store the preference. The toggle will reappear if the user cleans up the values or uses another browser.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/a7a48ad8-d57c-4d07-9a5c-748e33eb4bb4)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

⚠️ You will need an OpenAI Key.

1. Create an AI Block and make a first request.
2. When the request is done, the consent toggle should appear.
3. If you press the Close button, the toggle should appear when you make another block. If you change the browser, the toggle should be visible since this is working at the browser level.
4. If you accept the consent, the toggle will disappear, and it will not be visible even if you change the browser since this is working at the server level.

ℹ️ When testing, ensure this value is NOT ON by default in the Dashboard. People who already made consent for this will not see the toggle.

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/dcb48cf6-6b96-4d84-a8a8-8329b0765524)


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

