### PR TITLE
Experiment with formats in the toolbar

### DIFF
--- a/src/blocks/plugins/dynamic-content/editor.scss
+++ b/src/blocks/plugins/dynamic-content/editor.scss
@@ -33,6 +33,22 @@ o-dynamic-link {
 	cursor: pointer;
 }
 
+.components-toolbar {
+	.o-dynamic-button {
+		opacity: 1;
+
+		&.is-pressed {
+			&::before {
+				background: rgba(237, 111, 87, 0.1);
+			}
+		}
+	
+		svg {
+			fill: #ED6F57;
+		}
+	}
+}
+
 .wp-block.is-selected o-dynamic,
 .wp-block:not(.is-selected) o-dynamic:not([data-preview]),
 .wp-block:not(.is-selected) o-dynamic[data-preview=""] {

--- a/src/blocks/plugins/dynamic-content/link/edit.js
+++ b/src/blocks/plugins/dynamic-content/link/edit.js
@@ -8,9 +8,13 @@ import { globe } from '@wordpress/icons';
  */
 import { __ } from '@wordpress/i18n';
 
-import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { BlockControls } from '@wordpress/block-editor';
 
-import { Modal } from '@wordpress/components';
+import {
+	Modal,
+	ToolbarButton,
+	ToolbarGroup
+} from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
 
@@ -92,13 +96,17 @@ const Edit = ({
 
 	return (
 		<Fragment>
-			<RichTextToolbarButton
-				icon={ globe }
-				title={ __( 'Dynamic Link', 'otter-blocks' ) }
-				onClick={ () => setOpen( true ) }
-				isDisabled={ isActive }
-				isActive={ isActive }
-			/>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ globe }
+						title={ __( 'Dynamic Link', 'otter-blocks' ) }
+						onClick={ () => setOpen( true ) }
+						isDisabled={ isActive }
+						isActive={ isActive }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
 
 			{ isOpen && (
 				<Modal

--- a/src/blocks/plugins/dynamic-content/link/edit.js
+++ b/src/blocks/plugins/dynamic-content/link/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-import { globe } from '@wordpress/icons';
+import { link } from '@wordpress/icons';
 
 /**
  * WordPress dependencies.
@@ -99,11 +99,12 @@ const Edit = ({
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton
-						icon={ globe }
+						icon={ link }
 						title={ __( 'Dynamic Link', 'otter-blocks' ) }
 						onClick={ () => setOpen( true ) }
 						isDisabled={ isActive }
 						isActive={ isActive }
+						className="o-dynamic-button"
 					/>
 				</ToolbarGroup>
 			</BlockControls>

--- a/src/blocks/plugins/dynamic-content/value/edit.js
+++ b/src/blocks/plugins/dynamic-content/value/edit.js
@@ -121,6 +121,7 @@ const Edit = ({
 						onClick={ () => setOpen( true ) }
 						isDisabled={ isActive }
 						isActive={ isActive }
+						className="o-dynamic-button"
 					/>
 				</ToolbarGroup>
 			</BlockControls>

--- a/src/blocks/plugins/dynamic-content/value/edit.js
+++ b/src/blocks/plugins/dynamic-content/value/edit.js
@@ -8,9 +8,13 @@ import { globe } from '@wordpress/icons';
  */
 import { __ } from '@wordpress/i18n';
 
-import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { BlockControls } from '@wordpress/block-editor';
 
-import { Modal } from '@wordpress/components';
+import {
+	Modal,
+	ToolbarButton,
+	ToolbarGroup
+} from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
 
@@ -109,13 +113,17 @@ const Edit = ({
 
 	return (
 		<Fragment>
-			<RichTextToolbarButton
-				icon={ globe }
-				title={ __( 'Dynamic Value', 'otter-blocks' ) }
-				onClick={ () => setOpen( true ) }
-				isDisabled={ isActive }
-				isActive={ isActive }
-			/>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ globe }
+						title={ __( 'Dynamic Value', 'otter-blocks' ) }
+						onClick={ () => setOpen( true ) }
+						isDisabled={ isActive }
+						isActive={ isActive }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
 
 			{ isOpen && (
 				<Modal


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/208
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This moves the Dynamic Link and Value from Format Dropdown to the main toolbar to improve visibility. It also changes the icon for Dynamic Link to avoid confusion.

### Screenshots <!-- if applicable -->

<img width="566" alt="Screenshot 2024-07-24 at 1 46 26 AM" src="https://github.com/user-attachments/assets/cf8d147f-9fa5-485b-8014-bf8307a042f1">

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Confirm the feature works as before with the new UI.

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

