### PR TITLE
fix: form privacy statement typo

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -271,7 +271,7 @@ class Registration {
 					[
 						'public'              => true,
 						'exclude_from_search' => false,
-					] 
+					]
 				),
 				'rootUrl'                 => get_site_url(),
 				'restRoot'                => get_rest_url( null, 'otter/v1' ),
@@ -532,7 +532,7 @@ class Registration {
 						'invalid-email'        => __( 'The email address is invalid!', 'otter-blocks' ),
 						'already-registered'   => __( 'The email was already registered!', 'otter-blocks' ),
 						'try-again'            => __( 'Error. Something is wrong with the server! Try again later.', 'otter-blocks' ),
-						'privacy'              => __( 'I have read and agreed the privacy statement.', 'otter-blocks' ),
+						'privacy'              => __( 'I have read and agree to the privacy statement.', 'otter-blocks' ),
 						'too-many-files'       => __( 'Too many files loaded. Maximum is: ', 'otter-blocks' ),
 						'big-file'             => __( 'File size is to big. The limit is: ', 'otter-blocks' ),
 						'invalid-file'         => __( 'Invalid files type. The submitted files could not be processed.', 'otter-blocks' ),

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -1013,7 +1013,7 @@ const Edit = ({
 									<div className="otter-form-consent">
 										<input id="o-consent" name="o-consent" type="checkbox" />
 										<label htmlFor="o-consent">
-											{ __( 'I have read and agreed the privacy statement.', 'otter-blocks' ) }
+											{ __( 'I have read and agree to the privacy statement.', 'otter-blocks' ) }
 										</label>
 									</div>
 								) }

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -535,7 +535,7 @@ const renderConsentCheckbox = ( form ) => {
 	input.id = 'o-consent';
 
 	const label = document.createElement( 'label' );
-	label.innerHTML = window?.themeisleGutenbergForm?.messages?.privacy || 'I have read and agreed the privacy statement.';
+	label.innerHTML = window?.themeisleGutenbergForm?.messages?.privacy || 'I have read and agree to the privacy statement.';
 	label.htmlFor = 'o-consent';
 
 	inputContainer.appendChild( input );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2212
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix the typo on the privacy statement for Form Block Marketing Integration.

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/79979261-a8e0-47f7-80d0-92c909c9994c)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a From block
2. Activate marketing integration for Mailchimp or Sendinblue
3. Select `Submit & Subscribe` as action.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] ~Included E2E or unit tests for the changes in this PR.~
- [X] Visual elements are not affected by independent changes.
- [X] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [X] It loads additional script in frontend only if it is required.
- [X] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [X] In case of deprecation, old blocks are safely migrated.
- [X] It is usable in Widgets and FSE.
- [X] Copy/Paste is working if the attributes are modified.
- [X] PR is following [the best practices]()

