### PR TITLE
fix: resize leaflet maps on resize

### DIFF
--- a/src/blocks/frontend/leaflet-map/index.js
+++ b/src/blocks/frontend/leaflet-map/index.js
@@ -74,6 +74,12 @@ const createLeafletMap = ( container, attributes ) => {
 	attributes.markers.map( ( markerProps ) => createMarker( markerProps ) ).forEach( ( marker ) => {
 		map.addLayer( marker );
 	});
+
+	const resizeObserver = new ResizeObserver( () => {
+		map.invalidateSize();
+	});
+
+	resizeObserver.observe( container );
 };
 
 domReady( () => {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2053.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
 Adds a resizer-observer to Leaflet Maps block to fix an issue with Tabs not rendering Map Block properly.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add Maps Block to a Tab
- Load in frontend and resize the window.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

