### PR TITLE
fix: margin and padding range for section block

### DIFF
--- a/src/blocks/blocks/section/column/block.json
+++ b/src/blocks/blocks/section/column/block.json
@@ -12,22 +12,58 @@
 			"type": "string"
 		},
 		"padding": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"paddingTablet": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"paddingMobile": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"margin": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"marginTablet": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"marginMobile": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"color": {
 			"type": "string"

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -44,6 +44,7 @@ import {
 	ResponsiveControl,
 	SyncControlDropdown
 } from '../../../components/index.js';
+import metadata from './block.json';
 
 import {
 	isNullObject,
@@ -285,6 +286,7 @@ const Inspector = ({
 										max: 500
 									} }
 									onChange={ changePadding }
+									resetValues={ metadata.attributes.padding.default }
 								/>
 							</Disabled>
 
@@ -300,6 +302,7 @@ const Inspector = ({
 										max: 500
 									} }
 									onChange={ changeMargin }
+									resetValues={ metadata.attributes.margin.default }
 								/>
 							</Disabled>
 						</ResponsiveControl>

--- a/src/blocks/blocks/section/columns/block.json
+++ b/src/blocks/blocks/section/columns/block.json
@@ -26,22 +26,58 @@
 			"default": "equal"
 		},
 		"padding": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"paddingTablet": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"paddingMobile": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"margin": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"marginTablet": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"marginMobile": {
-			"type": "object"
+			"type": "object",
+			"default": {
+				"top": "0px",
+				"right": "0px",
+				"bottom": "0px",
+				"left": "0px"
+			}
 		},
 		"columnsWidth": {
 			"type": [ "number", "string" ]

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -35,6 +35,7 @@ import {
  * Internal dependencies
  */
 import LayoutControl from './../components/layout-control/index.js';
+import metadata from './block.json';
 
 import {
 	isNullObject,
@@ -734,6 +735,7 @@ const Inspector = ({
 											max: 500
 										} }
 										onChange={ changePadding }
+										resetValues={ metadata.attributes.padding.default }
 									/>
 								</Disabled>
 
@@ -750,6 +752,7 @@ const Inspector = ({
 										} }
 										sides={ [ 'top', 'bottom' ] }
 										onChange={ changeMargin }
+										resetValues={ metadata.attributes.margin.default }
 									/>
 								</Disabled>
 							</ResponsiveControl>

--- a/src/blocks/test/e2e/blocks/section.spec.js
+++ b/src/blocks/test/e2e/blocks/section.spec.js
@@ -99,42 +99,42 @@ test.describe( 'Section Block', () => {
 		await page.click( 'role=button[name="Add default block"i]' );
 		await page.keyboard.type( '/section' );
 		await page.keyboard.press( 'Enter' );
-		await page.getByLabel('Single column').click();
-		await page.getByLabel('Add block').click();
-		await page.getByRole('option', { name: 'Paragraph' }).click();
-		await page.getByLabel('Empty block; start writing or').fill('Test');
-		await page.getByLabel('Document Overview').click();
-		await page.getByLabel('Section', { exact: true }).click();
+		await page.getByLabel( 'Single column' ).click();
+		await page.getByLabel( 'Add block' ).click();
+		await page.getByRole( 'option', { name: 'Paragraph' }).click();
+		await page.getByLabel( 'Empty block; start writing or' ).fill( 'Test' );
+		await page.getByLabel( 'Document Overview' ).click();
+		await page.getByLabel( 'Section', { exact: true }).click();
 
 		// Open Setting panel
-		await page.getByLabel('Settings', { exact: true }).click();
-		await page.getByRole('button', { name: 'Style' }).click();
+		await page.getByLabel( 'Settings', { exact: true }).click();
+		await page.getByRole( 'button', { name: 'Style' }).click();
 
 		// Check Default values for Section Block
-		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toBeVisible();
-		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toBeVisible();
-		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toHaveValue('0');
-		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toHaveValue('0');
+		await expect( page.getByLabel( 'Padding' ).getByRole( 'textbox', { name: 'All sides' }) ).toBeVisible();
+		await expect( page.getByLabel( 'Margin' ).getByRole( 'textbox', { name: 'All sides' }) ).toBeVisible();
+		await expect( page.getByLabel( 'Padding' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '0' );
+		await expect( page.getByLabel( 'Margin' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '0' );
 
 		// Set Padding and Margin values and check if they are set for the Section Block
-		await page.getByLabel('Padding').getByRole('slider', { name: 'All sides' }).fill('30');
-		await page.getByLabel('Margin').getByRole('slider', { name: 'All sides' }).fill('15');
-		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toHaveValue('30');
-		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toHaveValue('15');
+		await page.getByLabel( 'Padding' ).getByRole( 'slider', { name: 'All sides' }).fill( '30' );
+		await page.getByLabel( 'Margin' ).getByRole( 'slider', { name: 'All sides' }).fill( '15' );
+		await expect( page.getByLabel( 'Padding' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '30' );
+		await expect( page.getByLabel( 'Margin' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '15' );
 
 		// Check Default values for Section Column Block
-		await page.getByLabel('Section Column', { exact: true }).click();
-		await page.getByRole('button', { name: 'Style' }).click();
-		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toHaveValue('0');
-		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toHaveValue('0');
+		await page.getByLabel( 'Section Column', { exact: true }).click();
+		await page.getByRole( 'button', { name: 'Style' }).click();
+		await expect( page.getByLabel( 'Padding' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '0' );
+		await expect( page.getByLabel( 'Margin' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '0' );
 
 		// Set Padding and Margin values and check if they are set for the Section Column Block
-		await page.getByLabel('Padding').getByRole('slider', { name: 'All sides' }).fill('20');
-		await page.getByLabel('Margin').getByRole('slider', { name: 'All sides' }).fill('10');
-		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toHaveValue('20');
-		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toHaveValue('10');
+		await page.getByLabel( 'Padding' ).getByRole( 'slider', { name: 'All sides' }).fill( '20' );
+		await page.getByLabel( 'Margin' ).getByRole( 'slider', { name: 'All sides' }).fill( '10' );
+		await expect( page.getByLabel( 'Padding' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '20' );
+		await expect( page.getByLabel( 'Margin' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '10' );
 
 		// Close Setting panel to preserve the original state
-		await page.getByLabel('Settings', { exact: true }).click();
+		await page.getByLabel( 'Settings', { exact: true }).click();
 	});
 });

--- a/src/blocks/test/e2e/blocks/section.spec.js
+++ b/src/blocks/test/e2e/blocks/section.spec.js
@@ -92,4 +92,49 @@ test.describe( 'Section Block', () => {
 
 		expect( sectionBlock.innerBlocks.length ).toBe( 1 );
 	});
+
+	test( 'check margin and padding controls', async({ editor, page }) => {
+
+		// Create a Section Block with the slash block shortcut. Add a column and a paragraph block.
+		await page.click( 'role=button[name="Add default block"i]' );
+		await page.keyboard.type( '/section' );
+		await page.keyboard.press( 'Enter' );
+		await page.getByLabel('Single column').click();
+		await page.getByLabel('Add block').click();
+		await page.getByRole('option', { name: 'Paragraph' }).click();
+		await page.getByLabel('Empty block; start writing or').fill('Test');
+		await page.getByLabel('Document Overview').click();
+		await page.getByLabel('Section', { exact: true }).click();
+
+		// Open Setting panel
+		await page.getByLabel('Settings', { exact: true }).click();
+		await page.getByRole('button', { name: 'Style' }).click();
+
+		// Check Default values for Section Block
+		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toBeVisible();
+		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toBeVisible();
+		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toHaveValue('0');
+		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toHaveValue('0');
+
+		// Set Padding and Margin values and check if they are set for the Section Block
+		await page.getByLabel('Padding').getByRole('slider', { name: 'All sides' }).fill('30');
+		await page.getByLabel('Margin').getByRole('slider', { name: 'All sides' }).fill('15');
+		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toHaveValue('30');
+		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toHaveValue('15');
+
+		// Check Default values for Section Column Block
+		await page.getByLabel('Section Column', { exact: true }).click();
+		await page.getByRole('button', { name: 'Style' }).click();
+		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toHaveValue('0');
+		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toHaveValue('0');
+
+		// Set Padding and Margin values and check if they are set for the Section Column Block
+		await page.getByLabel('Padding').getByRole('slider', { name: 'All sides' }).fill('20');
+		await page.getByLabel('Margin').getByRole('slider', { name: 'All sides' }).fill('10');
+		await expect(page.getByLabel('Padding').getByRole('textbox', { name: 'All sides' })).toHaveValue('20');
+		await expect(page.getByLabel('Margin').getByRole('textbox', { name: 'All sides' })).toHaveValue('10');
+
+		// Close Setting panel to preserve the original state
+		await page.getByLabel('Settings', { exact: true }).click();
+	});
 });


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2148.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Fixed the range control when first adding the section block for the margin and padding.
Added e2e test for this behavior.

### Screenshots <!-- if applicable -->
<img width="1512" alt="image" src="https://github.com/Codeinwp/otter-blocks/assets/23024731/c034905a-2c82-450d-9a75-9d119827a678">

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Add a Section block with one Column
2. Add a paragraph in that Column
3. Try to add a Margin or Padding using the slider control, not entering the numeric value
4. E2E tests should pass

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

