### PR TITLE
Load Live Search deps via WordPress Action Hook

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-live-search.php
+++ b/plugins/otter-pro/inc/plugins/class-live-search.php
@@ -71,6 +71,13 @@ class Live_Search {
 	 * @static
 	 */
 	public static function load_deps() {
+
+		$has_license = in_array( License::get_license_type(), array( 2, 3 ) ) || ( License::has_active_license() && isset( License::get_license_data()->otter_pro ) );
+
+		if ( ! $has_license ) {
+			return;
+		}
+
 		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/live-search.asset.php';
 		wp_enqueue_script(
 			'otter-live-search',

--- a/plugins/otter-pro/inc/plugins/class-live-search.php
+++ b/plugins/otter-pro/inc/plugins/class-live-search.php
@@ -23,6 +23,7 @@ class Live_Search {
 	 */
 	public function init() {
 		add_filter( 'render_block', array( $this, 'render_blocks' ), 10, 2 );
+		add_action( 'otter_load_live_search_deps', array( $this, 'load_deps' ) );
 	}
 
 	/**
@@ -39,6 +40,37 @@ class Live_Search {
 			return $block_content;
 		}
 
+		do_action( 'otter_load_live_search_deps' );
+
+		$post_types_data = '';
+		if ( isset( $block['attrs']['otterSearchQuery']['post_type'] ) ) {
+			$post_types_data = 'data-post-types=' . wp_json_encode( $block['attrs']['otterSearchQuery']['post_type'] );
+		}
+
+		// Insert hidden fields to filter core's search results.
+		$query_params_markup = '';
+		if ( isset( $block['attrs']['otterSearchQuery'] ) && count( $block['attrs']['otterSearchQuery'] ) > 0 ) {
+			foreach ( $block['attrs']['otterSearchQuery'] as $param => $value ) {
+				$query_params_markup .= sprintf(
+					'<input type="hidden" name="o_%s" value="%s" />',
+					esc_attr( $param ),
+					esc_attr( implode( ',', $value ) )
+				);
+			}
+		}
+
+		$block_content = substr( $block_content, 0, strpos( $block_content, '</form>' ) ) . $query_params_markup . substr( $block_content, strpos( $block_content, '</form>' ) );
+		return '<div class="o-live-search"' . $post_types_data . '>' . $block_content . '</div>';
+	}
+
+	/**
+	 * Load the live search dependencies.
+	 *
+	 * @return void
+	 *
+	 * @static
+	 */
+	public static function load_deps() {
 		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/live-search.asset.php';
 		wp_enqueue_script(
 			'otter-live-search',
@@ -64,26 +96,6 @@ class Live_Search {
 
 		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/live-search-style.asset.php';
 		wp_enqueue_style( 'otter-live-search-style', OTTER_BLOCKS_URL . 'build/blocks/live-search-style.css', $asset_file['dependencies'], $asset_file['version'] );
-
-		$post_types_data = '';
-		if ( isset( $block['attrs']['otterSearchQuery']['post_type'] ) ) {
-			$post_types_data = 'data-post-types=' . wp_json_encode( $block['attrs']['otterSearchQuery']['post_type'] );
-		}
-
-		// Insert hidden fields to filter core's search results.
-		$query_params_markup = '';
-		if ( isset( $block['attrs']['otterSearchQuery'] ) && count( $block['attrs']['otterSearchQuery'] ) > 0 ) {
-			foreach ( $block['attrs']['otterSearchQuery'] as $param => $value ) {
-				$query_params_markup .= sprintf(
-					'<input type="hidden" name="o_%s" value="%s" />',
-					esc_attr( $param ),
-					esc_attr( implode( ',', $value ) )
-				);
-			}
-		}
-
-		$block_content = substr( $block_content, 0, strpos( $block_content, '</form>' ) ) . $query_params_markup . substr( $block_content, strpos( $block_content, '</form>' ) );
-		return '<div class="o-live-search"' . $post_types_data . '>' . $block_content . '</div>';
 	}
 
 	/**


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #91
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Wrap the live-search deps with a wp action named: `otter_load_live_search_deps`

#### Docs

If you want to load Live Search functionality in your custom theme or 3-rd party plugin. Use the wordpress action `otter_load_live_search_deps`.

Example:

```php
do_action( 'otter_load_live_search_deps' );
```

ℹ️ This feature can only be used by Otter Pro users.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

This is a dev-only change. The Libe Search should work as expected. 

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

