### PR TITLE
Improve Heading typo component

### DIFF
--- a/.github/workflows/e2e-js.yml
+++ b/.github/workflows/e2e-js.yml
@@ -10,11 +10,11 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-    
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -40,11 +40,11 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-cache-
-      
+
       - name: npm ci
         run: |
           npm ci
-          
+
       - name: Make dev build
         run: |
           npm run build-dev
@@ -60,11 +60,11 @@ jobs:
       - name: Install Playwright
         run: |
           npm install -g playwright-cli
-          npx playwright install    
+          npx playwright install
 
-      - name: Playwright Blocks 
+      - name: Playwright Blocks
         run: |
-          npm run test:e2e:playwright    
+          npm run test:e2e:playwright
 
       # run the node.js puppeteer script (which takes the screenshots and controls chrome)
       - name: Performance check
@@ -80,9 +80,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: artifact
-          path: ./artifacts/tests/
+          path: ./artifacts
           retention-days: 1
-      
+
       - name: Print the results
         run: |
           echo "::set-output name=TYPING_AVG::$(jq '.summary.type.average' ./artifacts/performance.spec.performance-results.json)"
@@ -91,7 +91,7 @@ jobs:
           echo "::set-output name=TYPING_QR60::$(jq '.summary.type.quantileRank60' ./artifacts/performance.spec.performance-results.json)"
           echo "::set-output name=TYPING_ABOVE_60::$(jq -c '.summary.type.above60' ./artifacts/performance.spec.performance-results.json)"
           echo "::set-output name=TYPING_QR80::$(jq '.summary.type.quantileRank80' ./artifacts/performance.spec.performance-results.json)"
-        id: summary  
+        id: summary
 
       - name: Comment
         uses: NejcZdovc/comment-pr@v1
@@ -107,5 +107,5 @@ jobs:
           TYPING_QR80: ${{ steps.summary.outputs.TYPING_QR80 }}
           TYPING_ABOVE_60: ${{ steps.summary.outputs.TYPING_ABOVE_60 }}
 
-  
-  
+
+

--- a/src/blocks/blocks/advanced-heading/edit.js
+++ b/src/blocks/blocks/advanced-heading/edit.js
@@ -8,7 +8,7 @@ import hexToRgba from 'hex-rgba';
  */
 import { __ } from '@wordpress/i18n';
 
-import { isObjectLike, omitBy } from 'lodash';
+import { isObjectLike, isString, omitBy } from 'lodash';
 
 import {
 	createBlock,
@@ -158,7 +158,7 @@ const Edit = ({
 		fontWeight: 'regular' === attributes.fontVariant ? 'normal' : attributes.fontVariant,
 		fontStyle: attributes.fontStyle || undefined,
 		textTransform: attributes.textTransform || undefined,
-		lineHeight: ( 3 < attributes.lineHeight ? attributes.lineHeight + 'px' : attributes.lineHeight ) || undefined,
+		lineHeight: ( ( ! isString( attributes.lineHeight ) &&  3 < attributes.lineHeight ) ? attributes.lineHeight + 'px' : attributes.lineHeight ) || undefined,
 		letterSpacing: _px( attributes.letterSpacing ),
 		background: attributes.backgroundColor,
 		...textShadowStyle,

--- a/src/blocks/blocks/advanced-heading/inspector.js
+++ b/src/blocks/blocks/advanced-heading/inspector.js
@@ -254,7 +254,9 @@ const Inspector = ({
 												[responsiveGetAttributes([ 'fontSize', 'fontSizeTablet', 'fontSizeMobile' ])]: undefined
 											});
 										} else {
-											setAttributes({ [fieldMapping[field]]: undefined });
+											setAttributes({
+												[fieldMapping[field]]: undefined
+											});
 										}
 									}}
 

--- a/src/blocks/blocks/advanced-heading/inspector.js
+++ b/src/blocks/blocks/advanced-heading/inspector.js
@@ -34,6 +34,7 @@ import {
 } from '@wordpress/element';
 
 import {
+	isEmpty,
 	isObjectLike
 } from 'lodash';
 
@@ -55,6 +56,17 @@ import { useResponsiveAttributes } from '../../helpers/utility-hooks.js';
 import { makeBox } from '../../plugins/copy-paste/utils';
 import { _px } from '../../helpers/helper-functions.js';
 import { useTabSwitch } from '../../helpers/block-utility';
