### PR TITLE
Fix/product review line breaks

### DIFF
--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -112,7 +112,7 @@ class Review_Block {
 			}
 
 			if ( isset( $attributes['description'] ) && ! empty( $attributes['description'] ) ) {
-				$html .= '	<p>' . esc_html( $attributes['description'] ) . '</p>';
+				$html .= '	<p>' . wp_kses( $attributes['description'], array( 'br' => array() ) ) . '</p>';
 			}
 			$html .= '	</div>';
 		}

--- a/src/blocks/test/e2e/blocks/product-review.spec.js
+++ b/src/blocks/test/e2e/blocks/product-review.spec.js
@@ -103,4 +103,34 @@ test.describe( 'Product Review Block', () => {
 		await expect( page.getByRole( 'link', { name: 'Buy Now', exact: true }) ).toHaveAttribute( 'target', '_blank' );
 
 	});
+
+	test( 'check description new lines preserved', async({ editor, page }) => {
+		await editor.insertBlock({ name: 'themeisle-blocks/review' });
+
+		const title = page.getByRole( 'textbox', { name: 'Name of your product…' });
+
+		await title.type( 'Test Product' );
+
+		// Check if the value is added in title
+		expect( await title.innerHTML() ).toBe( 'Test Product' );
+
+		// Add a multi line description
+		await page.getByLabel( 'Product description or a' ).click();
+		await page.getByLabel( 'Product description or a' ).fill( 'Product description' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Line 1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Line 2' );
+
+		// Check if the value is added in description and is multiline
+		await expect( page.getByLabel( 'Product description or a' ) ).toContainText( 'Product description\nLine 1\nLine 2', { useInnerText: true });
+
+		// Publish the post and view the post
+		await page.getByRole( 'button', { name: 'Publish', exact: true }).click();
+		await page.getByLabel( 'Editor publish' ).getByRole( 'button', { name: 'Publish', exact: true }).click();
+		await page.getByLabel( 'Editor publish' ).getByRole( 'link', { name: 'View Post' }).click();
+
+		// Check if the value is added in description and multiline is preserved
+		await expect( page.locator( '.wp-block-themeisle-blocks-review .o-review__header_details' ) ).toContainText( 'Product description\nLine 1\nLine 2', { useInnerText: true });
+	});
 });


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2162.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Fixed multiline description for product review while maintaining sanitization.
Added e2e test to check for this specific case.

### Screenshots <!-- if applicable -->
<img width="662" alt="image" src="https://github.com/Codeinwp/otter-blocks/assets/23024731/4d34f920-384f-4912-ab35-ec7ca2031693">


----

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Add a Product Review block
2. In the Description of the product, add more lines of content
3. Check the Product Review block on frontend multiline should be preserved

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

