### PR TITLE
Remove unnecessary deps when using widgets

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -36,6 +36,13 @@ class Registration {
 	public static $block_dependencies = array();
 
 	/**
+	 * The ids of the used widgets in the page.
+	 *
+	 * @var array<string>
+	 */
+	public static $widget_used = array(); // TODO: Monitor all the rendered widgets and enqueue the assets.
+
+	/**
 	 * Flag to mark that the scripts which have loaded.
 	 *
 	 * @var array
@@ -81,6 +88,7 @@ class Registration {
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_assets' ) );
 		add_filter( 'render_block', array( $this, 'load_sticky' ), 900, 2 );
 		add_filter( 'render_block', array( $this, 'subscribe_fa' ), 10, 2 );
+		add_filter( 'dynamic_sidebar_params', array( $this, 'watch_used_widgets' ), 9999 );
 
 		add_action(
 			'wp_footer',
@@ -348,7 +356,15 @@ class Registration {
 		}
 
 		if ( $has_widgets ) {
-			$this->enqueue_dependencies( 'widgets' );
+			add_filter(
+				'wp_footer',
+				function ( $content ) {
+					$this->enqueue_dependencies( 'widgets' );
+
+					return $content;
+				}
+			);
+
 		}
 
 		if ( function_exists( 'get_block_templates' ) && function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() && current_theme_supports( 'block-templates' ) ) {
@@ -967,24 +983,30 @@ class Registration {
 	 * @return string
 	 */
 	public static function get_active_widgets_content() {
+		$content = '';
+
+		if ( 0 === count( self::$widget_used ) ) {
+			return $content;
+		}
+
 		global $wp_registered_widgets;
-		$content       = '';
 		$valid_widgets = array();
 		$widget_data   = get_option( 'widget_block', array() );
 
 		// Loop through all widgets, and add any that are active.
 		foreach ( $wp_registered_widgets as $widget_name => $widget ) {
-			// Get the active sidebar the widget is located in.
-			$sidebar = is_active_widget( $widget['callback'], $widget['id'] );
+			if ( ! in_array( $widget['id'], self::$widget_used, true ) ) {
+				continue;
+			}
 
-			if ( $sidebar && 'wp_inactive_widgets' !== $sidebar ) {
-				$key = $widget['params'][0]['number'];
+			$key = $widget['params'][0]['number'];
 
-				if ( isset( $widget_data[ $key ] ) ) {
-					$valid_widgets[] = (object) $widget_data[ $key ];
-				}
+			if ( isset( $widget_data[ $key ] ) ) {
+				$valid_widgets[] = (object) $widget_data[ $key ];
 			}
 		}
+
+		self::$widget_used = array();
 
 		foreach ( $valid_widgets as $widget ) {
 			if ( isset( $widget->content ) ) {
@@ -993,6 +1015,20 @@ class Registration {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Watch and save the used widgets.
+	 *
+	 * @param array $params The widget params.
+	 * @return mixed
+	 */
+	public function watch_used_widgets( $params ) {
+		if ( isset( $params[0]['widget_id'] ) && ! in_array( $params[0]['widget_id'], self::$widget_used ) ) {
+			self::$widget_used[] = $params[0]['widget_id'];
+		}
+
+		return $params;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1665
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Using `'dynamic_sidebar_params'` we can identify the used widgets in the page. The great changes is that we need to run the assets loading in `wp_footer` since that filter will not run during `'enqueue_block_assets'`.

### Screenshots <!-- if applicable -->


https://github.com/Codeinwp/otter-blocks/assets/17597852/1576d926-6429-409c-a259-7735480fdfae


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

ℹ️  Use a classic theme like Neve.

1. In the widgets page, add blocks like Maps, Google Maps, and progress bar in different parts of the widgets section.
2. Insert a widget in a page and ensure the scripts from another widget section are not loaded.
3. If you a have widget with a Maps block that load `leaflet.js` and is not present in page, then that script should be loaded.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

