### PR TITLE
Animation enhancements

### DIFF
--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -166,7 +166,7 @@ class Blocks_Animation {
 
 			wp_script_add_data( 'otter-animation-frontend', 'async', true );
 
-			add_action( 'wp_head', array( $this, 'add_fontend_anim_inline_style' ), 10 );
+			add_action( 'wp_footer', array( $this, 'add_frontend_anim_inline_style'), 10 );
 
 			self::$scripts_loaded['animation'] = true;
 		}
@@ -208,10 +208,11 @@ class Blocks_Animation {
 	 * @access public
 	 * @since 2.0.14
 	 */
-	public static function add_fontend_anim_inline_style() {
+	public static function add_frontend_anim_inline_style() {
 		echo '<style id="o-anim-hide-inline-css"> .animated:not(.o-anim-ready) {
 			visibility: hidden;
 			animation-play-state: paused;
+			animation: none !important;
 		 }</style>
 		 <noscript><style>.animated { visibility: visible; animation-play-state: running; }</style></noscript>';
 	}

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -166,7 +166,7 @@ class Blocks_Animation {
 
 			wp_script_add_data( 'otter-animation-frontend', 'async', true );
 
-			add_action( 'wp_footer', array( $this, 'add_frontend_anim_inline_style'), 10 );
+			add_action( 'wp_footer', array( $this, 'add_frontend_anim_inline_style' ), 10 );
 
 			self::$scripts_loaded['animation'] = true;
 		}

--- a/src/animation/data.js
+++ b/src/animation/data.js
@@ -353,6 +353,10 @@ export const delayList = [
 	{
 		label: __( 'Five Second', 'otter-blocks' ),
 		value: 'delay-5s'
+	},
+	{
+		label: __( 'Custom', 'otter-blocks' ),
+		value: 'o-anim-custom-delay'
 	}
 ];
 
@@ -376,5 +380,9 @@ export const speedList = [
 	{
 		label: __( 'Faster', 'otter-blocks' ),
 		value: 'faster'
+	},
+	{
+		label: __( 'Custom', 'otter-blocks' ),
+		value: 'o-anim-custom-speed'
 	}
 ];

--- a/src/animation/editor.js
+++ b/src/animation/editor.js
@@ -216,7 +216,7 @@ function AnimationControls({
 	useEffect( () => {
 		setNodeCSS(
 			attributes.className
-				.split( ' ' )
+				?.split( ' ' )
 				.map( ( i ) => {
 					if ( i.includes( 'o-anim-value-delay-' ) ) {
 						return `.${ i } { animation-delay: ${ i.replace( 'o-anim-value-delay-', '' ) }; --webkit-animation-delay: ${ i.replace( 'o-anim-value-delay-', '' ) }; }`;
@@ -225,7 +225,7 @@ function AnimationControls({
 					}
 					return '';
 				})
-				.filter( ( i ) => i )
+				.filter( ( i ) => i ) ?? ''
 		);
 
 	}, [ attributes.className ]);

--- a/src/animation/editor.js
+++ b/src/animation/editor.js
@@ -438,6 +438,7 @@ function AnimationControls({
 											}
 										]
 									}
+									help={ triggerOffsetValue?.endsWith( '%' ) ? __( 'Is the percentage of the screen height. E.g: with 50% the animation will trigger after passing the middle of screen.', 'otter-blocks' ) : '' }
 								/>
 							)
 						}

--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -101,6 +101,10 @@
          position: absolute;
       }
    }
