### PR TITLE
fix: replace the original block of the AI Toolbar action

### DIFF
--- a/.wp-env.override.json
+++ b/.wp-env.override.json
@@ -34,5 +34,8 @@
           "wp-content/themes/raft": "https://downloads.wordpress.org/theme/raft.zip"
         }
     }
+  },
+  "lifecycleScripts": {
+    "afterStart": "bash bin/e2e-tests.sh"
   }
 }

--- a/bin/e2e-tests.sh
+++ b/bin/e2e-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Set-up the `wp_env` environment.
+npm run wp-env run tests-cli wp option set themeisle_open_ai_api_key "sk_XXXXXXXXXXXXXXXXXXXXXXXx" # Used by AI tools.

--- a/src/blocks/blocks/content-generator/block.json
+++ b/src/blocks/blocks/content-generator/block.json
@@ -19,6 +19,9 @@
 		"resultHistory": {
 			"type": "array",
 			"default": []
+		},
+		"replaceTargetBlock": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/src/blocks/blocks/content-generator/types.d.ts
+++ b/src/blocks/blocks/content-generator/types.d.ts
@@ -3,6 +3,11 @@ import { BlockProps, InspectorProps } from '../../helpers/blocks';
 type Attributes = {
 	promptID: string;
 	resultHistory: {result: string, meta: { usedToken: number, prompt: string }}[]
+
+	/**
+	 * The block identifier for replace action. (Used by AI Toolbar actions).
+	 */
+	replaceTargetBlock: Pick<BlockProps<unknown>, 'clientId' | 'name'>;
 }
 
 export type ContentGeneratorAttrs = Partial<Attributes>

--- a/src/blocks/plugins/ai-content/index.tsx
+++ b/src/blocks/plugins/ai-content/index.tsx
@@ -194,7 +194,11 @@ const AIToolbar = ({
 							usedToken: response?.usage.total_tokens,
 							prompt: ''
 						}
-					}]
+					}],
+					replaceTargetBlock: {
+						clientId: props.clientId,
+						name: props.name
+					}
 				},
 				newBlocks
 			);
@@ -240,6 +244,13 @@ const AIToolbar = ({
 					</MenuGroup>
 				)
 			}
+			<MenuGroup>
+				<ExternalLink className='o-menu-item-alignment' href="https://docs.themeisle.com/collection/1563-otter---page-builder-blocks-extensions" target="_blank" rel="noopener noreferrer">
+					{
+						__( 'Edit Prompts', 'otter-blocks' )
+					}
+				</ExternalLink>
+			</MenuGroup>
 			<MenuGroup>
 				<span className="o-menu-item-header o-menu-item-alignment">{__( 'Writing', 'otter-blocks' )}</span>
 				<ActionMenuItem actionKey='otter_action_generate_title' callback={onClose}>
