### PR TITLE
Prevent rank math filter to erase previous content

### DIFF
--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -354,13 +354,14 @@ domReady( () => {
 	let maxTries = 10;
 
 	const init = () => {
-		window.wp.hooks.addFilter( 'rank_math_content', 'rank-math', () => {
+
+		window.wp.hooks.addFilter( 'rank_math_content', 'rank-math', ( content ) => {
 
 			/**
 			 * @type {NodeListOf<HTMLDivElement>} postsHtml - The HTML nodes which contain the relevent post content for RankMath.
 			 */
 			const postsHtml = document.querySelectorAll( '.o-posts-grid-post-body' );
-			return Array.from( postsHtml ).map( ( post ) => post.innerHTML ).join( '' );
+			return ( content ?? '' ) + ( Array.from( postsHtml )?.map( ( post ) => post.innerHTML )?.join( '' ) ?? '' );
 		});
 
 		window?.rankMathEditor?.refresh( 'content' );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1955
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Make the custom `'rank_math_content'` filter to return its given content by params.

⚠️ It seems that not given the original content made some condition to show negative. 

### Screenshots <!-- if applicable -->

Without Otter

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/4add92d4-c5f7-4a16-a778-43b3d838cd93)

Current version

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/5a90bee8-32dc-41ed-9f95-91578e9f5912)


With fix

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/e51f3a16-6c32-44ac-a755-1e34082a16ca)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Install MathRank
2. Make a page and check the store.
3. Install Otter with the fix and score that should remain the same or go higher*.

*The code was initially added to detect Post blocks. Check this https://github.com/Codeinwp/otter-blocks/pull/1874


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

