### PR TITLE
Add Pagination for Posts

### DIFF
--- a/inc/css/blocks/class-posts-css.php
+++ b/inc/css/blocks/class-posts-css.php
@@ -354,6 +354,10 @@ class Posts_CSS extends Base_CSS {
 						'value'    => 'pagBorderColorActive',
 					),
 					array(
+						'property' => '--pag-size',
+						'value'    => 'pagSize',
+					),
+					array(
 						'property' => '--pag-border-radius',
 						'value'    => 'pagBorderRadius',
 						'format'   => function( $value, $attrs ) {

--- a/inc/css/blocks/class-posts-css.php
+++ b/inc/css/blocks/class-posts-css.php
@@ -313,6 +313,91 @@ class Posts_CSS extends Base_CSS {
 						'property' => '--content-gap',
 						'value'    => 'contentGap',
 					),
+					array(
+						'property' => '--pag-gap',
+						'value'    => 'pagGap',
+					),
+					array(
+						'property' => '--pag-color',
+						'value'    => 'pagColor',
+					),
+					array(
+						'property' => '--pag-bg-color',
+						'value'    => 'pagBgColor',
+					),
+					array(
+						'property' => '--pag-color-hover',
+						'value'    => 'pagColorHover',
+					),
+					array(
+						'property' => '--pag-bg-color-hover',
+						'value'    => 'pagBgColorHover',
+					),
+					array(
+						'property' => '--pag-color-active',
+						'value'    => 'pagColorActive',
+					),
+					array(
+						'property' => '--pag-bg-color-active',
+						'value'    => 'pagBgColorActive',
+					),
+					array(
+						'property' => '--pag-border-color',
+						'value'    => 'pagBorderColor',
+					),
+					array(
+						'property' => '--pag-border-color-hover',
+						'value'    => 'pagBorderColorHover',
+					),
+					array(
+						'property' => '--pag-border-color-active',
+						'value'    => 'pagBorderColorActive',
+					),
+					array(
+						'property' => '--pag-border-radius',
+						'value'    => 'pagBorderRadius',
+						'format'   => function( $value, $attrs ) {
+							return CSS_Utility::box_values(
+								$value,
+								array(
+									'left'   => '0px',
+									'right'  => '0px',
+									'top'    => '0px',
+									'bottom' => '0px',
+								)
+							);
+						},
+					),
+					array(
+						'property' => '--pag-border-width',
+						'value'    => 'pagBorderWidth',
+						'format'   => function( $value, $attrs ) {
+							return CSS_Utility::box_values(
+								$value,
+								array(
+									'left'   => '0px',
+									'right'  => '0px',
+									'top'    => '0px',
+									'bottom' => '0px',
+								)
+							);
+						},
+					),
+					array(
+						'property' => '--pag-padding',
+						'value'    => 'pagPadding',
+						'format'   => function( $value, $attrs ) {
+							return CSS_Utility::box_values(
+								$value,
+								array(
+									'left'   => '0px',
+									'right'  => '0px',
+									'top'    => '0px',
+									'bottom' => '0px',
+								)
+							);
+						},
+					),
 				),
 			)
 		);

