### PR TITLE
Add Form Submission Export

### DIFF
--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -299,12 +299,16 @@ class Dashboard {
 					})
 						.then(response => response.text())
 						.then(response => {
-							console.log(response);
+							const currentDate = new Date();
+							const year = currentDate.getFullYear();
+							const month = String(currentDate.getMonth() + 1).padStart(2, '0');
+							const day = String(currentDate.getDate()).padStart(2, '0');
+
 							const blob = new Blob([response], {type: 'text/xml'});
 							const url = window.URL.createObjectURL(blob);
 							const a = document.createElement('a');
 							a.href = url;
-							a.download = 'otter-form-submissions.xml';
+							a.download = `otter_form_submissions__${year}-${month}-${day}.xml`;
 							document.body.appendChild(a);
 							a.click();
 						})

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -252,16 +252,23 @@ class Dashboard {
 				flex-wrap: wrap;
 				align-content: center;
 				width: 100%;
-				margin-left: 10px
+				margin-left: 10px;
+				align-items: center;
 			}
 
 			.otter-banner__version {
 				align-self: center;
+				font-size: 11px;
 			}
 
 			/* Hide the "Add New" button for Multisite WP. Second part is for Elementor */
 			a.page-title-action:first-of-type, #e-admin-top-bar-root:not(.e-admin-top-bar--active)~#wpbody .wrap a.page-title-action:first-of-type {
 				display: none;
+			}
+
+			#export-submissions {
+				font-size: 14px;
+				max-height: 35px;
 			}
 		</style>
 		<div class="otter-banner">
@@ -269,10 +276,43 @@ class Dashboard {
 				<img src="<?php echo esc_url( OTTER_BLOCKS_URL . 'assets/images/logo-alt.png' ); ?>" alt="<?php esc_attr_e( 'Otter Blocks', 'otter-blocks' ); ?>" style="width: 90px">
 			</div>
 			<div class="otter-banner__content">
-				<h1 class="otter-banner__title" style="line-height: normal;"><?php esc_html_e( 'Form Submissions', 'otter-blocks' ); ?></h1>
-				<span class="otter-banner__version"><?php echo esc_html( 'v' . OTTER_BLOCKS_VERSION ); ?></span>
+				<h1 class="otter-banner__title" style="line-height: normal;"><?php esc_html_e( 'Form Submissions', 'otter-blocks' ); ?>
+					<sub class="otter-banner__version"><?php echo esc_html( 'v' . OTTER_BLOCKS_VERSION ); ?></sub>
+				</h1>
+				<button id="export-submissions" class="button">
+					<?php esc_html_e( 'Export', 'otter-blocks' ); ?>
+				</button>
 			</div>
 		</div>
+		<script>
+			window.document.addEventListener('DOMContentLoaded', () => {
+				document.querySelector('#export-submissions')?.addEventListener('click', () => {
+					fetch('<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>', {
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded'
+						},
+						body: new URLSearchParams({
+							action: 'otter_form_submissions',
+							_nonce: '<?php echo esc_attr( wp_create_nonce( 'otter_form_export_submissions' ) ); ?>'
+						})
+					})
+						.then(response => response.text())
+						.then(response => {
+							console.log(response);
+							const blob = new Blob([response], {type: 'text/xml'});
+							const url = window.URL.createObjectURL(blob);
+							const a = document.createElement('a');
+							a.href = url;
+							a.download = 'otter-form-submissions.xml';
+							document.body.appendChild(a);
+							a.click();
+						})
+						.catch(error => console.error('Error:', error));
+				});
+
+			})
+		</script>
 		<?php
 	}
 

--- a/src/blocks/test/e2e/blocks/form.spec.js
+++ b/src/blocks/test/e2e/blocks/form.spec.js
@@ -392,4 +392,28 @@ test.describe( 'Form Block', () => {
 
 		expect( await saveBtn.isEnabled() ).toBeTruthy();
 	});
+
+	test( 'can export form data', async({ page, editor }) => {
+		let downloadTriggered = false;
+		let fileName = '';
+
+		await page.goto( '/wp-admin/edit.php?post_type=otter_form_record' );
+
+		page.on( 'download', async download => {
+			await download.path(); // Wait for download to complete.
+			downloadTriggered = true;
+			fileName = download.suggestedFilename();
+		});
+
+		const exportBtn = page.getByRole( 'button', { name: 'Export' });
+
+		await expect( exportBtn ).toBeVisible();
+
+		await exportBtn.click();
+
+		await page.waitForTimeout( 1000 );
+
+		expect( downloadTriggered ).toBeTruthy();
+		expect( fileName.startsWith( 'otter_form_submissions' ) ).toBeTruthy();
+	});
 });


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1671
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add a button that exports the form submission in XML format via `export_wp`.

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/otter-blocks/assets/17597852/141bc427-c7c0-422a-81f3-de5143c01ebd

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Make some submissions.
2. Try Export them via any method. Our button, or native one, via Tools > Export. Or any popular plugin for exporting WP pots or pages.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

