### PR TITLE
fix: style conflict with third-party plugins

### DIFF
--- a/src/blocks/editor.scss
+++ b/src/blocks/editor.scss
@@ -1,9 +1,3 @@
-.block-editor-block-inspector {
-	.components-base-control:not(.components-input-control) {
-		margin: 24px 0;
-	}
-}
-
 .otter-masonry {
 	.blocks-gallery-grid {
 		.blocks-gallery-item {

--- a/src/blocks/editor.scss
+++ b/src/blocks/editor.scss
@@ -1,3 +1,9 @@
+.components-tools-panel-item {
+	.components-base-control:not(.components-input-control) {
+		margin: 24px 0;
+	}
+}
+
 .otter-masonry {
 	.blocks-gallery-grid {
 		.blocks-gallery-item {
@@ -205,4 +211,8 @@ svg.o-block-icon {
 			display: block;
 		}
 	}
+}
+
+.w-full {
+	width: 100%;
 }

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -472,13 +472,6 @@ export function pullReusableBlockContentById( id ) {
 }
 
 /**
- * Open the Otter sidebar menu.
- */
-export function openOtterSidebarMenu() {
-	document?.querySelector( '.interface-pinned-items button[aria-label~="Otter"]' )?.click();
-}
-
-/**
  * Insert a block below the given block.
  *
  * @param {string} clientId The client id of the reference block.

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -466,7 +466,7 @@ const Edit = ({
 										<select
 											value={ condObj.type || '' }
 											onChange={ e => changeCondition( e.target.value, index, condIdx ) }
-											className="components-select-control__input"
+											className="components-select-control__input w-full"
 											id={ `o-conditions-${ index }-${ condIdx }` }
 										>
 											<option value="none">{ __( 'Select a condition', 'otter-blocks' ) }</option>

--- a/src/blocks/plugins/otter-tools-inspector/index.tsx
+++ b/src/blocks/plugins/otter-tools-inspector/index.tsx
@@ -11,6 +11,11 @@ import {
 
 import { createHigherOrderComponent } from '@wordpress/compose';
 
+import {
+	useDispatch,
+	useSelect
+} from '@wordpress/data';
+
 import { Fragment } from '@wordpress/element';
 
 import {
@@ -23,7 +28,6 @@ import {
  */
 import './editor.scss';
 import { useInspectorSlot } from '../../components/inspector-slot-fill/index.js';
-import { useSelect } from '@wordpress/data';
 import { openOtterSidebarMenu } from '../../helpers/block-utility';
 
 const FeaturePanel = ({ props }) => {
@@ -32,6 +36,8 @@ const FeaturePanel = ({ props }) => {
 	const _ = useSelect( ( select ) => {
 		select( 'core/preferences' );
 	}, []);
+
+	const { enableComplementaryArea } = useDispatch( 'core/interface' );
 
 	return (
 		<ToolsPanel
@@ -42,7 +48,7 @@ const FeaturePanel = ({ props }) => {
 			<ToolsPanelItem
 				hasValue={ () => false }
 				label={ __( 'Manage Default Tools', 'otter-blocks' ) }
-				onSelect={ openOtterSidebarMenu }
+				onSelect={ () => enableComplementaryArea( 'core/edit-post', 'themeisle-blocks/otter-options' ) }
 				isShownByDefault={ false }
 			/>
 		</ToolsPanel>

--- a/src/blocks/plugins/otter-tools-inspector/index.tsx
+++ b/src/blocks/plugins/otter-tools-inspector/index.tsx
@@ -28,7 +28,6 @@ import {
  */
 import './editor.scss';
 import { useInspectorSlot } from '../../components/inspector-slot-fill/index.js';
-import { openOtterSidebarMenu } from '../../helpers/block-utility';
 
 const FeaturePanel = ({ props }) => {
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2021.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix styling conflict with third-party plugins.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the styling issue described in the issue aren't there anymore.
---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

