### PR TITLE
fix: decode entities for post block category

### DIFF
--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -104,7 +104,7 @@ const Layout = ({
 
 export const PostsCategory = ({ attributes, element, category, categoriesList }) => {
 	if ( undefined !== category && ( attributes.displayCategory && categoriesList ) ) {
-		return <span key={ element } className="o-posts-grid-post-category">{ category.name }</span>;
+		return <span key={ element } className="o-posts-grid-post-category">{ unescapeHTML( category.name ) }</span>;
 	}
 	return '';
 };


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2183
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added a decoder for the entities in the categories. 

The Gutenberg API sends encoded entities when requesting categories. So `Click & Go` becomes `Click &Amp Go`. Construction like `Click&Go` or `Click&` are unaffected; only isolated `&` are encoded.

### Screenshots <!-- if applicable -->

#### Before

![escaping-problem](https://github.com/Codeinwp/otter-blocks/assets/17597852/87fe8600-2691-4ba1-9e9f-a8e78ab69e8d)

#### After

![image](https://github.com/Codeinwp/otter-blocks/assets/17597852/b297f4d5-ec63-42e0-9748-fcdd5bf2fbbf)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a category named `Click & GO`. 
2. Attach it to some posts.
3. Make a new post, insert the Post block, and filter by this category.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] ~Included E2E or unit tests for the changes in this PR.~
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

