### PR TITLE
fix: build including duplicate files

### DIFF
--- a/webpack.config.plugins.js
+++ b/webpack.config.plugins.js
@@ -1,4 +1,5 @@
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const FileManagerPlugin = require( 'filemanager-webpack-plugin' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const path = require( 'path' );
 
@@ -35,6 +36,28 @@ const getConfig = textdomain => {
 	};
 };
 
+const plugins = {
+	plugins: [
+		...defaultConfig.plugins,
+		new FileManagerPlugin({
+			events: {
+				onEnd: {
+					delete: [
+						'build/animation/blocks/',
+						'build/animation/pro/',
+						'build/css/blocks/',
+						'build/css/pro/',
+						'build/export-import/blocks/',
+						'build/export-import/pro/'
+					]
+				}
+			},
+			runOnceInWatchMode: false,
+			runTasksInSeries: true
+		})
+	]
+};
+
 module.exports = [
 	{
 
@@ -51,7 +74,8 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/animation' )
 		},
-		module: { ...getConfig( 'blocks-animation' ) }
+		module: { ...getConfig( 'blocks-animation' ) },
+		...plugins
 	},
 	{
 
@@ -65,7 +89,8 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/css' )
 		},
-		module: { ...getConfig( 'blocks-css' ) }
+		module: { ...getConfig( 'blocks-css' ) },
+		...plugins
 	},
 	{
 
@@ -79,6 +104,7 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/export-import' )
 		},
-		module: { ...getConfig( 'blocks-export-import' ) }
+		module: { ...getConfig( 'blocks-export-import' ) },
+		...plugins
 	}
 ];

--- a/webpack.config.pro.js
+++ b/webpack.config.pro.js
@@ -1,4 +1,4 @@
-const BundleAnalyzerPlugin = require( 'webpack-bundle-analyzer' ).BundleAnalyzerPlugin;
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const ANALYZER = 'true' === process.env.NODE_ANALYZER ? true : false;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2058.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fixes the issue where build files include files from other build folders.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

After setting up the plugin, run npm run build & npm run dist, you will notice block plugins have pro and blocks files from other plugins.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

