### PR TITLE
Add Modal Block

### DIFF
--- a/blocks.json
+++ b/blocks.json
@@ -148,6 +148,9 @@
 			"popup/style.css": "blocks/blocks/popup/style.scss"
 		}
 	},
+	"modal": {
+		"block": "blocks/blocks/modal/block.json"
+	},
 	"posts-grid": {
 		"block": "blocks/blocks/posts/block.json",
 		"assets": {

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -624,7 +624,10 @@ class Registration {
 			wp_script_add_data( 'otter-tabs', 'defer', true );
 		}
 
-		if ( ! self::$scripts_loaded['popup'] && has_block( 'themeisle-blocks/popup', $post ) ) {
+		if (
+			! self::$scripts_loaded['popup'] && 
+			( has_block( 'themeisle-blocks/popup', $post ) || has_block( 'themeisle-blocks/modal', $post ) )
+		) {
 			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/popup.asset.php';
 			wp_register_script( 'otter-popup', OTTER_BLOCKS_URL . 'build/blocks/popup.js', $asset_file['dependencies'], $asset_file['version'], true );
 			wp_script_add_data( 'otter-popup', 'defer', true );
@@ -662,6 +665,11 @@ class Registration {
 		foreach ( self::$blocks as $block ) {
 			if ( in_array( $block, self::$styles_loaded ) || ! has_block( 'themeisle-blocks/' . $block, $post ) ) {
 				continue;
+			}
+
+			// Shared styles.
+			if ( 'modal' === $block ) {
+				$block = 'popup';
 			}
 
 			$block_path = OTTER_BLOCKS_PATH . '/build/blocks/' . $block;
@@ -751,6 +759,7 @@ class Registration {
 			'lottie',
 			'plugin-cards',
 			'popup',
+			'modal',
 			'posts-grid',
 			'pricing',
 			'progress-bar',

--- a/plugins/otter-pro/inc/class-main.php
+++ b/plugins/otter-pro/inc/class-main.php
@@ -140,6 +140,7 @@ class Main {
 			'form-file'                 => '\ThemeIsle\OtterPro\Render\Form_File_Block',
 			'form-hidden-field'         => '\ThemeIsle\OtterPro\Render\Form_Hidden_Block',
 			'form-stripe-field'         => '\ThemeIsle\OtterPro\Render\Form_Stripe_Block',
+			'modal'                     => '\ThemeIsle\OtterPro\Render\Modal_Block',
 		);
 
 		$dynamic_blocks = array_merge( $dynamic_blocks, $blocks );
@@ -162,6 +163,7 @@ class Main {
 			'\ThemeIsle\OtterPro\CSS\Blocks\Review_Comparison_CSS',
 			'\ThemeIsle\OtterPro\CSS\Blocks\Form_File_CSS',
 			'\ThemeIsle\OtterPro\CSS\Blocks\Form_Stripe_Field_CSS',
+			'\ThemeIsle\OtterPro\CSS\Blocks\Modal_CSS',
 		);
 
 		$blocks = array_merge( $blocks, $pro_blocks );

--- a/plugins/otter-pro/inc/css/blocks/class-modal-css.php
+++ b/plugins/otter-pro/inc/css/blocks/class-modal-css.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Css handling logic for blocks.
+ *
+ * @package ThemeIsle\OtterPro\CSS\Blocks
+ */
+
+namespace ThemeIsle\OtterPro\CSS\Blocks;
+
+use ThemeIsle\GutenbergBlocks\CSS\Blocks\Popup_CSS;
+
+/**
+ * Class Modal_CSS
+ */
+class Modal_CSS extends Popup_CSS {
+	/**
+	 * The namespace under which the blocks are registered.
+	 *
+	 * @var string
+	 */
+	public $block_prefix = 'modal';
+}

--- a/plugins/otter-pro/inc/render/class-modal-block.php
+++ b/plugins/otter-pro/inc/render/class-modal-block.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Class Modal_CSS.
+ *
+ * @package ThemeIsle\GutenbergBlocks\Render
+ */
+
+namespace ThemeIsle\OtterPro\Render;
+
+use ThemeIsle\OtterPro\Plugins\License;
+
+/**
+ * Class Modal_CSS.
+ *
+ * This class handles the CSS for the modal block.
+ */
+class Modal_Block {
+
+	/**
+	 * Block render function for server-side.
+	 *
+	 * This method will pe passed to the render_callback parameter and it will output
+	 * the server side output of the block.
+	 *
+	 * @param array     $attributes The block attributes.
+	 * @param array     $content The saved content.
+	 * @param \WP_Block $block The parsed block.
+	 * 
+	 * @return mixed|string
+	 */
+	public function render( $attributes, $content, $block ) {
+
+		if ( ! License::has_active_license() ) {
+			return '';
+		}
+
+		if ( empty( $attributes['trigger'] ) ) {
+			$attributes['trigger'] = 'onClick';
+		}
+
+		$container_tag = '<div ';
+		if ( ! empty( $attributes['id'] ) ) {
+			$container_tag .= 'id="' . esc_attr( $attributes['id'] ) . '" ';
+		}
+
+		$classes = array( 'wp-block-themeisle-blocks-modal', 'is-active', 'is-front' );
+
+		if ( ! empty( $attributes['className'] ) ) {
+			$classes[] = esc_attr( $attributes['className'] );
+		}
+
+		if ( ! empty( $attributes['closeButtonType'] ) && 'outside' === $attributes['closeButtonType'] ) {
+			$classes[] = 'with-outside-button';
+		}
+
+		$container_tag .= 'class="' . ( implode( ' ', $classes ) ) . '" ';
+		$container_tag .= 'data-open="' . esc_attr( $attributes['trigger'] ) . '" ';
+	
+		if ( 'onClick' === $attributes['trigger'] ) {
+			$container_tag .= 'data-anchor="' . ( ! empty( $attributes['anchor'] ) ? esc_attr( $attributes['anchor'] ) : '' ) . '" ';
+		}
+
+		if ( ! empty( $attributes['recurringClose'] ) ) {
+			$container_tag .= 'data-dismiss="' . ( ! empty( $attributes['recurringTime'] ) ? esc_attr( $attributes['recurringTime'] ) : '' ) . '" ';
+		}
+
+		if ( ! empty( $attributes['outsideClose'] ) ) {
+			$container_tag .= 'data-outside="' . esc_attr( $attributes['outsideClose'] ) . '" ';
+		}
+
+		if ( ! empty( $attributes['anchorClose'] ) ) {
+			$container_tag .= 'data-anchorclose="' . esc_attr( $attributes['closeAnchor'] ) . '" ';
+		}
+
+		if ( ! empty( $attributes['lockScrolling'] ) ) {
+			$container_tag .= 'data-lock-scrolling="1" ';
+		}
+
+		if ( ! empty( $attributes['disableOn'] ) ) {
+			$container_tag .= 'data-disable-on="' . esc_attr( $attributes['disableOn'] ) . '" ';
+		}
+
+		$container_tag .= '>';
+
+		$modal_wrap  = '<div class="otter-popup__modal_wrap">';
+		$modal_wrap .= '<div role="presentation" class="otter-popup__modal_wrap_overlay"></div>';
+
+		$modal_content = '<div class="otter-popup__modal_content">';
+		if ( ! empty( $attributes['showClose'] ) ) {
+			$modal_content .= '<div class="otter-popup__modal_header">';
+			$modal_content .= '<button type="button" class="components-button has-icon">';
+			$modal_content .= '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true">';
+			$modal_content .= '<path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path>';
+			$modal_content .= '</svg>';
+			$modal_content .= '</button>';
+			$modal_content .= '</div>';
+		}
+
+		$modal_content .= '<div class="otter-popup__modal_body">';
+		foreach ( $block->inner_blocks as $inner_block ) {
+			$modal_content .= $inner_block->render();
+		}
+		$modal_content .= '</div>'; // Close otter-popup__modal_body.
+		$modal_content .= '</div>'; // Close otter-popup__modal_content.
+
+		$modal_wrap .= $modal_content;
+		$modal_wrap .= '</div>'; // Close otter-popup__modal_wrap.
+
+		$container_tag .= $modal_wrap;
+		$container_tag .= '</div>'; // Close container tag.
+
+		return $container_tag;
+	}
+}

--- a/src/blocks/blocks/index.js
+++ b/src/blocks/blocks/index.js
@@ -25,3 +25,4 @@ import './tabs/index.js';
 import './deprecated/index.js';
 import './content-generator/index.js';
 import './timeline/index.js';
+import './modal/index.js';

--- a/src/blocks/blocks/modal/block.json
+++ b/src/blocks/blocks/modal/block.json
@@ -1,0 +1,131 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "themeisle-blocks/modal",
+	"title": "Modal",
+	"category": "themeisle-blocks",
+	"description": "Display your content in beautiful Modal with many customization options. Powered by Otter.",
+	"keywords": [ "modal", "lightbox" ],
+	"textdomain": "otter-blocks",
+	"attributes": {
+		"id": {
+			"type": "string"
+		},
+		"minWidth": {
+			"type": ["number", "string"]
+		},
+		"maxWidth": {
+			"type": ["number", "string"]
+		},
+		"anchor": {
+			"type": "string"
+		},
+		"showClose": {
+			"type": "boolean",
+			"default": true
+		},
+		"outsideClose": {
+			"type": "boolean",
+			"default": true
+		},
+		"anchorClose": {
+			"type": "boolean",
+			"default": false
+		},
+		"closeAnchor": {
+			"type": "string"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"closeColor": {
+			"type": "string"
+		},
+		"overlayColor": {
+			"type": "string"
+		},
+		"overlayOpacity": {
+			"type": "number"
+		},
+		"padding": {
+			"type": "object"
+		},
+		"paddingTablet": {
+			"type": "object"
+		},
+		"paddingMobile": {
+			"type": "object"
+		},
+		"borderWidth": {
+			"type": "object"
+		},
+		"borderRadius": {
+			"type": "object"
+		},
+		"borderColor": {
+			"type": "string"
+		},
+		"borderStyle": {
+			"type": "string"
+		},
+		"width": {
+			"type": "string"
+		},
+		"widthTablet": {
+			"type": "string"
+		},
+		"widthMobile": {
+			"type": "string"
+		},
+		"heightMode": {
+			"type": "string"
+		},
+		"height":{
+			"type": "string"
+		},
+		"heightTablet":{
+			"type": "string"
+		},
+		"heightMobile":{
+			"type": "string"
+		},
+		"verticalPosition": {
+			"type": "string"
+		},
+		"horizontalPosition": {
+			"type": "string"
+		},
+		"verticalPositionTablet": {
+			"type": "string"
+		},
+		"horizontalPositionTablet": {
+			"type": "string"
+		},
+		"verticalPositionMobile": {
+			"type": "string"
+		},
+		"horizontalPositionMobile": {
+			"type": "string"
+		},
+		"closeButtonType": {
+			"type": "string"
+		},
+		"boxShadow": {
+			"type": "object",
+			"default": {
+				"active": false,
+				"colorOpacity": 50,
+				"blur": 5,
+				"spread": 1,
+				"horizontal": 0,
+				"vertical": 0
+			}
+		},
+		"disableOn": {
+			"type": "string"
+		}
+	},
+	"editorStyle": "otter-popup-editor",
+	"style": "otter-popup-style",
+	"script": "otter-popup"
+}

--- a/src/blocks/blocks/modal/index.js
+++ b/src/blocks/blocks/modal/index.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+import { registerBlockType } from '@wordpress/blocks';
+
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+import { Placeholder } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import save from './save.js';
+import { popupIcon as icon } from '../../helpers/icons';
+
+const { name } = metadata;
+
+if ( ! Boolean( window.themeisleGutenberg.hasPro ) ) {
+	registerBlockType( name, {
+		...metadata,
+		title: __( 'Modal (PRO)', 'otter-blocks' ),
+		description: __( 'Display your content in beautiful Modal with many customization options. Powered by Otter.', 'otter-blocks' ),
+		icon,
+		keywords: [
+			'modal',
+			'lightbox'
+		],
+		edit: () => {
+			const instructions = sprintf(
+				__( 'You need to activate your Otter Pro to use %1$s block.', 'otter-blocks' ),
+				metadata.title
+			);
+
+			return (
+				<div { ...useBlockProps() }>
+					<Placeholder
+						icon={ icon }
+						label={ metadata.title }
+						instructions={ instructions }
+						className="o-license-warning"
+					/>
+				</div>
+			);
+		},
+		save,
+		example: {
+			attributes: {}
+		}
+	});
+}

--- a/src/blocks/blocks/modal/save.js
+++ b/src/blocks/blocks/modal/save.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	InnerBlocks,
+	useBlockProps
+} from '@wordpress/block-editor';
+import classnames from 'classnames';
+
+const Save = ({
+	attributes,
+	className
+}) => {
+	const blockProps = useBlockProps.save({
+		id: attributes.id,
+		className: classnames( className )
+	});
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+};
+
+export default Save;

--- a/src/blocks/blocks/popup/editor.scss
+++ b/src/blocks/blocks/popup/editor.scss
@@ -1,6 +1,6 @@
 @import 'style';
 
-.wp-block-themeisle-blocks-popup {
+:is( .wp-block-themeisle-blocks-modal, .wp-block-themeisle-blocks-popup ) {
 	.otter-popup__modal_wrap {
 		z-index: 2;
 	}
@@ -12,7 +12,7 @@
 }
 
 .is-sidebar-opened {
-	.wp-block-themeisle-blocks-popup {
+	:is( .wp-block-themeisle-blocks-modal, .wp-block-themeisle-blocks-popup ) {
 		.otter-popup__modal_content {
 			margin-right: 295px;
 		}

--- a/src/blocks/blocks/popup/style.scss
+++ b/src/blocks/blocks/popup/style.scss
@@ -1,6 +1,6 @@
 $base-index: 99999 !default;
 
-.wp-block-themeisle-blocks-popup {
+:is( .wp-block-themeisle-blocks-modal, .wp-block-themeisle-blocks-popup ) {
 	--min-width: 400px;
 	--background-color: #fff;
 	--close-color: #000;
@@ -152,6 +152,10 @@ $base-index: 99999 !default;
 				border: none !important;
 				outline: none;
 			}
+
+			svg {
+				fill: currentColor;
+			}
 		}
 	}
 
@@ -200,7 +204,7 @@ $base-index: 99999 !default;
 }
 
 body:has(#wpadminbar) {
-	.wp-block-themeisle-blocks-popup {
+	:is( .wp-block-themeisle-blocks-modal, .wp-block-themeisle-blocks-popup ) {
 		.otter-popup__modal_content {
 			margin-top: 25px;
 		}
@@ -215,4 +219,8 @@ body:has(#wpadminbar) {
 	to {
 		opacity:1
 	}
+}
+
+.wp-block-themeisle-blocks-modal:not( .is-active ) {
+    display: none;
 }

--- a/src/blocks/frontend/popup/index.js
+++ b/src/blocks/frontend/popup/index.js
@@ -6,7 +6,7 @@ import { domReady } from '../../helpers/frontend-helper-functions.js';
 import Popup from './popup';
 
 domReady( () => {
-	const popups = document.querySelectorAll( '.wp-block-themeisle-blocks-popup' );
+	const popups = document.querySelectorAll( '.wp-block-themeisle-blocks-popup, .wp-block-themeisle-blocks-modal' );
 
 	if ( ! popups.length ) {
 		return;

--- a/src/blocks/test/e2e/blocks/modal.spec.js
+++ b/src/blocks/test/e2e/blocks/modal.spec.js
@@ -3,7 +3,7 @@
  */
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
-test.describe( 'Popup', () => {
+test.describe( 'Modal', () => {
 	test.beforeEach( async({ admin }) => {
 		await admin.createNewPost();
 	});
@@ -16,18 +16,17 @@ test.describe( 'Popup', () => {
 				{
 					name: 'core/button',
 					attributes: {
-						text: 'Open Popup',
-						anchor: 'popup-trigger'
+						text: 'Open Modal',
+						anchor: 'modal-trigger'
 					}
 				}
 			]
 		});
 
 		await editor.insertBlock({
-			name: 'themeisle-blocks/popup',
+			name: 'themeisle-blocks/modal',
 			attributes: {
-				anchor: 'popup-trigger',
-				trigger: 'onClick'
+				anchor: 'modal-trigger'
 			},
 			innerBlocks: [
 				{
@@ -42,7 +41,7 @@ test.describe( 'Popup', () => {
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${postId}` );
 
-		await page.locator( 'div' ).filter({ hasText: /^Open Popup$/ }).click();
+		await page.locator( 'div' ).filter({ hasText: /^Open Modal$/ }).click();
 
 		await expect( page.getByText( 'Popup Content Test' ) ).toBeVisible();
 	});
@@ -50,9 +49,23 @@ test.describe( 'Popup', () => {
 	test( 'close on escape', async({ editor, page }) => {
 
 		await editor.insertBlock({
-			name: 'themeisle-blocks/popup',
-			attributes: {
+			name: 'core/buttons',
+			attributes: {},
+			innerBlocks: [
+				{
+					name: 'core/button',
+					attributes: {
+						text: 'Open Modal',
+						anchor: 'modal-trigger'
+					}
+				}
+			]
+		});
 
+		await editor.insertBlock({
+			name: 'themeisle-blocks/modal',
+			attributes: {
+				anchor: 'modal-trigger'
 			},
 			innerBlocks: [
 				{
@@ -66,6 +79,8 @@ test.describe( 'Popup', () => {
 
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${postId}` );
+
+		await page.locator( 'div' ).filter({ hasText: /^Open Modal$/ }).click();
 
 		await expect( page.getByText( 'Popup Content Test' ) ).toBeVisible();
 		await page.keyboard.press( 'Escape' );

--- a/src/dashboard/components/pages/Blocks.js
+++ b/src/dashboard/components/pages/Blocks.js
@@ -128,6 +128,13 @@ const otterBlocks = [
 		'docLink': 'https://docs.themeisle.com/article/1675-location-blocks#maps'
 	},
 	{
+		'slug': 'themeisle-blocks/modal',
+		'name': __( 'Modal', 'otter-blocks' ),
+		'icon': popupIcon,
+		'docLink': 'https://docs.themeisle.com/article/2050-modal-block',
+		'isPro': true
+	},
+	{
 		'slug': 'themeisle-blocks/lottie',
 		'name': __( 'Lottie Animation', 'otter-blocks' ),
 		'icon': lottieIcon,

--- a/src/pro/blocks/index.js
+++ b/src/pro/blocks/index.js
@@ -8,3 +8,4 @@ import './woo-comparison/index.js';
 import './file/index.js';
 import './form-hidden-field/index.js';
 import './form-stripe-field/index.js';
+import './modal/index.js';

--- a/src/pro/blocks/modal/block.json
+++ b/src/pro/blocks/modal/block.json
@@ -1,0 +1,131 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "themeisle-blocks/modal",
+	"title": "Modal",
+	"category": "themeisle-blocks",
+	"description": "Display your content in beautiful Modal with many customization options. Powered by Otter.",
+	"keywords": [ "modal", "lightbox" ],
+	"textdomain": "otter-blocks",
+	"attributes": {
+		"id": {
+			"type": "string"
+		},
+		"minWidth": {
+			"type": ["number", "string"]
+		},
+		"maxWidth": {
+			"type": ["number", "string"]
+		},
+		"anchor": {
+			"type": "string"
+		},
+		"showClose": {
+			"type": "boolean",
+			"default": true
+		},
+		"outsideClose": {
+			"type": "boolean",
+			"default": true
+		},
+		"anchorClose": {
+			"type": "boolean",
+			"default": false
+		},
+		"closeAnchor": {
+			"type": "string"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"closeColor": {
+			"type": "string"
+		},
+		"overlayColor": {
+			"type": "string"
+		},
+		"overlayOpacity": {
+			"type": "number"
+		},
+		"padding": {
+			"type": "object"
+		},
+		"paddingTablet": {
+			"type": "object"
+		},
+		"paddingMobile": {
+			"type": "object"
+		},
+		"borderWidth": {
+			"type": "object"
+		},
+		"borderRadius": {
+			"type": "object"
+		},
+		"borderColor": {
+			"type": "string"
+		},
+		"borderStyle": {
+			"type": "string"
+		},
+		"width": {
+			"type": "string"
+		},
+		"widthTablet": {
+			"type": "string"
+		},
+		"widthMobile": {
+			"type": "string"
+		},
+		"heightMode": {
+			"type": "string"
+		},
+		"height":{
+			"type": "string"
+		},
+		"heightTablet":{
+			"type": "string"
+		},
+		"heightMobile":{
+			"type": "string"
+		},
+		"verticalPosition": {
+			"type": "string"
+		},
+		"horizontalPosition": {
+			"type": "string"
+		},
+		"verticalPositionTablet": {
+			"type": "string"
+		},
+		"horizontalPositionTablet": {
+			"type": "string"
+		},
+		"verticalPositionMobile": {
+			"type": "string"
+		},
+		"horizontalPositionMobile": {
+			"type": "string"
+		},
+		"closeButtonType": {
+			"type": "string"
+		},
+		"boxShadow": {
+			"type": "object",
+			"default": {
+				"active": false,
+				"colorOpacity": 50,
+				"blur": 5,
+				"spread": 1,
+				"horizontal": 0,
+				"vertical": 0
+			}
+		},
+		"disableOn": {
+			"type": "string"
+		}
+	},
+	"editorStyle": "otter-popup-editor",
+	"style": "otter-popup-style",
+	"script": "otter-popup"
+}

--- a/src/pro/blocks/modal/edit.js
+++ b/src/pro/blocks/modal/edit.js
@@ -1,0 +1,235 @@
+/**
+ * External dependencies
+ */
+import {
+	closeSmall,
+	external
+} from '@wordpress/icons';
+
+import classnames from 'classnames';
+import { merge } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+
+import {
+	InnerBlocks,
+	useBlockProps,
+	__experimentalBlockVariationPicker as VariationPicker
+} from '@wordpress/block-editor';
+
+import { Button } from '@wordpress/components';
+
+import {
+	Fragment,
+	useEffect,
+	useState
+} from '@wordpress/element';
+
+import {
+	createBlocksFromInnerBlocksTemplate
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Inspector from './inspector.js';
+import { blockInit, useCSSNode } from '../../../blocks/helpers/block-utility';
+import { boxValues, _cssBlock, stringToBox } from '../../../blocks/helpers/helper-functions';
+import { useDarkBackground } from '../../../blocks/helpers/utility-hooks';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+const { attributes: defaultAttributes } = metadata;
+
+/**
+ * Popup component
+ * @param {import('./types').PopupPros} props
+ * @returns
+ */
+const Edit = ({
+	attributes,
+	setAttributes,
+	clientId,
+	className,
+	name
+}) => {
+	useEffect( () => {
+		const unsubscribe = blockInit( clientId, defaultAttributes );
+		return () => unsubscribe( attributes.id );
+	}, []);
+
+	const [ isEditing, setEditing ] = useState( false );
+
+	const {
+		replaceInnerBlocks,
+		selectBlock
+	} = useDispatch( 'core/block-editor' );
+
+	const { blockType, defaultVariation, variations } = useSelect(
+		select => {
+			const {
+				getBlockVariations,
+				getBlockType,
+				getDefaultBlockVariation
+			} = select( 'core/blocks' );
+
+			return {
+				blockType: getBlockType( name ),
+				defaultVariation: getDefaultBlockVariation( name, 'block' ),
+				variations: getBlockVariations( name, 'block' )
+			};
+		},
+		[ name ]
+	);
+
+	const height = 'custom' === attributes.heightMode ? {
+		'--height': attributes.height,
+		'--height-tablet': attributes.heightMobile,
+		'--height-mobile': attributes.heightMobile
+	} : { '--height': 'fit-content' };
+
+	const inlineStyles = {
+		'--min-width': attributes.minWidth ? attributes.minWidth + 'px' : '400px',
+		'--max-width': attributes.maxWidth ? attributes.maxWidth + 'px' : undefined,
+		'--background-color': attributes.backgroundColor,
+		'--close-color': attributes.closeColor,
+		'--overlay-color': attributes.overlayColor,
+		'--overlay-opacity': attributes.overlayOpacity !== undefined ? attributes.overlayOpacity / 100 : 1,
+		'--brd-width': boxValues( attributes.borderWidth ),
+		'--brd-radius': boxValues( attributes.borderRadius ),
+		'--brd-color': attributes.borderColor,
+		'--brd-style': attributes.borderStyle,
+
+		// Responsive
+		'--width': ! Boolean( attributes.width ) && attributes.maxWidth ? attributes.maxWidth + 'px' : attributes.width,
+		'--width-tablet': attributes.widthTablet,
+		'--width-mobile': attributes.widthMobile,
+
+		'--padding': attributes.padding ?  boxValues( merge( stringToBox( '20px' ), attributes.padding ) ) : undefined,
+		'--padding-tablet': attributes.paddingTablet ?  boxValues( merge( stringToBox( '20px' ), attributes.padding ?? {}, attributes.paddingTablet ) ) : undefined,
+		'--padding-mobile': attributes.paddingMobile ?  boxValues( merge( stringToBox( '20px' ), attributes.padding ?? {}, attributes.paddingTablet  ?? {}, attributes.paddingMobile ) ) : undefined,
+		'--box-shadow': attributes.boxShadow.active && `${ attributes.boxShadow.horizontal }px ${ attributes.boxShadow.vertical }px ${ attributes.boxShadow.blur }px ${ attributes.boxShadow.spread }px ${ hexToRgba( attributes.boxShadow.color || '#FFFFFF', attributes.boxShadow.colorOpacity ) }`,
+
+		...height
+	};
+
+	const [ cssNode, setNodeCSS ] = useCSSNode();
+
+	useEffect( () => {
+		setNodeCSS(
+			[
+				' .otter-popup__modal_content ' + _cssBlock([
+					[ 'top', '30px', 'top' === attributes.verticalPosition ],
+					[ 'bottom', '30px', 'bottom' === attributes.verticalPosition ],
+					[ 'left', '30px', 'left' === attributes.horizontalPosition ],
+					[ 'right', '30px', 'right' === attributes.horizontalPosition ]
+				]),
+				' .otter-popup__modal_content ' + _cssBlock([
+					[ 'top', '15px', 'top' === attributes.verticalPositionTablet ],
+					[ 'bottom', '15px', 'bottom' === attributes.verticalPositionTablet ],
+					[ 'left', '15px', 'left' === attributes.horizontalPositionTablet ],
+					[ 'right', '15px', 'right' === attributes.horizontalPositionTablet ]
+				]),
+				' .otter-popup__modal_content ' + _cssBlock([
+					[ 'top', '10px', 'top' === attributes.verticalPositionMobile ],
+					[ 'bottom', '10px', 'bottom' === attributes.verticalPositionMobile ],
+					[ 'left', '10px', 'left' === attributes.horizontalPositionMobile ],
+					[ 'right', '10px', 'right' === attributes.horizontalPositionMobile ]
+				])
+			],
+			[
+				'@media ( min-width: 960px )',
+				'@media ( min-width: 600px ) and ( max-width: 960px )',
+				'@media ( max-width: 600px )'
+			]);
+	},
+	[
+		attributes.horizontalPosition,
+		attributes.verticalPosition,
+		attributes.horizontalPositionTablet,
+		attributes.verticalPositionTablet,
+		attributes.horizontalPositionMobile,
+		attributes.verticalPositionMobile
+	]);
+
+	useDarkBackground( attributes.backgroundColor, attributes, setAttributes );
+
+	const blockProps = useBlockProps({
+		id: attributes.id,
+		style: inlineStyles,
+		className: classnames( className, 'is-active', cssNode, { 'with-outside-button': 'outside' === attributes.closeButtonType })
+	});
+
+	return (
+		<Fragment>
+			<Inspector
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+
+			<div { ...blockProps }>
+				<Fragment>
+					<Button
+						variant={ 'primary' }
+						isPrimary
+						icon={ external }
+						onClick={ () => setEditing( true ) }
+					>
+						{ __( 'Edit Modal', 'otter-blocks' ) }
+					</Button>
+
+					{ isEditing && (
+						<div className='otter-popup__modal_wrap'>
+							<div
+								role="presentation"
+								className="otter-popup__modal_wrap_overlay"
+								onClick={ () => setEditing( false ) }
+							/>
+
+							<div className="otter-popup__modal_content">
+								{ attributes.showClose && (
+									<div className="otter-popup__modal_header">
+										<Button
+											icon={ closeSmall }
+											onClick={ () => setEditing( false ) }
+										/>
+									</div>
+								) }
+
+								<div className="otter-popup__modal_body">
+									<InnerBlocks template={[
+										[
+											'core/group',
+											{
+												style: {
+													spacing: {
+														padding: { 'top': '40px' }
+													}
+												},
+												layout: {
+													type: 'flex',
+													orientation: 'vertical'
+												}
+											},
+											[
+												[ 'core/image', { height: '150px' }],
+												[ 'core/heading', { placeholder: __( 'Modal Title' ) }],
+												[ 'core/paragraph', { placeholder: __( 'Modal Content' ) }]
+											]
+										]
+									]} />
+								</div>
+							</div>
+						</div>
+					) }
+				</Fragment>
+			</div>
+		</Fragment>
+	);
+};
+
+export default Edit;

--- a/src/pro/blocks/modal/index.js
+++ b/src/pro/blocks/modal/index.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import { registerBlockType, createBlock } from '@wordpress/blocks';
+
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit.js';
+import save from './save.js';
+import { popupIcon as icon } from '../../../blocks/helpers/icons';
+import Inactive from '../../components/inactive';
+
+const { name } = metadata;
+
+if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExpired ) ) ) {
+	edit = () => <Inactive
+		icon={ icon }
+		label={ metadata.title }
+		blockProps={ useBlockProps() }
+	/>;
+}
+
+registerBlockType( name, {
+	...metadata,
+	title: __( 'Modal', 'otter-blocks' ),
+	description: __( 'Display your content in beautiful Modal with many customization options. Powered by Otter.', 'otter-blocks' ),
+	icon,
+	keywords: [
+		'modal',
+		'lightbox'
+	],
+	edit,
+	save,
+	example: {
+		attributes: {}
+	},
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'themeisle-blocks/popup' ],
+				transform: ( attributes ) => {
+					return createBlock( 'themeisle-blocks/popup', {
+						...attributes
+					});
+				}
+			}
+		],
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'themeisle-blocks/popup' ],
+				transform: ( attributes ) => {
+					return createBlock( name, {
+						...attributes
+					});
+				}
+			}
+		]
+	}
+});

--- a/src/pro/blocks/modal/inspector.js
+++ b/src/pro/blocks/modal/inspector.js
@@ -1,0 +1,343 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import {
+	InspectorControls,
+	PanelColorSettings
+} from '@wordpress/block-editor';
+
+import {
+	Disabled,
+	ExternalLink,
+	PanelBody,
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+	TextControl,
+	__experimentalBoxControl as BoxControl,
+	__experimentalUnitControl as UnitControl,
+	__experimentalAlignmentMatrixControl as AlignmentMatrixControl
+} from '@wordpress/components';
+
+import { Fragment, useState } from '@wordpress/element';
+
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies.
+ */
+import {
+	BoxShadowControl,
+	InspectorExtensions,
+	InspectorHeader,
+	Notice,
+	ResponsiveControl
+} from '../../../blocks/components/index.js';
+
+import { removeBoxDefaultValues, setUtm } from '../../../blocks/helpers/helper-functions.js';
+import { useResponsiveAttributes } from '../../../blocks/helpers/utility-hooks.js';
+import { useTabSwitch } from '../../../blocks/helpers/block-utility.js';
+
+/**
+ *
+ * @param {import('./types').PopupInspectorProps} param0
+ * @returns
+ */
+const Inspector = ({
+	attributes,
+	setAttributes
+}) => {
+	const [ tab, setTab ] = useTabSwitch( attributes.id, 'settings' );
+
+	const {
+		responsiveSetAttributes,
+		responsiveGetAttributes
+	} = useResponsiveAttributes( setAttributes );
+
+	const changeBoxShadow = data => {
+		const boxShadow = { ...attributes.boxShadow };
+		Object.entries( data ).map( ([ key, val ] = data ) => {
+			boxShadow[key] = val;
+		});
+
+		setAttributes({ boxShadow });
+	};
+
+	const Controls = () => {
+		return (
+			<Fragment>
+				<ToggleControl
+					label={ __( 'Show Close Button', 'otter-blocks' ) }
+					checked={ attributes.showClose }
+					onChange={ () => setAttributes({ showClose: ! attributes.showClose }) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Close on Click Outside', 'otter-blocks' ) }
+					checked={ attributes.outsideClose }
+					onChange={ () => setAttributes({ outsideClose: ! attributes.outsideClose }) }
+				/>
+			</Fragment>
+		);
+	};
+
+	return (
+		<InspectorControls>
+			{ applyFilters( 'otter.feedback', '', 'popup-block', __( 'Help us improve this block', 'otter-blocks' ) ) }
+
+			<InspectorHeader
+				value={ tab }
+				options={[
+					{
+						label: __( 'Settings', 'otter-blocks' ),
+						value: 'settings'
+					},
+					{
+						label: __( 'Style', 'otter-blocks' ),
+						value: 'style'
+					}
+				]}
+				onChange={ setTab }
+			/>
+
+			<div>
+				{ 'settings' === tab && (
+					<Fragment>
+						<PanelBody
+							title={ __( 'Modal Settings', 'otter-blocks' )}
+							initialOpen={ true }
+						>
+							<TextControl
+								label={ __( 'Anchor', 'otter-blocks' ) }
+								help={ __( 'You can use this anchor as an anchor link anywhere on the page to open the popup.', 'otter-blocks' ) }
+								value={ attributes.anchor }
+								onChange={ anchor => setAttributes({ anchor }) }
+							/>
+							<ToggleControl
+								label={ __( 'Close On Anchor Click', 'otter-blocks' ) }
+								checked={ attributes.anchorClose }
+								onChange={ () => setAttributes({ anchorClose: ! attributes.anchorClose }) }
+							/>
+
+							{ attributes.anchorClose && (
+								<TextControl
+									label={ __( 'Close Anchor', 'otter-blocks' ) }
+									help={ __( 'You can use this anchor as an anchor link anywhere on the page to close the popup.', 'otter-blocks' ) }
+									value={ attributes.closeAnchor }
+									onChange={ closeAnchor => setAttributes({ closeAnchor }) }
+								/>
+							) }
+						</PanelBody>
+
+						<PanelBody
+							title={ __( 'Modal Position', 'otter-blocks' )}
+							initialOpen={ false }
+						>
+							<ResponsiveControl
+								label={ __( 'Screen Type', 'otter-blocks' ) }
+							>
+								<div className="o-position-picker">
+									<AlignmentMatrixControl
+										value={ responsiveGetAttributes([
+											`${	attributes.verticalPosition ?? 'center' } ${ attributes.horizontalPosition ?? 'center' }`,
+											`${	attributes.verticalPositionTablet ?? 'center' } ${ attributes.horizontalPositionTablet ?? 'center' }`,
+											`${	attributes.verticalPositionMobile ?? 'center' } ${ attributes.horizontalPositionMobile ?? 'center' }`
+										]) }
+										onChange={ value => {
+											const [ vertical, horizontal ] = value.split( ' ' );
+											responsiveSetAttributes( Boolean( vertical ) && 'center' !== vertical ? vertical : undefined, [ 'verticalPosition', 'verticalPositionTablet', 'verticalPositionMobile' ]);
+											responsiveSetAttributes( Boolean( horizontal ) && 'center' !== horizontal ? horizontal : undefined, [ 'horizontalPosition', 'horizontalPositionTablet', 'horizontalPositionMobile' ]);
+										}}
+									/>
+								</div>
+
+							</ResponsiveControl>
+						</PanelBody>
+						<InspectorExtensions />
+					</Fragment>
+				)}
+
+				{ 'style' === tab && (
+					<Fragment>
+						<PanelBody
+							title={ __( 'Dimensions', 'otter-blocks' ) }
+						>
+							<ResponsiveControl
+								label={ __( 'Width', 'otter-blocks' ) }
+							>
+								<UnitControl
+
+									value={ responsiveGetAttributes([
+										attributes.width,
+										attributes.widthTablet,
+										attributes.widthMobile
+									]) ?? '500px' }
+									onChange={ value => {
+										responsiveSetAttributes( value, [ 'width', 'widthTablet', 'widthMobile' ]);
+									}}
+								/>
+							</ResponsiveControl>
+
+							<SelectControl
+								label={ __( 'Height', 'otter-blocks' ) }
+								options={ [
+									{
+										label: __( 'Fit Content', 'otter-blocks' ),
+										value: 'none'
+									},
+									{
+										label: __( 'Custom', 'otter-blocks' ),
+										value: 'custom'
+									}
+								] }
+								value={ attributes.heightMode }
+								onChange={ value => setAttributes({ heightMode: 'none' !== value ? value : undefined })}
+							/>
+
+							{
+								'custom' === attributes.heightMode && (
+									<ResponsiveControl
+										label={ __( 'Custom Height', 'otter-blocks' ) }
+									>
+										<UnitControl
+											value={ responsiveGetAttributes([
+												attributes.height,
+												attributes.heightTablet,
+												attributes.heightMobile
+											]) ?? '400px' }
+											onChange={ value => {
+												responsiveSetAttributes( value, [ 'height', 'heightTablet', 'heightMobile' ]);
+											}}
+										/>
+									</ResponsiveControl>
+								)
+							}
+
+							<ResponsiveControl>
+								<BoxControl
+									label={ __( 'Padding', 'otter-blocks' ) }
+									values={ responsiveGetAttributes([
+										attributes.padding,
+										attributes.paddingTablet,
+										attributes.paddingMobile
+									]) ?? { top: '20px', bottom: '20px', left: '20px', right: '20px' } }
+									onChange={ value => {
+										responsiveSetAttributes(
+											removeBoxDefaultValues( value, { top: '20px', bottom: '20px', left: '20px', right: '20px' }),
+											[ 'padding', 'paddingTablet', 'paddingMobile' ]
+										);
+									}}
+								/>
+							</ResponsiveControl>
+						</PanelBody>
+
+						<PanelColorSettings
+							title={ __( 'Color', 'otter-blocks' ) }
+							initialOpen={ false }
+							colorSettings={ [
+								{
+									value: attributes.backgroundColor,
+									onChange: backgroundColor => setAttributes({ backgroundColor }),
+									label: __( 'Background', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.closeColor,
+									onChange: closeColor => setAttributes({ closeColor }),
+									label: __( 'Close Button', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.overlayColor,
+									onChange: overlayColor => setAttributes({ overlayColor }),
+									label: __( 'Overlay', 'otter-blocks' ),
+									isShownByDefault: false
+								},
+								{
+									value: attributes.borderColor,
+									onChange: borderColor => setAttributes({ borderColor }),
+									label: __( 'Border', 'otter-blocks' ),
+									isShownByDefault: false
+								}
+							] }
+						/>
+						<PanelBody
+							title={ __( 'Overlay', 'otter-blocks' ) }
+							initialOpen={ false }
+						>
+							<RangeControl
+								label={ __( 'Overlay Opacity', 'otter-blocks' ) }
+								value={ attributes.overlayOpacity }
+								initialPosition={ 100 }
+								onChange={ value => setAttributes({ overlayOpacity: value !== undefined ? Number( value ) : undefined }) }
+								allowReset
+							/>
+						</PanelBody>
+
+						<PanelBody
+							title={ __( 'Close Button', 'otter-blocks' ) }
+							initialOpen={ false }
+						>
+							<ToggleControl
+								label={ __( 'Show Close Button', 'otter-blocks' ) }
+								checked={ attributes.showClose }
+								onChange={ () => setAttributes({ showClose: ! attributes.showClose }) }
+							/>
+							<SelectControl
+								label={ __( 'Position', 'otter-blocks' ) }
+								options={ [
+									{
+										label: __( 'Inside', 'otter-blocks' ),
+										value: 'none'
+									},
+									{
+										label: __( 'Outside', 'otter-blocks' ),
+										value: 'outside'
+									}
+								] }
+								value={ attributes.closeButtonType }
+								onChange={ value => setAttributes({ closeButtonType: 'none' !== value ? value : undefined })}
+							/>
+						</PanelBody>
+
+						<PanelBody
+							title={ __( 'Border', 'otter-blocks' ) }
+							initialOpen={ false }
+						>
+							<BoxControl
+								label={ __( 'Width', 'otter-blocks' ) }
+								values={ attributes.borderWidth ?? { top: '0px', bottom: '0px', left: '0px', right: '0px' } }
+								onChange={ value => {
+									setAttributes({
+										borderWidth: removeBoxDefaultValues( value, { top: '0px', bottom: '0px', left: '0px', right: '0px' })
+									});
+								}}
+							/>
+
+							<BoxControl
+								id="o-border-raduis-box"
+								label={ __( 'Radius', 'otter-blocks' ) }
+								values={ attributes.borderRadius ?? { top: '0px', bottom: '0px', left: '0px', right: '0px' } }
+								onChange={ value => {
+									setAttributes({
+										borderRadius: removeBoxDefaultValues( value, { top: '0px', bottom: '0px', left: '0px', right: '0px' })
+									});
+								}}
+							/>
+
+							<BoxShadowControl
+								boxShadow={ attributes.boxShadow }
+								onChange={ changeBoxShadow }
+							/>
+						</PanelBody>
+					</Fragment>
+				) }
+			</div>
+		</InspectorControls>
+	);
+};
+
+export default Inspector;
+

--- a/src/pro/blocks/modal/save.js
+++ b/src/pro/blocks/modal/save.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	InnerBlocks,
+	useBlockProps
+} from '@wordpress/block-editor';
+import classnames from 'classnames';
+
+const Save = ({
+	attributes,
+	className
+}) => {
+	const blockProps = useBlockProps.save({
+		id: attributes.id,
+		className: classnames( className )
+	});
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+};
+
+export default Save;

--- a/src/pro/blocks/modal/types.d.ts
+++ b/src/pro/blocks/modal/types.d.ts
@@ -1,0 +1,48 @@
+import { BlockProps, BorderType, BoxShadow, InspectorProps, PaddingType  } from '../../../blocks/helpers/blocks';
+
+type Attributes = {
+	id: string
+	minWidth: number
+	maxWidth: number
+	trigger: string
+	wait: number
+	anchor: string
+	scroll: number
+	showClose: boolean
+	outsideClose: boolean
+	anchorClose: boolean
+	closeAnchor: string
+	recurringClose: number
+	recurringTime: number
+	backgroundColor: string
+	closeColor: string
+	overlayColor: string
+	overlayOpacity: number
+	borderWidth: BorderType
+	borderRadius: BorderType
+	borderColor: string
+	borderStyle: string
+	padding: PaddingType
+	paddingTablet: PaddingType
+	paddingMobile: PaddingType
+	width: string
+	widthTablet: string
+	widthMobile: string
+	height: string
+	heightTablet: string
+	heightMobile: string
+	verticalPosition: string
+	horizontalPosition: string
+	verticalPositionTablet: string
+	horizontalPositionTablet: string
+	verticalPositionMobile: string
+	horizontalPositionMobile: string
+	boxShadow: BoxShadow
+	closeButtonType: 'outside'
+	lockScrolling: boolean
+	disableOn: 'mobile'
+	heightMode: string
+}
+
+export type PopupPros = BlockProps<Attributes>
+export interface PopupInspectorProps extends InspectorProps<Attributes> {}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/175
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The same features like Popup except for Popup Settings tabs in the Inspector

#### Dynamic Overriding 

The `save` function of the modal saves only the inner content. The complete HTML structure is done via PHP, which overrides the default saving data. 

This method ensures that the modal is working under a valid license while keeping the original data safe. 

### Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/23ff20c7-f2df-4a55-b9f3-47d7288f063e

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

> [!NOTE]
> This is PRO block, you will need Otter Pro

Modal is a popup with only the anchor option.

1. Insert a button and set an anchor
2. Insert a modal with the anche for the button
3. Check if it works like in the video.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

