### PR TITLE
Add extra condition check for upsell

### DIFF
--- a/inc/class-pro.php
+++ b/inc/class-pro.php
@@ -159,6 +159,10 @@ class Pro {
 	 * @access  public
 	 */
 	public function should_show_dashboard_upsell() {
+		if ( defined( 'OTTER_PRO_VERSION' ) ) {
+			return;
+		}
+
 		$show_upsell = false;
 
 		$installed     = get_option( 'otter_blocks_install' );
@@ -398,6 +402,11 @@ class Pro {
 	 * @access public
 	 */
 	public function add_pro_link( $links ) {
+
+		if ( defined( 'OTTER_PRO_VERSION' ) ) {
+			return $links;
+		}
+
 		$links[] = sprintf(
 			'<a href="%s" target="_blank" style="color:#ed6f57;font-weight:bold;">%s</a>',
 			esc_url_raw( tsdk_utmify( self::get_url(), 'pluginspage', 'action' ) ),


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1679 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add extra conditional checks for upsell for:
- Notice
- `Get Otter Pro` label

### Screenshots <!-- if applicable -->

#### Before
![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/8661b2d1-ffd9-4f9e-91f7-462c06956a20)

#### After
![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/ccb91317-ba53-496c-b128-42824493ccdc)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

⚠️ You will need a multisite and make the Upsell notice appear.

When you switch to the current build, the notice and the label `Get Otter Pro` should disappear.

ℹ️ The following message is a part of the Themeisle SDK and is not subject to this PR.

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/cdeb3e2b-aca7-44de-aa95-ed95002b7caf)



<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

