### PR TITLE
Remove extra files from build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -172,7 +172,10 @@ module.exports = [
 							'build/dashboard/pro/',
 							'build/export-import/blocks/',
 							'build/export-import/pro/',
-							'build/blocks/pro/'
+							'build/blocks/pro/',
+							'build/blocks/blocks/',
+							'build/pro/pro',
+							'build/pro/blocks'
 						]
 					}
 				},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -162,11 +162,22 @@ module.exports = [
 				events: {
 					onEnd: {
 						mkdir: blockFolders,
-						copy: blockFiles
+						copy: blockFiles,
+						delete: [
+							'build/animation/blocks/',
+							'build/animation/pro/',
+							'build/css/blocks/',
+							'build/css/pro/',
+							'build/dashboard/blocks/',
+							'build/dashboard/pro/',
+							'build/export-import/blocks/',
+							'build/export-import/pro/',
+							'build/blocks/pro/'
+						]
 					}
 				},
 				runOnceInWatchMode: false,
-				runTasksInSeries: true
+				runTasksInSeries: false
 			}),
 			new BundleAnalyzerPlugin({
 				analyzerMode: 'disabled',


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1876 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

`wp-scripts` automatically gathers all `.json` files and puts them inside each build.

Reference: https://github.com/WordPress/gutenberg/blob/1fb1343c42a59d5062660a7da20a4bff4d06e369/packages/scripts/config/webpack.config.js#L263-L313

ℹ️ By using the already existing FIleManager in our setup, we can delete the extra file generated.

### Screenshots <!-- if applicable -->

Output of `tree build -d`


After change:

```
build
├── animation
│   └── images
├── blocks
│   ├── about-author
│   ├── accordion
│   ├── accordion-item
│   ├── advanced-column
│   ├── advanced-columns
│   ├── advanced-heading
│   ├── button
│   ├── button-group
│   ├── circle-counter
│   ├── content-generator
│   ├── countdown
│   ├── flip
│   ├── font-awesome-icons
│   ├── form
│   ├── form-file
│   ├── form-hidden-field
│   ├── form-input
│   ├── form-multiple-choice
│   ├── form-nonce
│   ├── form-stripe-field
│   ├── form-textarea
│   ├── google-map
│   ├── icon-list
│   ├── icon-list-item
│   ├── leaflet-map
│   ├── lottie
│   ├── plugin-cards
│   ├── popup
│   ├── posts-grid
│   ├── pricing
│   ├── progress-bar
│   ├── review
│   ├── service
│   ├── sharing-icons
│   ├── slider
│   ├── stripe-checkout
│   ├── tabs
│   ├── tabs-item
│   └── testimonials
├── css
├── dashboard
├── export-import
└── pro
    ├── add-to-cart-button
    ├── business-hours
    ├── business-hours-item
    ├── product-add-to-cart
    ├── product-images
    ├── product-meta
    ├── product-price
    ├── product-rating
    ├── product-related-products
    ├── product-short-description
    ├── product-stock
    ├── product-tabs
    ├── product-title
    ├── product-upsells
    ├── review-comparison
    └── woo-comparison

63 directories
```

Before the change, the number was `471 directories` (you can see [here the structure](https://app.warp.dev/block/cIv6T4zytj68jyeJijPeka)), now we have `63 directories`

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Make sure that the build is valid since we deleted some extra files from the it.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

