### PR TITLE
fix: otter making repeated api calls

### DIFF
--- a/docs/coding-best-practices.md
+++ b/docs/coding-best-practices.md
@@ -102,3 +102,5 @@ In this project, we do not have cases when the code must do a lot of things at a
 The challenge in this project is to extend the code to support more features. The more we have, the harder it will be to maintain the code. Fancy tricks without a good reason are not good.
 
 A piece code that is performant, easy to read and understand, and easy to maintain is the best. [But sometime you can not have it all](https://www.youtube.com/watch?v=hFDcoX7s6rE). So, you need to choose what is more important for your case.
+
+If you are using filters or HOC to add, for example, a Toolbar to all Blocks, it's recommended that you make useSelect or other requests inside child components to avoid them being triggered when they're not needed. An example of what type of issues it can cause: https://github.com/Codeinwp/otter-blocks/pull/1974

--- a/src/blocks/helpers/use-settings.js
+++ b/src/blocks/helpers/use-settings.js
@@ -5,15 +5,15 @@ import api from '@wordpress/api';
 
 import { __ } from '@wordpress/i18n';
 
-import { dispatch } from '@wordpress/data';
-
 import {
-	useEffect,
-	useState
-} from '@wordpress/element';
+	dispatch,
+	useSelect
+} from '@wordpress/data';
+
+import { useState } from '@wordpress/element';
 
 /**
- * useSettings Hook.
+ * useSettings Hook, modifed for Otter usage.
  *
  * useSettings hook to get/update WordPress' settings database.
  *
@@ -32,25 +32,23 @@ import {
 const useSettings = () => {
 	const { createNotice } = dispatch( 'core/notices' );
 
-	const [ settings, setSettings ] = useState({});
 	const [ status, setStatus ] = useState( 'loading' );
+	const [ settings, setSettings ] = useState({});
 
-	const getSettings = () => {
-		api.loadPromise.then( async() => {
-			try {
-				const settings = new api.models.Settings();
-				const response = await settings.fetch();
-				setSettings( response );
-			} catch ( error ) {
-				setStatus( 'error' );
-			} finally {
-				setStatus( 'loaded' );
-			}
-		});
-	};
+	useSelect( select => {
+		const { getEntityRecord } = select( 'core' );
 
-	useEffect( () => {
-		getSettings();
+		// Bail out if settings are already loaded.
+		if ( Object.keys( settings ).length ) {
+			return;
+		}
+
+		const request = getEntityRecord( 'root', 'site' );
+
+		if ( request ) {
+			setStatus( 'loaded' );
+			setSettings( request );
+		}
 	}, []);
 
 	/**
@@ -107,7 +105,7 @@ const useSettings = () => {
 				);
 			}
 
-			getSettings();
+			setSettings( response );
 			onSuccess?.( response );
 		});
 

--- a/src/blocks/plugins/ai-content/index.tsx
+++ b/src/blocks/plugins/ai-content/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 
-// @ts-ignore
+
 import {
 	DropdownMenu,
 	MenuGroup,
@@ -18,12 +18,9 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 
 import { Fragment, useEffect, useState } from '@wordpress/element';
 
-import {
-	addFilter,
-	applyFilters
-} from '@wordpress/hooks';
+import { addFilter } from '@wordpress/hooks';
 
-import { useDispatch, useSelect, dispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { rawHandler, createBlock } from '@wordpress/blocks';
 import { BlockControls } from '@wordpress/block-editor';
 
@@ -74,20 +71,238 @@ const extractContent = ( source: BlockProps<unknown> | BlockProps<unknown>[]): s
 
 let embeddedPromptsCache: PromptsData|null = null;
 
+const AIToolbar = ({
+	props,
+	onClose
+}) => {
+	const [ getOption, _, status ] = useSettings();
+	const [ hasAPIKey, setHasAPIKey ] = useState<boolean>( false );
+	const [ isProcessing, setIsProcessing ] = useState<Record<string, boolean>>({});
+	const [ displayError, setDisplayError ] = useState<string|undefined>( undefined );
+
+	// Get the create notice function from the hooks api.
+	const { createNotice } = useDispatch( 'core/notices' );
+
+	const {
+		isMultipleSelection,
+		selectedBlocks
+	} = useSelect( ( select ) => {
+		const selectedBlocks = select( 'core/block-editor' ).getMultiSelectedBlocks();
+
+		return {
+			isMultipleSelection: 1 < selectedBlocks.length,
+			selectedBlocks
+		};
+	}, []);
+
+	useEffect( () => {
+		if ( 'loading' === status ) {
+			return;
+		}
+
+		if ( 'loaded' === status && ! hasAPIKey ) {
+			const key = getOption( openAiAPIKeyName ) as string;
+			setHasAPIKey(  Boolean( key ) && 0 < key.length );
+		}
+	}, [ status, getOption ]);
+
+	useEffect( () => {
+		if ( ! displayError ) {
+			return;
+		}
+
+		createNotice(
+			'error',
+			displayError,
+			{
+				type: 'snackbar',
+				isDismissible: true
+			}
+		);
+
+		setDisplayError( undefined );
+	}, [ displayError ]);
+
+	const generateContent = async( content: string, actionKey: string, callback: Function = () =>{}) => {
+
+		if ( ! content ) {
+			setDisplayError( __( 'No content detected in selected block.', 'otter-blocks' ) );
+			return;
+		}
+
+		if ( ! embeddedPromptsCache ) {
+			const response = await retrieveEmbeddedPrompt( 'textTransformation' );
+			embeddedPromptsCache = response?.prompts ?? [];
+		}
+
+		const embeddedPrompt = embeddedPromptsCache?.find( ( prompt ) => 'textTransformation' === prompt.otter_name );
+
+		if ( ! embeddedPrompt ) {
+			setDisplayError( __( 'Something when wrong retrieving the prompts.', 'otter-blocks' ) );
+			return;
+		}
+
+		const action: undefined | string = embeddedPrompt?.[actionKey];
+
+		if ( ! action ) {
+			setDisplayError( __( 'The action is not longer available.', 'otter-blocks' ) );
+			return;
+		}
+
+		if ( ! hasAPIKey ) {
+			setDisplayError( __( 'No Open API key detected. Please add your key.', 'otter-blocks' ) );
+			return;
+		}
+
+		setIsProcessing( prevState => ({ ...prevState, [ actionKey ]: true }) );
+
+		window.oTrk?.add({ feature: 'ai-generation', featureComponent: 'ai-toolbar', featureValue: actionKey }, { consent: true });
+
+		sendPromptToOpenAI(
+			content,
+			injectActionIntoPrompt(
+				embeddedPrompt,
+				action
+			),
+			{
+				'otter_used_action': `textTransformation::${ actionKey }`,
+				'otter_user_content': content
+			}
+		).then( ( response ) => {
+			if ( response.error ) {
+				setDisplayError( response.error?.message ?? response.error );
+				return;
+			}
+
+			const blockContentRaw = response?.choices?.[0]?.message.content;
+
+			if ( ! blockContentRaw ) {
+				return;
+			}
+
+			const newBlocks = rawHandler({
+				HTML: blockContentRaw
+			});
+
+			const aiBlock = createBlock(
+				'themeisle-blocks/content-generator',
+				{
+					promptID: 'textTransformation',
+					resultHistory: [{
+						result: response?.choices?.[0]?.message.content ?? '',
+						meta: {
+							usedToken: response?.usage.total_tokens,
+							prompt: ''
+						}
+					}]
+				},
+				newBlocks
+			);
+
+			insertBlockBelow( props.clientId, aiBlock );
+
+			setIsProcessing( prevState => ({ ...prevState, [ actionKey ]: false }) );
+			callback?.();
+		}).catch( ( error ) => {
+			setDisplayError( error.message );
+			setIsProcessing( prevState => ({ ...prevState, [ actionKey ]: false }) );
+		});
+	};
+
+	const ActionMenuItem = ( args: { actionKey: string, children: React.ReactNode, callback: Function }) => {
+		return (
+			<Disabled isDisabled={Object.values( isProcessing ).some( x => x )}>
+				<MenuItem
+					onClick={ () => {
+						generateContent( extractContent( isMultipleSelection ? selectedBlocks : props ), args.actionKey, () => args.callback?.( args.actionKey ) );
+					}}
+				>
+					{ args.children }
+					{ isProcessing?.[args.actionKey] && <Spinner /> }
+				</MenuItem>
+			</Disabled>
+		);
+	};
+
+	return (
+		<Fragment>
+			{
+				( ! hasAPIKey ) && (
+					<MenuGroup>
+						<span className='o-menu-item-alignment' style={{ display: 'block', marginBottom: '10px' }}>
+							{ __( 'Please add your OpenAI API key in Integrations.', 'otter-blocks' ) }
+						</span>
+						<ExternalLink className='o-menu-item-alignment' href={window.themeisleGutenberg.optionsPath} target="_blank" rel="noopener noreferrer">
+							{
+								__( 'Go to Dashboard', 'otter-blocks' )
+							}
+						</ExternalLink>
+					</MenuGroup>
+				)
+			}
+			<MenuGroup>
+				<span className="o-menu-item-header o-menu-item-alignment">{__( 'Writing', 'otter-blocks' )}</span>
+				<ActionMenuItem actionKey='otter_action_generate_title' callback={onClose}>
+					{ __( 'Generate a heading', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_continue_writing' callback={onClose}>
+					{ __( 'Continue writing', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_summarize' callback={onClose}>
+					{ __( 'Summarize it', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_make_shorter' callback={onClose}>
+					{ __( 'Make it shorter', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_make_longer' callback={onClose}>
+					{ __( 'Make it longer', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_make_descriptive' callback={onClose}>
+					{ __( 'Make it more descriptive', 'otter-blocks' ) }
+				</ActionMenuItem>
+			</MenuGroup>
+			<MenuGroup>
+				<span className="o-menu-item-header o-menu-item-alignment">{__( 'Tone', 'otter-blocks' )}</span>
+				<ActionMenuItem actionKey='otter_action_tone_professional' callback={onClose}>
+					{ __( 'Professional', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_tone_friendly' callback={onClose}>
+					{ __( 'Friendly', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_tone_humorous' callback={onClose}>
+					{ __( 'Humorous', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_tone_confident' callback={onClose}>
+					{ __( 'Confident', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_tone_persuasive' callback={onClose}>
+					{ __( 'Persuasive', 'otter-blocks' ) }
+				</ActionMenuItem>
+				<ActionMenuItem actionKey='otter_action_tone_casual' callback={onClose}>
+					{ __( 'Casual', 'otter-blocks' ) }
+				</ActionMenuItem>
+			</MenuGroup>
+			<MenuGroup>
+				<ActionMenuItem actionKey='otter_action_prompt' callback={onClose}>
+					{ __( 'Use as prompt', 'otter-blocks' ) }
+				</ActionMenuItem>
+			</MenuGroup>
+			<MenuGroup>
+				<ExternalLink className='o-menu-item-alignment' href="https://docs.themeisle.com/collection/1563-otter---page-builder-blocks-extensions" target="_blank" rel="noopener noreferrer">
+					{
+						__( 'Go to docs', 'otter-blocks' )
+					}
+				</ExternalLink>
+			</MenuGroup>
+		</Fragment>
+	);
+};
+
 const withConditions = createHigherOrderComponent( BlockEdit => {
 	return props => {
-		const [ getOption, _, status ] = useSettings();
-		const [ hasAPIKey, setHasAPIKey ] = useState<boolean>( false );
-		const [ isProcessing, setIsProcessing ] = useState<Record<string, boolean>>({});
-		const [ displayError, setDisplayError ] = useState<string|undefined>( undefined );
-
-		// Get the create notice function from the hooks api.
-		const { createNotice } = useDispatch( 'core/notices' );
-
 		const {
 			isMultipleSelection,
 			areValidBlocks,
-			selectedBlocks,
 			isHidden
 		} = useSelect( ( select ) => {
 			const selectedBlocks = select( 'core/block-editor' ).getMultiSelectedBlocks();
@@ -96,139 +311,9 @@ const withConditions = createHigherOrderComponent( BlockEdit => {
 			return {
 				isMultipleSelection: 1 < selectedBlocks.length,
 				areValidBlocks: selectedBlocks.every( ( block ) => isValidBlock( block.name ) ),
-				selectedBlocks,
 				isHidden: hiddenBlocks.find( ( blockName: string ) => 'themeisle-blocks/content-generator' === blockName ) ?? false
 			};
 		}, []);
-
-		useEffect( () => {
-			if ( 'loading' === status ) {
-				return;
-			}
-
-			if ( 'loaded' === status && ! hasAPIKey ) {
-				const key = getOption( openAiAPIKeyName ) as string;
-				setHasAPIKey(  Boolean( key ) && 0 < key.length );
-			}
-		}, [ status, getOption ]);
-
-		useEffect( () => {
-			if ( ! displayError ) {
-				return;
-			}
-
-			createNotice(
-				'error',
-				displayError,
-				{
-					type: 'snackbar',
-					isDismissible: true
-				}
-			);
-
-			setDisplayError( undefined );
-		}, [ displayError ]);
-
-		const generateContent = async( content: string, actionKey: string, callback: Function = () =>{}) => {
-
-			if ( ! content ) {
-				setDisplayError( __( 'No content detected in selected block.', 'otter-blocks' ) );
-				return;
-			}
-
-			if ( ! embeddedPromptsCache ) {
-				const response = await retrieveEmbeddedPrompt( 'textTransformation' );
-				embeddedPromptsCache = response?.prompts ?? [];
-			}
-
-			const embeddedPrompt = embeddedPromptsCache?.find( ( prompt ) => 'textTransformation' === prompt.otter_name );
-
-			if ( ! embeddedPrompt ) {
-				setDisplayError( __( 'Something when wrong retrieving the prompts.', 'otter-blocks' ) );
-				return;
-			}
-
-			const action: undefined | string = embeddedPrompt?.[actionKey];
-
-			if ( ! action ) {
-				setDisplayError( __( 'The action is not longer available.', 'otter-blocks' ) );
-				return;
-			}
-
-			if ( ! hasAPIKey ) {
-				setDisplayError( __( 'No Open API key detected. Please add your key.', 'otter-blocks' ) );
-				return;
-			}
-
-			setIsProcessing( prevState => ({ ...prevState, [ actionKey ]: true }) );
-
-			window.oTrk?.add({ feature: 'ai-generation', featureComponent: 'ai-toolbar', featureValue: actionKey }, { consent: true });
-
-			sendPromptToOpenAI(
-				content,
-				injectActionIntoPrompt(
-					embeddedPrompt,
-					action
-				),
-				{
-					'otter_used_action': `textTransformation::${ actionKey }`,
-					'otter_user_content': content
-				}
-			).then( ( response ) => {
-				if ( response.error ) {
-					setDisplayError( response.error?.message ?? response.error );
-					return;
-				}
-
-				const blockContentRaw = response?.choices?.[0]?.message.content;
-
-				if ( ! blockContentRaw ) {
-					return;
-				}
-
-				const newBlocks = rawHandler({
-					HTML: blockContentRaw
-				});
-
-				const aiBlock = createBlock(
-					'themeisle-blocks/content-generator',
-					{
-						promptID: 'textTransformation',
-						resultHistory: [{
-							result: response?.choices?.[0]?.message.content ?? '',
-							meta: {
-								usedToken: response?.usage.total_tokens,
-								prompt: ''
-							}
-						}]
-					},
-					newBlocks
-				);
-
-				insertBlockBelow( props.clientId, aiBlock );
-
-				setIsProcessing( prevState => ({ ...prevState, [ actionKey ]: false }) );
-				callback?.();
-			}).catch( ( error ) => {
-				setDisplayError( error.message );
-				setIsProcessing( prevState => ({ ...prevState, [ actionKey ]: false }) );
-			});
-		};
-
-		const ActionMenuItem = ( args: { actionKey: string, children: React.ReactNode, callback: Function }) => {
-			return (
-				<Disabled isDisabled={Object.values( isProcessing ).some( x => x )}>
-					<MenuItem
-						onClick={ () => {
-							generateContent( extractContent( isMultipleSelection ? selectedBlocks : props ), args.actionKey, () => args.callback?.( args.actionKey ) );
-						}}
-					>
-						{ args.children }
-						{ isProcessing?.[args.actionKey] && <Spinner /> }
-					</MenuItem>
-				</Disabled>
-			);
-		};
 
 		return (
 			<Fragment>
@@ -244,81 +329,12 @@ const withConditions = createHigherOrderComponent( BlockEdit => {
 						<BlockControls>
 							<Toolbar>
 								<DropdownMenu
-									icon={aiGeneration}
+									icon={ aiGeneration }
 									label={ __( 'Otter AI Content' ) }
 								>
 									{
 										({ onClose }) => (
-											<Fragment>
-												{
-													( ! hasAPIKey ) && (
-														<MenuGroup>
-															<span className='o-menu-item-alignment' style={{ display: 'block', marginBottom: '10px' }}>
-																{ __( 'Please add your OpenAI API key in Integrations.', 'otter-blocks' ) }
-															</span>
-															<ExternalLink className='o-menu-item-alignment' href={window.themeisleGutenberg.optionsPath} target="_blank" rel="noopener noreferrer">
-																{
-																	__( 'Go to Dashboard', 'otter-blocks' )
-																}
-															</ExternalLink>
-														</MenuGroup>
-													)
-												}
-												<MenuGroup>
-													<span className="o-menu-item-header o-menu-item-alignment">{__( 'Writing', 'otter-blocks' )}</span>
-													<ActionMenuItem actionKey='otter_action_generate_title' callback={onClose}>
-														{ __( 'Generate a heading', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_continue_writing' callback={onClose}>
-														{ __( 'Continue writing', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_summarize' callback={onClose}>
-														{ __( 'Summarize it', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_make_shorter' callback={onClose}>
-														{ __( 'Make it shorter', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_make_longer' callback={onClose}>
-														{ __( 'Make it longer', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_make_descriptive' callback={onClose}>
-														{ __( 'Make it more descriptive', 'otter-blocks' ) }
-													</ActionMenuItem>
-												</MenuGroup>
-												<MenuGroup>
-													<span className="o-menu-item-header o-menu-item-alignment">{__( 'Tone', 'otter-blocks' )}</span>
-													<ActionMenuItem actionKey='otter_action_tone_professional' callback={onClose}>
-														{ __( 'Professional', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_tone_friendly' callback={onClose}>
-														{ __( 'Friendly', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_tone_humorous' callback={onClose}>
-														{ __( 'Humorous', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_tone_confident' callback={onClose}>
-														{ __( 'Confident', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_tone_persuasive' callback={onClose}>
-														{ __( 'Persuasive', 'otter-blocks' ) }
-													</ActionMenuItem>
-													<ActionMenuItem actionKey='otter_action_tone_casual' callback={onClose}>
-														{ __( 'Casual', 'otter-blocks' ) }
-													</ActionMenuItem>
-												</MenuGroup>
-												<MenuGroup>
-													<ActionMenuItem actionKey='otter_action_prompt' callback={onClose}>
-														{ __( 'Use as prompt', 'otter-blocks' ) }
-													</ActionMenuItem>
-												</MenuGroup>
-												<MenuGroup>
-													<ExternalLink className='o-menu-item-alignment' href="https://docs.themeisle.com/collection/1563-otter---page-builder-blocks-extensions" target="_blank" rel="noopener noreferrer">
-														{
-															__( 'Go to docs', 'otter-blocks' ) // TODO: Add link to docs & CSS styling
-														}
-													</ExternalLink>
-												</MenuGroup>
-											</Fragment>
+											<AIToolbar props={ props } onClose={ onClose } />
 										)
 									}
 								</DropdownMenu>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1973.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
The useSettings hook repeated calls to settings API after a recent version, probably after AI Content creator as that hooks to function to each block.

After trying various methods, I settled on this one as it seems to work with all the current usage of useSettings that we have in Otter.

I also tried to use a better implementation but those seem to not always work with the various use cases that we have with Otter. (as in using the Data Store for saving/retrieving the data)

In the future, I'd avoid using useSettings in plugins as now Gutenebrg has built-in methods to use Settings API from the store, and as we work on different parts of Otter, we can try to remove the existing usage of useSettings.
### Test instructions
<!-- Describe how this pull request can be tested. -->

- Try using Otter blocks and Patterns and make sure the calls to Settings route aren't made repetedly.
- Also make sure anyplace where useSettings is used, it works as before.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

