### PR TITLE
fix: add logo option to onboarding

### DIFF
--- a/inc/plugins/class-fse-onboarding.php
+++ b/inc/plugins/class-fse-onboarding.php
@@ -172,7 +172,7 @@ class FSE_Onboarding {
 	 * Get Theme Logo
 	 * 
 	 * @access public
-	 * @return array|false
+	 * @return string|false
 	 */
 	public function get_theme_logo() {
 		$support = get_theme_support( self::SUPPORT_KEY );

--- a/inc/plugins/class-fse-onboarding.php
+++ b/inc/plugins/class-fse-onboarding.php
@@ -166,7 +166,28 @@ class FSE_Onboarding {
 		}
 
 		return apply_filters( 'otter_fse_onboarding_templates', $templates );
+	}
 
+	/**
+	 * Get Theme Logo
+	 * 
+	 * @access public
+	 * @return array|false
+	 */
+	public function get_theme_logo() {
+		$support = get_theme_support( self::SUPPORT_KEY );
+
+		if ( false === $support || ! is_array( $support ) || ( ! isset( $support[0]['logo'] ) ) ) {
+			return false;
+		}
+
+		$logo = esc_url( $support[0]['logo'] );
+
+		if ( ! $logo ) {
+			return false;
+		}
+
+		return $logo;
 	}
 
 	/**
@@ -237,6 +258,7 @@ class FSE_Onboarding {
 					'version'        => OTTER_BLOCKS_VERSION,
 					'assetsPath'     => OTTER_BLOCKS_URL . 'assets/',
 					'supportedSteps' => $this->get_templates_types(),
+					'logo'           => $this->get_theme_logo(),
 					'license'        => apply_filters( 'product_otter_license_key', 'free' ),
 					'rootUrl'        => get_site_url(),
 					'dashboardUrl'   => get_admin_url(),

--- a/src/onboarding/components/Finish.js
+++ b/src/onboarding/components/Finish.js
@@ -77,7 +77,7 @@ const Finish = () => {
 			<div className="o-finish__container">
 				<img
 					className="o-finish__logo"
-					src={ `${ window.otterOnboardingData.assetsPath }images/logo-alt.png` }
+					src={ window.otterOnboardingData?.logo || `${ window.otterOnboardingData.assetsPath }images/logo-alt.png` }
 				/>
 
 				<h1>{ __( 'Your website is ready!', 'otter-blocks' ) }</h1>

--- a/src/onboarding/components/Sidebar.js
+++ b/src/onboarding/components/Sidebar.js
@@ -75,7 +75,7 @@ const Sidebar = ({ isEditorLoading }) => {
 			<div className="o-sidebar__header">
 				<img
 					className="o-sidebar__logo"
-					src={ `${ window.otterOnboardingData.assetsPath }images/logo-alt.png` }
+					src={ window.otterOnboardingData?.logo || `${ window.otterOnboardingData.assetsPath }images/logo-alt.png` }
 				/>
 
 				{ 0 !== stepIndex ? (

--- a/src/onboarding/components/Start.js
+++ b/src/onboarding/components/Start.js
@@ -21,7 +21,7 @@ const Start = () => {
 					src={ window.otterOnboardingData?.logo || `${ window.otterOnboardingData.assetsPath }images/logo-alt.png` }
 				/>
 
-				<h1>{ __( 'Welcome to Theme Setup, by Otter.', 'otter-blocks' ) }</h1>
+				<h1>{ __( 'Welcome to Theme Setup, by Raft.', 'otter-blocks' ) }</h1>
 				<p>
 					{ __( 'This process will guide you through a basic setup of your theme, helping you to launch your new site easily, with style. You can revisit this setup wizard anytime by navigating to "Appearance → Theme Setup" in your dashboard.', 'otter-blocks' ) }
 

--- a/src/onboarding/components/Start.js
+++ b/src/onboarding/components/Start.js
@@ -18,7 +18,7 @@ const Start = () => {
 			<div className="o-start__container">
 				<img
 					className="o-start__logo"
-					src={ `${ window.otterOnboardingData.assetsPath }images/logo-alt.png` }
+					src={ window.otterOnboardingData?.logo || `${ window.otterOnboardingData.assetsPath }images/logo-alt.png` }
 				/>
 
 				<h1>{ __( 'Welcome to Theme Setup, by Otter.', 'otter-blocks' ) }</h1>

--- a/src/onboarding/style.scss
+++ b/src/onboarding/style.scss
@@ -121,6 +121,7 @@ div.error, div.notice {
 	&__logo {
 		width: 120px;
 		height: 120px;
+		margin-bottom: 1rem;
 	}
 
 	&__actions {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/141.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Adds option to display the logo of the theme if provided in the theme support.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Follow here: https://github.com/Codeinwp/raft/pull/103


---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

