### PR TITLE
fix: introduce svgSanitize to sanitize SVG

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
 		"tubalmartin/cssmin": "^4.1",
 		"wptt/webfont-loader": "^1.1",
 		"sabberworm/php-css-parser": "^8.4",
-		"stripe/stripe-php": "^13.1"
+		"stripe/stripe-php": "^13.1",
+		"enshrined/svg-sanitize": "^0.18.0"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "661c5e02d7fa160de952624932f3b78d",
+    "content-hash": "bb0253e169852781202f8d6ca51ba70b",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
@@ -45,6 +45,51 @@
                 "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.13"
             },
             "time": "2024-02-01T14:10:46+00:00"
+        },
+        {
+            "name": "enshrined/svg-sanitize",
+            "version": "0.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/darylldoyle/svg-sanitizer.git",
+                "reference": "6a2c069dab3843ca4d887ff09c972fc7033888d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/6a2c069dab3843ca4d887ff09c972fc7033888d0",
+                "reference": "6a2c069dab3843ca4d887ff09c972fc7033888d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "enshrined\\svgSanitize\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Daryll Doyle",
+                    "email": "daryll@enshrined.co.uk"
+                }
+            ],
+            "description": "An SVG sanitizer for PHP",
+            "support": {
+                "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.18.0"
+            },
+            "time": "2024-02-22T17:51:05+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/inc/integrations/class-form-utils.php
+++ b/inc/integrations/class-form-utils.php
@@ -7,6 +7,8 @@
 
 namespace ThemeIsle\GutenbergBlocks\Integration;
 
+use enshrined\svgSanitize\Sanitizer;
+
 /**
  * Form Utils
  *
@@ -21,7 +23,6 @@ class Form_Utils {
 	 * @since 2.0.3
 	 */
 	public static function generate_test_email() {
-
 		$words = array(
 			'alfa',
 			'bravo',
@@ -50,7 +51,7 @@ class Form_Utils {
 		$name_1 = $words[ wp_rand( 0, count( $words ) - 1 ) ];
 		$name_2 = $words[ wp_rand( 2, count( $words ) ) - 1 ];
 
-		return "Otter-Form-successfully-connected.delete-on-confirmation.$name_1.$name_2@otter-blocks.com";
+		return "Otter-Form-successfully-connected.delete-on-confirmation.$name_1.$name_2@themeisle.com";
 	}
 
 	/**
@@ -92,7 +93,6 @@ class Form_Utils {
 			'error'     => null,
 		);
 
-
 		$file_name     = self::generate_file_name( $field['metadata']['name'] );
 		$file_data_key = $field['metadata']['data'];
 
@@ -102,6 +102,14 @@ class Form_Utils {
 
 		try {
 			$file_data = $files[ $file_data_key ];
+
+			if ( 'svg' === pathinfo( $file_name, PATHINFO_EXTENSION ) ) {
+				$file_contents = file_get_contents( $file_data['tmp_name'] );
+
+				$sanitizer = new Sanitizer();
+				$file_contents = $sanitizer->sanitize( $file_contents );
+				file_put_contents( $file_data['tmp_name'], $file_contents );
+			}
 
 			// Save file to uploads folder.
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/inc/integrations/class-form-utils.php
+++ b/inc/integrations/class-form-utils.php
@@ -106,9 +106,17 @@ class Form_Utils {
 			if ( 'svg' === pathinfo( $file_name, PATHINFO_EXTENSION ) ) {
 				$file_contents = file_get_contents( $file_data['tmp_name'] );
 
-				$sanitizer = new Sanitizer();
+				$sanitizer     = new Sanitizer();
 				$file_contents = $sanitizer->sanitize( $file_contents );
-				file_put_contents( $file_data['tmp_name'], $file_contents );
+
+				global $wp_filesystem;
+
+				if ( ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
+					$creds = request_filesystem_credentials( site_url() );
+					wp_filesystem( $creds );
+				}
+
+				$wp_filesystem->put_contents( $file_data['tmp_name'], $file_contents );
 			}
 
 			// Save file to uploads folder.


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #152.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Introduces the SVG Sanitize to sanitize SVG files to prevent XSS attacks.

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure SVG uploads work as expected.
- Make sure the issue mentioned in the issue is solved.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

