### PR TITLE
Do not ignore CURSOR color during typiing anim

### DIFF
--- a/src/animation/frontend/typing/index.js
+++ b/src/animation/frontend/typing/index.js
@@ -67,6 +67,7 @@ const initTyping = ( elem ) => {
 	const typingPlaceholder = document.createElement( 'span' );
 	typingPlaceholder.classList.add( 'o-anim-typing-caret' );
 	typingPlaceholder.style.whiteSpace = 'pre-wrap';
+	typingPlaceholder.style.color = 'inherit';
 
 	const fillPlaceholder = document.createElement( 'span' );
 	fillPlaceholder.style.whiteSpace = 'pre-wrap';
@@ -112,7 +113,7 @@ domReady( () => {
 			color: #2E3D48;
 			animation: 1s blink step-end infinite;
 		}
-	
+
 		@keyframes blink {
 			from, to {
 			  color: transparent;

--- a/src/animation/frontend/typing/index.js
+++ b/src/animation/frontend/typing/index.js
@@ -67,7 +67,6 @@ const initTyping = ( elem ) => {
 	const typingPlaceholder = document.createElement( 'span' );
 	typingPlaceholder.classList.add( 'o-anim-typing-caret' );
 	typingPlaceholder.style.whiteSpace = 'pre-wrap';
-	typingPlaceholder.style.color = 'inherit';
 
 	const fillPlaceholder = document.createElement( 'span' );
 	fillPlaceholder.style.whiteSpace = 'pre-wrap';
@@ -110,7 +109,6 @@ domReady( () => {
 		.o-anim-typing-caret::after {
 			font-weight: 100;
 			content: '|';
-			color: #2E3D48;
 			animation: 1s blink step-end infinite;
 		}
 
@@ -119,7 +117,7 @@ domReady( () => {
 			  color: transparent;
 		   }
 			50% {
-			  color: black;
+			  color: inherit;
 		   }
 		}
 	`;

--- a/src/blocks/test/e2e/blocks/animations.spec.js
+++ b/src/blocks/test/e2e/blocks/animations.spec.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Animations', () => {
+	test.beforeEach( async({ admin }) => {
+		await admin.createNewPost();
+	});
+
+	test( 'can add a typing animation"', async({ editor, page }) => {
+		await editor.insertBlock({
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Magna mollis sed ipsum convallis tellus donec. Maximus ligula nostra fusce inceptos in fermentum phasellus. Ante sollicitudin euismod ultrices nullam etiam eu. Himenaeos si ridiculus suscipit velit donec dui tristique. Habitant auctor ridiculus a consectetuer nisi volutpat magnis sed enim lacus. Quisque habitant litora sodales turpis montes.'
+			}
+		});
+
+		const box = await page.getByLabel( 'Paragraph block' ).boundingBox();
+
+		// Select a text inside the paragraph block.
+		await page.mouse.move( box.x + 10, box.y + 10 );
+		await page.mouse.down();
+		await page.mouse.move( box.x + box.width - 50, box.y + box.height - 100 );
+		await page.mouse.up();
+
+		await page.getByLabel( 'More' ).click();
+
+		await page.getByRole( 'menuitem', { name: 'Typing Animation' }).click();
+
+		expect( page.getByLabel( 'Paragraph block' ).locator( 'o-anim-typing' ).first() ).toBeTruthy();
+		expect( page.getByLabel( 'Paragraph block' ).locator( '.o-typing-delay-500ms' ).first() ).toBeTruthy();
+	});
+});


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1717
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Now, the typing animation will respect the text color.

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/otter-blocks/assets/17597852/974a3c85-8b9e-4936-bd5d-48951833165b


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a paragraph and set a color.
2. Add typing animation.
3. See if it keeps the colors.

Sample

```html
<!-- wp:paragraph {"textColor":"vivid-red","className":"o-typing-delay-500ms"} -->
<p class="o-typing-delay-500ms has-vivid-red-color has-text-color">Placerat habitasse commodo ante hac erat diam vehicula in porttitor. Ridiculus facilisis cursus inceptos orci dis faucibus neque justo curae. Mattis velit et accumsan sapien justo vivamus si. Netus hac fames aliquam ullamcorper convallis est habitasse letius molestie phasellus dui. Elit per adipiscing sodales nascetur est turpis vel curabitur. <o-anim-typing>Sapien quam class vel luctus a sagittis ad pellentesque. Viverra consectetur montes rhoncus inceptos cursus arcu.</o-anim-typing> Sodales etiam iaculis taciti augue ipsum montes placerat tristique per aliquam. Eget pede molestie placerat hac nulla conubia class habitasse maximus sit. Convallis molestie vitae morbi fames facilisi tempor.</p>
<!-- /wp:paragraph -->
```

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