--- a/inc/css/blocks/class-posts-css.php
+++ b/inc/css/blocks/class-posts-css.php
@@ -361,43 +361,31 @@ class Posts_CSS extends Base_CSS {
 						'property' => '--pag-border-radius',
 						'value'    => 'pagBorderRadius',
 						'format'   => function( $value, $attrs ) {
-							return CSS_Utility::box_values(
-								$value,
-								array(
-									'left'   => '0px',
-									'right'  => '0px',
-									'top'    => '0px',
-									'bottom' => '0px',
-								)
-							);
+							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property' => '--pag-border-width',
 						'value'    => 'pagBorderWidth',
 						'format'   => function( $value, $attrs ) {
-							return CSS_Utility::box_values(
-								$value,
-								array(
-									'left'   => '0px',
-									'right'  => '0px',
-									'top'    => '0px',
-									'bottom' => '0px',
-								)
-							);
+							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property' => '--pag-padding',
 						'value'    => 'pagPadding',
 						'format'   => function( $value, $attrs ) {
+							return CSS_Utility::box_values( $value );
+						},
+					),
+					array(
+						'property' => '--pag-cont-margin',
+						'value'    => 'pagContMargin',
+						'format'   => function( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
-									'left'   => '0px',
-									'right'  => '0px',
-									'top'    => '0px',
-									'bottom' => '0px',
+									'top' => '10px',
 								)
 							);
 						},

--- a/inc/css/class-css-utility.php
+++ b/inc/css/class-css-utility.php
@@ -371,7 +371,7 @@ class CSS_Utility {
 			$views,
 			function( $view ) {
 				return isset( $view ) && is_array( $view );
-			} 
+			}
 		);
 
 		foreach ( $valid as $arr ) {

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -396,8 +396,12 @@ class Posts_Grid_Block {
 			$format = 'page/%#%/';
 		} else {
 			$format = '&paged=%#%';
+
+			if ( is_front_page() ) {
+				$format = '?paged=%#%';
+			}
 		}
-		$base = get_pagenum_link( 1 ) . '%_%';
+		$base = get_pagenum_link() . '%_%';
 
 		$output  = '<div class="o-posts-grid-pag">';
 		$output .= paginate_links(

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -23,6 +23,8 @@ class Posts_Grid_Block {
 	 */
 	public function render( $attributes ) {
 
+		$start_time = microtime( true );
+
 		$uri = esc_url_raw( $_SERVER['REQUEST_URI'] );
 
 		if ( preg_match( '#/page/(\d+)$#', $uri, $matches ) ) {
@@ -152,6 +154,11 @@ class Posts_Grid_Block {
 			$list_items_markup,
 			$this->render_pagination( $uri, $page_number, ceil( $total_posts / $attributes['postsToShow'] ) )
 		);
+
+		// TODO: Remove after QA.
+		$end_time       = microtime( true );
+		$elapsed_time   = $end_time - $start_time;
+		$block_content .= '<!-- Rendered in ' . $elapsed_time . ' seconds -->';
 
 		return $block_content;
 	}
@@ -418,23 +425,25 @@ class Posts_Grid_Block {
 		$output = '<div class="o-posts-grid-pag">';
 
 		if ( $page_number > 1 ) {
-			$output .= '<div class="o-posts-grid-pag-btn">';
-			$output .= '<a href="' . $url . '/page/' . ( $page_number - 1 ) . '">';
+			$output .= '<a class="o-pag-item" href="' . $url . '/page/' . ( $page_number - 1 ) . '">';
 			$output .= __( 'Prev', 'otter-blocks' );
 			$output .= '</a>';
-			$output .= '</div>';
 		}
 
 		$current_btn  = 1;
-		$skip 	      = false;
+		$skip         = false;
 		$skip_trigger = 5;
 
 		while ( $current_btn <= $total_pages && ! $skip ) {
-			$output .= '<div class="o-posts-grid-pag-btn"' . ( $current_btn === $page_number ? ' aria-current="page"' : '' ) . '>';
-			$output .= '<a href="' . $url . 'page/' . $current_btn . '">';
-			$output .= $current_btn;
-			$output .= '</a>';
-			$output .= '</div>';
+			if ( $current_btn === $page_number ) {
+				$output .= '<span class="o-pag-item" aria-current="page" >';
+				$output .= $current_btn;
+				$output .= '</span>';
+			} else {
+				$output .= '<a class="o-pag-item" href="' . $url . 'page/' . $current_btn . '">';
+				$output .= $current_btn;
+				$output .= '</a>';
+			}
 			$current_btn++;
 
 			if ( $current_btn > $skip_trigger && ! $skip ) {
@@ -444,20 +453,16 @@ class Posts_Grid_Block {
 		}
 
 		if ( $skip ) {
-			$output .= '...';
-			$output .= '<div class="o-posts-grid-pag-btn">';
-			$output .= '<a href="' . $url . 'page/' . $current_btn . '">';
+			$output .= '<span class="o-pag-item o-dots">...</span>';
+			$output .= '<a class="o-pag-item" href="' . $url . 'page/' . $current_btn . '">';
 			$output .= $total_pages;
 			$output .= '</a>';
-			$output .= '</div>';
 		}
 
 		if ( $page_number < $total_pages ) {
-			$output .= '<div class="o-posts-grid-pag-btn">';
-			$output .= '<a href="' . $url . 'page/' . ( $page_number + 1 ) . '">';
+			$output .= '<a class="o-pag-item" href="' . $url . 'page/' . ( $page_number + 1 ) . '">';
 			$output .= __( 'Next', 'otter-blocks' );
 			$output .= '</a>';
-			$output .= '</div>';
 		}
 
 		$output .= '</div>';

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -24,7 +24,7 @@ class Posts_Grid_Block {
 	public function render( $attributes ) {
 
 		$start_time = microtime( true );
-		
+
 		$has_pagination = isset( $attributes['hasPagination'] ) && $attributes['hasPagination'];
 		$page_number    = 1;
 

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -391,7 +391,7 @@ class Posts_Grid_Block {
 	 */
 	protected function render_pagination( $page_number, $total_pages ) {
 		$big  = 9999999;
-		$base = str_replace( $big, '%#%', esc_url( get_pagenum_link( $big ) ) );
+		$base = str_replace( strval( $big ), '%#%', esc_url( get_pagenum_link( $big ) ) );
 
 		$output  = '<div class="o-posts-grid-pag">';
 		$output .= paginate_links(

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -152,7 +152,7 @@ class Posts_Grid_Block {
 			isset( $attributes['enableFeaturedPost'] ) && $attributes['enableFeaturedPost'] && isset( $recent_posts[0] ) ? $this->render_featured_post( $recent_posts[0], $attributes ) : '',
 			trim( $class ),
 			$list_items_markup,
-			$this->render_pagination( $uri, $page_number, ceil( $total_posts / $attributes['postsToShow'] ) )
+			$this->render_pagination( $uri, $page_number, intval( ceil( $total_posts / $attributes['postsToShow'] ) ) )
 		);
 
 		// TODO: Remove after QA.
@@ -446,7 +446,7 @@ class Posts_Grid_Block {
 			}
 			$current_btn++;
 
-			if ( $current_btn > $skip_trigger && ! $skip ) {
+			if ( $current_btn > $skip_trigger ) {
 				$current_btn = $total_pages - 1;
 				$skip        = true;
 			}

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -22,6 +22,17 @@ class Posts_Grid_Block {
 	 * @return mixed|string
 	 */
 	public function render( $attributes ) {
+
+		$uri = esc_url_raw( $_SERVER['REQUEST_URI'] );
+
+		if ( preg_match( '#/page/(\d+)$#', $uri, $matches ) ) {
+			$page_number = intval( $matches[1] );
+		} else {
+			$page_number = 1;
+		}
+
+		$offset = ( $page_number - 1 ) * $attributes['postsToShow'] + $attributes['offset'];
+
 		$categories = 0;
 
 		if ( isset( $attributes['categories'] ) ) {
@@ -34,50 +45,24 @@ class Posts_Grid_Block {
 			$categories = join( ', ', $cats );
 		}
 
-		$get_custom_post_types_posts = function ( $post_type ) use ( $attributes, $categories ) {
-
-			if ( 'product' === $post_type && isset( $attributes['categories'] ) ) {
-				$categories = array();
-				foreach ( $attributes['categories'] as $category ) {
-					if ( isset( $category['slug'] ) ) {
-						array_push( $categories, $category['slug'] );
-					}
-				}
-			}
-
-			return $this->get_posts(
-				apply_filters(
-					'themeisle_gutenberg_posts_block_query',
-					array(
-						'post_type'        => $post_type,
-						'numberposts'      => $attributes['postsToShow'],
-						'post_status'      => 'publish',
-						'order'            => $attributes['order'],
-						'orderby'          => $attributes['orderBy'],
-						'offset'           => $attributes['offset'],
-						'category'         => $categories,
-						'suppress_filters' => false,
-					),
-					$attributes
-				)
-			);
-		};
-
-		$recent_posts = ( isset( $attributes['postTypes'] ) && 0 < count( $attributes['postTypes'] ) ) ? array_merge( ...array_map( $get_custom_post_types_posts, $attributes['postTypes'] ) ) : $this->get_posts(
-			apply_filters(
-				'themeisle_gutenberg_posts_block_query',
-				array(
-					'numberposts'      => $attributes['postsToShow'],
-					'post_status'      => 'publish',
-					'order'            => $attributes['order'],
-					'orderby'          => $attributes['orderBy'],
-					'offset'           => $attributes['offset'],
-					'category'         => $categories,
-					'suppress_filters' => false,
-				),
-				$attributes
-			)
+		$base_query_args = array(
+			'numberposts'      => $attributes['postsToShow'],
+			'post_status'      => 'publish',
+			'order'            => $attributes['order'],
+			'orderby'          => $attributes['orderBy'],
+			'offset'           => $offset,
+			'category'         => $categories,
+			'suppress_filters' => false,
 		);
+
+		$query_args = apply_filters(
+			'themeisle_gutenberg_posts_block_query',
+			$base_query_args,
+			$attributes
+		);
+
+		$total_posts  = 0;
+		$recent_posts = $this->get_posts( $query_args, $attributes, $total_posts );
 
 		if ( isset( $attributes['featuredPostOrder'] ) && 'sticky-first' === $attributes['featuredPostOrder'] ) {
 
@@ -159,12 +144,13 @@ class Posts_Grid_Block {
 		$wrapper_attributes = get_block_wrapper_attributes();
 
 		$block_content = sprintf(
-			'<div %1$s id="%2$s">%3$s<div class="%4$s">%5$s</div> </div>',
+			'<div %1$s id="%2$s">%3$s<div class="%4$s">%5$s</div> %6$s</div>',
 			$wrapper_attributes,
 			isset( $attributes['id'] ) ? $attributes['id'] : '',
 			isset( $attributes['enableFeaturedPost'] ) && $attributes['enableFeaturedPost'] && isset( $recent_posts[0] ) ? $this->render_featured_post( $recent_posts[0], $attributes ) : '',
 			trim( $class ),
-			$list_items_markup
+			$list_items_markup,
+			$this->render_pagination( $uri, $page_number, ceil( $total_posts / $attributes['postsToShow'] ) )
 		);
 
 		return $block_content;
@@ -351,25 +337,131 @@ class Posts_Grid_Block {
 	 * Get posts to display.
 	 *
 	 * @param array $args Query args.
+	 * @param array $attributes Blocks attrs.
+	 * @param int   $total_posts Total posts.
 	 * @return array|array[]|int[]|null[]|\WP_Post[] Posts.
 	 */
-	protected function get_posts( $args ) {
-		if ( isset( $args['post_type'] ) && 'product' === $args['post_type'] && function_exists( 'wc_get_products' ) ) {
+	protected function get_posts( $args, $attributes, &$total_posts ) {
 
-			// drop the post_type arg, as wc_get_products() doesn't support it.
-			unset( $args['post_type'] );
+		$posts               = array();
+		$fetch_only_products = false;
+
+		if ( isset( $args['post_type'] ) && in_array( 'product', $args['post_type'] ) && function_exists( 'wc_get_products' ) ) {
+
+			$copy_args = json_decode( wp_json_encode( $args ), true );
+			unset( $copy_args['post_type'] );
+
+			// Remove 'product' from $args['post_type'] so that get_posts() doesn't complain about an invalid post type.
+			$args['post_type'] = array_diff( $args['post_type'], array( 'product' ) );
+
+			if ( empty( $args['post_type'] ) ) {
+				$fetch_only_products = true;
+			}
+
+			$categories = array();
+			if ( isset( $attributes['categories'] ) ) {
+				foreach ( $attributes['categories'] as $category ) {
+					if ( isset( $category['slug'] ) ) {
+						array_push( $categories, $category['slug'] );
+					}
+				}
+				$copy_args['category'] = $categories;
+			}
+
 
 			$products = wc_get_products( $args );
+			foreach ( $products as $product ) {
+				$posts[] = $product->get_id();
+			}
 
-			// convert to array of post objects since the rest of the code expects that.
-			return array_map(
-				function( $product ) {
-					return $product->get_id();
-				},
-				$products
+			$count_args = array(
+				'limit'            => -1,
+				'post_status'      => 'publish',
+				'order'            => $attributes['order'],
+				'orderby'          => $attributes['orderBy'],
+				'category'         => $categories,
+				'suppress_filters' => false,
+				'return'           => 'ids',
 			);
+
+			$query        = new \WC_Product_Query( $count_args );
+			$total_posts += count( $query->get_products() );
 		}
 
-		return get_posts( $args );
+		if ( ! $fetch_only_products ) {
+			$posts = array_merge( $posts, get_posts( $args ) );
+
+			unset( $args['offset'] );
+			unset( $args['numberposts'] );
+			$args['posts_per_page'] = -1;
+			$args['fields']         = 'ids';
+
+			$total_posts += ( new \WP_Query( $args ) )->found_posts;
+		}
+
+		return $posts;
+	}
+
+	/**
+	 * Render the pagination.
+	 *
+	 * @param string $url The url.
+	 * @param int    $page_number The page number.
+	 * @param int    $total_pages The total pages.
+	 * @return string
+	 */
+	protected function render_pagination( $url, $page_number, $total_pages ) {
+
+		// Remove the page number from the url.
+		$url = preg_replace( '#page/\d+#', '', $url );
+
+		$output = '<div class="o-posts-grid-pag">';
+
+		if ( $page_number > 1 ) {
+			$output .= '<div class="o-posts-grid-pag-btn">';
+			$output .= '<a href="' . $url . '/page/' . ( $page_number - 1 ) . '">';
+			$output .= __( 'Prev', 'otter-blocks' );
+			$output .= '</a>';
+			$output .= '</div>';
+		}
+
+		$current_btn  = 1;
+		$skip 	      = false;
+		$skip_trigger = 5;
+
+		while ( $current_btn <= $total_pages && ! $skip ) {
+			$output .= '<div class="o-posts-grid-pag-btn"' . ( $current_btn === $page_number ? ' aria-current="page"' : '' ) . '>';
+			$output .= '<a href="' . $url . 'page/' . $current_btn . '">';
+			$output .= $current_btn;
+			$output .= '</a>';
+			$output .= '</div>';
+			$current_btn++;
+
+			if ( $current_btn > $skip_trigger && ! $skip ) {
+				$current_btn = $total_pages - 1;
+				$skip        = true;
+			}
+		}
+
+		if ( $skip ) {
+			$output .= '...';
+			$output .= '<div class="o-posts-grid-pag-btn">';
+			$output .= '<a href="' . $url . 'page/' . $current_btn . '">';
+			$output .= $total_pages;
+			$output .= '</a>';
+			$output .= '</div>';
+		}
+
+		if ( $page_number < $total_pages ) {
+			$output .= '<div class="o-posts-grid-pag-btn">';
+			$output .= '<a href="' . $url . 'page/' . ( $page_number + 1 ) . '">';
+			$output .= __( 'Next', 'otter-blocks' );
+			$output .= '</a>';
+			$output .= '</div>';
+		}
+
+		$output .= '</div>';
+
+		return $output;
 	}
 }

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -129,7 +129,7 @@ class Posts_Grid_Block {
 		// TODO: Remove after QA.
 		$end_time       = microtime( true );
 		$elapsed_time   = $end_time - $start_time;
-		$block_content .= '<!-- Rendered in ' . $elapsed_time . ' seconds -->';
+		$block_content .= '<!-- Rendered in ' . $elapsed_time . ' seconds | Page ' . $page_number . ' -->';
 
 		return $block_content;
 	}
@@ -349,6 +349,7 @@ class Posts_Grid_Block {
 		);
 
 		if ( $count_posts ) {
+			$args['offset']        = $args['posts_per_page'] * ( $page_number - 1 ) + $args['offset'];
 			$args['no_found_rows'] = false;
 			$args['paged']         = $page_number;
 		}

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -390,13 +390,20 @@ class Posts_Grid_Block {
 	 * @return string
 	 */
 	protected function render_pagination( $page_number, $total_pages ) {
-		$big = 9999999;
+		// Check permalink structure.
+		$permalink_structure = get_option( 'permalink_structure' );
+		if ( $permalink_structure ) {
+			$format = 'page/%#%/';
+		} else {
+			$format = '&paged=%#%';
+		}
+		$base = get_pagenum_link( 1 ) . '%_%';
 
 		$output  = '<div class="o-posts-grid-pag">';
 		$output .= paginate_links(
 			array(
-				'base'      => str_replace( (string) $big, '%#%', esc_url( get_pagenum_link( $big ) ) ),
-				'format'    => '?paged=%#%',
+				'base'      => $base,
+				'format'    => $format,
 				'current'   => $page_number,
 				'total'     => $total_pages,
 				'prev_text' => __( 'Prev', 'otter-blocks' ),

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -19,11 +19,9 @@ class Posts_Grid_Block {
 	 * the server side output of the block.
 	 *
 	 * @param array $attributes Blocks attrs.
-	 * @return mixed|string
+	 * @return string
 	 */
 	public function render( $attributes ) {
-
-		$start_time = microtime( true );
 
 		$has_pagination = isset( $attributes['hasPagination'] ) && $attributes['hasPagination'];
 		$page_number    = 1;
@@ -35,7 +33,7 @@ class Posts_Grid_Block {
 		}
 
 		$total_posts  = 0;
-		$recent_posts = $this->retrive_posts( $attributes, $has_pagination, $page_number, $total_posts );
+		$recent_posts = $this->retrieve_posts( $attributes, $has_pagination, $page_number, $total_posts );
 
 		if ( isset( $attributes['featuredPostOrder'] ) && 'sticky-first' === $attributes['featuredPostOrder'] ) {
 
@@ -125,11 +123,6 @@ class Posts_Grid_Block {
 			$list_items_markup,
 			$has_pagination ? $this->render_pagination( $page_number, $total_posts ) : ''
 		);
-
-		// TODO: Remove after QA.
-		$end_time       = microtime( true );
-		$elapsed_time   = $end_time - $start_time;
-		$block_content .= '<!-- Rendered in ' . $elapsed_time . ' seconds | Page ' . $page_number . ' -->';
 
 		return $block_content;
 	}
@@ -320,7 +313,7 @@ class Posts_Grid_Block {
 	 * @param int   $total_posts Total posts.
 	 * @return array|int[]|null[]|\WP_Post[] Posts.
 	 */
-	protected function retrive_posts( $attributes, $count_posts, $page_number, &$total_posts ) {
+	protected function retrieve_posts( $attributes, $count_posts, $page_number, &$total_posts ) {
 
 		$offset = ! empty( $attributes['offset'] ) ? $attributes['offset'] : 0;
 
@@ -330,7 +323,7 @@ class Posts_Grid_Block {
 			$cats = array();
 
 			foreach ( $attributes['categories'] as $category ) {
-				array_push( $cats, $category['id'] );
+				$cats[] = $category['id'];
 			}
 
 			$categories = join( ', ', $cats );
@@ -356,11 +349,6 @@ class Posts_Grid_Block {
 
 		// Handle the case when the post type is a WooCommerce product.
 		if ( isset( $args['post_type'] ) && in_array( 'product', $args['post_type'] ) && function_exists( 'wc_get_products' ) ) {
-
-			if ( $count_posts ) {
-				// Paged is not working for WC, so we doing a manual count.
-				$args['offset'] = $args['offset'] + ( $args['posts_per_page'] * ( $args['paged'] - 1 ) );
-			}
 
 			if ( isset( $attributes['categories'] ) ) {
 

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -390,24 +390,14 @@ class Posts_Grid_Block {
 	 * @return string
 	 */
 	protected function render_pagination( $page_number, $total_pages ) {
-		// Check permalink structure.
-		$permalink_structure = get_option( 'permalink_structure' );
-		if ( $permalink_structure ) {
-			$format = 'page/%#%/';
-		} else {
-			$format = '&paged=%#%';
-
-			if ( is_front_page() ) {
-				$format = '?paged=%#%';
-			}
-		}
-		$base = get_pagenum_link() . '%_%';
+		$big  = 9999999;
+		$base = str_replace( $big, '%#%', esc_url( get_pagenum_link( $big ) ) );
 
 		$output  = '<div class="o-posts-grid-pag">';
 		$output .= paginate_links(
 			array(
 				'base'      => $base,
-				'format'    => $format,
+				'format'    => '?paged=%#%',
 				'current'   => $page_number,
 				'total'     => $total_pages,
 				'prev_text' => __( 'Prev', 'otter-blocks' ),

--- a/src/blocks/blocks/posts/block.json
+++ b/src/blocks/blocks/posts/block.json
@@ -316,6 +316,9 @@
 					"type": "string"
 				}
 			}
+		},
+		"pagSize": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/src/blocks/blocks/posts/block.json
+++ b/src/blocks/blocks/posts/block.json
@@ -317,6 +317,23 @@
 				}
 			}
 		},
+		"pagContMargin": {
+			"type": "object",
+			"properties": {
+				"top": {
+					"type": "string"
+				},
+				"left": {
+					"type": "string"
+				},
+				"right": {
+					"type": "string"
+				},
+				"bottom": {
+					"type": "string"
+				}
+			}
+		},
 		"pagSize": {
 			"type": "string"
 		}

--- a/src/blocks/blocks/posts/block.json
+++ b/src/blocks/blocks/posts/block.json
@@ -231,6 +231,91 @@
 		},
 		"featuredPostOrder": {
 			"type": "string"
+		},
+		"hasPagination": {
+			"type": "boolean",
+			"default": false
+		},
+		"pagColor": {
+			"type": "string"
+		},
+		"pagBgColor": {
+			"type": "string"
+		},
+		"pagColorHover": {
+			"type": "string"
+		},
+		"pagBgColorHover": {
+			"type": "string"
+		},
+		"pagColorActive": {
+			"type": "string"
+		},
+		"pagBgColorActive": {
+			"type": "string"
+		},
+		"pagBorderColor": {
+			"type": "string"
+		},
+		"pagBorderColorHover": {
+			"type": "string"
+		},
+		"pagBorderColorActive": {
+			"type": "string"
+		},
+		"pagGap": {
+			"type": "string"
+		},
+		"pagBorderRadius": {
+			"type": "object",
+			"properties": {
+				"top": {
+					"type": "string"
+				},
+				"left": {
+					"type": "string"
+				},
+				"right": {
+					"type": "string"
+				},
+				"bottom": {
+					"type": "string"
+				}
+			}
+		},
+		"pagBorderWidth": {
+			"type": "object",
+			"properties": {
+				"top": {
+					"type": "string"
+				},
+				"left": {
+					"type": "string"
+				},
+				"right": {
+					"type": "string"
+				},
+				"bottom": {
+					"type": "string"
+				}
+			}
+		},
+		"pagPadding": {
+			"type": "object",
+			"properties": {
+				"top": {
+					"type": "string"
+				},
+				"left": {
+					"type": "string"
+				},
+				"right": {
+					"type": "string"
+				},
+				"bottom": {
+					"type": "string"
+				}
+			}
 		}
 	},
 	"supports": {

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -189,35 +189,35 @@ export const PostsDescription = ({ attributes,  element, post }) => {
 
 export const PaginationPreview = () => (
 	<div className='o-posts-grid-pag'>
-		<a className="o-pag-item">
+		<a className="page-numbers">
 			{
 				__( 'Prev', 'otter-blocks' )
 			}
 		</a>
-		<a className="o-pag-item">
+		<a className="page-numbers" aria-current="page">
 			{
 				__( '1', 'otter-blocks' )
 			}
 		</a>
-		<span className="o-pag-item" aria-current="page">
+		<span className="page-numbers">
 			{
 				__( '2', 'otter-blocks' )
 			}
 		</span>
-		<a className="o-pag-item">
+		<a className="page-numbers">
 			{
 				__( '3', 'otter-blocks' )
 			}
 		</a>
-		<span className="o-pag-item o-dots">
+		<span className="page-numbers dots">
 			...
 		</span>
-		<a className="o-pag-item">
+		<a className="page-numbers">
 			{
 				__( '8', 'otter-blocks' )
 			}
 		</a>
-		<a className="o-pag-item">
+		<a className="page-numbers">
 			{
 				__( 'Next', 'otter-blocks' )
 			}

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -187,4 +187,42 @@ export const PostsDescription = ({ attributes,  element, post }) => {
 	return '';
 };
 
+export const PaginationPreview = () => (
+	<div className='o-posts-grid-pag'>
+		<a className="o-pag-item">
+			{
+				__( 'Prev', 'otter-blocks' )
+			}
+		</a>
+		<a className="o-pag-item">
+			{
+				__( '1', 'otter-blocks' )
+			}
+		</a>
+		<span className="o-pag-item" aria-current="page">
+			{
+				__( '2', 'otter-blocks' )
+			}
+		</span>
+		<a className="o-pag-item">
+			{
+				__( '3', 'otter-blocks' )
+			}
+		</a>
+		<span className="o-pag-item o-dots">
+			...
+		</span>
+		<a className="o-pag-item">
+			{
+				__( '8', 'otter-blocks' )
+			}
+		</a>
+		<a className="o-pag-item">
+			{
+				__( 'Next', 'otter-blocks' )
+			}
+		</a>
+	</div>
+);
+
 export default Layout;

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -38,7 +38,7 @@ import {
 	blockInit,
 	getDefaultValueByField
 } from '../../helpers/block-utility.js';
-import Layout from './components/layout/index.js';
+import Layout, { PaginationPreview } from './components/layout/index.js';
 import {
 	_align,
 	_px,
@@ -244,7 +244,20 @@ const Edit = ({
 		'--row-gap-mobile': attributes.rowGapMobile,
 		'--content-padding': responsiveGetAttributes([ attributes.padding, attributes.paddingTablet, attributes.paddingMobile ]),
 		'--content-padding-tablet': attributes.paddingTablet,
-		'--content-padding-mobile': attributes.paddingMobile
+		'--content-padding-mobile': attributes.paddingMobile,
+		'--pag-color': attributes.pagColor,
+		'--pag-bg-color': attributes.pagBgColor,
+		'--pag-color-hover': attributes.pagColorHover,
+		'--pag-bg-color-hover': attributes.pagBgColorHover,
+		'--pag-color-active': attributes.pagColorActive,
+		'--pag-bg-color-active': attributes.pagBgColorActive,
+		'--pag-border-color': attributes.pagBorderColor,
+		'--pag-border-color-hover': attributes.pagBorderColorHover,
+		'--pag-border-color-active': attributes.pagBorderColorActive,
+		'--pag-border-radius': boxValues( attributes.pagBorderRadius ),
+		'--pag-border-width': boxValues( attributes.pagBorderWidth ),
+		'--pag-padding': boxValues( attributes.pagPadding, { top: '5px', right: '15px', bottom: '5px', left: '15px' }),
+		'--pag-gap': attributes.pagGap
 	};
 
 	const blockProps = useBlockProps();
@@ -297,56 +310,10 @@ const Edit = ({
 						authors={ authors }
 					/>
 
-					{
-						attributes.hasPagination && (
-							<div className='o-posts-grid-pag'>
-								<div class="o-posts-grid-pag-btn">
-									<a>
-										{
-											__( 'Prev', 'otter-blocks' )
-										}
-									</a>
-								</div>
-								<div class="o-posts-grid-pag-btn">
-									<a>
-										{
-											__( '1', 'otter-blocks' )
-										}
-									</a>
-								</div>
-								<div class="o-posts-grid-pag-btn" aria-current="page" >
-									<a>
-										{
-											__( '2', 'otter-blocks' )
-										}
-									</a>
-								</div>
-								<div class="o-posts-grid-pag-btn">
-									<a>
-										{
-											__( '3', 'otter-blocks' )
-										}
-									</a>
-								</div>
-								...
-								<div class="o-posts-grid-pag-btn">
-									<a>
-										{
-											__( '8', 'otter-blocks' )
-										}
-									</a>
-								</div>
-								<div class="o-posts-grid-pag-btn">
-									<a>
-										{
-											__( 'Prev', 'otter-blocks' )
-										}
-									</a>
-								</div>
-							</div>
-						)
-					}
 				</Disabled>
+				{
+					attributes.hasPagination && <PaginationPreview />
+				}
 			</div>
 		);
 	};

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -296,6 +296,56 @@ const Edit = ({
 						categoriesList={ categoriesList }
 						authors={ authors }
 					/>
+
+					{
+						attributes.hasPagination && (
+							<div className='o-posts-grid-pag'>
+								<div class="o-posts-grid-pag-btn">
+									<a>
+										{
+											__( 'Prev', 'otter-blocks' )
+										}
+									</a>
+								</div>
+								<div class="o-posts-grid-pag-btn">
+									<a>
+										{
+											__( '1', 'otter-blocks' )
+										}
+									</a>
+								</div>
+								<div class="o-posts-grid-pag-btn" aria-current="page" >
+									<a>
+										{
+											__( '2', 'otter-blocks' )
+										}
+									</a>
+								</div>
+								<div class="o-posts-grid-pag-btn">
+									<a>
+										{
+											__( '3', 'otter-blocks' )
+										}
+									</a>
+								</div>
+								...
+								<div class="o-posts-grid-pag-btn">
+									<a>
+										{
+											__( '8', 'otter-blocks' )
+										}
+									</a>
+								</div>
+								<div class="o-posts-grid-pag-btn">
+									<a>
+										{
+											__( 'Prev', 'otter-blocks' )
+										}
+									</a>
+								</div>
+							</div>
+						)
+					}
 				</Disabled>
 			</div>
 		);

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -222,6 +222,10 @@ const Edit = ({
 		dispatch( 'otter-store' ).setPostsSlugs( slugs );
 	}, [ slugs ]);
 
+	useEffect( () => {
+		console.log( attributes );
+	}, [ attributes ]);
+
 	useDarkBackground( attributes.backgroundColor, attributes, setAttributes );
 
 	const getValue = field => getDefaultValueByField({ name, field, defaultAttributes, attributes });
@@ -275,7 +279,8 @@ const Edit = ({
 		'--pag-border-width': boxValues( attributes.pagBorderWidth ),
 		'--pag-padding': boxValues( attributes.pagPadding, { top: '5px', right: '15px', bottom: '5px', left: '15px' }),
 		'--pag-gap': attributes.pagGap,
-		'--pag-size': attributes.pagSize
+		'--pag-size': attributes.pagSize,
+		'--pag-cont-margin': boxValues( attributes.pagContMargin, { top: '10px' })
 	};
 
 	const blockProps = useBlockProps();

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -257,7 +257,8 @@ const Edit = ({
 		'--pag-border-radius': boxValues( attributes.pagBorderRadius ),
 		'--pag-border-width': boxValues( attributes.pagBorderWidth ),
 		'--pag-padding': boxValues( attributes.pagPadding, { top: '5px', right: '15px', bottom: '5px', left: '15px' }),
-		'--pag-gap': attributes.pagGap
+		'--pag-gap': attributes.pagGap,
+		'--pag-size': attributes.pagSize
 	};
 
 	const blockProps = useBlockProps();

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -302,7 +302,7 @@ const Inspector = ({
 						<ToggleControl
 							label={ __( 'Enable Featured Post', 'otter-blocks' ) }
 							checked={ attributes.enableFeaturedPost }
-							onChange={ enableFeaturedPost => setAttributes({ enableFeaturedPost })}
+							onChange={ () => setAttributes({ enableFeaturedPost: ! Boolean( attributes.enableFeaturedPost ), hasPagination: undefined })}
 						/>
 
 						{
@@ -322,7 +322,7 @@ const Inspector = ({
 						<ToggleControl
 							label={ __( 'Enable Pagination', 'otter-blocks' ) }
 							checked={ attributes.hasPagination }
-							onChange={ hasPagination => setAttributes({ hasPagination })}
+							onChange={ () => setAttributes({ hasPagination: ! Boolean( attributes.hasPagination ), enableFeaturedPost: undefined, featuredPostOrder: undefined }) }
 						/>
 
 					</PanelBody>
@@ -475,12 +475,6 @@ const Inspector = ({
 									isShownByDefault: false
 								},
 								{
-									value: attributes.pagBorderColorActive,
-									onChange: pagBorderColorActive => setAttributes({ pagBorderColorActive }),
-									label: __( 'Pagination Active Border', 'otter-blocks' ),
-									isShownByDefault: false
-								},
-								{
 									value: attributes.pagColorHover,
 									onChange: pagColorHover => setAttributes({ pagColorHover }),
 									label: __( 'Pagination Hover Link', 'otter-blocks' ),
@@ -616,6 +610,13 @@ const Inspector = ({
 										label={ __( 'Pagination Padding', 'otter-blocks' ) }
 										values={ attributes.pagPadding ?? { top: '5px', right: '15px', bottom: '5px', left: '15px' } }
 										onChange={ pagPadding => setAttributes({ pagPadding }) }
+										allowReset
+									/>
+									<BoxControl
+										label={ __( 'Pagination Container Margin', 'otter-blocks' ) }
+										values={ attributes.pagContMargin ?? { top: '10px' } }
+										onChange={ pagContMargin => setAttributes({ pagContMargin }) }
+										sides={[ 'top' ]}
 										allowReset
 									/>
 								</Fragment>

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -443,66 +443,68 @@ const Inspector = ({
 								label: __( 'Border', 'otter-blocks' ),
 								isShownByDefault: false
 							},
-							{
-								value: attributes.pagColor,
-								onChange: pagColor => setAttributes({ pagColor }),
-								label: __( 'Pagination Link', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagBgColor,
-								onChange: pagBgColor => setAttributes({ pagBgColor }),
-								label: __( 'Pagination Background', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagBorderColor,
-								onChange: pagBorderColor => setAttributes({ pagBorderColor }),
-								label: __( 'Pagination Border', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagColorActive,
-								onChange: pagColorActive => setAttributes({ pagColorActive }),
-								label: __( 'Pagination Active Link', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagBgColorActive,
-								onChange: pagBgColorActive => setAttributes({ pagBgColorActive }),
-								label: __( 'Pagination Active Background', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagBorderColorActive,
-								onChange: pagBorderColorActive => setAttributes({ pagBorderColorActive }),
-								label: __( 'Pagination Active Border', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagColorHover,
-								onChange: pagColorHover => setAttributes({ pagColorHover }),
-								label: __( 'Pagination Hover Link', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagBgColorHover,
-								onChange: pagBgColorHover => setAttributes({ pagBgColorHover }),
-								label: __( 'Pagination Hover Background', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagBorderColorHover,
-								onChange: pagBorderColorHover => setAttributes({ pagBorderColorHover }),
-								label: __( 'Pagination Hover Border', 'otter-blocks' ),
-								isShownByDefault: false
-							},
-							{
-								value: attributes.pagBorderColorActive,
-								onChange: pagBorderColorActive => setAttributes({ pagBorderColorActive }),
-								label: __( 'Pagination Active Border', 'otter-blocks' ),
-								isShownByDefault: false
-							}
+							...( attributes.hasPagination ? [
+								{
+									value: attributes.pagColor,
+									onChange: pagColor => setAttributes({ pagColor }),
+									label: __( 'Pagination Link', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagBgColor,
+									onChange: pagBgColor => setAttributes({ pagBgColor }),
+									label: __( 'Pagination Background', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagBorderColor,
+									onChange: pagBorderColor => setAttributes({ pagBorderColor }),
+									label: __( 'Pagination Border', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagColorActive,
+									onChange: pagColorActive => setAttributes({ pagColorActive }),
+									label: __( 'Pagination Active Link', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagBgColorActive,
+									onChange: pagBgColorActive => setAttributes({ pagBgColorActive }),
+									label: __( 'Pagination Active Background', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagBorderColorActive,
+									onChange: pagBorderColorActive => setAttributes({ pagBorderColorActive }),
+									label: __( 'Pagination Active Border', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagColorHover,
+									onChange: pagColorHover => setAttributes({ pagColorHover }),
+									label: __( 'Pagination Hover Link', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagBgColorHover,
+									onChange: pagBgColorHover => setAttributes({ pagBgColorHover }),
+									label: __( 'Pagination Hover Background', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagBorderColorHover,
+									onChange: pagBorderColorHover => setAttributes({ pagBorderColorHover }),
+									label: __( 'Pagination Hover Border', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.pagBorderColorActive,
+									onChange: pagBorderColorActive => setAttributes({ pagBorderColorActive }),
+									label: __( 'Pagination Active Border', 'otter-blocks' ),
+									isShownByDefault: false
+								}
+							] : [])
 						] }
 					/>
 

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -93,7 +93,7 @@ const defaultFontSizes = [
 
 /**
  *
- * @param {import('../popup/types.js').PopupInspectorProps} props
+ * @param {import('./types.js').PostInspectorProps} props
  * @returns
  */
 const Inspector = ({
@@ -318,6 +318,12 @@ const Inspector = ({
 							)
 						}
 
+						<ToggleControl
+							label={ __( 'Enable Pagination', 'otter-blocks' ) }
+							checked={ attributes.hasPagination }
+							onChange={ hasPagination => setAttributes({ hasPagination })}
+						/>
+
 					</PanelBody>
 
 					<PanelBody
@@ -419,6 +425,66 @@ const Inspector = ({
 								onChange: borderColor => setAttributes({ borderColor }),
 								label: __( 'Border', 'otter-blocks' ),
 								isShownByDefault: false
+							},
+							{
+								value: attributes.pagColor,
+								onChange: pagColor => setAttributes({ pagColor }),
+								label: __( 'Pagination Link', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagBgColor,
+								onChange: pagBgColor => setAttributes({ pagBgColor }),
+								label: __( 'Pagination Background', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagBorderColor,
+								onChange: pagBorderColor => setAttributes({ pagBorderColor }),
+								label: __( 'Pagination Border', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagColorActive,
+								onChange: pagActiveColor => setAttributes({ pagActiveColor }),
+								label: __( 'Pagination Active Link', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagBgColorActive,
+								onChange: pagBgColorActive => setAttributes({ pagBgColorActive }),
+								label: __( 'Pagination Active Background', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagBorderColorActive,
+								onChange: pagBorderColorActive => setAttributes({ pagBorderColorActive }),
+								label: __( 'Pagination Active Border', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagColorHover,
+								onChange: pagColorHover => setAttributes({ pagColorHover }),
+								label: __( 'Pagination Hover Link', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagBgColorHover,
+								onChange: pagBgColorHover => setAttributes({ pagBgColorHover }),
+								label: __( 'Pagination Hover Background', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagBorderColorHover,
+								onChange: pagBorderColorHover => setAttributes({ pagBorderColorHover }),
+								label: __( 'Pagination Hover Border', 'otter-blocks' ),
+								isShownByDefault: false
+							},
+							{
+								value: attributes.pagBorderColorActive,
+								onChange: pagBorderColorActive => setAttributes({ pagBorderColorActive }),
+								label: __( 'Pagination Active Border', 'otter-blocks' ),
+								isShownByDefault: false
 							}
 						] }
 					/>
@@ -516,6 +582,26 @@ const Inspector = ({
 								onChange={ contentGap => setAttributes({ contentGap }) }
 							/>
 						</BaseControl>
+
+						{
+							attributes.hasPagination && (
+								<Fragment>
+									<RangeControl
+										label={ __( 'Pagination Gap', 'otter-blocks' ) }
+										value={ attributes.pagGap ? parseInt( attributes.pagGap ) : 10 }
+										onChange={ pagGap => setAttributes({ pagGap: pagGap + 'px' }) }
+										min={ 0 }
+										max={ 50 }
+									/>
+									<BoxControl
+										label={ __( 'Pagination Padding', 'otter-blocks' ) }
+										values={ attributes.pagPadding }
+										onChange={ pagPadding => setAttributes({ pagPadding }) }
+										allowReset
+									/>
+								</Fragment>
+							)
+						}
 					</PanelBody>
 
 					<PanelBody
@@ -539,6 +625,26 @@ const Inspector = ({
 							onChange={ cardBorderRadius => setAttributes({ cardBorderRadius }) }
 							id="o-border-raduis-box"
 						/>
+
+						{
+							attributes.hasPagination && (
+								<Fragment>
+									<BoxControl
+										label={ __( 'Pagination Border Radius', 'otter-blocks' ) }
+										values={ attributes.pagBorderRadius }
+										onChange={ pagBorderRadius => setAttributes({ pagBorderRadius }) }
+										id="o-border-raduis-box"
+										allowReset
+									/>
+									<BoxControl
+										label={ __( 'Pagination Border Width', 'otter-blocks' ) }
+										values={ attributes.pagBorderWidth }
+										onChange={ pagBorderWidth => setAttributes({ pagBorderWidth }) }
+										allowReset
+									/>
+								</Fragment>
+							)
+						}
 
 						<BoxShadowControl
 							boxShadow={ attributes.boxShadow }

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -403,6 +403,22 @@ const Inspector = ({
 								onChange={ value => responsiveSetAttributes( value, [ 'customMetaFontSize', 'customMetaFontSizeTablet', 'customMetaFontSizeMobile' ]) }
 							/>
 						</ResponsiveControl>
+
+						{
+							attributes.hasPagination && (
+								<BaseControl
+									id="o-posts-grid-pagination-font-size"
+									label={ __( 'Pagination', 'otter-blocks' ) }
+								>
+									<FontSizePicker
+										fontSizes={ defaultFontSizes }
+										withReset
+										value={ attributes.pagSize ?? '16px' }
+										onChange={ pagSize => setAttributes({ pagSize }) }
+									/>
+								</BaseControl>
+							)
+						}
 					</PanelBody>
 
 					<PanelColorSettings

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -50,6 +50,7 @@ import {
 } from '../../helpers/helper-functions.js';
 import { useResponsiveAttributes } from '../../helpers/utility-hooks.js';
 import { useTabSwitch } from '../../helpers/block-utility';
+import { makeBox } from '../../plugins/copy-paste/utils';
 
 const styles = [
 	{
@@ -446,7 +447,7 @@ const Inspector = ({
 							},
 							{
 								value: attributes.pagColorActive,
-								onChange: pagActiveColor => setAttributes({ pagActiveColor }),
+								onChange: pagColorActive => setAttributes({ pagColorActive }),
 								label: __( 'Pagination Active Link', 'otter-blocks' ),
 								isShownByDefault: false
 							},
@@ -533,7 +534,7 @@ const Inspector = ({
 								label={ __( 'Column Gap', 'otter-blocks' ) }
 							>
 								<UnitContol
-									value={ responsiveGetAttributes([ attributes.columnGap, attributes.columnGapTablet, attributes.columnGapMobile ]) }
+									value={ responsiveGetAttributes([ attributes.columnGap, attributes.columnGapTablet, attributes.columnGapMobile ]) ?? '30px' }
 									onChange={ value => responsiveSetAttributes( value, [ 'columnGap', 'columnGapTablet', 'columnGapMobile' ]) }
 								/>
 
@@ -548,7 +549,7 @@ const Inspector = ({
 							label={ __( 'Row Gap', 'otter-blocks' ) }
 						>
 							<UnitContol
-								value={ responsiveGetAttributes([ attributes.rowGap, attributes.rowGapTablet, attributes.rowGapMobile ]) }
+								value={ responsiveGetAttributes([ attributes.rowGap, attributes.rowGapTablet, attributes.rowGapMobile ]) ?? '30px' }
 								onChange={ value => responsiveSetAttributes( value, [ 'rowGap', 'rowGapTablet', 'rowGapMobile' ]) }
 							/>
 
@@ -588,14 +589,14 @@ const Inspector = ({
 								<Fragment>
 									<RangeControl
 										label={ __( 'Pagination Gap', 'otter-blocks' ) }
-										value={ attributes.pagGap ? parseInt( attributes.pagGap ) : 10 }
+										value={ attributes.pagGap ? parseInt( attributes.pagGap ) : 5 }
 										onChange={ pagGap => setAttributes({ pagGap: pagGap + 'px' }) }
 										min={ 0 }
 										max={ 50 }
 									/>
 									<BoxControl
 										label={ __( 'Pagination Padding', 'otter-blocks' ) }
-										values={ attributes.pagPadding }
+										values={ attributes.pagPadding ?? { top: '5px', right: '15px', bottom: '5px', left: '15px' } }
 										onChange={ pagPadding => setAttributes({ pagPadding }) }
 										allowReset
 									/>
@@ -610,7 +611,7 @@ const Inspector = ({
 					>
 						<UnitContol
 							label={ __( 'Width', 'otter-blocks' ) }
-							value={ attributes.borderWidth }
+							value={ attributes.borderWidth ?? '0px' }
 							onChange={ borderWidth => setAttributes({ borderWidth }) }
 						/>
 
@@ -621,7 +622,7 @@ const Inspector = ({
 
 						<BoxControl
 							label={ __( 'Radius', 'otter-blocks' ) }
-							value={ attributes.cardBorderRadius }
+							values={ attributes.cardBorderRadius ?? makeBox( '0px' )  }
 							onChange={ cardBorderRadius => setAttributes({ cardBorderRadius }) }
 							id="o-border-raduis-box"
 						/>
@@ -631,14 +632,14 @@ const Inspector = ({
 								<Fragment>
 									<BoxControl
 										label={ __( 'Pagination Border Radius', 'otter-blocks' ) }
-										values={ attributes.pagBorderRadius }
+										values={ attributes.pagBorderRadius ?? makeBox( '0px' ) }
 										onChange={ pagBorderRadius => setAttributes({ pagBorderRadius }) }
 										id="o-border-raduis-box"
 										allowReset
 									/>
 									<BoxControl
 										label={ __( 'Pagination Border Width', 'otter-blocks' ) }
-										values={ attributes.pagBorderWidth }
+										values={ attributes.pagBorderWidth ?? makeBox( '0px' ) }
 										onChange={ pagBorderWidth => setAttributes({ pagBorderWidth }) }
 										allowReset
 									/>

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -47,11 +47,11 @@
 	--pag-bg-color-active: rgba(0,0,0,0.1);
 
 	--pag-border-color: transparent;
+	--pag-border-color-hover: var(--pag-border-color); // TODO: add handles for this.
 	--pag-border-color-active: var(--pag-border-color);
 
 	--pag-border-radius: 0;
 	--pag-border-width: 0;
-	--pag-margin: 0;
 	--pag-padding: 5px 15px;
 	--pag-gap: 5px;
 
@@ -275,40 +275,37 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: center;
+		align-items: baseline;
 		width: 100%;
-		gap: var( --pag-gap );
-	}
+		gap: var(--pag-gap);
+		color: var(--pag-color);
 
-	.o-posts-grid-pag-btn {
-		background-color: var( --pag-bg-color );
-		border-color: var( --pag-border-color );
-		border-radius: var( --pag-border-radius );
-		border-width: var( --pag-border-width );
-		margin: var( --pag-margin );
-		padding: var( --pag-padding );
+		.o-pag-item:not(.o-dots) {
+			background-color: var(--pag-bg-color);
+			border-color: var(--pag-border-color);
+			border-radius: var(--pag-border-radius);
+			border-width: var(--pag-border-width);
+			padding: var(--pag-padding);
 
-		text-align: center;
-
-		a {
 			text-decoration: none;
-			color: var( --pag-color );
-		}
+			color: inherit;
+			border-style: solid;
+			box-sizing: border-box;
+			text-align: center;
+			margin: 0;
 
-		&[aria-current="page"] {
-			background-color: var( --pag-bg-color-active );
-			border-color: var( --pag-border-color-active );
+			&:hover {
+				background-color: var(--pag-bg-color-hover);
+				border-color: var(--pag-border-color-hover);
 
-			a {
-				color: var( --pag-color-active );
+				color: var(--pag-color-hover);
 			}
-		}
 
-		&:hover {
-			background-color: var( --pag-bg-color-hover );
-			border-color: var( --pag-border-color-hover );
+			&[aria-current="page"] {
+				background-color: var(--pag-bg-color-active);
+				border-color: var(--pag-border-color-active);
 
-			a {
-				color: var( --pag-color-hover );
+				color: var(--pag-color-active);
 			}
 		}
 	}

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -55,6 +55,7 @@
 	--pag-border-width: 0;
 	--pag-padding: 5px 15px;
 	--pag-gap: 5px;
+	--pag-cont-margin: 10px 0 0 0;
 
 	border: none;
 
@@ -270,7 +271,6 @@
 	}
 
 	.o-posts-grid-pag {
-		margin-top: 10px;
 		margin-bottom: 30px;
 
 		display: flex;
@@ -279,9 +279,11 @@
 		justify-content: center;
 		align-items: baseline;
 		width: 100%;
+
 		gap: var(--pag-gap);
 		color: var(--pag-color);
 		font-size: var(--pag-size);
+		margin: var(--pag-cont-margin);
 
 		.page-numbers:not(.dots) {
 			background-color: var(--pag-bg-color);

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -283,7 +283,7 @@
 		color: var(--pag-color);
 		font-size: var(--pag-size);
 
-		.o-pag-item:not(.o-dots) {
+		.page-numbers:not(.dots) {
 			background-color: var(--pag-bg-color);
 			border-color: var(--pag-border-color);
 			border-radius: var(--pag-border-radius);

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -39,6 +39,22 @@
 	--content-padding-tablet: var( --content-padding );
 	--content-padding-mobile: var( --content-padding-tablet );
 
+	--pag-color: inherit;
+	--pag-bg-color: transparent;
+	--pag-color-hover: var(--pag-color);
+	--pag-bg-color-hover: rgba(0,0,0,0.5);
+	--pag-color-active: var(--pag-color);
+	--pag-bg-color-active: rgba(0,0,0,0.1);
+
+	--pag-border-color: transparent;
+	--pag-border-color-active: var(--pag-border-color);
+
+	--pag-border-radius: 0;
+	--pag-border-width: 0;
+	--pag-margin: 0;
+	--pag-padding: 5px 15px;
+	--pag-gap: 5px;
+
 	border: none;
 
 	&.has-dark-bg {
@@ -238,17 +254,62 @@
 			background-color: var( --background-color );
 			box-shadow: var( --box-shadow );
 			margin-bottom: var( --row-gap );
-	
+
 			.o-posts-grid-post-image a {
 				width: 100%;
-	
+
 				img {
 					width: 100%;
 					height: 250px;
 					object-fit: cover;
 				}
 			}
-	
+
+		}
+	}
+
+	.o-posts-grid-pag {
+		margin-top: 10px;
+		margin-bottom: 30px;
+
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		width: 100%;
+		gap: var( --pag-gap );
+	}
+
+	.o-posts-grid-pag-btn {
+		background-color: var( --pag-bg-color );
+		border-color: var( --pag-border-color );
+		border-radius: var( --pag-border-radius );
+		border-width: var( --pag-border-width );
+		margin: var( --pag-margin );
+		padding: var( --pag-padding );
+
+		text-align: center;
+
+		a {
+			text-decoration: none;
+			color: var( --pag-color );
+		}
+
+		&[aria-current="page"] {
+			background-color: var( --pag-bg-color-active );
+			border-color: var( --pag-border-color-active );
+
+			a {
+				color: var( --pag-color-active );
+			}
+		}
+
+		&:hover {
+			background-color: var( --pag-bg-color-hover );
+			border-color: var( --pag-border-color-hover );
+
+			a {
+				color: var( --pag-color-hover );
+			}
 		}
 	}
 }
@@ -275,7 +336,7 @@
 			a {
 				width: var( --img-width-tablet );
 			}
-	
+
 			img {
 				width: var( --img-width-tablet );
 			}
@@ -297,7 +358,7 @@
 			.o-posts-grid-post-category {
 				font-size: var( --meta-text-size-tablet );
 			}
-	
+
 			.o-posts-grid-post-meta {
 				font-size: var( --meta-text-size-tablet );
 			}
@@ -312,7 +373,7 @@
 				p {
 					font-size: var( --description-text-size-tablet );
 				}
-	
+
 				.read-more {
 					font-size: var( --description-text-size-tablet );
 				}
@@ -363,7 +424,7 @@
 			a {
 				width: var( --img-width-mobile );
 			}
-	
+
 			img {
 				width: var( --img-width-mobile );
 			}
@@ -385,7 +446,7 @@
 			.o-posts-grid-post-category {
 				font-size: var( --meta-text-size-mobile );
 			}
-	
+
 			.o-posts-grid-post-meta {
 				font-size: var( --meta-text-size-mobile );
 			}
@@ -400,7 +461,7 @@
 				p {
 					font-size: var( --description-text-size-mobile );
 				}
-	
+
 				.read-more {
 					font-size: var( --description-text-size-mobile );
 				}

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -39,6 +39,7 @@
 	--content-padding-tablet: var( --content-padding );
 	--content-padding-mobile: var( --content-padding-tablet );
 
+	--pag-size: 16px;
 	--pag-color: inherit;
 	--pag-bg-color: transparent;
 	--pag-color-hover: var(--pag-color);
@@ -274,11 +275,13 @@
 
 		display: flex;
 		flex-direction: row;
+		flex-wrap: wrap;
 		justify-content: center;
 		align-items: baseline;
 		width: 100%;
 		gap: var(--pag-gap);
 		color: var(--pag-color);
+		font-size: var(--pag-size);
 
 		.o-pag-item:not(.o-dots) {
 			background-color: var(--pag-bg-color);

--- a/src/blocks/blocks/posts/types.d.ts
+++ b/src/blocks/blocks/posts/types.d.ts
@@ -1,4 +1,5 @@
 import { BlockProps, InspectorProps, BoxShadow } from '../../helpers/blocks';
+import { BoxBorder, BoxPadding } from '../../common';
 
 type Attributes = {
 	id: string
@@ -54,6 +55,20 @@ type Attributes = {
 	paddingMobile: string
 	contentGap: string
 	featuredPostOrder: string
+	hasPagination: boolean
+	pagColor: string
+	pagBgColor: string
+	pagColorHover: string
+	pagBgHoverColor: string
+	pagColorActive: string
+	pagBgColorActive: string
+	pagPadding: BoxPadding
+	pagGap: string
+	pagBorderRadius: BoxBorder
+	pagBorderWidth: BoxBorder
+	pagBorderColor: string
+	pagBorderColorHover: string
+	pagBorderColorActive: string
 }
 
 export type PostProps = BlockProps<Attributes>

--- a/src/blocks/blocks/posts/types.d.ts
+++ b/src/blocks/blocks/posts/types.d.ts
@@ -1,4 +1,4 @@
-import { BlockProps, InspectorProps, BoxShadow } from '../../helpers/blocks';
+import { BlockProps, InspectorProps, BoxShadow, BoxType } from '../../helpers/blocks';
 import { BoxBorder, BoxPadding } from '../../common';
 
 type Attributes = {
@@ -70,6 +70,7 @@ type Attributes = {
 	pagBorderColorHover: string
 	pagBorderColorActive: string
 	pagSize: string
+	pagContMargin: BoxType
 }
 
 export type PostProps = BlockProps<Attributes>

--- a/src/blocks/blocks/posts/types.d.ts
+++ b/src/blocks/blocks/posts/types.d.ts
@@ -69,6 +69,7 @@ type Attributes = {
 	pagBorderColor: string
 	pagBorderColorHover: string
 	pagBorderColorActive: string
+	pagSize: string
 }
 
 export type PostProps = BlockProps<Attributes>

--- a/src/blocks/helpers/helper-functions.js
+++ b/src/blocks/helpers/helper-functions.js
@@ -369,6 +369,7 @@ export const lightnessFromColor = color => {
  * @return {string}
  */
 export const boxValues = ( box = {}, defaultBox = {}) => {
+	box ??= {};
 	return `${ box?.top ?? defaultBox?.top ?? '0px' } ${ box?.right ?? defaultBox?.right ?? '0px' } ${ box?.bottom ?? defaultBox?.bottom ?? '0px' } ${ box?.left ?? defaultBox?.left ?? '0px' }`;
 };
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1046
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add pagination for Posts Block.

Developing notes:
 - It seems that Dynamic Content collides with the counting mechanism. It needs some investigation on the cause.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/50b16af4-5f71-4991-8582-96d6b4a46ae7)

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/c94e6b7e-e16a-40d9-a7b3-f105e8a9d602)


https://github.com/Codeinwp/otter-blocks/assets/17597852/9bdbff2e-11cb-457d-8271-2a2572167e12

----




### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Post Block
2. Enable pagination and customize it.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

