### PR TITLE
fix: fix woo products not appearing in block conditions

### DIFF
--- a/src/pro/plugins/conditions/edit.js
+++ b/src/pro/plugins/conditions/edit.js
@@ -147,16 +147,16 @@ const ProductsMultiselect = ( props ) => {
 		} = select( COLLECTIONS_STORE_KEY );
 
 		// eslint-disable-next-line camelcase
-		const productsError = getCollectionError?.( '/wc/store', 'products', { per_page: -1 });
+		const productsError = getCollectionError?.( '/wc/store', 'products', { per_page: 0 });
 
-		const products = productsError ? [] : ( getCollection?.( '/wc/store', 'products', { 'per_page': -1 }) ?? [])?.map( result => ({
+		const products = productsError ? [] : ( getCollection?.( '/wc/store', 'products', { 'per_page': 0 }) ?? [])?.map( result => ({
 			value: result.id,
 			label: decodeEntities( result.name )
 		}) );
 
 		return {
 			products,
-			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products', { 'per_page': -1 }])
+			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products', { 'per_page': 0 }])
 		};
 	}, []);
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2018.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This PR fixes the change in Woo rest route that requires the per_page attribute to be 0 instead of -1 to display all products.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure Block Conditions' Product conditions work.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

