### PR TITLE
fix: widget_styles

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -244,7 +244,7 @@ class Registration {
 		}
 
 		global $wp_roles;
-		
+
 		wp_localize_script(
 			'otter-blocks',
 			'themeisleGutenberg',
@@ -329,7 +329,7 @@ class Registration {
 			return;
 		}
 
-		
+
 
 		if ( is_singular() ) {
 			$this->enqueue_dependencies();
@@ -362,7 +362,7 @@ class Registration {
 		}
 
 		if ( $has_widgets ) {
-			
+
 			add_filter(
 				'wp_footer',
 				function ( $content ) {

--- a/inc/css/class-block-frontend.php
+++ b/inc/css/class-block-frontend.php
@@ -536,7 +536,7 @@ class Block_Frontend extends Base_CSS {
 			}
 		}
 
-		if ( CSS_Handler::has_css_file( 'widgets' ) ) {
+		if ( ! CSS_Handler::has_css_file( 'widgets' ) ) {
 			if ( CSS_Handler::is_writable() ) {
 				CSS_Handler::save_widgets_styles();
 			}

--- a/inc/css/class-block-frontend.php
+++ b/inc/css/class-block-frontend.php
@@ -536,7 +536,7 @@ class Block_Frontend extends Base_CSS {
 			}
 		}
 
-		if ( ! CSS_Handler::has_css_file( 'widgets' ) ) {
+		if ( CSS_Handler::has_css_file( 'widgets' ) ) {
 			if ( CSS_Handler::is_writable() ) {
 				CSS_Handler::save_widgets_styles();
 			}

--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -31,7 +31,86 @@ class CSS_Handler extends Base_CSS {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 		add_action( 'rest_api_init', array( $this, 'autoload_block_classes' ) );
 		add_action( 'before_delete_post', array( __CLASS__, 'delete_css_file' ) );
-		add_action( 'customize_save_after', array( __CLASS__, 'save_widgets_styles' ) );
+		add_action( 'customize_save_after', array( $this, 'customize_save_after' ) );
+		add_filter( 'customize_dynamic_partial_args', array( $this, 'customize_dynamic_partial_args' ), 10, 2 );
+	}
+
+	/**
+	 * Method used to register actively used widgets.
+	 *
+	 * @return void
+	 */
+	private function register_used_widgets() {
+		$registration = Registration::instance();
+		$widgets_used = $registration::$widget_used;
+		if ( empty( $widgets_used ) ) {
+			$sidebar_widgets = get_option( 'sidebars_widgets' );
+			foreach ( $sidebar_widgets as $sidebar => $widgets ) {
+				if ( 'wp_inactive_widgets' === $sidebar || ! is_array( $widgets ) ) {
+					continue;
+				}
+				foreach ( $widgets as $widget ) {
+					$widgets_used[] = $widget;
+				}
+			}
+			$registration::$widget_used = $widgets_used;
+		}
+	}
+
+	/**
+	 * Method used to add a filter for widget rendering before the partial is rendered.
+	 *
+	 * @return array
+	 */
+	public function customize_dynamic_partial_args( $partial_args, $partial_id ) {
+		if ( preg_match( '/^widget\[(?P<widget_id>.+)\]$/', $partial_id, $matches ) ) {
+			add_filter( 'widget_block_content', array( $this, 'customize_widget_block_content' ), 10, 3 );
+		}
+
+		return $partial_args;
+	}
+
+	/**
+	 * Add inline styles for partially rendered block inside customizer.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array $block The block data.
+	 * @param \WP_Widget $instance The widget instance.
+	 *
+	 * @return string
+	 */
+	public function customize_widget_block_content( $block_content, $block, $instance ) {
+		$widget_data    = get_option( 'widget_block', array() );
+		$partial_widget = (object) $widget_data[ $instance->number ];
+		if ( ! isset( $widget_data[ $instance->number ] ) ) {
+			return $block_content;
+		}
+		if ( ! $widget_data[ $instance->number ] ) {
+			return $block_content;
+		}
+
+		$content = $partial_widget->content;
+		$blocks  = parse_blocks( $content );
+
+		if ( ! is_array( $blocks ) || empty( $blocks ) ) {
+			return $block_content;
+		}
+
+		$animations = boolval( preg_match( '/\banimated\b/', $content ) );
+		$css        = $this->cycle_through_static_blocks( $blocks, $animations );
+
+		return '<style>.customize-previewing ' . $css . '</style>' . $block_content;
+	}
+
+	/**
+	 * Method after the customizer save is done.
+	 *
+	 * @return void
+	 */
+	public function customize_save_after() {
+		$this->register_used_widgets();
+
+		$this->save_widgets_styles();
 	}
 
 	/**
@@ -114,20 +193,7 @@ class CSS_Handler extends Base_CSS {
 	 * @return \WP_REST_Response | \WP_Error
 	 */
 	public function save_widgets_styles_rest( \WP_REST_Request $request ) {
-		$registration = Registration::instance();
-		$widgets_used = $registration::$widget_used;
-		if ( empty( $widgets_used ) ) {
-			$sidebar_widgets = get_option( 'sidebars_widgets' );
-			foreach ( $sidebar_widgets as $sidebar => $widgets ) {
-				if ( 'wp_inactive_widgets' === $sidebar || ! is_array( $widgets ) ) {
-					continue;
-				}
-				foreach ( $widgets as $widget ) {
-					$widgets_used[] = $widget;
-				}
-			}
-			$registration::$widget_used = $widgets_used;
-		}
+		$this->register_used_widgets();
 
 		$response = $this->save_widgets_styles();
 		if ( is_null( $response ) ) {

--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -109,7 +109,7 @@ class CSS_Handler extends Base_CSS {
 	/**
 	 * When in REST API context, autoload widgets used so that all css data is updated.
 	 *
-	 * @param \WP_REST_Request $request
+	 * @param \WP_REST_Request $request The request object.
 	 *
 	 * @return \WP_REST_Response | \WP_Error
 	 */
@@ -119,7 +119,7 @@ class CSS_Handler extends Base_CSS {
 		if ( empty( $widgets_used ) ) {
 			$sidebar_widgets = get_option( 'sidebars_widgets' );
 			foreach ( $sidebar_widgets as $sidebar => $widgets ) {
-				if ( $sidebar === 'wp_inactive_widgets' || ! is_array( $widgets ) ) {
+				if ( 'wp_inactive_widgets' === $sidebar || ! is_array( $widgets ) ) {
 					continue;
 				}
 				foreach ( $widgets as $widget ) {

--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -73,8 +73,8 @@ class CSS_Handler extends Base_CSS {
 	/**
 	 * Add inline styles for partially rendered block inside customizer.
 	 *
-	 * @param string $block_content The block content.
-	 * @param array $block The block data.
+	 * @param string     $block_content The block content.
+	 * @param array      $block The block data.
 	 * @param \WP_Widget $instance The widget instance.
 	 *
 	 * @return string

--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -60,6 +60,9 @@ class CSS_Handler extends Base_CSS {
 	/**
 	 * Method used to add a filter for widget rendering before the partial is rendered.
 	 *
+	 * @param array  $partial_args Partial args.
+	 * @param string $partial_id Partial ID.
+	 *
 	 * @return array
 	 */
 	public function customize_dynamic_partial_args( $partial_args, $partial_id ) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve#4150.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
The condition for enqueueing frontend styles for the widgets blocked the styles from registering.

### Screenshots <!-- if applicable -->
![image](https://github.com/Codeinwp/otter-blocks/assets/23024731/06eb165a-7d81-4be2-98f5-0aa840f974a8)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Use Neve
2. Add Otter blocks to the footer widget area
3. Customize the widgets with styles
4. Check that the styles are preserved on the frontend.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

