### PR TITLE
Do not clean detected widgets on widget content detection

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -327,6 +327,8 @@ class Registration {
 			return;
 		}
 
+		
+
 		if ( is_singular() ) {
 			$this->enqueue_dependencies();
 		} else {
@@ -358,6 +360,7 @@ class Registration {
 		}
 
 		if ( $has_widgets ) {
+			
 			add_filter(
 				'wp_footer',
 				function ( $content ) {
@@ -1008,8 +1011,6 @@ class Registration {
 				$valid_widgets[] = (object) $widget_data[ $key ];
 			}
 		}
-
-		self::$widget_used = array();
 
 		foreach ( $valid_widgets as $widget ) {
 			if ( isset( $widget->content ) ) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1931 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

It seems that there are more than one executions of https://github.com/Codeinwp/otter-blocks/blob/3ed5af1cc875b2fba08690228e6ef3d0f1bc0cb5/inc/class-registration.php#L991

Each execution overrides the previous one. Since the detected widgets were cleaned off the first execution, the next one overrides the previous but without the content of widgets since the variable that was holding the detected widgets is not empty.

⚠️ There might be some changes in WP since when it was added it worked fine when it was added. 

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Check if block styles are loaded on the page when blocks are in widgets.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

