### PR TITLE
Improve Posts block output sanitization

### DIFF
--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -153,12 +153,7 @@ class Posts_Grid_Block {
 
 			if ( 'title' === $element ) {
 				if ( isset( $attributes['displayTitle'] ) && $attributes['displayTitle'] ) {
-					$html .= sprintf(
-						'<%1$s class="o-posts-grid-post-title"><a href="%2$s">%3$s</a></%1$s>',
-						esc_attr( $attributes['titleTag'] ),
-						esc_url( get_the_permalink( $id ) ),
-						esc_html( get_the_title( $id ) )
-					);
+					$html .= $this->render_post_title( $attributes['titleTag'], get_the_permalink( $id ), get_the_title( $id ) );
 				}
 			}
 
@@ -409,5 +404,23 @@ class Posts_Grid_Block {
 		$output .= '</div>';
 
 		return $output;
+	}
+
+	/**
+	 * Render the post title.
+	 * 
+	 * @param string $tag The html tag.
+	 * @param string $post_url The post URL.
+	 * @param string $post_title The post title.
+	 * 
+	 * @return string The rendered post title.
+	 */
+	public function render_post_title( $tag, $post_url, $post_title ) {
+		return sprintf(
+			'<%1$s class="o-posts-grid-post-title"><a href="%2$s">%3$s</a></%1$s>',
+			sanitize_key( $tag ),
+			esc_url( $post_url ),
+			esc_html( $post_title )
+		);
 	}
 }

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -416,9 +416,16 @@ class Posts_Grid_Block {
 	 * @return string The rendered post title.
 	 */
 	public function render_post_title( $tag, $post_url, $post_title ) {
+
+		$tag = sanitize_key( $tag );
+		
+		if ( ! in_array( $tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ), true ) ) {
+			$tag = 'h5';
+		}
+
 		return sprintf(
 			'<%1$s class="o-posts-grid-post-title"><a href="%2$s">%3$s</a></%1$s>',
-			sanitize_key( $tag ),
+			$tag,
 			esc_url( $post_url ),
 			esc_html( $post_title )
 		);

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -110,17 +110,20 @@ export const PostsCategory = ({ attributes, element, category, categoriesList })
 };
 
 export const PostsTitle = ({ attributes, element, post }) => {
-	const Tag = attributes.titleTag || 'h5';
-	if ( attributes.displayTitle ) {
-		return (
-			<Tag key={ element } className="o-posts-grid-post-title">
-				<a href={ post.link }>
-					{ unescapeHTML( post.title?.rendered ) }
-				</a>
-			</Tag>
-		);
+
+	if ( ! attributes.displayTitle ) {
+		return '';
 	}
-	return '';
+
+	const Tag = ! [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes( attributes.titleTag ) ? 'h5' : attributes.titleTag;
+
+	return (
+		<Tag key={ element } className="o-posts-grid-post-title">
+			<a href={ post.link }>
+				{ unescapeHTML( post.title?.rendered ) }
+			</a>
+		</Tag>
+	);
 };
 
 export const PostsMeta = ({ attributes, element, post, author, categories }) => {

--- a/tests/test-post-grid-block.php
+++ b/tests/test-post-grid-block.php
@@ -77,25 +77,52 @@ class Test_Post_Grid_Block extends WP_UnitTestCase {
 	);
 
 	/**
-	 * Test the fetching of patterns.
+	 * Test the rendering of the block.
+	 */
+	public function test_render() {
+		$this->post_grid_block = new Posts_Grid_Block();
+		WP_Block_Supports::init();
+		WP_Block_Supports::$block_to_render = array( 'blockName' => 'themeisle-blocks/posts-grid' );
+
+		$base_attributes = unserialize(serialize($this->attributes));
+
+		$output = $this->post_grid_block->render( $base_attributes );
+		$expected = '<div class="wp-block-themeisle-blocks-posts-grid" id="wp-block-themeisle-blocks-posts-grid-a94bab18"><div class="is-grid o-posts-grid-columns-2"></div> </div>';
+		$this->assertEquals( $expected, $output );
+	}
+
+	/**
+	 * Test the rendering of the item post title.
+	 */
+	public function test_render_post_title() {
+		$this->post_grid_block = new Posts_Grid_Block();
+
+		$output = $this->post_grid_block->render_post_title( 'h5', 'www.example.com', 'Title' );
+		$expected = '<h5 class="o-posts-grid-post-title"><a href="http://www.example.com">Title</a></h5>';
+		$this->assertEquals( $expected, $output );
+	}
+
+	/**
+	 * Test render sanitization.
 	 */
 	public function test_render_sanitization() {
 		$this->post_grid_block = new Posts_Grid_Block();
 		WP_Block_Supports::init();
 		WP_Block_Supports::$block_to_render = array( 'blockName' => 'themeisle-blocks/posts-grid' );
-
-		$base_attributes = $this->attributes;
-
-		$output = $this->post_grid_block->render( $base_attributes );
-		$expected = '<div class="wp-block-themeisle-blocks-posts-grid" id="wp-block-themeisle-blocks-posts-grid-a94bab18"><div class="is-grid o-posts-grid-columns-2"></div> </div>';
-		$this->assertEquals( $expected, $output );
-
-		$malformed_attributes = $base_attributes;
+		
+		$malformed_attributes = unserialize(serialize($this->attributes));
 		$malformed_attributes['id'] = 'wp-block-themeisle-blocks-posts-grid-12345\\"onmouseover=alert(123) b=';
+		$malformed_attributes['titleTag'] = 'h5 onmouseover=alert(456)';
 
 		// We expect the id to be sanitized.
 		$expected = '<div class="wp-block-themeisle-blocks-posts-grid" id="wp-block-themeisle-blocks-posts-grid-12345\&quot;onmouseover=alert(123) b="><div class="is-grid o-posts-grid-columns-2"></div> </div>';
 		$output = $this->post_grid_block->render( $malformed_attributes );
+
+		$this->assertEquals( $expected, $output );
+
+		// We expect the titleTag to be sanitized.
+		$expected = '<h5onmouseoveralert456 class="o-posts-grid-post-title"><a href="http://www.example.com">Title</a></h5onmouseoveralert456>';
+		$output = $this->post_grid_block->render_post_title( $malformed_attributes['titleTag'], 'www.example.com', 'Title' );
 
 		$this->assertEquals( $expected, $output );
 	}

--- a/tests/test-post-grid-block.php
+++ b/tests/test-post-grid-block.php
@@ -97,8 +97,8 @@ class Test_Post_Grid_Block extends WP_UnitTestCase {
 	public function test_render_post_title() {
 		$this->post_grid_block = new Posts_Grid_Block();
 
-		$output = $this->post_grid_block->render_post_title( 'h5', 'www.example.com', 'Title' );
-		$expected = '<h5 class="o-posts-grid-post-title"><a href="http://www.example.com">Title</a></h5>';
+		$output = $this->post_grid_block->render_post_title( 'h3', 'www.example.com', 'Title' );
+		$expected = '<h3 class="o-posts-grid-post-title"><a href="http://www.example.com">Title</a></h3>';
 		$this->assertEquals( $expected, $output );
 	}
 
@@ -112,7 +112,7 @@ class Test_Post_Grid_Block extends WP_UnitTestCase {
 		
 		$malformed_attributes = unserialize(serialize($this->attributes));
 		$malformed_attributes['id'] = 'wp-block-themeisle-blocks-posts-grid-12345\\"onmouseover=alert(123) b=';
-		$malformed_attributes['titleTag'] = 'h5 onmouseover=alert(456)';
+		$malformed_attributes['titleTag'] = 'h3 onmouseover=alert(456)';
 
 		// We expect the id to be sanitized.
 		$expected = '<div class="wp-block-themeisle-blocks-posts-grid" id="wp-block-themeisle-blocks-posts-grid-12345\&quot;onmouseover=alert(123) b="><div class="is-grid o-posts-grid-columns-2"></div> </div>';
@@ -121,7 +121,7 @@ class Test_Post_Grid_Block extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $output );
 
 		// We expect the titleTag to be sanitized.
-		$expected = '<h5onmouseoveralert456 class="o-posts-grid-post-title"><a href="http://www.example.com">Title</a></h5onmouseoveralert456>';
+		$expected = '<h5 class="o-posts-grid-post-title"><a href="http://www.example.com">Title</a></h5>';
 		$output = $this->post_grid_block->render_post_title( $malformed_attributes['titleTag'], 'www.example.com', 'Title' );
 
 		$this->assertEquals( $expected, $output );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/165
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added better sanitation function for `titleTag` attribute.


### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a new post.
2. Use Code Editor instead of Visual Editor.
3. Paste the code below into the page and check if the alert starts when you hover the mouse over the title. If the alert start, the issue was not fixed. 

```html
<!-- wp:themeisle-blocks/posts-grid {"id":"wp-block-themeisle-blocks-posts-grid-dce24f89","template":["title","category","meta","description"],"titleTag":"h1 onmouseover=alert(123)","className":""} /-->
```

On the page, you should see this HTML output: 

<img width="702" alt="Screenshot 2024-04-15 at 11 14 00" src="https://github.com/Codeinwp/otter-blocks/assets/17597852/c6c91014-3bfb-43ad-b7c2-64bc1712191d">

This means sanitation succeeded, and somebody tried to create an XSS attack from a compromised account.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [X] Included E2E or unit tests for the changes in this PR.
- [X] Visual elements are not affected by independent changes.
- [X] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [X] It loads additional script in frontend only if it is required.
- [X] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [X] In case of deprecation, old blocks are safely migrated.
- [X] It is usable in Widgets and FSE.
- [X] Copy/Paste is working if the attributes are modified.
- [X] PR is following [the best practices]()

