### PR TITLE
Escape block attributes to avoid bad-faith actors

### DIFF
--- a/inc/render/class-leaflet-map-block.php
+++ b/inc/render/class-leaflet-map-block.php
@@ -33,7 +33,7 @@ class Leaflet_Map_Block {
 		}
 
 		// Set the ID and the class name.
-		$id    = isset( $attributes['id'] ) ? $attributes['id'] : 'wp-block-themeisle-blocks-map-' . wp_rand( 10, 100 );
+		$id    = isset( $attributes['id'] ) ? esc_attr( $attributes['id'] ) : 'wp-block-themeisle-blocks-map-' . wp_rand( 10, 100 );
 		$class = '';
 		$style = '';
 
@@ -58,7 +58,7 @@ class Leaflet_Map_Block {
 		$output .= '<script type="text/javascript">' . "\n";
 		$output .= '	/* <![CDATA[ */' . "\n";
 		$output .= '		if ( ! window.themeisleLeafletMaps ) window.themeisleLeafletMaps =[];' . "\n";
-		$output .= '		window.themeisleLeafletMaps.push( { container: "' . $id . '", attributes: ' . wp_json_encode( $attributes ) . ' } );' . "\n";
+		$output .= '		window.themeisleLeafletMaps.push( { container: "' . esc_attr( $id ) . '", attributes: ' . wp_json_encode( $attributes ) . ' } );' . "\n";
 		$output .= '	/* ]]> */' . "\n";
 		$output .= '</script>' . "\n";
 

--- a/inc/render/class-masonry-variant.php
+++ b/inc/render/class-masonry-variant.php
@@ -60,7 +60,7 @@ class Masonry_Variant {
 
 			wp_script_add_data( 'otter-masonry', 'defer', true );
 
-			$margin = isset( $block['attrs']['margin'] ) ? $block['attrs']['margin'] : 10;
+			$margin = isset( $block['attrs']['margin'] ) ? esc_attr( $block['attrs']['margin'] ) : 10;
 
 			$style = '<style type="text/css">.otter-masonry .blocks-gallery-grid .blocks-gallery-item img{ width:100% }</style>';
 

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -119,7 +119,7 @@ class Posts_Grid_Block {
 			$wrapper_attributes,
 			isset( $attributes['id'] ) ? $attributes['id'] : '',
 			isset( $attributes['enableFeaturedPost'] ) && $attributes['enableFeaturedPost'] && isset( $recent_posts[0] ) ? $this->render_featured_post( $recent_posts[0], $attributes ) : '',
-			trim( $class ),
+			esc_attr( trim( $class ) ),
 			$list_items_markup,
 			$has_pagination ? $this->render_pagination( $page_number, $total_posts ) : ''
 		);

--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -39,7 +39,7 @@ class Review_Block {
 			);
 		}
 
-		$id            = isset( $attributes['id'] ) ? $attributes['id'] : 'wp-block-themeisle-blocks-review-' . wp_rand( 10, 100 );
+		$id            = isset( $attributes['id'] ) ? esc_attr( $attributes['id'] ) : 'wp-block-themeisle-blocks-review-' . wp_rand( 10, 100 );
 		$class         = '';
 		$details_class = ( isset( $attributes['image'] ) && isset( $attributes['description'] ) && ! empty( $attributes['description'] ) ) ? '' : 'is-single ';
 		$scale         = get_option( 'themeisle_blocks_settings_review_scale', false ) ? 2 : 1;
@@ -70,11 +70,11 @@ class Review_Block {
 		$is_one_colum_layout = strpos( $wrapper_attributes, 'is-style-single-column' ) !== false;
 		$is_inline_features  = strpos( $wrapper_attributes, 'is-style-inline-features' ) !== false;
 
-		$main_heading = isset( $attributes['mainHeading'] ) ? $attributes['mainHeading'] : 'h2';
-		$sub_heading  = isset( $attributes['subHeading'] ) ? $attributes['subHeading'] : 'h3';
+		$main_heading = isset( $attributes['mainHeading'] ) ? esc_attr( $attributes['mainHeading'] ) : 'h2';
+		$sub_heading  = isset( $attributes['subHeading'] ) ? esc_attr( $attributes['subHeading'] ) : 'h3';
 
 		$html  = '<div ' . $wrapper_attributes . '>';
-		$html .= '  <div class ="o-review__header">';
+		$html .= '  <div class="o-review__header">';
 
 		if ( isset( $attributes['title'] ) && ! empty( $attributes['title'] ) ) {
 			$html .= '<' . $main_heading . '>' . esc_html( $attributes['title'] ) . '</' . $main_heading . '>';
@@ -93,7 +93,7 @@ class Review_Block {
 			$html .= '			<span class="o-review__header_price">';
 
 			if ( ( isset( $attributes['price'] ) && ! empty( $attributes['price'] ) ) && isset( $attributes['discounted'] ) ) {
-				$html .= '			<del>' . self::get_currency( isset( $attributes['currency'] ) ? $attributes['currency'] : 'USD' ) . $attributes['price'] . '</del>';
+				$html .= '			<del>' . self::get_currency( isset( $attributes['currency'] ) ? $attributes['currency'] : 'USD' ) . esc_html( $attributes['price'] ) . '</del>';
 			}
 
 			$html .= self::get_currency( isset( $attributes['currency'] ) ? $attributes['currency'] : 'USD' ) . ( isset( $attributes['discounted'] ) ? $attributes['discounted'] : $attributes['price'] );
@@ -102,17 +102,17 @@ class Review_Block {
 
 		$html .= '		</div>';
 		if ( ( isset( $attributes['image'] ) || ( isset( $attributes['description'] ) && ! empty( $attributes['description'] ) ) ) ) {
-			$html .= '	<div class="o-review__header_details ' . trim( $details_class ) . '">';
+			$html .= '	<div class="o-review__header_details ' . trim( esc_attr( $details_class ) ) . '">';
 			if ( isset( $attributes['image'] ) ) {
 				if ( isset( $attributes['image']['id'] ) && wp_attachment_is_image( $attributes['image']['id'] ) ) {
-					$html .= wp_get_attachment_image( $attributes['image']['id'], isset( $attributes['imageSize'] ) ? $attributes['imageSize'] : 'medium' );
+					$html .= wp_get_attachment_image( $attributes['image']['id'], isset( $attributes['imageSize'] ) ? esc_attr( $attributes['imageSize'] ) : 'medium' );
 				} else {
 					$html .= '	<img src="' . esc_url( $attributes['image']['url'] ) . '" alt="' . esc_attr( $attributes['image']['alt'] ) . '"/>';
 				}
 			}
 
 			if ( isset( $attributes['description'] ) && ! empty( $attributes['description'] ) ) {
-				$html .= '	<p>' . $attributes['description'] . '</p>';
+				$html .= '	<p>' . esc_html( $attributes['description'] ) . '</p>';
 			}
 			$html .= '	</div>';
 		}
@@ -125,7 +125,7 @@ class Review_Block {
 			foreach ( $attributes['features'] as $feature ) {
 				$html .= '	<div class="o-review__left_feature">';
 				if ( isset( $feature['title'] ) ) {
-					$html .= '	<span class="o-review__left_feature_title">' . $feature['title'] . '</span>';
+					$html .= '	<span class="o-review__left_feature_title">' . esc_html( $feature['title'] ) . '</span>';
 				}
 
 				$html .= '		<div class="o-review__left_feature_ratings">';
@@ -140,7 +140,7 @@ class Review_Block {
 				$html .= '		</div>';
 
 				if ( isset( $feature['description'] ) ) {
-					$html .= '	<span class="o-review__left_feature_description">' . $feature['description'] . '</span>';
+					$html .= '	<span class="o-review__left_feature_description">' . esc_html( $feature['description'] ) . '</span>';
 				}
 
 				$html .= '	</div>';
@@ -154,7 +154,7 @@ class Review_Block {
 			if ( isset( $attributes['pros'] ) && count( $attributes['pros'] ) > 0 ) {
 				$html .= '	<div class="o-review__right_pros">';
 				if ( isset( $attributes['prosLabel'] ) && ! empty( $attributes['prosLabel'] ) ) {
-					$html .= '		<' . $sub_heading . '>' . $attributes['prosLabel'] . '</' . $sub_heading . '>';
+					$html .= '		<' . $sub_heading . '>' . esc_html( $attributes['prosLabel'] ) . '</' . $sub_heading . '>';
 				}
 
 				foreach ( $attributes['pros'] as $pro ) {
@@ -169,7 +169,7 @@ class Review_Block {
 			if ( isset( $attributes['cons'] ) && count( $attributes['cons'] ) > 0 ) {
 				$html .= '	<div class="o-review__right_cons">';
 				if ( isset( $attributes['consLabel'] ) && ! empty( $attributes['consLabel'] ) ) {
-					$html .= '		<' . $sub_heading . '>' . $attributes['consLabel'] . '</' . $sub_heading . '>';
+					$html .= '		<' . $sub_heading . '>' . esc_html( $attributes['consLabel'] ) . '</' . $sub_heading . '>';
 				}
 
 				foreach ( $attributes['cons'] as $con ) {
@@ -186,21 +186,21 @@ class Review_Block {
 		if ( isset( $attributes['links'] ) && count( $attributes['links'] ) > 0 ) {
 			$html .= '	<div class="o-review__footer">';
 			if ( isset( $attributes['buttonsLabel'] ) && ! empty( $attributes['buttonsLabel'] ) ) {
-				$html .= '		<' . $sub_heading . ' class="o-review__footer_label">' . $attributes['buttonsLabel'] . '</' . $sub_heading . '>';
+				$html .= '		<' . $sub_heading . ' class="o-review__footer_label">' . esc_html( $attributes['buttonsLabel'] ) . '</' . $sub_heading . '>';
 			}
 
 			$html .= '		<div class="o-review__footer_buttons">';
 
 			foreach ( $attributes['links'] as $link ) {
 				$rel   = ( isset( $link['isSponsored'] ) && true === $link['isSponsored'] ) ? 'sponsored' : 'nofollow';
-				$html .= '	<a href="' . esc_url( $link['href'] ) . '" rel="' . $rel . '" target="' . ( empty( $link['target'] ) ? '_blank' : $link['target'] ) . '">' . esc_html( $link['label'] ) . '</a>';
+				$html .= '	<a href="' . esc_url( $link['href'] ) . '" rel="' . $rel . '" target="' . ( empty( $link['target'] ) ? '_blank' : esc_attr( $link['target'] ) ) . '">' . esc_html( $link['label'] ) . '</a>';
 			}
 			$html .= '		</div>';
 			$html .= '	</div>';
 		}
 		$html .= '</div>';
 
-		return $html;
+		return wp_kses_post( $html );
 	}
 
 	/**
@@ -266,15 +266,15 @@ class Review_Block {
 		$json = array(
 			'@context' => 'https://schema.org/',
 			'@type'    => 'Product',
-			'name'     => $attributes['title'],
+			'name'     => esc_attr( $attributes['title'] ),
 		);
 
 		if ( isset( $attributes['image'] ) && isset( $attributes['image']['url'] ) ) {
-			$json['image'] = $attributes['image']['url'];
+			$json['image'] = esc_url( $attributes['image']['url'] );
 		}
 
 		if ( isset( $attributes['description'] ) && ! empty( $attributes['description'] ) ) {
-			$json['description'] = $attributes['description'];
+			$json['description'] = esc_attr( $attributes['description'] );
 		}
 
 		$json['review'] = array(
@@ -349,8 +349,8 @@ class Review_Block {
 				$offer = array(
 					'@type'         => 'Offer',
 					'url'           => esc_url( $link['href'] ),
-					'priceCurrency' => isset( $attributes['currency'] ) ? $attributes['currency'] : 'USD',
-					'price'         => isset( $attributes['discounted'] ) ? $attributes['discounted'] : $attributes['price'],
+					'priceCurrency' => isset( $attributes['currency'] ) ? esc_attr( $attributes['currency'] ) : 'USD',
+					'price'         => isset( $attributes['discounted'] ) ? esc_attr( $attributes['discounted'] ) : esc_attr( $attributes['price'] ),
 				);
 
 				array_push( $offers, $offer );

--- a/inc/render/class-stripe-checkout-block.php
+++ b/inc/render/class-stripe-checkout-block.php
@@ -62,7 +62,7 @@ class Stripe_Checkout_Block {
 		$details_markup = '';
 
 		if ( 0 < count( $product['images'] ) ) {
-			$details_markup .= '<img src="' . $product['images'][0] . '" alt="' . $product['description'] . '" />';
+			$details_markup .= '<img src="' . esc_url( $product['images'][0] ) . '" alt="' . esc_attr( $product['description'] ) . '" />';
 		}
 
 		$price = $stripe->create_request( 'price', $attributes['price'] );
@@ -79,7 +79,7 @@ class Stripe_Checkout_Block {
 		$amount   = number_format( $price['unit_amount'] / 100, 2, '.', ' ' );
 
 		$details_markup .= '<div class="o-stripe-checkout-description">';
-		$details_markup .= '<h3>' . $product['name'] . '</h3>';
+		$details_markup .= '<h3>' . esc_html( $product['name'] ) . '</h3>';
 		$details_markup .= '<h5>' . $currency . $amount . '</h5>';
 		$details_markup .= '</div>';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
 	"packages": {
 		"": {
 			"name": "otter-blocks",
-			"version": "2.6.4",
+			"version": "2.6.5",
 			"license": "GPL-2.0+",
 			"dependencies": {
-				"@formbricks/js": "^1.5.0",
+				"@formbricks/js": "^1.6.5",
 				"@wordpress/icons": "^9.43.0",
 				"array-move": "^3.0.1",
 				"classnames": "^2.5.1",
@@ -2752,9 +2752,9 @@
 			"dev": true
 		},
 		"node_modules/@formbricks/js": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@formbricks/js/-/js-1.5.0.tgz",
-			"integrity": "sha512-Q8kwqwlWk4FAuVnOGeQBD7v160fg1bVgxXSIWy6q7oqb7o9xIxTrG7+tFBln6Os0G7ko9iPKKqcCWXQAoDE+Vg=="
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/@formbricks/js/-/js-1.6.5.tgz",
+			"integrity": "sha512-eGlnauNgzv4ye22/yN+FyQAl6gLgHbNOCxysex/UoLjTZbXYOali7ilQ1Ksyl/ujBBcqcrXKe/OnsGena2zP8A=="
 		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"lasttranslator": "Themeisle Translate Team <friends@themeisle.com>"
 	},
 	"dependencies": {
-		"@formbricks/js": "^1.5.0",
+		"@formbricks/js": "^1.6.5",
 		"@wordpress/icons": "^9.43.0",
 		"array-move": "^3.0.1",
 		"classnames": "^2.5.1",


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/158, https://github.com/Codeinwp/otter-internals/issues/159.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Escape block attributes in SSR
- Update Formbricks library


### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

