### PR TITLE
fix: undefined array key in block conditions

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -1005,7 +1005,7 @@ class Registration {
 
 		foreach ( $block['attrs']['otterConditions'] as $group ) {
 			foreach ( $group as $condition ) {
-				if ( 'screenSize' === $condition['type'] && isset( $condition['screen_sizes'] ) && is_array( $condition['screen_sizes'] ) ) {
+				if ( array_key_exists( 'type', $condition ) && 'screenSize' === $condition['type'] && isset( $condition['screen_sizes'] ) && is_array( $condition['screen_sizes'] ) ) {
 					$has_condition = true;
 					break;
 				}

--- a/tests/test-block-conditions.php
+++ b/tests/test-block-conditions.php
@@ -5,6 +5,7 @@
  * @package gutenberg-blocks
  */
 
+use ThemeIsle\GutenbergBlocks\Registration;
 use ThemeIsle\GutenbergBlocks\Plugins\Block_Conditions;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsCanonicalizing;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertNotEqualsCanonicalizing;
@@ -590,5 +591,42 @@ class TestBlockConditions extends WP_UnitTestCase
 		$result = $this->block_conditions->get_hide_css_condition( $collection );
 		
 		$this->assertFalse( $result );
+	}
+
+	public function test_load_condition_hide_on_styles() {
+		$registration = new Registration();
+
+		$block_content = '<p>Hello!</p>';
+
+		$block = [
+			"name" => "core/paragraph",
+			"attrs" => [
+				"otterConditions" => [[]]
+			]
+		];
+
+		$result = $registration->load_condition_hide_on_styles( $block_content, $block );
+
+		// Make sure styles are not loaded.
+		$this->assertEquals( Registration::$scripts_loaded['condition_hide_on'], false );
+
+		$block = [
+			"name" => "core/paragraph",
+			"attrs" => [
+				"otterConditions" => [
+					[
+						[
+							"type" => "screenSize",
+							"screen_sizes" => ["mobile"]
+						]
+					]
+				]
+			]
+		];
+
+		$result = $registration->load_condition_hide_on_styles( $block_content, $block );
+
+		// Make sure styles are loaded.
+		$this->assertEquals( Registration::$scripts_loaded['condition_hide_on'], true );
 	}
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2001.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Fixes the issue with Block Conditions causing a PHP error in certain cases.


### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure Block Conditions, specially if Device Visibility conditions are used, don't throw any PHP errors in debugging logs.

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

