### PR TITLE
Fix pattern upsell show condtion

### DIFF
--- a/src/blocks/plugins/upsell-block/index.js
+++ b/src/blocks/plugins/upsell-block/index.js
@@ -30,9 +30,9 @@ const MONTH_IN_MS = 60 * 60 * 1000 * 24 * 30;
 const edit = props => {
 	const { removeBlock } = useDispatch( 'core/block-editor' );
 
-	const isEditor = null !== document.querySelector( `#o-upsell-${ props.clientId }` );
-
 	useEffect( () => {
+		const isEditor = Boolean( document.querySelector( `#o-upsell-${ props.clientId }` ) );
+
 		if ( isEditor && undefined === window.themeisleGutenberg.hasPatternUpsell ) {
 			window.themeisleGutenberg.hasPatternUpsell = props.clientId;
 		}
@@ -50,7 +50,7 @@ const edit = props => {
 				removeBlock( props.clientId );
 			}
 		}
-	}, [ isEditor ]);
+	}, []);
 
 	return (
 		<div


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2193 
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Each pattern has an Upsell Notice embedded. If there are multiple notices, they are removed except the first one.

The condition that checked if the block is rendered inside the editor was using `document.querySelected` and evaluated before the rendering, thus making it to be always false.

By moving the check inside the `effect`, we fix this problem since the hook runs after the component is rendered on the page.

### Screenshots <!-- if applicable -->



----

https://github.com/Codeinwp/otter-blocks/assets/17597852/3c7de8dd-1ad9-4f78-9f38-f4b89162a7c2

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Use Otter Free
2. Insert many patterns
3. You should see only one Upsell Notice block like in the video

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