+import TypographySelectorControl from '../../components/typography-selector-control';
+
+const fieldMapping = {
+	'fontFamily': 'fontFamily',
+	'fontSize': 'fontSize',
+	'lineHeight': 'lineHeight',
+	'letterCase': 'textTransform',
+	'spacing': 'letterSpacing',
+	'appearance': 'fontStyle',
+	'variant': 'fontVariant'
+};
 
 /**
  *
@@ -204,97 +216,50 @@ const Inspector = ({
 								title={ __( 'Typography', 'otter-blocks' ) }
 								initialOpen={ true }
 							>
+								<TypographySelectorControl
+									enableComponents={{
+										fontFamily: true,
+										appearance: true,
+										lineHeight: true,
+										letterCase: true,
+										spacing: true,
+										variant: true
+									}}
 
-								<ResponsiveControl
-									label={ __( 'Font Size', 'otter-blocks' ) }
-								>
+									componentsValue={{
+										fontSize: _px( responsiveGetAttributes([ attributes.fontSize, attributes.fontSizeTablet, attributes.fontSizeMobile  ]) ),
+										fontFamily: attributes.fontFamily,
+										lineHeight: attributes.lineHeight,
+										appearance: attributes.fontStyle,
+										letterCase: attributes.textTransform,
+										spacing: attributes.letterSpacing,
+										variant: attributes.fontVariant
+									}}
 
-									<FontSizePicker
-										value={ _px( responsiveGetAttributes([ attributes.fontSize, attributes.fontSizeTablet, attributes.fontSizeMobile  ]) ) }
-										onChange={ value => responsiveSetAttributes( value, [ 'fontSize', 'fontSizeTablet', 'fontSizeMobile' ]) }
-										fontSizes={
-											[
-												{
-													name: __( '13', 'otter-blocks' ),
-													size: '13px',
-													slug: 'small'
-												},
-												{
-													name: __( '20', 'otter-blocks' ),
-													size: '20px',
-													slug: 'medium'
-												},
-												{
-													name: __( '36', 'otter-blocks' ),
-													size: '36px',
-													slug: 'large'
-												},
-												{
-													name: __( '42', 'otter-blocks' ),
-													size: '42px',
-													slug: 'xl'
-												}
-											]
+									onChange={ ( values ) => {
+										setAttributes({
+											fontFamily: values.fontFamily,
+											lineHeight: values.lineHeight,
+											fontStyle: values.appearance,
+											textTransform: values.letterCase,
+											letterSpacing: values.spacing,
+											[responsiveGetAttributes([ 'fontSize', 'fontSizeTablet', 'fontSizeMobile' ]) ?? 'fontSize']: values.fontSize,
+											fontVariant: values.variant
+										});
+									} }
+
+									onReset={ field => {
+										if ( 'fontSize' === field ) {
+											setAttributes({
+												[responsiveGetAttributes([ 'fontSize', 'fontSizeTablet', 'fontSizeMobile' ])]: undefined
+											});
+										} else {
+											setAttributes({ [fieldMapping[field]]: undefined });
 										}
-									/>
-								</ResponsiveControl>
+									}}
 
-								<GoogleFontsControl
-									label={ __( 'Font Family', 'otter-blocks' ) }
-									value={ attributes.fontFamily }
-									onChangeFontFamily={ changeFontFamily }
-									valueVariant={ attributes.fontVariant }
-									onChangeFontVariant={ fontVariant => setAttributes({ fontVariant }) }
-									valueStyle={ attributes.fontStyle }
-									onChangeFontStyle={ fontStyle => setAttributes({ fontStyle }) }
-									valueTransform={ attributes.textTransform }
-									onChangeTextTransform={ textTransform => setAttributes({ textTransform }) }
+									allowVariants={true}
 								/>
-
-								<UnitControl
-									label={ __( 'Line Height', 'otter-blocks' ) }
-									value={ attributes.lineHeight }
-									onChange={ lineHeight => setAttributes({ lineHeight }) }
-									step={ 0.1 }
-									min={ 0 }
-									units={[
-										{
-											a11yLabel: 'Unitless (-)',
-											label: '-',
-											step: 0.1,
-											value: ''
-										},
-										{
-											a11yLabel: 'Pixels (px)',
-											label: 'px',
-											step: 0.1,
-											value: 'px'
-										},
-										{
-											a11yLabel: 'Percentage (%)',
-											label: '%',
-											step: 1,
-											value: '%'
-										}
-									]}
-								/>
-
-								<br />
-
-								<UnitControl
-									label={ __( 'Letter Spacing', 'otter-blocks' ) }
-									value={ attributes.letterSpacing }
-									onChange={ letterSpacing => setAttributes({ letterSpacing }) }
-									step={ 0.1 }
-									min={ -50 }
-									max={ 100 }
-								/>
-
-								<ClearButton
-									values={[ 'fontFamily', 'fontVariant', 'fontStyle', 'textTransform', 'lineHeight', 'letterSpacing' ]}
-									setAttributes={ setAttributes }
-								/>
-
 							</PanelBody>
 
 							<PanelColorSettings

--- a/src/blocks/components/typography-selector-control/editor.scss
+++ b/src/blocks/components/typography-selector-control/editor.scss
@@ -2,12 +2,12 @@
 .o-typo-component {
 	.o-typo-header {
 		padding: 10px 0px 0px 0px;
-	
+
 		&> .components-heading {
 			margin: 0;
 		}
 	}
-	
+
 	.o-two-column-components {
 		gap: 10px;
 		justify-content: space-between;
@@ -16,9 +16,17 @@
 		justify-items: stretch;
 		grid-template-columns: 1fr 1fr;
 		max-height: 55px;
-	
+
+		&> div:first-child:last-child {
+			grid-column: 1 / 3;
+		}
+
 		&> div > .components-base-control {
 			margin: 8px 0px;
+		}
+
+		&~ .o-two-column-components {
+			margin-top: 10px;
 		}
 	}
 }
@@ -30,7 +38,7 @@
 .block-editor-block-inspector, .o-options-global-defaults-modal {
 	.o-typo-component .components-base-control.o-no-margin {
 		margin: 0px;
-	
+
 		&> .components-base-control__field .components-base-control {
 			margin: 0px 0px 14px 0px;
 		}

--- a/src/blocks/components/typography-selector-control/editor.scss
+++ b/src/blocks/components/typography-selector-control/editor.scss
@@ -29,6 +29,10 @@
 			margin-top: 10px;
 		}
 	}
+
+	.components-font-size-picker__controls .components-base-control {
+		margin: 0 0 8px 0;
+	}
 }
 
 .o-options-global-defaults-modal .o-typo-component .o-two-column-components {
@@ -36,11 +40,11 @@
 }
 
 .block-editor-block-inspector, .o-options-global-defaults-modal {
-	.o-typo-component .components-base-control.o-no-margin {
-		margin: 0px;
+	:is(.o-typo-component) :is(.components-base-control).o-no-margin {
+		margin: 0;
 
 		&> .components-base-control__field .components-base-control {
-			margin: 0px 0px 14px 0px;
+			margin: 0 0 14px 0;
 		}
 	}
 }

--- a/src/blocks/components/typography-selector-control/index.tsx
+++ b/src/blocks/components/typography-selector-control/index.tsx
@@ -345,6 +345,7 @@ const TypographySelectorControl = ( props: TypographySelectorControlProps ) => {
 					/*@ts-ignore */
 					fontSizes={ props.fontSizes ?? defaultStates.fontSizes }
 					onChange={ fontSize => onChangeValue( 'fontSize', fontSize?.toString() ) }
