### PR TITLE
Allow a subset of HTML tags for Multiple Choices label rendering

### DIFF
--- a/inc/render/class-form-multiple-choice.php
+++ b/inc/render/class-form-multiple-choice.php
@@ -89,7 +89,28 @@ class Form_Multiple_Choice_Block {
 		$output = '<div class="o-form-multiple-choice-field">';
 
 		$output .= '<input type="' . esc_attr( $type ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $id ) . '" value="' . esc_attr( $value ) . '" ' . ( $is_required ? 'required' : '' ) . ( $checked ? ' checked' : '' ) . ' />';
-		$output .= '<label for="' . esc_attr( $id ) . '" class="o-form-choice-label">' . esc_html( $label ) . '</label>';
+		
+		$allowed_tags = array(
+			'a'      => array(
+				'href'   => true,
+				'target' => true,
+			),
+			'img'    => array(
+				'src'    => true,
+				'alt'    => true,
+				'width'  => true,
+				'height' => true,
+			),
+			'span'   => array(),
+			'em'     => array(),
+			'strong' => array(),
+			'i'      => array(),
+			'b'      => array(),
+		);
+		
+		$label = wp_kses( $label, $allowed_tags );
+
+		$output .= '<label for="' . esc_attr( $id ) . '" class="o-form-choice-label">' . $label . '</label>';
 
 		$output .= '</div>';
 

--- a/tests/test-choices-field-block.php
+++ b/tests/test-choices-field-block.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Test Multiple Choice Field Block.
+ *
+ * @package otter-blocks
+ */
+
+use ThemeIsle\GutenbergBlocks\Render\Form_Multiple_Choice_Block;
+
+/**
+ * Class Test Multiple Choices Block
+ */
+class Test_Multiple_Choices_Block extends WP_UnitTestCase {
+
+    public function test_label_sanitization_render() {
+        $block_render = new Form_Multiple_Choice_Block();
+
+        $expected  = '<div class="o-form-multiple-choice-field">';
+        $expected .= '<input type="checkbox" name="otter-blocks" id="otter-blocks" value="otter-blocks"  />';
+        $expected .= '<label for="otter-blocks" class="o-form-choice-label">Option with <a href="www.example.com">link</a></label>';
+        $expected .= '</div>';
+
+        $output = $block_render->render_field( 'checkbox', 'Option with <a href="www.example.com">link</a>', 'otter-blocks', 'otter-blocks', 'otter-blocks' );
+
+        $this->assertEquals( $expected, $output );
+
+        $malicious_label = 'Option with <a href="www.example.com">link</a><script></script>';
+        $output = $block_render->render_field( 'checkbox', $malicious_label, 'otter-blocks', 'otter-blocks', 'otter-blocks' );
+
+        $this->assertEquals( $expected, $output );
+
+        $malicious_label = 'Option with <a href="www.example.com" onclick="alert(123)">link</a>';
+        $output = $block_render->render_field( 'checkbox', $malicious_label, 'otter-blocks', 'otter-blocks', 'otter-blocks' );
+
+        $this->assertEquals( $expected, $output );
+    }
+}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2091
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Instead of escaping the HTML, I used the `wp_kses` to clean and allow only a subset of HTML tags.

### Screenshots <!-- if applicable -->

<img width="1707" alt="Screenshot 2024-04-17 at 17 36 03" src="https://github.com/Codeinwp/otter-blocks/assets/17597852/63146a39-7665-4407-af2b-d69e1674d3be">

<img width="1343" alt="Screenshot 2024-04-17 at 17 36 31" src="https://github.com/Codeinwp/otter-blocks/assets/17597852/9fe6a7bd-f6ae-4f5d-a8fc-1f08ba66377f">

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Form and a multiple choices field.
2. In the field label, select the text and add a link using the native widget.
3. Check if the link is present in Frontend(Page Preview)

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

