### PR TITLE
fix: onboarding imported_items tracking

### DIFF
--- a/.wp-env.override.json
+++ b/.wp-env.override.json
@@ -13,7 +13,7 @@
     "development": {
       "themes": [ "./test/emptytheme" ],
         "mappings": {
-          "wp-content/themes/raft": "https://github.com/Codeinwp/raft/archive/refs/heads/onboarding.zip"
+          "wp-content/themes/raft": "https://downloads.wordpress.org/theme/raft.zip"
         }
     },
     "tests": {
@@ -29,9 +29,9 @@
           "wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
           "wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
           "wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",
-          "wp-content/themes/gutenberg-test-themes/twentytwentyone": "https://downloads.wordpress.org/theme/twentytwentyone.1.7.zip",
-          "wp-content/themes/gutenberg-test-themes/twentytwentythree": "https://downloads.wordpress.org/theme/twentytwentythree.1.0.zip",
-          "wp-content/themes/raft": "https://github.com/Codeinwp/raft/archive/refs/heads/onboarding.zip"
+          "wp-content/themes/gutenberg-test-themes/twentytwentyone": "https://downloads.wordpress.org/theme/twentytwentyone.zip",
+          "wp-content/themes/gutenberg-test-themes/twentytwentythree": "https://downloads.wordpress.org/theme/twentytwentythree.zip",
+          "wp-content/themes/raft": "https://downloads.wordpress.org/theme/raft.zip"
         }
     }
   }

--- a/inc/plugins/class-fse-onboarding.php
+++ b/inc/plugins/class-fse-onboarding.php
@@ -87,6 +87,9 @@ class FSE_Onboarding {
 			return;
 		}
 
+		// Flag onboarding status in case being run from a theme.
+		self::set_onboarding_status();
+
 		// Run the onboarding.
 		$redirect = add_query_arg(
 			array(

--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -718,7 +718,7 @@ class Options_Settings {
 			'themeisle_blocks_settings_onboarding_wizard',
 			array(
 				'type'         => 'boolean',
-				'description'  => __( 'Enable Onboarding Wizard.', 'otter-blocks' ),
+				'description'  => __( 'Enable FSE Onboarding Wizard.', 'otter-blocks' ),
 				'show_in_rest' => true,
 				'default'      => true,
 			)

--- a/src/onboarding/store.js
+++ b/src/onboarding/store.js
@@ -177,7 +177,10 @@ const actions = {
 				const pageTemplates = select.getLibrary( 'page_templates' );
 				const importedTemplates = select.getImportedTemplates();
 
-				event.imported_items = selectedTemplates;
+				event.imported_items = selectedTemplates.reduce( ( obj, item ) => {
+					obj[item] = true;
+					return obj;
+				}, {});
 
 				await Promise.all(
 					selectedTemplates


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Fixes post-release issues found here: https://github.com/Codeinwp/raft/issues/99

- Fix imported items array being a value of only booleans in tracking data.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure tracking data in MongoDB is for imported_items is recorded correctly.

<!-- Issues that this pull request closes. -->
Closes #99.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

