### PR TITLE
fix: form submit button accepting linebreaks

### DIFF
--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -1040,7 +1040,12 @@ const Edit = ({
 										className='wp-block-button__link'
 										placeholder={ __( 'Submit', 'otter-blocks' ) }
 										value={ attributes.submitLabel }
-										onChange={ submitLabel => setAttributes({ submitLabel }) }
+										onChange={ submitLabel => {
+											submitLabel = submitLabel.replace( /<br\s*\/?>/gi, ' ' );
+											setAttributes({ submitLabel });
+										} }
+										multiline={ false }
+										multiple={ false }
 										tagName="button"
 										type='submit'
 										onClick={ e => e.preventDefault() }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #1978.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Fixes an issue when form submit button accepts line-breaks in the editor.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure Submit button doesn't accept line breaks in the editor.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

