### PR TITLE
Add AI Toolbar visibility toggle in Dashboard

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -282,6 +282,7 @@ class Registration {
 					'blockCSS'        => boolval( get_option( 'themeisle_blocks_settings_css_module', true ) ),
 					'blockAnimations' => boolval( get_option( 'themeisle_blocks_settings_blocks_animation', true ) ),
 					'blockConditions' => boolval( get_option( 'themeisle_blocks_settings_block_conditions', true ) ),
+					'aiToolbar'       => boolval( get_option( 'themeisle_blocks_settings_block_ai_toolbar_module', true ) ),
 				),
 				'isLegacyPre59'           => version_compare( get_bloginfo( 'version' ), '5.8.22', '<=' ),
 				'isAncestorTypeAvailable' => version_compare( get_bloginfo( 'version' ), '5.9.22', '>=' ),

--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -136,6 +136,17 @@ class Options_Settings {
 
 		register_setting(
 			'themeisle_blocks_settings',
+			'themeisle_blocks_settings_block_ai_toolbar_module',
+			array(
+				'type'         => 'boolean',
+				'description'  => __( 'Enable the AI Block Toolbar in Editor', 'otter-blocks' ),
+				'show_in_rest' => true,
+				'default'      => true,
+			)
+		);
+
+		register_setting(
+			'themeisle_blocks_settings',
 			'otter_blocks_logger_flag',
 			array(
 				'type'         => 'string',

--- a/src/blocks/global.d.ts
+++ b/src/blocks/global.d.ts
@@ -82,6 +82,7 @@ declare global {
 				blockCSS: boolean
 				blockAnimations: boolean
 				blockConditions: boolean
+				aiToolbar: boolean
 			}
 			blocksIDs: string[]
 			isAncestorTypeAvailable: boolean

--- a/src/blocks/plugins/ai-content/index.tsx
+++ b/src/blocks/plugins/ai-content/index.tsx
@@ -305,13 +305,24 @@ const withConditions = createHigherOrderComponent( BlockEdit => {
 			areValidBlocks,
 			isHidden
 		} = useSelect( ( select ) => {
-			const selectedBlocks = select( 'core/block-editor' ).getMultiSelectedBlocks();
-			const hiddenBlocks = select( 'core/preferences' )?.get( 'core/edit-post', 'hiddenBlockTypes' ) || [];
+
+			const canUse = Boolean( window.themeisleGutenberg?.hasModule?.aiToolbar );
+
+			if ( ! canUse ) {
+				return {
+					isMultipleSelection: false,
+					areValidBlocks: false,
+					isHidden: true
+				};
+			}
+
+			const selectedBlocks: {name: string; [key: string]: any}[] = select( 'core/block-editor' )?.getMultiSelectedBlocks() ?? [];
+			const hiddenBlocks: string[] = select( 'core/preferences' )?.get( 'core/edit-post', 'hiddenBlockTypes' ) ?? [];
 
 			return {
 				isMultipleSelection: 1 < selectedBlocks.length,
 				areValidBlocks: selectedBlocks.every( ( block ) => isValidBlock( block.name ) ),
-				isHidden: hiddenBlocks.find( ( blockName: string ) => 'themeisle-blocks/content-generator' === blockName ) ?? false
+				isHidden: hiddenBlocks.includes( 'themeisle-blocks/content-generator' ) ?? false
 			};
 		}, []);
 
@@ -344,6 +355,7 @@ const withConditions = createHigherOrderComponent( BlockEdit => {
 			</Fragment>
 		);
 	};
+
 }, 'withConditions' );
 
 addFilter( 'editor.BlockEdit', 'themeisle-gutenberg/otter-ai-content-toolbar', withConditions );

--- a/src/blocks/test/e2e/blocks/dashboard.spec.js
+++ b/src/blocks/test/e2e/blocks/dashboard.spec.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Dashboard', () => {
+	test.beforeEach( async({ admin }) => {
+		await admin.visitAdminPage( 'admin.php?page=otter' );
+	});
+
+	test( 'toggle AI Block Toolbar', async({ editor, page }) => {
+
+		const toggle = page.getByLabel( 'Enable AI Block Toolbar Module' );
+		const initialToggleValue = await toggle.isChecked();
+
+		await toggle.click();
+		await page.waitForTimeout( 1000 ); // Wait for the toggle to be updated.
+		expect( await toggle.isChecked() ).not.toEqual( initialToggleValue );
+
+		page.reload();
+
+		await toggle.click();
+		await page.waitForTimeout( 1000 );
+		expect( await toggle.isChecked() ).toEqual( initialToggleValue );
+	});
+});

--- a/src/dashboard/components/pages/Dashboard.js
+++ b/src/dashboard/components/pages/Dashboard.js
@@ -43,7 +43,8 @@ const optionMapping = {
 	enableRichSchema: 'themeisle_blocks_settings_disable_review_schema',
 	enableReviewScale: 'themeisle_blocks_settings_review_scale',
 	enableHighlightDynamic: 'themeisle_blocks_settings_highlight_dynamic',
-	enableAnonymousDataTracking: 'otter_blocks_logger_flag'
+	enableAnonymousDataTracking: 'otter_blocks_logger_flag',
+	enableAIToolbar: 'themeisle_blocks_settings_block_ai_toolbar_module'
 };
 
 const initialState = {
@@ -57,7 +58,8 @@ const initialState = {
 		enableRichSchema: false,
 		enableReviewScale: false,
 		enableHighlightDynamic: false,
-		enableAnonymousDataTracking: 'no'
+		enableAnonymousDataTracking: 'no',
+		enableAIToolbar: false
 	},
 	status: {
 		enableCustomCss: 'init',
@@ -69,7 +71,8 @@ const initialState = {
 		enableRichSchema: 'init',
 		enableReviewScale: 'init',
 		enableHighlightDynamic: 'init',
-		enableAnonymousDataTracking: 'init'
+		enableAnonymousDataTracking: 'init',
+		enableAIToolbar: 'init'
 	},
 	dirty: {
 		enableCustomCss: false,
@@ -81,7 +84,8 @@ const initialState = {
 		enableRichSchema: false,
 		enableReviewScale: false,
 		enableHighlightDynamic: false,
-		enableAnonymousDataTracking: false
+		enableAnonymousDataTracking: false,
+		enableAIToolbar: false
 	},
 	old: {}
 };
@@ -226,6 +230,18 @@ const Dashboard = () => {
 						disabled={ 'saving' === state.status.enableCustomCss }
 						onChange={ ( value ) => {
 							applyAction({ type: 'update', name: 'enableCustomCss', value });
+						} }
+					/>
+				</PanelRow>
+
+				<PanelRow>
+					<ToggleControl
+						label={ __( 'Enable AI Block Toolbar Module', 'otter-blocks' ) }
+						help={ __( 'Display AI Block shortcut in Editor Blocks toolbar.', 'otter-blocks' ) }
+						checked={ state.values.enableAIToolbar }
+						disabled={ 'saving' === state.status.enableAIToolbar }
+						onChange={ ( value ) => {
+							applyAction({ type: 'update', name: 'enableAIToolbar', value });
 						} }
 					/>
 				</PanelRow>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/206
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added a toggle for the AI Toolbar similar to the CSS module.

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/6658bb76-5187-49ba-8504-250994a7b7a0)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Check the dashboard for the new toggle.
2. Toggle it off, then check the Paragraphs block in the Post. It should be hidden.
3. Re-enable the option and check again.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

