### PR TITLE
Fix Live Search initialisation inside containers like Popup Block

### DIFF
--- a/src/blocks/test/e2e/blocks/live-search.spec.js
+++ b/src/blocks/test/e2e/blocks/live-search.spec.js
@@ -40,9 +40,11 @@ test.describe( 'Live Search Block', () => {
 
 		await page.goto( `/?p=${postId}` );
 
-		expect ( page.locator( '#wp-block-search__input-1' ) ).toBeVisible();
+		const input = page.locator( '.otter-popup__modal_body .o-live-search input' );
 
-		await page.fill( '#wp-block-search__input-1', 'u' );
+		expect ( input ).toBeVisible();
+
+		await input.fill( 'u' );
 
 		// If the width is 0, it means the results are not rendered properly.
 		const container = page.locator( '.o-live-search .container-wrap' );

--- a/src/blocks/test/e2e/blocks/live-search.spec.js
+++ b/src/blocks/test/e2e/blocks/live-search.spec.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Live Search Block', () => {
+	test.beforeEach( async({ admin }) => {
+		await admin.createNewPost();
+	});
+
+	test( 'can be created by typing "/live-search"', async({ editor, page }) => {
+
+		// Create a Progress Block with the slash block shortcut.
+		await page.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '/live-search' );
+		await page.keyboard.press( 'Enter' );
+
+		const blocks = await editor.getBlocks();
+
+		// Since Live Search is a variation of the Search block, we check for the Search block instead.
+		const hasSearch = blocks.some( ( block ) => 'core/search' === block.name );
+
+		expect( hasSearch ).toBeTruthy();
+	});
+
+	test( 'add a live search block inside a Popup and check results rendering', async({ admin, editor, page }) => {
+		await editor.insertBlock({
+			name: 'themeisle-blocks/popup',
+			innerBlocks: [
+				{
+					name: 'core/search',
+					attributes: {
+						otterIsLive: true
+					}
+				}
+			]
+		});
+
+		const postId = await editor.publishPost();
+
+		await page.goto( `/?p=${postId}` );
+
+		expect ( page.locator( '#wp-block-search__input-1' ) ).toBeVisible();
+
+		await page.fill( '#wp-block-search__input-1', 'u' );
+
+		// If the width is 0, it means the results are not rendered properly.
+		const container = page.locator( '.o-live-search .container-wrap' );
+		let width = await container.evaluate( node => node.offsetWidth );
+		expect( width ).toBeGreaterThan( 0 );
+	});
+});


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1930
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Initialize live search when the block is visible. Add an E2E case for it.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/61928c65-76db-4a77-a201-de72fbd369e0)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Popup block, then put a Live Search on it.
2. Check if the results are visible.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