+					__nextHasNoMarginBottom={ true }
 				/>
 			</Disabled>
 

--- a/src/blocks/components/typography-selector-control/index.tsx
+++ b/src/blocks/components/typography-selector-control/index.tsx
@@ -510,7 +510,7 @@ const TypographySelectorControl = ( props: TypographySelectorControlProps ) => {
 										label={ __( 'Variants', 'otter-blocks' ) }
 										value={ componentsValue?.variant ?? 'normal' }
 										options={ variants }
-										onChange={ appearance => onChangeValue( 'variant', appearance ) }
+										onChange={ variant => onChangeValue( 'variant', variant ) }
 									/>
 								</Disabled>
 							)

--- a/src/blocks/components/typography-selector-control/index.tsx
+++ b/src/blocks/components/typography-selector-control/index.tsx
@@ -190,8 +190,6 @@ const TypographySelectorControl = ( props: TypographySelectorControlProps ) => {
 		allowVariants
 	} = props;
 
-	console.log( allowVariants );
-
 	const [ showComponent, setShowComponent ] = useState(
 		mapValues( componentsValue ?? defaultStates.isEnabled, x => Boolean( x ) )
 	);

--- a/src/blocks/test/e2e/blocks/heading.spec.js
+++ b/src/blocks/test/e2e/blocks/heading.spec.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Advanced Heading Block', () => {
+	test.beforeEach( async({ admin }) => {
+		await admin.createNewPost();
+	});
+
+	test( 'can be created by typing "/advanced-heading"', async({ editor, page }) => {
+
+		// Create a Progress Block with the slash block shortcut.
+		await page.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '/advanced-heading' );
+		await page.keyboard.press( 'Enter' );
+
+		const blocks = await editor.getBlocks();
+		const hasProgressBar = blocks.some( ( block ) => 'themeisle-blocks/advanced-heading' === block.name );
+
+		expect( hasProgressBar ).toBeTruthy();
+	});
+
+	test( 'can use typo component"', async({ editor, page }) => {
+		await editor.insertBlock({
+			name: 'themeisle-blocks/advanced-heading'
+		});
+
+		// Open Style tab.
+		await page.getByRole( 'button', { name: 'Style' }).click();
+
+		// Select font size.
+		await page.getByRole( 'radio', { name: '16' }).click();
+
+		// Open the menu for more options.
+		await page.getByRole( 'button', { name: 'View options' }).click();
+
+		// Enable all options.
+		await page.getByRole( 'menuitemcheckbox', { name: 'Font Family' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Appearance' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Spacing' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Letter Case' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Line Height' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Variant' }).click();
+
+		// Close the menu.
+		await page.getByRole( 'button', { name: 'View options' }).click();
+
+		// Open the family font menu to start the fonts loading. Then close the panel and come back after some time.
+		await page.getByRole( 'button', { name: 'Select Font Family' }).click();
+
+		// Fill the line height.
+		await page.getByLabel( 'Line Height' ).fill( '1.5' );
+
+		// Fill the letter spacing.
+		await page.getByLabel( 'Spacing' ).fill( '10' );
+
+		// Select a letter case.
+		await page.getByRole( 'button', { name: 'Uppercase' }).click();
+
+		// Select an appearance.
+		await page.getByRole( 'combobox', { name: 'Appearance' }).selectOption( 'Italic' );
+
+		// Select a font family.
+		await page.getByRole( 'button', { name: 'Select Font Family' }).click();
+		await page.waitForSelector( '.o-gfont-popover .components-menu-item__button div[style*="Comic Neue"]' );
+		await page.getByRole( 'menuitem', { name: 'Comic Neue' }).click();
+
+		// Select a variant.
+		await page.getByRole( 'combobox', { name: 'Variants' }).selectOption( '700' );
+
+		// Compare with the saved data.
+		const blocks = await editor.getBlocks();
+		const attrs = blocks.filter( ( block ) => 'themeisle-blocks/advanced-heading' === block.name )?.pop()?.attributes;
+
+		expect( attrs ).toBeDefined();
+		expect( attrs?.fontSize ).toBe( '16px' );
+		expect( attrs?.fontFamily ).toBe( 'Comic Neue' );
+		expect( attrs?.fontVariant ).toBe( '700' );
+		expect( attrs?.letterSpacing ).toBe( '10px' );
+		expect( attrs?.lineHeight ).toBe( '1.5' );
+		expect( attrs?.textTransform ).toBe( 'uppercase' );
+		expect( attrs?.fontStyle ).toBe( 'italic' );
+	});
+});

