### PR TITLE
fix: button group breaking when nofollow isn't being used

### DIFF
--- a/src/blocks/blocks/button-group/button/save.js
+++ b/src/blocks/blocks/button-group/button/save.js
@@ -31,7 +31,7 @@ const Save = ({
 			<a
 				href={ attributes.link }
 				target={ attributes.newTab ? '_blank' : '_self' }
-				rel={ attributes.noFollow ? 'noopener noreferrer' : undefined }
+				rel={ attributes.noFollow ? 'noopener noreferrer' : 'noopener' }
 				className="wp-block-button__link"
 			>
 				{ ( 'left' === attributes.iconType || 'only' === attributes.iconType ) && (


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2009.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Seems like WordPress started to add noopener rel to all links that have a target attribute that is breaking Button Group block. This PR makes sure to account for that.

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a button group with few buttons with norel enabled and disabled.
- Save the post and refresh to make sure it doesn't break after using this version.
- It should also fix any blocks that have previously been saved.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