@@ -327,7 +338,7 @@ const withConditions = createHigherOrderComponent( BlockEdit => {
 					) &&
 					(
 						<BlockControls>
-							<Toolbar>
+							<Toolbar label={__( 'AI Block', 'otter-blocks' )}>
 								<DropdownMenu
 									icon={ aiGeneration }
 									label={ __( 'Otter AI Content' ) }

--- a/src/blocks/test/e2e/blocks/ai-block.spec.js
+++ b/src/blocks/test/e2e/blocks/ai-block.spec.js
@@ -53,6 +53,24 @@ test.describe( 'AI Block', () => {
 		await admin.createNewPost();
 	});
 
+	test( 'replace action', async({ editor, page }) => {
+		const aiBlock = await editor.insertBlock({
+			name: 'themeisle-blocks/content-generator',
+			attributes: {
+				promptID: 'textTransformation'
+			}
+		});
+
+		await page.getByPlaceholder( 'Start describing what content' ).type( 'Write about Space nation on the rise.' );
+		await page.getByRole( 'button', { name: 'Generate' }).click();
+		await page.getByRole( 'button', { name: 'Replace' }).click();
+
+		const blocks = await editor.getBlocks();
+
+		expect( blocks.every( block => 'themeisle-blocks/content-generator' !== block.name ) ).toBe( true );
+		await expect( page.getByText( 'Discover the Next Frontier' ) ).toBeVisible();
+	});
+
 	test( 'replace target block', async({ editor, page }) => {
 
 		// Create target blocks.
@@ -86,5 +104,24 @@ test.describe( 'AI Block', () => {
 		await page.getByRole( 'button', { name: 'Replace' }).click();
 
 		await expect( page.getByText( 'Target Block.' ) ).toBeHidden();
+	});
+
+	test( 'insert below action', async({ editor, page }) => {
+		const aiBlock = await editor.insertBlock({
+			name: 'themeisle-blocks/content-generator',
+			attributes: {
+				promptID: 'textTransformation'
+			}
+		});
+
+		await page.getByPlaceholder( 'Start describing what content' ).type( 'Write about Space nation on the rise.' );
+		await page.getByRole( 'button', { name: 'Generate' }).click();
+		await page.getByRole( 'button', { name: 'Insert below' }).click();
+
+		const blocks = await editor.getBlocks();
+
+		expect( blocks.some( block => 'themeisle-blocks/content-generator' === block.name ) ).toBe( true ); // The block is still present.
+		await expect( page.getByText( 'Discover the Next Frontier' ).nth( 0 ) ).toBeVisible(); // The header in the AI block content.
+		await expect( page.getByText( 'Discover the Next Frontier' ).nth( 1 ) ).toBeVisible(); // The header inserted below.
 	});
 });

--- a/src/blocks/test/e2e/blocks/ai-block.spec.js
+++ b/src/blocks/test/e2e/blocks/ai-block.spec.js
@@ -1,0 +1,90 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'AI Block', () => {
+	test.beforeEach( async({ admin, page }) => {
+
+		// Mock the api response of the otter/v1/generate endpoint for `textTransformation`.
+		await page.route( '**/index.php?rest_route=%2Fotter%2Fv1%2Fgenerate&_locale=user', async( route ) => {
+
+			const request = route.request();
+			if ( 'POST' !== request.method() ) {
+				return route.continue();
+			}
+
+			const postData = JSON.parse( request.postData() );
+			if ( 'textTransformation::otter_action_prompt' !== postData.otter_used_action ) {
+				return route.continue();
+			}
+
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify(
+					{
+						'id': 'chatcmpl-9oWud5dugI37NCO4ZIUFH2GRFJ9Z4',
+						'object': 'chat.completion',
+						'created': 1721829943,
+						'model': 'gpt-3.5-turbo-0125',
+						'choices': [
+							{
+								'index': 0,
+								'message': {
+									'role': 'assistant',
+									'content': '<h1><strong>Discover the Next Frontier: Space Nation on the Rise<\/strong><\/h1>\n\n<p>Are you ready to embark on a journey to a new world beyond our wildest dreams? Look no further than the rapidly emerging Space Nation that is captivating the imaginations of millions. From groundbreaking technologies to bold explorations, this cosmic civilization is redefining what it means to reach for the stars.<\/p>\n\n<h2><em>Unveiling the Wonders of Space Nation<\/em><\/h2>\n\n<p>Peer into the future and witness the awe-inspiring advancements taking place in this celestial realm. With each innovation, Space Nation pushes the boundaries of possibility, offering a glimpse into a future where the impossible becomes reality.<\/p>\n\n<h2><em>Join the Movement<\/em><\/h2>\n\n<p>Don\'t miss your chance to be part of history in the making. Whether you are an aspiring pioneer or a curious observer, there is a place for you in the unfolding saga of Space Nation. Embrace the spirit of exploration and venture into a realm where the skies are no longer the limit.<\/p>\n\n<h3><strong>Why Space Nation?<\/strong><\/h3>\n\n<ul>\n  <li>Experience groundbreaking technologies shaping the future<\/li>\n  <li>Witness bold explorations into the unknown<\/li>\n  <li>Join a community of visionaries and trailblazers<\/li>\n<\/ul>\n\n<h3><strong>Take Action Today<\/strong><\/h3>\n\n<p>Ready to embark on an adventure that transcends the confines of Earth? Step into the world of Space Nation and dare to dream beyond the stars.<\/p>'
+								},
+								'logprobs': null,
+								'finish_reason': 'stop'
+							}
+						],
+						'usage': {
+							'prompt_tokens': 331,
+							'completion_tokens': 338,
+							'total_tokens': 669
+						},
+						'system_fingerprint': null
+					}
+				)
+			});
+		});
+
+		await admin.createNewPost();
+	});
+
+	test( 'replace target block', async({ editor, page }) => {
+
+		// Create target blocks.
+		await editor.insertBlock({
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Target Block.'
+			}
+		});
+		const { clientId, name } = await page.evaluate( () => {
+			const blocks = wp.data.select( 'core/block-editor' ).getBlocks();
+			return blocks[ 0 ];
+		});
+
+		expect( name ).toBe( 'core/paragraph' );
+
+		// Create the AI Block linked to the target block.
+		const aiBlock = await editor.insertBlock({
+			name: 'themeisle-blocks/content-generator',
+			attributes: {
+				promptID: 'textTransformation',
+				replaceTargetBlock: {
+					name: 'core/paragraph',
+					clientId: clientId
+				}
+			}
+		});
+
+		await page.getByPlaceholder( 'Start describing what content' ).type( 'Write about Space nation on the rise.' );
+		await page.getByRole( 'button', { name: 'Generate' }).click();
+		await page.getByRole( 'button', { name: 'Replace' }).click();
+
+		await expect( page.getByText( 'Target Block.' ) ).toBeHidden();
+	});
+});


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/214
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The origin block in which the AI actions are triggered is now linked to the AI Block created. On Replace actions, the origin block will be replaced, and the AI Block will be deleted.

> [!NOTE]
> This works when both blocks are part of the same session. It is considered a new session if you reload the page or switch to code mode and come back.

### Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/33448ebe-5a18-4e9b-8561-fe2a5558a271

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

> [!NOTE]
> You will need an OpenAI key.

1. Use the actions AI Toolbar from a paragraph block.
2. Click `Replace` after the AI Block generates the content.
3. The original block should be replaced.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

