### PR TITLE
Add NPS Survey

### DIFF
--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -195,6 +195,8 @@ class Dashboard {
 					'docsLink'           => Pro::get_docs_url(),
 					'showFeedbackNotice' => $this->should_show_feedback_notice(),
 					'deal'               => ! Pro::is_pro_installed() ? $offer->get_localized_data() : array(),
+					'days_since_install' => round( ( time() - get_option( 'otter_blocks_install', 0 ) ) / DAY_IN_SECONDS ),
+					'rootUrl'            => get_site_url(),
 				)
 			)
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
 	"packages": {
 		"": {
 			"name": "otter-blocks",
-			"version": "2.4.1",
+			"version": "2.5.2",
 			"license": "GPL-2.0+",
 			"dependencies": {
+				"@formbricks/js": "^1.2.7",
 				"@wordpress/icons": "^9.35.0",
 				"array-move": "^3.0.1",
 				"classnames": "^2.3.1",
@@ -2695,6 +2696,11 @@
 			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
 			"integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==",
 			"dev": true
+		},
+		"node_modules/@formbricks/js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@formbricks/js/-/js-1.2.7.tgz",
+			"integrity": "sha512-DjMJ8GAQOrz2yLxVjuJz9+si0UpPgkYroGuCPg87ciiPKIsj3rXZHAymwNFlbh2Ur5zRi68AEBnx36iS8qHcpA=="
 		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.3.0",
@@ -28233,6 +28239,15 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/sockjs/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/socks": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -28278,15 +28293,6 @@
 			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
 			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
 			"dev": true
-		},
-		"node_modules/sockjs/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
 		},
 		"node_modules/source-map": {
 			"version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"lasttranslator": "Themeisle Translate Team <friends@themeisle.com>"
 	},
 	"dependencies": {
+		"@formbricks/js": "^1.2.7",
 		"@wordpress/icons": "^9.35.0",
 		"array-move": "^3.0.1",
 		"classnames": "^2.3.1",

--- a/plugins/otter-pro/inc/server/class-dashboard-server.php
+++ b/plugins/otter-pro/inc/server/class-dashboard-server.php
@@ -60,6 +60,7 @@ class Dashboard_Server {
 					'key'        => apply_filters( 'product_otter_license_key', 'free' ),
 					'valid'      => apply_filters( 'product_otter_license_status', false ),
 					'expiration' => License::get_license_expiration_date(),
+					'type'	     => License::get_license_type(),
 				),
 				'hasNevePro'         => defined( 'NEVE_PRO_VERSION' ),
 				'storeURL'           => 'https://store.themeisle.com/',

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -1,3 +1,9 @@
+/* eslint-disable camelcase */
+/**
+ * External dependencies.
+ */
+import formbricks from '@formbricks/js';
+
 /**
  * WordPress dependencies.
  */
@@ -24,11 +30,37 @@ if ( undefined === window.otterUtils ) {
 
 window.otterUtils.useSettings = useSettings;
 
-function getInitialStateFromURLQuery() {
+const getInitialStateFromURLQuery = () => {
 	const hash = window.location.hash.slice( 1 ); // Remove the '#' at the start
 	return hash;
-}
+};
 
+const convertToCategory = ( number, scale = 1 ) => {
+	const normalizedNumber = Math.round( number / scale );
+	if ( 0 === normalizedNumber || 1 === normalizedNumber ) {
+		return 0;
+	} else if ( 1 < normalizedNumber && 8 > normalizedNumber ) {
+		return 7;
+	} else if ( 8 <= normalizedNumber && 31 > normalizedNumber ) {
+		return 30;
+	} else if ( 30 < normalizedNumber && 90 > normalizedNumber ) {
+		return 90;
+	} else if ( 90 > normalizedNumber ) {
+		return 91;
+	}
+};
+
+if ( 'undefined' !== typeof window ) {
+	formbricks.init({
+		environmentId: 'clp9hqm8c1osfdl2ixwd0k0iz',
+		apiHost: 'https://app.formbricks.com',
+		userId: 'otter_' + ( undefined !== window.otterObj?.license?.key ? window.otterObj.license.key : encodeURIComponent( window.otterObj.rootUrl ) ),
+		attributes: {
+			plan: undefined !== window.otterObj?.license?.type ? window.otterObj.license.type : 'free',
+			days_since_install: convertToCategory( window.otterObj.days_since_install )
+		}
+	});
+}
 
 const App = () => {
 	const [ currentTab, setTab ] = useState( getInitialStateFromURLQuery() );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/124.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This adds NPM survey using the FormBricks app.
### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- If your website is older than one day, it should show you the NPS survey. And vice-versa.
- You can update `otter_blocks_install` option to see how it reacts based on how long plugin has been active.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