--- a/src/blocks/test/e2e/blocks/heading.spec.js
+++ b/src/blocks/test/e2e/blocks/heading.spec.js
@@ -47,7 +47,7 @@ test.describe( 'Advanced Heading Block', () => {
 		await page.getByRole( 'button', { name: 'View options' }).click();
 
 		// Open the family font menu to start the fonts loading. Then close the panel and come back after some time.
-		await page.getByRole( 'button', { name: 'Select Font Family' }).click();
+		await page.getByRole( 'button', { name: 'Font Family' }).click();
 
 		// Fill the line height.
 		await page.getByLabel( 'Line Height' ).fill( '1.5' );

--- a/src/blocks/test/e2e/blocks/heading.spec.js
+++ b/src/blocks/test/e2e/blocks/heading.spec.js
@@ -62,7 +62,7 @@ test.describe( 'Advanced Heading Block', () => {
 		await page.getByRole( 'combobox', { name: 'Appearance' }).selectOption( 'Italic' );
 
 		// Select a font family.
-		await page.getByRole( 'button', { name: 'Select Font Family' }).click();
+		await page.getByRole( 'button', { name: 'Font Family' }).click();
 		await page.waitForSelector( '.o-gfont-popover .components-menu-item__button div[style*="Comic Neue"]' );
 		await page.getByRole( 'menuitem', { name: 'Comic Neue' }).click();
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1882
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Moved the old typo component to the new one.

Development notes: It was not a smooth experience, but I was glad to find a new trick to tackle the responsive option.

### Screenshots <!-- if applicable -->

Before

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/cb7cd9d3-5259-446f-a9f6-85c795632d09)

After

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/32d02f4c-d869-4363-bcb0-d897064669f2)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

⚠️ Before using this build, make some Heading blocks with the current version and customize them with Typography.

Switching to the PR build and checking if the options are the same as before and if they are working like before.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

