### PR TITLE
chore: various small changes

### DIFF
--- a/inc/class-patterns.php
+++ b/inc/class-patterns.php
@@ -35,11 +35,11 @@ class Patterns {
 	 */
 	public function register_patterns() {
 		$block_pattern_categories = array(
-			'otter-blocks' => array( 'label' => __( 'Otter Blocks', 'otter-blocks' ) ),
-			'cta'          => array( 'label' => __( 'Call to Action', 'otter-blocks' ) ),
-			'team'         => array( 'label' => __( 'Team', 'otter-blocks' ) ),
-			'pricing'      => array( 'label' => __( 'Pricing', 'otter-blocks' ) ),
-			'testimonials' => array( 'label' => __( 'Testimonials', 'otter-blocks' ) ),
+			'otter-blocks'   => array( 'label' => __( 'Otter Blocks', 'otter-blocks' ) ),
+			'call-to-action' => array( 'label' => __( 'Call to Action', 'otter-blocks' ) ),
+			'team'           => array( 'label' => __( 'Team', 'otter-blocks' ) ),
+			'pricing'        => array( 'label' => __( 'Pricing', 'otter-blocks' ) ),
+			'testimonials'   => array( 'label' => __( 'Testimonials', 'otter-blocks' ) ),
 		);
 
 		$block_pattern_categories = apply_filters( 'otter_blocks_block_pattern_categories', $block_pattern_categories );

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -29,6 +29,7 @@ class Dashboard {
 		add_action( 'admin_menu', array( $this, 'register_menu_page' ) );
 		add_action( 'admin_init', array( $this, 'maybe_redirect' ) );
 		add_action( 'admin_notices', array( $this, 'maybe_add_otter_banner' ), 30 );
+		add_action( 'admin_head', array( $this, 'add_inline_css' ) );
 
 		$form_options = get_option( 'themeisle_blocks_form_emails' );
 		if ( ! empty( $form_options ) ) {
@@ -72,7 +73,11 @@ class Dashboard {
 		add_submenu_page(
 			'otter',
 			__( 'Form Submissions', 'otter-blocks' ),
-			__( 'Form Submissions', 'otter-blocks' ),
+			sprintf(
+				'<div class="o-menu-submissions">%s <span class="o-menu-badge">%s</span></div>',
+				esc_html__( 'Form Submissions', 'otter-blocks' ),
+				esc_html__( 'Pro', 'otter-blocks' )
+			),
 			'manage_options',
 			'form-submissions-free',
 			array( $this, 'form_submissions_callback' ),
@@ -90,6 +95,34 @@ class Dashboard {
 				<script>document.location.href = "/wp-admin/admin.php?page=otter#blocks";</script>';
 			}
 		);
+	}
+
+	/**
+	 * Add inline CSS.
+	 */
+	public function add_inline_css() {
+		?>
+		<style>
+			.o-menu-submissions {
+				display: flex;
+				align-items: center;
+			}
+
+			.o-menu-badge {
+				border: 1px solid;
+				border-radius: 16px;
+				color: inherit;
+				font-size: 10px;
+				font-weight: 600;
+				line-height: 8px;
+				margin: 0;
+				opacity: .8;
+				padding: 4px 6px;
+				text-transform: uppercase;
+			}
+		</style>
+		<?php
+	
 	}
 
 	/**
@@ -300,12 +333,13 @@ class Dashboard {
 				<img src="<?php echo esc_url( OTTER_BLOCKS_URL . 'assets/images/logo-alt.png' ); ?>" alt="<?php esc_attr_e( 'Otter Blocks', 'otter-blocks' ); ?>" style="width: 90px">
 			</div>
 			<div class="otter-banner__content">
-				<h1 class="otter-banner__title" style="line-height: normal;"><?php esc_html_e( 'Form Submissions', 'otter-blocks' ); ?>
-					<sub class="otter-banner__version"><?php echo esc_html( 'v' . OTTER_BLOCKS_VERSION ); ?></sub>
-				</h1>
+				<h1 class="otter-banner__title" style="line-height: normal;"><?php esc_html_e( 'Form Submissions', 'otter-blocks' ); ?></h1>
+
+				<?php if ( Pro::is_pro_active() ) : ?>
 				<button id="export-submissions" class="button">
 					<?php esc_html_e( 'Export', 'otter-blocks' ); ?>
 				</button>
+				<?php endif; ?>
 			</div>
 		</div>
 		<script>

--- a/src/blocks/blocks/countdown/edit.tsx
+++ b/src/blocks/blocks/countdown/edit.tsx
@@ -10,7 +10,6 @@ import { __ } from '@wordpress/i18n';
 
 import {
 	isEmpty,
-	isNumber,
 	pickBy
 } from 'lodash';
 
@@ -78,6 +77,13 @@ const Edit = ({
 				setAttributes({ borderRadiusBox, borderRadius: undefined, borderRadiusBottomLeft: undefined, borderRadiusTopRight: undefined, borderRadiusBottomRight: undefined, borderRadiusTopLeft: undefined, borderRadiusType: undefined });
 			}
 		}
+
+		/**
+		 * Set default time if no time is set.
+		 */
+		if ( 'timer' !== attributes.mode && ! attributes.date ) {
+			setAttributes({ date: moment().utc().add( 1, 'week' ).format( 'YYYY-MM-DDTHH:mm:ss' ) });
+		}
 	}, []);
 
 	/**
@@ -109,7 +115,6 @@ const Edit = ({
 			return unixTime;
 		}
 	};
-
 
 	const inlineStyles = {
 		'--border-radius': boxValues( attributes.borderRadiusBox ),

--- a/src/blocks/blocks/countdown/inspector.js
+++ b/src/blocks/blocks/countdown/inspector.js
@@ -76,36 +76,27 @@ const defaultFontSizes = [
 const fontWeights = [ '', '100', '200', '300', '400', '500', '600', '700', '800', '900' ].map( x => ({ label: x ? x : 'Default', value: x }) );
 
 const SettingsPanel = ({ attributes }) => (
-	<Fragment>
-		<SelectControl
-			label={ __( 'Countdown Type', 'otter-blocks' ) }
-			value={  attributes.mode }
-			options={[
-				{
-					label: __( 'Static', 'otter-blocks' ),
-					value: ''
-				},
-				{
-					label: __( 'Evergreen (Pro)', 'otter-blocks' ),
-					value: 'timer',
-					disabled: true
-				},
-				{
-					label: __( 'Interval (Pro)', 'otter-blocks' ),
-					value: 'interval',
-					disabled: true
-				}
-			]}
-			help={ __( 'An universal deadline for all visitors', 'otter-blocks' )}
-		/>
-
-		{ ! Boolean( window.themeisleGutenberg?.hasPro ) && (
-			<Notice
-				notice={ <ExternalLink href={ setUtm( window.themeisleGutenberg.upgradeLink, 'countdownfeature' ) }>{ __( 'Get more options with Otter Pro.', 'otter-blocks' ) }</ExternalLink> }
-				variant="upsell"
-			/>
-		) }
-	</Fragment>
+	<SelectControl
+		label={ __( 'Countdown Type', 'otter-blocks' ) }
+		value={  attributes.mode }
+		options={[
+			{
+				label: __( 'Static', 'otter-blocks' ),
+				value: ''
+			},
+			{
+				label: __( 'Evergreen (Pro)', 'otter-blocks' ),
+				value: 'timer',
+				disabled: true
+			},
+			{
+				label: __( 'Interval (Pro)', 'otter-blocks' ),
+				value: 'interval',
+				disabled: true
+			}
+		]}
+		help={ __( 'An universal deadline for all visitors', 'otter-blocks' )}
+	/>
 );
 
 const EndActionPanel = () => (

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -251,14 +251,6 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 							}
 							help={ __( 'The submissions are send only via email. No data will be saved on the server, use this option to handle sensitive data.', 'otter-blocks' ) }
 						/>
-
-						<div>
-							<Notice
-								notice={ <ExternalLink href={ setUtm( window.themeisleGutenberg.upgradeLink, 'form-block' ) }>{ __( 'Unlock this with Otter Pro.', 'otter-blocks' ) }</ExternalLink> }
-								variant="upsell"
-							/>
-							<p className="description">{ __( 'Enhance your email process with our new feature. Store submissions in a database for easy access.', 'otter-blocks' ) }</p>
-						</div>
 					</ToolsPanelItem>
 					<ToolsPanelItem
 						hasValue={ () => false }
@@ -327,7 +319,7 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 						</Button>
 
 						< br />
-						<ExternalLink href="https://docs.themeisle.com/article/1550-otter-pro-documentation">
+						<ExternalLink href="https://docs.themeisle.com/article/1878-how-to-use-webhooks-in-otter-forms">
 							{ __( 'Learn more about webhooks.', 'otter-blocks' ) }
 						</ExternalLink>
 
@@ -509,7 +501,7 @@ const Inspector = ({
 								options={ [
 									{ label: __( 'None', 'otter-blocks' ), value: '' },
 									{ label: __( 'Mailchimp', 'otter-blocks' ), value: 'mailchimp' },
-									{ label: __( 'Sendinblue', 'otter-blocks' ), value: 'sendinblue' }
+									{ label: __( 'Brevo', 'otter-blocks' ), value: 'sendinblue' }
 								] }
 								onChange={ provider => {
 									window.oTrk?.add({ feature: 'marketing', featureComponent: 'provider', featureValue: provider, groupID: attributes.id });

--- a/src/blocks/blocks/slider/block.json
+++ b/src/blocks/blocks/slider/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "themeisle-blocks/slider",
-	"title": "Slider",
+	"title": "Image Slider",
 	"category": "themeisle-blocks",
 	"description": "Minimal image slider to showcase beautiful images. Powered by Otter.",
 	"keywords": [ "slider", "gallery", "carousel" ],

--- a/src/blocks/blocks/slider/edit.js
+++ b/src/blocks/blocks/slider/edit.js
@@ -241,7 +241,7 @@ const Edit = ({
 			<div { ...blockProps }>
 				<Placeholder
 					labels={ {
-						title: __( 'Slider', 'otter-blocks' ),
+						title: __( 'Image Slider', 'otter-blocks' ),
 						instructions: __( 'Drag images, upload new ones or select files from your library.', 'otter-blocks' )
 					} }
 					icon="images-alt2"

--- a/src/blocks/blocks/slider/index.js
+++ b/src/blocks/blocks/slider/index.js
@@ -19,7 +19,7 @@ const { name } = metadata;
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'Slider', 'otter-blocks' ),
+	title: __( 'Image Slider', 'otter-blocks' ),
 	description: __( 'Minimal image slider to showcase beautiful images. Powered by Otter.', 'otter-blocks' ),
 	icon,
 	keywords: [

--- a/src/blocks/components/notice/editor.scss
+++ b/src/blocks/components/notice/editor.scss
@@ -8,11 +8,12 @@
 	margin: 10px 0;
 
 	&.is-upsell {
-		background: #ED6F57;
+		background: transparent;
 		font-size: 12px;
+		border: 1px solid #808080;
 
 		.components-external-link {
-			color: white;
+			color: #808080;
 		}
 	}
 
@@ -27,7 +28,7 @@
 		flex-direction: row-reverse;
 		text-decoration: unset;
 
-		svg {
+		.components-external-link__icon {
 			margin: 0 5px 0 0;
 		}
 	}

--- a/src/blocks/editor.scss
+++ b/src/blocks/editor.scss
@@ -26,40 +26,6 @@ svg.o-block-icon {
 	fill: #fff !important;
 }
 
-.o-notice {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	background: #F3F3F3;
-	border-radius: 4px;
-	padding: 10px 20px;
-	margin: 10px 0;
-
-	&.is-upsell {
-		background: #ED6F57;
-		font-size: 12px;
-
-		.components-external-link {
-			color: white;
-		}
-	}
-
-	.components-external-link {
-		display: flex;
-		flex-direction: row-reverse;
-		text-decoration: unset;
-
-		svg {
-			margin: 0 5px 0 0;
-		}
-	}
-
-	svg {
-		width: 18px;
-		height: 18px;
-	}
-}
-
 .o-is-new {
 	&.components-panel__body {
 		.components-panel__body-title {

--- a/src/blocks/helpers/icons.js
+++ b/src/blocks/helpers/icons.js
@@ -639,10 +639,10 @@ export const popupWithImageAndText = (
 			<Path d="M25 16C25 15.4477 25.4477 15 26 15H42C42.5523 15 43 15.4477 43 16V32C43 32.5523 42.5523 33 42 33H26C25.4477 33 25 32.5523 25 32V16Z"/>
 		</mask>
 		<Path d="M24 16C24 14.8954 24.8954 14 26 14H42C43.1046 14 44 14.8954 44 16H42H26H24ZM44 32C44 33.1046 43.1046 34 42 34H26C24.8954 34 24 33.1046 24 32H26H42H44ZM26 34C24.8954 34 24 33.1046 24 32V16C24 14.8954 24.8954 14 26 14V16V32V34ZM42 14C43.1046 14 44 14.8954 44 16V32C44 33.1046 43.1046 34 42 34V32V16V14Z" fill="#ED6F57" mask="url(#path-3-inside-1_3034_34948)"/>
-		<Path d="M5 18H21" stroke="#ED6F57" stroke-linecap="round" fill="none"/>
-		<Path d="M5 22H21" stroke="#ED6F57" stroke-linecap="round" fill="none"/>
-		<Path d="M5 26H21" stroke="#ED6F57" stroke-linecap="round" fill="none"/>
-		<Path d="M5 30H13.8889" stroke="#ED6F57" stroke-linecap="round" fill="none"/>
+		<Path d="M5 18H21" stroke="#ED6F57" strokeLinecap="round" fill="none"/>
+		<Path d="M5 22H21" stroke="#ED6F57" strokeLinecap="round" fill="none"/>
+		<Path d="M5 26H21" stroke="#ED6F57" strokeLinecap="round" fill="none"/>
+		<Path d="M5 30H13.8889" stroke="#ED6F57" strokeLinecap="round" fill="none"/>
 		<Rect x="1.5" y="8.5" width="45" height="31" rx="0.5" stroke="#ED6F57" fill="none"/>
 		<Rect x="42" y="11" width="2" height="2" rx="1" fill="#ED6F57"/>
 	</SVG>
@@ -651,66 +651,66 @@ export const popupWithImageAndText = (
 
 export const aiGeneration = (
 	<SVG data-target="generator-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" style={{ color: 'transparent' }}>
-		<Path d="M6 17V21" stroke="url(#paint0_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M4 19H8" stroke="url(#paint1_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M17 3V7" stroke="url(#paint2_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M15 5H19" stroke="url(#paint3_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M6.5 5C6.5 6.933 8.067 8.5 10 8.5" stroke="url(#paint4_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M10 8.5C8.067 8.5 6.5 10.067 6.5 12" stroke="url(#paint5_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M6.5 12C6.5 10.067 4.933 8.5 3 8.5" stroke="url(#paint6_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M3 8.5C4.933 8.5 6.5 6.933 6.5 5" stroke="url(#paint7_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M11.609 15.778C14.202 15.778 16.304 13.676 16.304 11.083" stroke="url(#paint8_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M16.3051 11.083C16.3051 13.676 18.4071 15.778 21.0001 15.778" stroke="url(#paint9_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M21.0001 15.7781C18.4071 15.7781 16.3051 17.8801 16.3051 20.4731" stroke="url(#paint10_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-		<Path d="M16.305 20.4731C16.305 17.8801 14.203 15.7781 11.61 15.7781" stroke="url(#paint11_linear_3599_37937)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+		<Path d="M6 17V21" stroke="url(#paint0_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M4 19H8" stroke="url(#paint1_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M17 3V7" stroke="url(#paint2_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M15 5H19" stroke="url(#paint3_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M6.5 5C6.5 6.933 8.067 8.5 10 8.5" stroke="url(#paint4_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M10 8.5C8.067 8.5 6.5 10.067 6.5 12" stroke="url(#paint5_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M6.5 12C6.5 10.067 4.933 8.5 3 8.5" stroke="url(#paint6_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M3 8.5C4.933 8.5 6.5 6.933 6.5 5" stroke="url(#paint7_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M11.609 15.778C14.202 15.778 16.304 13.676 16.304 11.083" stroke="url(#paint8_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M16.3051 11.083C16.3051 13.676 18.4071 15.778 21.0001 15.778" stroke="url(#paint9_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M21.0001 15.7781C18.4071 15.7781 16.3051 17.8801 16.3051 20.4731" stroke="url(#paint10_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+		<Path d="M16.305 20.4731C16.305 17.8801 14.203 15.7781 11.61 15.7781" stroke="url(#paint11_linear_3599_37937)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
 		<Defs>
 			<LinearGradient id="paint0_linear_3599_37937" x1="6" y1="17" x2="6" y2="21" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint1_linear_3599_37937" x1="6" y1="18.5" x2="6" y2="19.5" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint2_linear_3599_37937" x1="17" y1="3" x2="17" y2="7" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint3_linear_3599_37937" x1="17" y1="4.5" x2="17" y2="5.5" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint4_linear_3599_37937" x1="8.25" y1="5" x2="8.25" y2="8.5" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint5_linear_3599_37937" x1="8.25" y1="8.5" x2="8.25" y2="12" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint6_linear_3599_37937" x1="4.75" y1="8.5" x2="4.75" y2="12" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint7_linear_3599_37937" x1="4.75" y1="5" x2="4.75" y2="8.5" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint8_linear_3599_37937" x1="13.9565" y1="11.083" x2="13.9565" y2="15.778" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint9_linear_3599_37937" x1="18.6526" y1="11.083" x2="18.6526" y2="15.778" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint10_linear_3599_37937" x1="18.6526" y1="15.7781" x2="18.6526" y2="20.4731" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint11_linear_3599_37937" x1="13.9575" y1="15.7781" x2="13.9575" y2="20.4731" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 		</Defs>
 	</SVG>
@@ -718,31 +718,31 @@ export const aiGeneration = (
 
 export const formAiGeneration = (
 	<SVG width="20" height="21" viewBox="0 0 20 21" fill="none" style={{ color: 'transparent' }} xmlns="http://www.w3.org/2000/svg">
-		<Path d="M17.5044 8.5V20C17.5044 20.3 17.3044 20.5 17.0044 20.5H3.00439C2.70439 20.5 2.50439 20.3 2.50439 20V2C2.50439 1.7 2.70439 1.5 3.00439 1.5H12.8044" stroke="url(#paint0_linear_3726_618)" stroke-linecap="round"/>
+		<Path d="M17.5044 8.5V20C17.5044 20.3 17.3044 20.5 17.0044 20.5H3.00439C2.70439 20.5 2.50439 20.3 2.50439 20V2C2.50439 1.7 2.70439 1.5 3.00439 1.5H12.8044" stroke="url(#paint0_linear_3726_618)" strokeLinecap="round"/>
 		<Path d="M5.00439 3.5H10.0044C10.3044 3.5 10.5044 3.7 10.5044 4V6C10.5044 6.3 10.3044 6.5 10.0044 6.5H5.00439C4.70439 6.5 4.50439 6.3 4.50439 6V4C4.50439 3.7 4.70439 3.5 5.00439 3.5Z" stroke="url(#paint1_linear_3726_618)"/>
 		<Path d="M5.00439 9.5H13.0044C13.3044 9.5 13.5044 9.7 13.5044 10V11C13.5044 11.3 13.3044 11.5 13.0044 11.5H5.00439C4.70439 11.5 4.50439 11.3 4.50439 11V10C4.50439 9.7 4.70439 9.5 5.00439 9.5Z" stroke="url(#paint2_linear_3726_618)"/>
 		<Path d="M5.00439 13.5H15.0044C15.3044 13.5 15.5044 13.7 15.5044 14V18C15.5044 18.3 15.3044 18.5 15.0044 18.5H5.00439C4.70439 18.5 4.50439 18.3 4.50439 18V14C4.50439 13.7 4.70439 13.5 5.00439 13.5Z" stroke="url(#paint3_linear_3726_618)"/>
-		<Path d="M16.0044 7C16.0044 5.3 17.3044 4 19.0044 4C17.3044 4 16.0044 2.7 16.0044 1C16.0044 2.7 14.7044 4 13.0044 4C13.8044 4 14.6044 4.3 15.1044 4.9C15.7044 5.4 16.0044 6.2 16.0044 7Z" stroke="url(#paint4_linear_3726_618)" stroke-linecap="round" stroke-linejoin="round"/>
+		<Path d="M16.0044 7C16.0044 5.3 17.3044 4 19.0044 4C17.3044 4 16.0044 2.7 16.0044 1C16.0044 2.7 14.7044 4 13.0044 4C13.8044 4 14.6044 4.3 15.1044 4.9C15.7044 5.4 16.0044 6.2 16.0044 7Z" stroke="url(#paint4_linear_3726_618)" strokeLinecap="round" strokeLinejoin="round"/>
 		<Defs>
 			<LinearGradient id="paint0_linear_3726_618" x1="10.0044" y1="1" x2="10.0044" y2="21" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint1_linear_3726_618" x1="7.50439" y1="3" x2="7.50439" y2="7" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint2_linear_3726_618" x1="9.00439" y1="9" x2="9.00439" y2="12" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint3_linear_3726_618" x1="10.0044" y1="13" x2="10.0044" y2="19" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint4_linear_3726_618" x1="16.0057" y1="1" x2="16.0057" y2="7.0025" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 		</Defs>
 	</SVG>
@@ -750,36 +750,36 @@ export const formAiGeneration = (
 
 export const contentAiGenerationIcon = ( props = {}) => (
 	<SVG width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color: 'transparent' }} {...props}>
-		<Path d="M17.5044 8.49112V19.9911C17.5044 20.2911 17.3044 20.4911 17.0044 20.4911H3.00439C2.70439 20.4911 2.50439 20.2911 2.50439 19.9911V1.99112C2.50439 1.69112 2.70439 1.49112 3.00439 1.49112H12.8044" stroke="url(#paint0_linear_1006_2437)" stroke-linecap="round"/>
-		<Path d="M5.50439 4.49112H9.50439" stroke="url(#paint1_linear_1006_2437)" stroke-linecap="round"/>
-		<Path d="M5.50439 8.49112H13.5044" stroke="url(#paint2_linear_1006_2437)" stroke-linecap="round"/>
-		<Path d="M5.50439 12.4911H14.5044" stroke="url(#paint3_linear_1006_2437)" stroke-linecap="round"/>
-		<Path d="M5.50439 16.4911H14.5044" stroke="url(#paint4_linear_1006_2437)" stroke-linecap="round"/>
-		<Path d="M16.0044 6.99112C16.0044 5.29112 17.3044 3.99112 19.0044 3.99112C17.3044 3.99112 16.0044 2.69112 16.0044 0.991119C16.0044 2.69112 14.7044 3.99112 13.0044 3.99112C13.8044 3.99112 14.6044 4.29112 15.1044 4.89112C15.7044 5.39112 16.0044 6.19112 16.0044 6.99112Z" stroke="url(#paint5_linear_1006_2437)" stroke-linecap="round" stroke-linejoin="round"/>
+		<Path d="M17.5044 8.49112V19.9911C17.5044 20.2911 17.3044 20.4911 17.0044 20.4911H3.00439C2.70439 20.4911 2.50439 20.2911 2.50439 19.9911V1.99112C2.50439 1.69112 2.70439 1.49112 3.00439 1.49112H12.8044" stroke="url(#paint0_linear_1006_2437)" strokeLinecap="round"/>
+		<Path d="M5.50439 4.49112H9.50439" stroke="url(#paint1_linear_1006_2437)" strokeLinecap="round"/>
+		<Path d="M5.50439 8.49112H13.5044" stroke="url(#paint2_linear_1006_2437)" strokeLinecap="round"/>
+		<Path d="M5.50439 12.4911H14.5044" stroke="url(#paint3_linear_1006_2437)" strokeLinecap="round"/>
+		<Path d="M5.50439 16.4911H14.5044" stroke="url(#paint4_linear_1006_2437)" strokeLinecap="round"/>
+		<Path d="M16.0044 6.99112C16.0044 5.29112 17.3044 3.99112 19.0044 3.99112C17.3044 3.99112 16.0044 2.69112 16.0044 0.991119C16.0044 2.69112 14.7044 3.99112 13.0044 3.99112C13.8044 3.99112 14.6044 4.29112 15.1044 4.89112C15.7044 5.39112 16.0044 6.19112 16.0044 6.99112Z" stroke="url(#paint5_linear_1006_2437)" strokeLinecap="round" strokeLinejoin="round"/>
 		<Defs>
 			<LinearGradient id="paint0_linear_1006_2437" x1="10.0044" y1="1.49112" x2="10.0044" y2="20.4911" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint1_linear_1006_2437" x1="7.50439" y1="4.24112" x2="7.50439" y2="5.74112" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint2_linear_1006_2437" x1="9.50439" y1="8.24112" x2="9.50439" y2="9.74112" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint3_linear_1006_2437" x1="10.0044" y1="12.2411" x2="10.0044" y2="13.7411" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint4_linear_1006_2437" x1="10.0044" y1="16.2411" x2="10.0044" y2="17.7411" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint5_linear_1006_2437" x1="16.0044" y1="0.991119" x2="16.0044" y2="6.99112" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 		</Defs>
 	</SVG>
@@ -787,31 +787,31 @@ export const contentAiGenerationIcon = ( props = {}) => (
 
 export const aiLayoutGeneratorIcon = ( props = {}) => (
 	<SVG width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ color: 'transparent' }} {...props}>
-		<Path d="M19.5 8V19.5C19.5 19.8 19.3 20 19 20H1C0.7 20 0.5 19.8 0.5 19.5V1.5C0.5 1.2 0.7 1 1 1H12.8" stroke="url(#paint0_linear_1036_1071)" stroke-linecap="round"/>
-		<Path d="M17 6.5C17 4.8 18.3 3.5 20 3.5C18.3 3.5 17 2.2 17 0.5C17 2.2 15.7 3.5 14 3.5C14.8 3.5 15.6 3.8 16.1 4.4C16.7 4.9 17 5.7 17 6.5Z" stroke="url(#paint1_linear_1036_1071)" stroke-linecap="round" stroke-linejoin="round"/>
+		<Path d="M19.5 8V19.5C19.5 19.8 19.3 20 19 20H1C0.7 20 0.5 19.8 0.5 19.5V1.5C0.5 1.2 0.7 1 1 1H12.8" stroke="url(#paint0_linear_1036_1071)" strokeLinecap="round"/>
+		<Path d="M17 6.5C17 4.8 18.3 3.5 20 3.5C18.3 3.5 17 2.2 17 0.5C17 2.2 15.7 3.5 14 3.5C14.8 3.5 15.6 3.8 16.1 4.4C16.7 4.9 17 5.7 17 6.5Z" stroke="url(#paint1_linear_1036_1071)" strokeLinecap="round" strokeLinejoin="round"/>
 		<Path d="M3 3H10C10.3 3 10.5 3.2 10.5 3.5V9.5C10.5 9.8 10.3 10 10 10H3C2.7 10 2.5 9.8 2.5 9.5V3.5C2.5 3.2 2.7 3 3 3Z" stroke="url(#paint2_linear_1036_1071)"/>
 		<Path d="M3 12H10C10.3 12 10.5 12.2 10.5 12.5V17.5C10.5 17.8 10.3 18 10 18H3C2.7 18 2.5 17.8 2.5 17.5V12.5C2.5 12.2 2.7 12 3 12Z" stroke="url(#paint3_linear_1036_1071)"/>
 		<Path d="M13 9H17C17.3 9 17.5 9.2 17.5 9.5V17.5C17.5 17.8 17.3 18 17 18H13C12.7 18 12.5 17.8 12.5 17.5V9.5C12.5 9.2 12.7 9 13 9Z" stroke="url(#paint4_linear_1036_1071)"/>
 		<Defs>
 			<LinearGradient id="paint0_linear_1036_1071" x1="10" y1="0.99" x2="10" y2="19.99" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint1_linear_1036_1071" x1="17" y1="0.49" x2="17" y2="6.49" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint2_linear_1036_1071" x1="6.5" y1="2.5" x2="6.5" y2="10.5" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint3_linear_1036_1071" x1="6.5" y1="11.5" x2="6.5" y2="18.5" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint4_linear_1036_1071" x1="15" y1="8.5" x2="15" y2="18.5" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 		</Defs>
 	</SVG>
@@ -825,12 +825,12 @@ export const comparisonTableIcon = ( props = {}) => (
 		</G>
 		<Defs>
 			<LinearGradient id="paint0_linear_1028_2592" x1="12" y1="3" x2="12" y2="20" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<LinearGradient id="paint1_linear_1028_2592" x1="17" y1="12.3046" x2="17" y2="19.5407" gradientUnits="userSpaceOnUse">
-				<stop stop-color="#ED6F57"/>
-				<stop offset="1" stop-color="#F22B6C"/>
+				<stop stopColor="#ED6F57"/>
+				<stop offset="1" stopColor="#F22B6C"/>
 			</LinearGradient>
 			<clipPath id="clip0_1028_2592">
 				<rect width="18" height="17" fill="white" transform="translate(3 3)"/>

--- a/src/dashboard/components/pages/Blocks.js
+++ b/src/dashboard/components/pages/Blocks.js
@@ -176,7 +176,7 @@ const otterBlocks = [
 	},
 	{
 		'slug': 'themeisle-blocks/slider',
-		'name': __( 'Slider', 'otter-blocks' ),
+		'name': __( 'Image Slider', 'otter-blocks' ),
 		'icon': sliderIcon,
 		'docLink': 'https://docs.themeisle.com/article/1668-image-related-blocks#slider'
 	},


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/173.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- Rename Slider to Image Slider
- Remove notice from Countdown Block
- Change upsell notice color to Gray
- Remove Upsell from Form sidebar
- Add Pro label to Form Submission menu item
- Remove Export button from Form Submission page for in free version
- Rename sib to Brevo
- Remove CTA category, use the default one
- Replace webhook docs link
- Set default Countdown date

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

