### PR TITLE
Slider not working inside a flex container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "otter-blocks",
-			"version": "2.3.4",
+			"version": "2.4.0",
 			"license": "GPL-2.0+",
 			"dependencies": {
 				"@wordpress/icons": "^9.32.0",

--- a/src/blocks/blocks/slider/style.scss
+++ b/src/blocks/blocks/slider/style.scss
@@ -12,13 +12,14 @@
 	--width: auto;
 
 	width: var( --width );
+	display: grid;
 
 	.glide__track {
 		border: var( --border-width ) solid var( --border-color );
 		border-radius: var( --border-radius );
 		overflow: hidden;
 	}
-	
+
 	.glide__slides {
 		height: var( --height );
 		animation: load 4s 3;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1750, Codeinwp/neve#4092.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
- Due to a [Glide bug](https://github.com/glidejs/glide/issues/534), the slider is stretching far more than the container if the container has a flexible width.
- It seems that making the container "display:grid" fixes the issue
- The fix was already in Otter but it only worked if you would have added the Slider [inside a column](https://github.com/Codeinwp/otter-blocks/blob/master/src/blocks/blocks/section/style.scss#L77-L79)


### Test instructions
- Install Neve, Neve Pro and Otter
- Add a widget section inside Neve's header and inside that widget section add a Slider
- Save the customizer and check it on frontend
- Please check https://github.com/Codeinwp/otter-blocks/issues/1750 and also https://github.com/Codeinwp/neve/issues/4092 and try to see if the problem is solved

Please note that the issue I've mentioned [here](https://github.com/Codeinwp/neve/issues/4092#issuecomment-1727748053) is still there but I think we can consider it an edge case. Here's how it manifests: https://vertis.d.pr/v/Nm55m6

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

