### PR TITLE
Improve issue handlers for Form submissions

### DIFF
--- a/inc/integrations/api/form-request-data.php
+++ b/inc/integrations/api/form-request-data.php
@@ -96,6 +96,8 @@ class Form_Data_Request {
 
 	/**
 	 * A list of warning codes.
+	 * 
+	 * Those are used to inform the admin about some issues that happened during the form submission.
 	 *
 	 * @var array $warning_codes Warning codes.
 	 * @since 2.2.5

--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -393,9 +393,15 @@ class Form_Data_Response {
 			self::ERROR_STRIPE_METADATA_RECORD_NOT_FOUND   => __( 'The metadata submission record was not found.', 'otter-blocks' ),
 			self::ERROR_RUNTIME_STRIPE_SESSION_VALIDATION  => __( 'The payment has been processed. You will be contacted by the support team.', 'otter-blocks' ),
 		);
+		
+		// Give more details to the admin.
+		if ( is_user_logged_in() && current_user_can( 'manage_options' ) ) {
+			$error_messages[ self::ERROR_EMAIL_NOT_SEND ]      .= ' ' . __( 'The function `wp_mail` is not working properly. Please check the email provider settings.', 'otter-blocks' );
+			$error_messages[ self::ERROR_FILE_UPLOAD_TYPE_WP ] .= ' ' . __( 'The `wp_check_filetype` function could not validate the file type. Please check the server settings.', 'otter-blocks' );
+		}
 
 		if ( ! isset( $error_messages[ $error_code ] ) ) {
-			return 'Expected error whatever message';
+			return __( 'Unknown error.', 'otter-blocks' );
 		}
 
 		return $error_messages[ $error_code ];


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/176
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Improved the error messages when the tester is an admin.
- Added error log step for warnings.
- Code refactoring

### Screenshots <!-- if applicable -->

#### Erorr displayed with admin details.

![image](https://github.com/user-attachments/assets/618a4eac-02b9-4a7c-a196-b88e20655224)

#### Issue logged in `debug.log`

We are dumbing the error along with the requested data:

```
[23-Jul-2024 07:57:13 UTC] [Otter Blocks][Form Block] Issue: Email could not be send. Might be an error with the service. The function `wp_mail` is not working properly. Please check the email provider settings.| Form data received: {"form_data":{"handler":"submit","payload":{"formInputsData":[{"label":"Form submission from","value":"http:\/\/localhost:10005\/form-block\/","metadata":{"position":"0"}},{"label":"(Field 1) Name","value":"yes","type":"text","id":"wp-block-themeisle-blocks-form-input-d8b68920","metadata":{"version":"1","position":"1","mappedName":""}}],"formOption":"1675009503e227cf028e7b282a731f32510ba3df_35c3d102","formId":"wp-block-themeisle-blocks-form-35c3d102","nonceValue":"5cbc632f7a","antiSpamTime":"166789","antiSpamHoneyPot":"","postUrl":"http:\/\/localhost:10005\/form-block\/","postId":"385"}},"uploaded_files_path":[],"files_loaded_to_media_library":[],"keep_uploaded_files":false,"metadata":[]}
```


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

