### PR TITLE
fix: update to use createRoot instead of render

### DIFF
--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -11,11 +11,9 @@ import { dispatch, select } from '@wordpress/data';
 
 import domReady from '@wordpress/dom-ready';
 
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 import { addFilter } from '@wordpress/hooks';
-
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -147,7 +145,9 @@ domReady( () => {
 	gradient.setAttribute( 'aria-hidden', 'true' );
 	document.querySelector( 'body' ).appendChild( gradient );
 
-	render(
+	const root = createRoot( gradient );
+
+	root.render(
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			className="o-icon-gradient"
@@ -161,8 +161,7 @@ domReady( () => {
 					<stop offset="100%" stopColor="#F22B6C" stopOpacity="1" />
 				</linearGradient>
 			</defs>
-		</svg>,
-		gradient
+		</svg>
 	);
 });
 

--- a/src/blocks/plugins/dynamic-content/media/index.js
+++ b/src/blocks/plugins/dynamic-content/media/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 
 import { select } from '@wordpress/data';
 
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 
 import { addFilter } from '@wordpress/hooks';
 
@@ -154,12 +154,13 @@ jQuery( document ).ready( function( $ ) {
 			});
 		};
 
-		render(
+		const root = createRoot( element );
+
+		root.render(
 			<MediaContent
 				state={ state }
 				onSelectImage={ onSelectImage }
-			/>,
-			element
+			/>
 		);
 	};
 

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -8,7 +8,7 @@ import formbricks from '@formbricks/js';
  * WordPress dependencies.
  */
 import {
-	render,
+	createRoot,
 	Fragment,
 	useState
 } from '@wordpress/element';
@@ -84,7 +84,6 @@ const App = () => {
 	);
 };
 
-render(
-	<App />,
-	document.getElementById( 'otter' )
-);
+const root = createRoot( document.getElementById( 'otter' ) );
+
+root.render( <App /> );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2047.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Replace ReactDOM.render to use createRoot instead to remove console errors.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure you don't see any errors in console when you use Otter.
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

