### PR TITLE
fix: animation not trigger for large elements on screen

### DIFF
--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -284,8 +284,9 @@ const isElementInViewport = ( el ) => {
 	};
 
 	return (
-		( bounds.bottom >= viewport.top && bounds.bottom <= viewport.bottom ) ||
-		( bounds.top <= viewport.bottom && bounds.top >= viewport.top )
+		( bounds.bottom >= viewport.top && bounds.top <= viewport.bottom ) || // Element spans the viewport
+		( bounds.top <= viewport.bottom && bounds.bottom >= viewport.bottom ) || // Top part of the element is in the viewport
+		( bounds.bottom >= viewport.top && bounds.top <= viewport.top ) // Bottom part of the element is in the viewport
 	);
 };
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2005.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
It fixes an issue when animation isn't triggered for large elements that are in the viewport with their top and bottom being outside the viewport.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Create a page and add the whole content in a group block
- Add a loading animation to the group block (Fade in for example)
- Scroll to the middle of the page and reload
- Make sure it animated

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

