### PR TITLE
fix: enforce display condition to return string in `render_block` filter

### DIFF
--- a/inc/plugins/class-block-conditions.php
+++ b/inc/plugins/class-block-conditions.php
@@ -26,7 +26,7 @@ class Block_Conditions {
 	 */
 	public function init() {
 		if ( get_option( 'themeisle_blocks_settings_block_conditions', true ) ) {
-			add_action( 'render_block', array( $this, 'render_blocks' ), 999, 2 );
+			add_filter( 'render_block', array( $this, 'render_blocks' ), 999, 2 );
 			add_action( 'wp_loaded', array( $this, 'add_attributes_to_blocks' ), 999 );
 		}
 	}
@@ -36,6 +36,8 @@ class Block_Conditions {
 	 *
 	 * @param string $block_content Content of block.
 	 * @param array  $block Block Attributes.
+	 * 
+	 * @return string
 	 *
 	 * @since   1.7.0
 	 * @access  public
@@ -46,12 +48,12 @@ class Block_Conditions {
 			$display = $this->evaluate_condition_collection( $block['attrs']['otterConditions'] );
 
 			if ( false === $display ) {
-				return;
+				return '';
 			}
 
 			$enhanced_content = $this->should_add_hide_css_class( $this->get_hide_css_condition( $block['attrs']['otterConditions'] ), $block_content );
 
-			if ( false !== $enhanced_content ) {
+			if ( false !== $enhanced_content && is_string( $enhanced_content ) ) {
 				return $enhanced_content;
 			}
 		}

--- a/src/blocks/test/e2e/blocks/block-conditions.spec.js
+++ b/src/blocks/test/e2e/blocks/block-conditions.spec.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { tryLoginIn } from '../utils';
+
+test.describe( 'Block Conditions', () => {
+	test.beforeEach( async({ admin, requestUtils, page }) => {
+		await tryLoginIn( page, 'admin', 'password' );
+		await admin.createNewPost();
+	});
+
+	test( 'check logged out users', async({ editor, page, admin, requestUtils }) => {
+		await editor.insertBlock({
+			name: 'core/image',
+			attributes: {
+				url: 'https://mllj2j8xvfl0.i.optimole.com/cb:jC7e.37109/w:794/h:397/q:mauto/dpr:2.0/f:best/https://themeisle.com/blog/wp-content/uploads/2021/01/How-to-Change-Font-in-WordPress-Theme.png',
+				otterConditions: [
+					[
+						{
+							type: 'loggedInUser'
+						}
+					]
+				]
+			}
+		});
+
+		const postId = await editor.publishPost();
+
+		await page.goto( `/?p=${postId}` );
+
+		await expect( page.locator( '#wp--skip-link--target img' ) ).toBeVisible();
+
+		await page.getByRole( 'menuitem', { name: 'Howdy, admin' }).hover();
+
+		await page.waitForTimeout( 200 );
+
+		await page.getByRole( 'menuitem', { name: 'Log Out' }).click();
+		await page.goto( `/?p=${postId}` );
+		await expect( page.locator( '#wp--skip-link--target img' ) ).toBeHidden();
+	});
+});

--- a/src/blocks/test/e2e/blocks/block-conditions.spec.js
+++ b/src/blocks/test/e2e/blocks/block-conditions.spec.js
@@ -10,6 +10,14 @@ test.describe( 'Block Conditions', () => {
 		await admin.createNewPost();
 	});
 
+	test.afterEach( async({ page }) => {
+
+		/**
+		 * Because some conditions require an user to be logged in, we need to log in the user after each test so that we do not break the next test.
+		 */
+		await tryLoginIn( page, 'admin', 'password' );
+	});
+
 	test( 'check logged out users', async({ editor, page, admin, requestUtils }) => {
 		await editor.insertBlock({
 			name: 'core/image',
@@ -27,14 +35,13 @@ test.describe( 'Block Conditions', () => {
 
 		const postId = await editor.publishPost();
 
+		// Check the block for logged in users.
 		await page.goto( `/?p=${postId}` );
-
 		await expect( page.locator( '#wp--skip-link--target img' ) ).toBeVisible();
 
+		// Check the block for logged out users.
 		await page.getByRole( 'menuitem', { name: 'Howdy, admin' }).hover();
-
 		await page.waitForTimeout( 200 );
-
 		await page.getByRole( 'menuitem', { name: 'Log Out' }).click();
 		await page.goto( `/?p=${postId}` );
 		await expect( page.locator( '#wp--skip-link--target img' ) ).toBeHidden();

--- a/src/blocks/test/e2e/utils.js
+++ b/src/blocks/test/e2e/utils.js
@@ -68,3 +68,10 @@ export function deleteFile( filePath ) {
 		unlinkSync( filePath );
 	}
 }
+
+export async function tryLoginIn( page, username, password ) {
+	await page.goto( '/wp-login.php' );
+	await page.fill( 'input[name="log"]', username );
+	await page.fill( 'input[name="pwd"]', password );
+	await page.click( 'input[name="wp-submit"]' );
+}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2191 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Because the function `render_blocks` for block conditions could not return anything, an error is raised because the filter `render_block` must return a string.

I refactored the function so that it always returns a string. Also, change from `add_action` to `add_filter` since `render_block` exists as a filter, and with the new phpdoc added to the function, phpstan does not allow us to use the `add_action` since we are always returning something. 

> [!NOTE]
> By being aware of https://github.com/Codeinwp/otter-blocks/issues/2177, in this PR, the introduced test is critical to succeed.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Use Otter Free.
2. Create a new post and insert an Image Block
3. Set the condition to be visible to the Logged User.
4. Check the page if the block is rendered. 
5. Log out, then recheck the page. The block should be hidden, and no fatal error should happen. 

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

