### PR TITLE
disable creation of Masonry variation

### DIFF
--- a/src/blocks/helpers/icons.js
+++ b/src/blocks/helpers/icons.js
@@ -307,14 +307,6 @@ export const tabsItemIcon = () => {
 	);
 };
 
-export const masonryIcon = () => {
-	return (
-		<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" className="o-block-icon" width="24" height="24">
-			<Path fillRule="evenodd" d="M14 3H3v4h11V3ZM3 2a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H3Zm6 9H3v10h6V11Zm-6-1a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V11a1 1 0 0 0-1-1H3Zm18-7h-3v4h3V3Zm-3-1a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1h-3Zm3 9h-8v3h8v-3Zm-8-1a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-8Zm8 8h-8v3h8v-3Zm-8-1a1 1 0 0 0-1 1v3a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-8Z" clipRule="evenodd"/>
-		</SVG>
-	);
-};
-
 export const searchIcon = () => {
 	return (
 		<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" className="o-block-icon" width="24" height="24">

--- a/src/blocks/plugins/masonry-extension/index.js
+++ b/src/blocks/plugins/masonry-extension/index.js
@@ -5,8 +5,6 @@ import { __ } from '@wordpress/i18n';
 
 import { assign } from 'lodash';
 
-import { registerBlockVariation } from '@wordpress/blocks';
-
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 import { addFilter } from '@wordpress/hooks';
@@ -14,7 +12,6 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies.
  */
-import { masonryIcon as icon } from '../../helpers/icons.js';
 import Edit from './edit.js';
 
 const addAttribute = ( props ) => {
@@ -35,7 +32,7 @@ const addAttribute = ( props ) => {
 
 const withMasonryExtension = createHigherOrderComponent( BlockEdit => {
 	return props => {
-		if ( 'core/gallery' !== props.name ) {
+		if ( 'core/gallery' !== props.name || ! props.attributes?.isMasonry ) {
 			return <BlockEdit { ...props } />;
 		}
 
@@ -50,14 +47,3 @@ const withMasonryExtension = createHigherOrderComponent( BlockEdit => {
 
 addFilter( 'blocks.registerBlockType', 'themeisle-gutenberg/masonry-extension-attributes', addAttribute );
 addFilter( 'editor.BlockEdit', 'themeisle-gutenberg/masonry-extension', withMasonryExtension );
-
-registerBlockVariation( 'core/gallery', {
-	name: 'themeisle-gutenberg/masonry',
-	title: __( 'Masonry', 'otter-blocks' ),
-	description: __( 'Display multiple images in a rich masonry layout.', 'otter-blocks' ),
-	icon,
-	category: 'themeisle-blocks',
-	attributes: {
-		isMasonry: true
-	}
-});

--- a/src/dashboard/components/pages/Blocks.js
+++ b/src/dashboard/components/pages/Blocks.js
@@ -37,7 +37,6 @@ import {
 	iconListIcon,
 	lottieIcon,
 	mapIcon,
-	masonryIcon,
 	popupIcon,
 	postsIcon,
 	progressIcon,
@@ -206,11 +205,6 @@ const otterBlocks = [
 		'isPro': true,
 		'icon': searchIcon,
 		'docLink': 'https://docs.themeisle.com/article/1747-the-live-search-feature-otter-features-library'
-	},
-	{
-		'slug': 'themeisle-gutenberg/masonry', // TODO: find why this can not be disabled.
-		'name': __( 'Masonry', 'otter-blocks' ),
-		'icon': masonryIcon
 	},
 	{
 		'slug': 'themeisle-blocks/content-generator',


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

