### PR TITLE
fix: hardened escaping inside Pro Form Fields

### DIFF
--- a/inc/render/class-form-multiple-choice.php
+++ b/inc/render/class-form-multiple-choice.php
@@ -22,19 +22,23 @@ class Form_Multiple_Choice_Block {
 	 * @return mixed|string
 	 */
 	public function render( $attributes ) {
-
-		$class_names = 'wp-block-themeisle-blocks-form-multiple-choice ' . ( isset( $attributes['className'] ) ? $attributes['className'] : '' );
-		$id          = isset( $attributes['id'] ) ? $attributes['id'] : '';
-		$options     = isset( $attributes['options'] ) ? $attributes['options'] : array();
-		$field_type  = isset( $attributes['type'] ) ? $attributes['type'] : 'checkbox';
-		$label       = isset( $attributes['label'] ) ? $attributes['label'] : __( 'Select option', 'otter-blocks' );
-		$help_text   = isset( $attributes['helpText'] ) ? $attributes['helpText'] : '';
+		$id         = isset( $attributes['id'] ) ? esc_attr( $attributes['id'] ) : '';
+		$options    = isset( $attributes['options'] ) ? $attributes['options'] : array();
+		$field_type = isset( $attributes['type'] ) ? esc_attr( $attributes['type'] ) : 'checkbox';
+		$label      = isset( $attributes['label'] ) ? esc_html( $attributes['label'] ) : __( 'Select option', 'otter-blocks' );
+		$help_text  = isset( $attributes['helpText'] ) ? esc_html( $attributes['helpText'] ) : '';
 
 		$is_required            = isset( $attributes['isRequired'] ) ? boolval( $attributes['isRequired'] ) : false;
 		$has_multiple_selection = isset( $attributes['multipleSelection'] ) ? boolval( $attributes['multipleSelection'] ) : false;
-		$mapped_name            = isset( $attributes['mappedName'] ) ? $attributes['mappedName'] : $id;
+		$mapped_name            = isset( $attributes['mappedName'] ) ? esc_attr( $attributes['mappedName'] ) : $id;
 
-		$output = '<div class="' . $class_names . '" id="' . $id . '">';
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'id' => $id,
+			)
+		);
+
+		$output = '<div ' . $wrapper_attributes . '>';
 
 		// Compatibility with the old version of the block.
 		if ( ! empty( $options ) && is_string( $options ) ) {
@@ -53,8 +57,8 @@ class Form_Multiple_Choice_Block {
 					continue;
 				}
 
-				$field_value = implode( '_', explode( ' ', sanitize_title( $choice['content'] ) ) );
-				$field_id    = 'field-' . $field_value;
+				$field_value = implode( '_', explode( ' ', esc_attr( $choice['content'] ) ) );
+				$field_id    = 'field-' . esc_attr( $field_value );
 				$checked     = isset( $choice['isDefault'] ) && $choice['isDefault'];
 
 				$output .= $this->render_field( $field_type, $choice['content'], $field_value, $mapped_name, $field_id, $checked, $is_required );
@@ -84,8 +88,8 @@ class Form_Multiple_Choice_Block {
 	public function render_field( $type, $label, $value, $name, $id, $checked = false, $is_required = false ) {
 		$output = '<div class="o-form-multiple-choice-field">';
 
-		$output .= '<input type="' . $type . '" name="' . $name . '" id="' . $id . '" value="' . $value . '" ' . ( $is_required ? 'required' : '' ) . ( $checked ? ' checked' : '' ) . ' />';
-		$output .= '<label for="' . $id . '" class="o-form-choice-label">' . $label . '</label>';
+		$output .= '<input type="' . esc_attr( $type ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $id ) . '" value="' . esc_attr( $value ) . '" ' . ( $is_required ? 'required' : '' ) . ( $checked ? ' checked' : '' ) . ' />';
+		$output .= '<label for="' . esc_attr( $id ) . '" class="o-form-choice-label">' . esc_html( $label ) . '</label>';
 
 		$output .= '</div>';
 
@@ -104,8 +108,8 @@ class Form_Multiple_Choice_Block {
 	 * @return string
 	 */
 	public function render_select_field( $label, $options_array, $id, $name, $is_multiple, $is_required ) {
-		$output  = '<label class="otter-form-input-label" for="' . $id . '" >' . $label . $this->render_required_sign( $is_required ) . '</label>';
-		$output .= '<select id="' . $id . '" ' . ( $is_multiple ? ' multiple ' : '' ) . ( $is_required ? ' required ' : '' ) . ' name="' . $name . '">';
+		$output  = '<label class="otter-form-input-label" for="' . esc_attr( $id ) . '" >' . $label . $this->render_required_sign( $is_required ) . '</label>';
+		$output .= '<select id="' . esc_attr( $id ) . '" ' . ( $is_multiple ? ' multiple ' : '' ) . ( $is_required ? ' required ' : '' ) . ' name="' . esc_attr( $name ) . '">';
 
 		foreach ( $options_array as $option ) {
 
@@ -116,7 +120,7 @@ class Form_Multiple_Choice_Block {
 			$is_selected = isset( $option['isDefault'] ) && $option['isDefault'];
 
 			$field_value = implode( '_', explode( ' ', sanitize_title( $option['content'] ) ) );
-			$output     .= '<option value="' . $field_value . '"' . ( $is_selected ? 'selected' : '' ) . '>' . $option['content'] . '</option>';
+			$output     .= '<option value="' . esc_attr( $field_value ) . '"' . ( $is_selected ? 'selected' : '' ) . '>' . esc_html( $option['content'] ) . '</option>';
 		}
 
 		$output .= '</select>';

--- a/plugins/otter-pro/inc/render/class-form-file-block.php
+++ b/plugins/otter-pro/inc/render/class-form-file-block.php
@@ -29,16 +29,21 @@ class Form_File_Block {
 			return '';
 		}
 
-		$class_names        = 'wp-block-themeisle-blocks-form-file ' . ( isset( $attributes['className'] ) ? $attributes['className'] : '' );
-		$id                 = isset( $attributes['id'] ) ? $attributes['id'] : '';
-		$label              = isset( $attributes['label'] ) ? $attributes['label'] : __( 'Select option', 'otter-blocks' );
-		$help_text          = isset( $attributes['helpText'] ) ? $attributes['helpText'] : '';
+		$id                 = isset( $attributes['id'] ) ? esc_attr( $attributes['id'] ) : '';
+		$label              = isset( $attributes['label'] ) ? esc_html( $attributes['label'] ) : __( 'Select option', 'otter-blocks' );
+		$help_text          = isset( $attributes['helpText'] ) ? esc_html( $attributes['helpText'] ) : '';
 		$is_required        = isset( $attributes['isRequired'] ) && boolval( $attributes['isRequired'] );
 		$has_multiple_files = isset( $attributes['multipleFiles'] ) && boolval( $attributes['multipleFiles'] ) && ( ! isset( $attributes['maxFilesNumber'] ) || intval( $attributes['maxFilesNumber'] ) > 1 );
 		$allowed_files      = isset( $attributes['allowedFileTypes'] ) ? implode( ',', $attributes['allowedFileTypes'] ) : '';
 
-		$output      = '<div class="' . $class_names . '" id="' . $id . '">';
-		$mapped_name = isset( $attributes['mappedName'] ) ? $attributes['mappedName'] : 'field-' . $id;
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'id' => $id,
+			)
+		);
+
+		$output      = '<div ' . $wrapper_attributes . '>';
+		$mapped_name = isset( $attributes['mappedName'] ) ? esc_attr( $attributes['mappedName'] ) : 'field-' . $id;
 
 		$output .= '<label class="otter-form-input-label" for="' . $mapped_name . '" >' . $label . $this->render_required_sign( $is_required ) . '</label>';
 
@@ -46,10 +51,10 @@ class Form_File_Block {
 		. $mapped_name . '" '
 		. ( $is_required ? 'required ' : '' ) . ' '
 		. ( $has_multiple_files ? 'multiple ' : '' )
-		. ( isset( $attributes['allowedFileTypes'] ) ? ( ' accept="' . $allowed_files ) . '"' : '' )
-		. ( isset( $attributes['maxFileSize'] ) ? ( ' data-max-file-size="' . $attributes['maxFileSize'] . '"' ) : '' )
-		. ( isset( $attributes['fieldOptionName'] ) ? ( ' data-field-option-name="' . $attributes['fieldOptionName'] . '"' ) : '' )
-		. ( ( isset( $attributes['multipleFiles'] ) && isset( $attributes['maxFilesNumber'] ) ) ? ( ' data-max-files-number="' . $attributes['maxFilesNumber'] . '"' ) : '' )
+		. ( isset( $attributes['allowedFileTypes'] ) ? ( ' accept="' . esc_attr( $allowed_files ) ) . '"' : '' )
+		. ( isset( $attributes['maxFileSize'] ) ? ( ' data-max-file-size="' . esc_attr( $attributes['maxFileSize'] ) . '"' ) : '' )
+		. ( isset( $attributes['fieldOptionName'] ) ? ( ' data-field-option-name="' . esc_attr( $attributes['fieldOptionName'] ) . '"' ) : '' )
+		. ( ( isset( $attributes['multipleFiles'] ) && isset( $attributes['maxFilesNumber'] ) ) ? ( ' data-max-files-number="' . esc_attr( $attributes['maxFilesNumber'] ) . '"' ) : '' )
 		. ' />';
 
 		$output .= '<span class="o-form-help">'

--- a/plugins/otter-pro/inc/render/class-form-hidden-block.php
+++ b/plugins/otter-pro/inc/render/class-form-hidden-block.php
@@ -29,15 +29,19 @@ class Form_Hidden_Block {
 			return '';
 		}
 
-		$class_names   = 'wp-block-themeisle-blocks-form-hidden-field ' . ( isset( $attributes['className'] ) ? $attributes['className'] : '' );
-		$id            = isset( $attributes['id'] ) ? $attributes['id'] : '';
-		$label         = isset( $attributes['label'] ) ? $attributes['label'] : __( 'Hidden Field', 'otter-blocks' );
-		$param_name    = isset( $attributes['paramName'] ) ? $attributes['paramName'] : '';
-		$mapped_name   = isset( $attributes['mappedName'] ) ? $attributes['mappedName'] : 'field-' . $id;
-		$default_value = isset( $attributes['defaultValue'] ) ? $attributes['defaultValue'] : '';
+		$id            = isset( $attributes['id'] ) ? esc_attr( $attributes['id'] ) : '';
+		$label         = isset( $attributes['label'] ) ? esc_html( $attributes['label'] ) : __( 'Hidden Field', 'otter-blocks' );
+		$param_name    = isset( $attributes['paramName'] ) ? esc_attr( $attributes['paramName'] ) : '';
+		$mapped_name   = isset( $attributes['mappedName'] ) ? esc_attr( $attributes['mappedName'] ) : 'field-' . $id;
+		$default_value = isset( $attributes['defaultValue'] ) ? esc_attr( $attributes['defaultValue'] ) : '';
 
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'id' => $id,
+			)
+		);
 
-		$output = '<div style="display: none;" class="' . $class_names . '" id="' . $id . '">';
+		$output = '<div style="display: none;" ' . $wrapper_attributes . '>';
 
 		$output .= '<label class="otter-form-input-label" for="' . $mapped_name . '">' . $label . '</label>';
 
@@ -52,6 +56,4 @@ class Form_Hidden_Block {
 
 		return $output;
 	}
-
-
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/153.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Hardens escaping of attributes in Pro Form fields. The PR also makes use of `get_block_wrapper_attributes` function for attribute generation for the main div of the block.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Follow testing instructions mentioned in the issue and confirm the issue is mitigated, and features work as normal.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

