### PR TITLE
Remove obsolete base64 checking in Form File validation

### DIFF
--- a/inc/integrations/class-form-utils.php
+++ b/inc/integrations/class-form-utils.php
@@ -72,7 +72,7 @@ class Form_Utils {
 	 * @since 2.2.3
 	 */
 	public static function is_file_field_valid( $field ) {
-		return isset( $field['metadata']['name'] ) && isset( $field['metadata']['size'] ) && isset( $field['metadata']['data'] ) && is_string( $field['metadata']['name'] ) && is_numeric( $field['metadata']['size'] ) && is_string( $field['metadata']['data'] ) && self::is_base64_string( $field['metadata']['data'] );
+		return isset( $field['metadata']['name'] ) && isset( $field['metadata']['size'] ) && isset( $field['metadata']['data'] ) && is_string( $field['metadata']['name'] ) && is_numeric( $field['metadata']['size'] ) && is_string( $field['metadata']['data'] );
 	}
 
 	/**
@@ -139,18 +139,5 @@ class Form_Utils {
 		$hash_code     = substr( $hash_code, 0, 8 );
 
 		return $hash_code . '_' . $original_name;
-	}
-
-	/**
-	 * Check if a string is a valid base64 string.
-	 *
-	 * @param string $data String to check.
-	 * @return boolean
-	 * @since 2.2.3
-	 */
-	public static function is_base64_string( $data ) {
-		// Separate out the headers from the data.
-		$parts = explode( ';base64,', $data );
-		return preg_match( '%^[a-zA-Z0-9/+]*={0,2}$%', $parts[1] );
 	}
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1933
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Removed the obsolete checking for Files. New versions of PHP are smarter at detecting minor issues/

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Test with an instance with a version of PHP at least 8.

ℹ️ This will require Otter Pro

1. Create a Form Block with a File Field.
2. Send some files and check if everything is alright regarding the files.


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

