### PR TITLE
Use only searchable post type for Live Search

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -267,7 +267,12 @@ class Registration {
 				'canTrack'                => 'yes' === get_option( 'otter_blocks_logger_flag', false ) ? true : false,
 				'userRoles'               => $wp_roles->roles,
 				'isBlockEditor'           => 'post' === $current_screen->base,
-				'postTypes'               => get_post_types( [ 'public' => true ] ),
+				'postTypes'               => get_post_types(
+					[
+						'public'              => true,
+						'exclude_from_search' => false,
+					] 
+				),
 				'rootUrl'                 => get_site_url(),
 				'restRoot'                => get_rest_url( null, 'otter/v1' ),
 				'isPrettyPermalinks'      => boolval( get_option( 'permalink_structure' ) ),

--- a/tests/test-live-search.php
+++ b/tests/test-live-search.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Class CSS
+ *
+ * @package gutenberg-blocks
+ */
+
+use ThemeIsle\OtterPro\Server\Live_Search_Server;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsCanonicalizing;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertNotEqualsCanonicalizing;
+
+/**
+ * Live Search Test Case.
+ */
+class TestLiveSearch extends WP_UnitTestCase
+{
+    /**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+        
+        register_post_type( 'otter_shop_coupon', array(
+            'public' => false,
+            'label'  => 'Shop Coupon',
+        ) );
+
+        register_post_type( 'otter_shop_product', array(
+            'public' => true,
+            'label'  => 'Shop Product',
+        ) );
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tear_dow() {
+        unregister_post_type( 'otter_shop_coupon' );
+        unregister_post_type( 'otter_shop_product' );
+		parent::tear_down();
+	}
+
+    /**
+     * Test live search prepare query function.
+     */
+    public function test_live_search_prepare_query() {
+        $live_search = new Live_Search_Server();
+
+        $search_query = $live_search->prepare_search_query( 'test', '' );
+        $this->assertEquals( 'test', $search_query['s'] );
+        $this->assertEquals( '', $search_query['post_type'] );
+
+        $search_query = $live_search->prepare_search_query( 'test', 'otter_shop_product' );
+        $this->assertEquals( 'test', $search_query['s'] );
+        $this->assertEquals( 'otter_shop_product', $search_query['post_type'] );
+
+        $search_query = $live_search->prepare_search_query( 'test', 'otter_shop_coupon' );
+        $this->assertEquals( 'test', $search_query['s'] );
+        $this->assertEquals( '', $search_query['post_type'] ); // Non-public post type are filtered out.
+
+        $search_query = $live_search->prepare_search_query( 'test', 'otter_shop_product,otter_shop_coupon' );
+        $this->assertEquals( 'test', $search_query['s'] );
+        $this->assertEquals( 'otter_shop_product', $search_query['post_type'] ); // Keep only the public post type.
+    }
+}

--- a/tests/test-live-search.php
+++ b/tests/test-live-search.php
@@ -29,6 +29,12 @@ class TestLiveSearch extends WP_UnitTestCase
             'public' => true,
             'label'  => 'Shop Product',
         ) );
+
+        register_post_type( 'otter_page', array(
+            'public' => true,
+            'exclude_from_search' => true,
+            'label'  => 'Otter Page',
+        ) );
 	}
 
 	/**
@@ -37,6 +43,7 @@ class TestLiveSearch extends WP_UnitTestCase
 	public function tear_dow() {
         unregister_post_type( 'otter_shop_coupon' );
         unregister_post_type( 'otter_shop_product' );
+        unregister_post_type( 'otter_page' );
 		parent::tear_down();
 	}
 
@@ -52,14 +59,18 @@ class TestLiveSearch extends WP_UnitTestCase
 
         $search_query = $live_search->prepare_search_query( 'test', 'otter_shop_product' );
         $this->assertEquals( 'test', $search_query['s'] );
-        $this->assertEquals( 'otter_shop_product', $search_query['post_type'] );
+        $this->assertEquals( array('otter_shop_product'), $search_query['post_type'] );
 
         $search_query = $live_search->prepare_search_query( 'test', 'otter_shop_coupon' );
         $this->assertEquals( 'test', $search_query['s'] );
-        $this->assertEquals( '', $search_query['post_type'] ); // Non-public post type are filtered out.
+        $this->assertEquals( array(), $search_query['post_type'] ); // Non-public post type are filtered out.
 
-        $search_query = $live_search->prepare_search_query( 'test', 'otter_shop_product,otter_shop_coupon' );
+        $search_query = $live_search->prepare_search_query( 'test', 'otter_page' );
         $this->assertEquals( 'test', $search_query['s'] );
-        $this->assertEquals( 'otter_shop_product', $search_query['post_type'] ); // Keep only the public post type.
+        $this->assertEquals( array(), $search_query['post_type'] ); // Exclude from search post type are filtered out.
+
+        $search_query = $live_search->prepare_search_query( 'test', array('otter_shop_product', 'otter_shop_coupon', 'otter_page') );
+        $this->assertEquals( 'test', $search_query['s'] );
+        $this->assertEquals( array('otter_shop_product'), $search_query['post_type'] ); // Keep only the public post type.
     }
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/166
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Filter out any non-searchable post type from the Live Search Block.

<img width="1639" alt="Screenshot 2024-04-29 at 18 43 43" src="https://github.com/Codeinwp/otter-blocks/assets/17597852/51395984-6969-4993-b828-a29d0c15040d">

#### [Docs] For users who want to user their own Custom Post Type

Users who want their post type to appear in the search must register their post type with `public` set to `true` and `exclude_from_search` set to `false`.

```php
register_post_type( 'my_post_type', array(
            'public' => true,
            'exclude_from_search' => false,
            'label'  => 'My Post Type',
) );
```

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. With Otter Pro, insert a Search Block and activate the Live Search
2. In the post types, you should see only the searchable post types ( they are registered as public and not excluded from search query )

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