+
+   &> .components-unit-control-wrapper {
+      margin-top: 10px;
+   }
 }
 
 .otter-animations-count-image {

--- a/src/animation/editor.scss
+++ b/src/animation/editor.scss
@@ -122,7 +122,8 @@
 
 @media screen {
 	.hidden-animated {
-		visibility: hidden;
+       visibility: hidden;
+       animation-play-state: paused;
 	}
 
    .animated .wp-block-navigation,

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -156,7 +156,7 @@ const delay = [
 
 const speed = [ 'none', 'slow', 'slower', 'fast', 'faster' ];
 
-window.addEventListener( 'load', () => {
+const animateElements = () => {
 	const elements = document.querySelectorAll( '.animated' );
 
 	createCustomAnimationNode( elements );
@@ -164,8 +164,6 @@ window.addEventListener( 'load', () => {
 	for ( const element of elements ) {
 		classes = element.classList;
 		element.animationClasses = [];
-
-		classes.add( 'o-anim-ready' );
 
 		if ( ! isElementInViewport( element ) ) {
 			const animationClass = animations.find( ( i ) => {
@@ -179,8 +177,6 @@ window.addEventListener( 'load', () => {
 			const speedClass = speed.find( ( i ) => {
 				return Array.from( classes ).find( ( o ) => o === i );
 			});
-
-			element.classList.add( 'hidden-animated' );
 
 			if ( animationClass ) {
 				element.animationClasses.push( animationClass );
@@ -196,7 +192,11 @@ window.addEventListener( 'load', () => {
 				element.animationClasses.push( speedClass );
 				element.classList.remove( speedClass );
 			}
+
+			element.classList.add( 'hidden-animated' );
 		}
+
+		classes.add( 'o-anim-ready' );
 
 		outAnimation.forEach( ( i ) => {
 			const isOut = element.className.includes( i );
@@ -265,7 +265,7 @@ window.addEventListener( 'load', () => {
 			});
 		});
 	});
-});
+};
 
 const isElementInViewport = ( el ) => {
 	let scroll = window.scrollY || window.pageYOffset;
@@ -391,3 +391,5 @@ const calculateOffset = ( offset ) => {
 
 	return offset;
 };
+
+window.addEventListener( 'load', animateElements );

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -267,7 +267,7 @@ const isElementInViewport = ( el ) => {
 	let scroll = window.scrollY || window.pageYOffset;
 	const offset = calculateOffset( getTriggerOffset( el ) );
 
-	const boundsTop = el.getBoundingClientRect().top + scroll = offset;
+	const boundsTop = el.getBoundingClientRect().top + scroll + offset;
 
 	const viewport = {
 		top: scroll,

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -159,6 +159,8 @@ const speed = [ 'none', 'slow', 'slower', 'fast', 'faster' ];
 window.addEventListener( 'load', () => {
 	const elements = document.querySelectorAll( '.animated' );
 
+	createCustomAnimationNode( elements );
+
 	for ( const element of elements ) {
 		classes = element.classList;
 		element.animationClasses = [];
@@ -205,6 +207,15 @@ window.addEventListener( 'load', () => {
 				});
 			}
 		});
+
+		if ( classes.contains( 'o-anim-hover' ) ) {
+			element.classList.remove( 'hidden-animated' ); // We asume that elements with hover animation are visible by default.
+			element.classList.remove( 'animated' );
+
+			element.addEventListener( 'mouseenter', () => {
+				element.classList.add( 'animated' );
+			});
+		}
 	}
 
 	window.addEventListener( 'scroll', () => {
@@ -249,4 +260,72 @@ const isElementInViewport = ( el ) => {
 		( bounds.bottom >= viewport.top && bounds.bottom <= viewport.bottom ) ||
 		( bounds.top <= viewport.bottom && bounds.top >= viewport.top )
 	);
+};
+
+const createCustomAnimationNode = ( elements ) => {
+	let customDelays = [];
+	let customSpeeds = [];
+
+	for ( const element of elements ) {
+		const classes = element.classList;
+
+		if ( classes.contains( 'o-anim-custom-delay' ) ) {
+			let delay;
+			for ( const className of classes ) {
+				if ( className.includes( 'o-anim-value-delay-' ) ) {
+					delay = className;
+					break;
+				}
+			}
+			if ( delay ) {
+				customDelays.push( delay );
+			}
+		}
+
+		if ( classes.contains( 'o-anim-custom-speed' ) ) {
+			let speed;
+			for ( const className of classes ) {
+				if ( className.includes( 'o-anim-value-speed-' ) ) {
+					speed = className;
+					break;
+				}
+			}
+			if ( speed ) {
+				customSpeeds.push( speed );
+			}
+		}
+	}
+
+
+	// Remove duplicate values
+	customDelays = [ ...new Set( customDelays ) ];
+	customSpeeds = [ ...new Set( customSpeeds ) ];
+
+	if ( 0 < customDelays.length || 0 < customSpeeds.length ) {
+		const customValuesNode = document.createElement( 'style' );
+		customValuesNode.id = 'o-anim-custom-values';
+		customValuesNode.innerHTML = customDelays.reduce(
+			( accumulator, cssClass ) => {
+				const delayValue = cssClass.replace( 'o-anim-value-delay-', '' );
+
+				return (
+					accumulator +
+					`.animated.${ cssClass } { animation-delay: ${ delayValue }; -webkit-animation-delay: ${ delayValue }; }`
+				);
+			},
+			''
+		) + '\n' + customSpeeds.reduce(
+			( accumulator, cssClass ) => {
+				const speedValue = cssClass.replace( 'o-anim-value-speed-', '' );
+
+				return (
+					accumulator +
+					`.animated.${ cssClass } { animation-duration: ${ speedValue }; -webkit-animation-duration: ${ speedValue }; }`
+				);
+			},
+			''
+		);
+
+		document.body.appendChild( customValuesNode );
+	}
 };

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -212,8 +212,12 @@ window.addEventListener( 'load', () => {
 			element.classList.remove( 'hidden-animated' ); // We asume that elements with hover animation are visible by default.
 			element.classList.remove( 'animated' );
 
+			const { animationName } = element.style;
+			element.style.animationName = 'none';
+
 			element.addEventListener( 'mouseenter', () => {
 				element.classList.add( 'animated' );
+				element.style.animationName = animationName;
 			});
 		}
 	}

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -267,7 +267,7 @@ const isElementInViewport = ( el ) => {
 	let scroll = window.scrollY || window.pageYOffset;
 	const offset = calculateOffset( getTriggerOffset( el ) );
 
-	const boundsTop = el.getBoundingClientRect().top + scroll + offset;
+	const boundsTop = el.getBoundingClientRect().top + scroll = offset;
 
 	const viewport = {
 		top: scroll,

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -299,8 +299,8 @@ export const blockInit = ( clientId, defaultAttributes ) => {
 /**
  * Create a Style node for handling `head` Node change when working in a Tablet, Mobile mode or in FSE Editor.
  *
- * @param {OtterNodeCSSOptions } options The options.
- * @returns {OtterNodeCSSReturn} The name of the node and function handler.
+ * @param {import('./blocks.js').OtterNodeCSSOptions } options The options.
+ * @returns {import('./blocks.js').OtterNodeCSSReturn} The name of the node and function handler.
  */
 export const useCSSNode = ( options = {}) => {
 	const [ cssList, setCSSProps ] = useState({
@@ -392,9 +392,9 @@ export const useCSSNode = ( options = {}) => {
 				.map( x => {
 					const [ css, media ] = x;
 					if ( media ) {
-						return `${media} { \n\t .${settings.cssNodeName} ${css} }`;
+						return `${media} { \n\t .${settings.cssNodeName}${options?.appendToRoot ? '' : ' '}${css} }`;
 					}
-					return `.${settings.cssNodeName} ${css}`;
+					return `.${settings.cssNodeName}${options?.appendToRoot ? '' : ' '}${css}`;
 				})
 				.join( '\n' ) || '';
 			settings.node.textContent = text;

--- a/src/blocks/helpers/blocks.d.ts
+++ b/src/blocks/helpers/blocks.d.ts
@@ -49,7 +49,8 @@ export type BoxShadow = {
 }
 
 export type OtterNodeCSSOptions = {
-	selector: string
+	selector?: string
+	appendToRoot?: boolean
 }
 
 export type OtterSetNodeCSS = ( css: string[], media?: string[]) => void;

--- a/src/blocks/test/e2e/blocks/animations.spec.js
+++ b/src/blocks/test/e2e/blocks/animations.spec.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Animations', () => {
+	test.beforeEach( async({ admin }) => {
+		await admin.createNewPost();
+	});
+
+	test( 'can add a typing animation"', async({ editor, page }) => {
+		await editor.insertBlock({
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Magna mollis sed ipsum convallis tellus donec. Maximus ligula nostra fusce inceptos in fermentum phasellus. Ante sollicitudin euismod ultrices nullam etiam eu. Himenaeos si ridiculus suscipit velit donec dui tristique. Habitant auctor ridiculus a consectetuer nisi volutpat magnis sed enim lacus. Quisque habitant litora sodales turpis montes.'
+			}
+		});
+
+		const box = await page.getByLabel( 'Paragraph block' ).boundingBox();
+
+		// Select a text inside the paragraph block.
+		await page.mouse.move( box.x + 10, box.y + 10 );
+		await page.mouse.down();
+		await page.mouse.move( box.x + box.width - 50, box.y + box.height - 100 );
+		await page.mouse.up();
+
+		await page.getByLabel( 'More' ).click();
+
+		await page.getByRole( 'menuitem', { name: 'Typing Animation' }).click();
+
+		await expect( page.getByLabel( 'Paragraph block' ).locator( 'o-anim-typing' ).first() ).toBeVisible();
+		await expect( page.getByLabel( 'Paragraph block' ).locator( '.o-typing-delay-500ms' ).first() ).toBeVisible();
+	});
+
+	test( 'add simple animation', async({ editor, page }) => {
+		await editor.insertBlock({
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Magna mollis sed ipsum convallis tellus donec. Maximus ligula nostra fusce inceptos in fermentum phasellus. Ante sollicitudin euismod ultrices nullam etiam eu. Himenaeos si ridiculus suscipit velit donec dui tristique. Habitant auctor ridiculus a consectetuer nisi volutpat magnis sed enim lacus. Quisque habitant litora sodales turpis montes.'
+			}
+		});
+
+		// Activate
+		await page.getByRole( 'button', { name: 'Block Tools options' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Show Animations' }).click();
+		await page.getByRole( 'button', { name: 'Block Tools options' }).click();
+
+		// Open the animation panel.
+		await page.getByRole( 'button', { name: 'Animations' }).click();
+
+		// Select an animation
+		await page.getByRole( 'button', { name: 'None' }).click();
+		await page.getByRole( 'menuitem', { name: 'Head Shake' }).click();
+
+		// Select a delay
+		await page.getByRole( 'combobox', { name: 'Delay' }).selectOption( 'delay-500ms' );
+
+		// Select a speed
+		await page.getByRole( 'combobox', { name: 'Speed' }).selectOption( 'slower' );
+
+		// Check the CSS classes.
+		await expect( page.locator( '.headShake' ).first() ).toBeVisible();
+		await expect( page.locator( '.delay-500ms' ).first() ).toBeVisible();
+		await expect( page.locator( '.slower' ).first() ).toBeVisible();
+	});
+
+	test( 'add simple animation with custom values', async({ editor, page }) => {
+		await editor.insertBlock({
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Magna mollis sed ipsum convallis tellus donec. Maximus ligula nostra fusce inceptos in fermentum phasellus. Ante sollicitudin euismod ultrices nullam etiam eu. Himenaeos si ridiculus suscipit velit donec dui tristique. Habitant auctor ridiculus a consectetuer nisi volutpat magnis sed enim lacus. Quisque habitant litora sodales turpis montes.'
+			}
+		});
+
+		// Activate
+		await page.getByRole( 'button', { name: 'Block Tools options' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Show Animations' }).click();
+		await page.getByRole( 'button', { name: 'Block Tools options' }).click();
+
+		// Open the animation panel.
+		await page.getByRole( 'button', { name: 'Animations' }).click();
+
+		// Select an animation
+		await page.getByRole( 'button', { name: 'None' }).click();
+		await page.getByRole( 'menuitem', { name: 'Head Shake' }).click();
+
+		// Select a delay
+		await page.getByRole( 'combobox', { name: 'Delay' }).selectOption( 'o-anim-custom-delay' );
+		await page.locator( '#inspector-input-control-0' ).fill( '2' );
+
+		// Select a speed
+		await page.getByRole( 'combobox', { name: 'Speed' }).selectOption( 'o-anim-custom-speed' );
+		await page.locator( '#inspector-input-control-1' ).fill( '2' );
+
+		// Check the CSS classes.
+		await expect( page.locator( '.headShake' ).first() ).toBeVisible();
+		await expect( page.locator( '.o-anim-custom-delay.o-anim-value-delay-2s' ).first() ).toBeVisible();
+		await expect( page.locator( '.o-anim-custom-speed.o-anim-value-speed-2s' ).first() ).toBeVisible();
+	});
+});


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1548
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

🚀 Now, users can use custom values for Speed and Delay
🔍 Now, animations can trigger on mouse hover.
⛔ Offset for triggering the animation after passing a certain point.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/7ccf65fe-3e8b-482e-839c-79c6c5b95122)

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/c4fc0b9b-05f9-48b9-986c-d3de358c9f7a)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make a block and add an Otter animation via the Block Tools tab on the Sidebar/Inspector
2. Check if the custom values, offset and hover are working.

⚠️ Hover is *not* enabled for the Editor to preview.

⚠️ The reference point for offset is considered the top limit of the element. If you use an image as a test, do think that the middle of the image is the reference point when you set the value of the offset. If you want to trigger the animation when the image is fully visible, use the image width as the offset.

Also, make sure that CSS class names for the block that you are testing look clean, like this:

```
<!-- wp:paragraph {"className":"animated pulse o-anim-custom-speed o-anim-value-speed-3s o-anim-hover "} -->
<p class="animated pulse o-anim-custom-speed o-anim-value-speed-3s o-anim-hover">asdfasdfasdf</p>
<!-- /wp:paragraph -->
```

Check if we have malformed data like `o-anim-value-speed-3s30s`. ℹ️ If you are sure if it is ok or not, you can post here for confirmation.

If the custom values are not working, go to Console and run this code: `document.querySelector('#o-anim-custom-values').innerHTML`. The result should be included in SS or posted video with the issue.

You can copy the problematic block and paste it here (like the example above) for faster cooperation. They are independent of any settings, so I do not need an instance.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

