### PR TITLE
fix: remove field number

### DIFF
--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -72,8 +72,7 @@ const extractFormFields = async( form ) => {
 		const labelContainer = input.querySelector( '.otter-form-input-label' );
 		const labelElem = ( labelContainer ?? input ).querySelector( '.otter-form-input-label__label, .otter-form-textarea-label__label' );
 
-		const fieldNumberLabel = `(Field ${index + 1})`;
-		let label = `${fieldNumberLabel} ${( labelElem ?? labelContainer )?.innerHTML?.replace( /<[^>]*>?/gm, '' )}`;
+		let label = `${( labelElem ?? labelContainer )?.innerHTML?.replace( /<[^>]*>?/gm, '' )}`;
 
 		let value = undefined;
 		let fieldType = undefined;
@@ -141,7 +140,7 @@ const extractFormFields = async( form ) => {
 			} else if ( stripeField ) {
 
 				// Find more proper selectors instead of h3 and h5
-				label = `${fieldNumberLabel} ${input.querySelector( '.o-stripe-checkout-description h3' )?.innerHTML?.replace( /<[^>]*>?/gm, '' )}`;
+				label = `${input.querySelector( '.o-stripe-checkout-description h3' )?.innerHTML?.replace( /<[^>]*>?/gm, '' )}`;
 				value = input.querySelector( '.o-stripe-checkout-description h5' )?.innerHTML?.replace( /<[^>]*>?/gm, '' );
 				fieldType = 'stripe-field';
 				mappedName = input.name;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/186
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Remove the field number when sending the data.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

> [!NOTE]
> You must set up an email service so that `wp_mail` can work.

1. Make a simple Form block
2. Send some data and check if the field number is not longer present.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] ~Included E2E or unit tests for the changes in this PR.~
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

