### PR TITLE
feat: add themeisle-sdk to Blocks Animation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,7 +50,7 @@ module.exports = function( grunt ) {
 				options: {
 					flags: ''
 				},
-				src: [ 'package.json', 'composer.json', 'package-lock.json' ]
+				src: [ 'package.json', 'composer.json', 'package-lock.json', 'plugins/blocks-animation/composer.json' ]
 			},
 			metatag: {
 				options: {

--- a/bin/dist.sh
+++ b/bin/dist.sh
@@ -86,6 +86,11 @@ do
 
   cd plugins/$BUILD_NAME
 
+  # We install dependencies only if composer.json exists.
+  if [ -f "composer.json" ]; then
+    composer install --no-dev
+  fi
+
   rsync -rc --exclude-from ".distignore" "./" "../../dist/$DIST_FOLDER"
 
   cd ../..

--- a/plugins/blocks-animation/blocks-animation.php
+++ b/plugins/blocks-animation/blocks-animation.php
@@ -29,6 +29,21 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'BLOCKS_ANIMATION_URL', plugins_url( '/', __FILE__ ) );
 define( 'BLOCKS_ANIMATION_PATH', dirname( __FILE__ ) );
 
+$vendor_file = BLOCKS_ANIMATION_PATH . '/vendor/autoload.php';
+
+if ( is_readable( $vendor_file ) ) {
+	require_once $vendor_file;
+}
+
+add_filter(
+	'themeisle_sdk_products',
+	function ( $products ) {
+		$products[] = __FILE__;
+
+		return $products;
+	}
+);
+
 add_action(
 	'plugins_loaded',
 	function () {

--- a/plugins/blocks-animation/composer.json
+++ b/plugins/blocks-animation/composer.json
@@ -1,0 +1,32 @@
+{
+	"name": "codeinwp/blocks-animation",
+	"description": "Blocks Animation: CSS Animations for Gutenberg Blocks",
+	"type": "wordpress-plugin",
+	"version": "2.6.13",
+	"license": "GPL-2.0+",
+	"authors": [
+		{
+			"name": "ThemeIsle Team",
+			"email": "friends@themeisle.com"
+		}
+	],
+	"prefer-stable": true,
+	"config": {
+		"optimize-autoloader": true,
+		"platform": {
+			"php": "7.4"
+		}
+	},
+	"extra": {
+		"installer-disable": "true"
+	},
+	"autoload": {
+		"files": [
+			"vendor/codeinwp/themeisle-sdk/load.php"
+		]
+	},
+	"minimum-stability": "dev",
+	"require": {
+		"codeinwp/themeisle-sdk": "^3.2"
+	}
+}

--- a/plugins/blocks-animation/composer.lock
+++ b/plugins/blocks-animation/composer.lock
@@ -1,0 +1,62 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ea8f98e8dd0f89202c94f9b316205943",
+    "packages": [
+        {
+            "name": "codeinwp/themeisle-sdk",
+            "version": "3.3.25",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeinwp/themeisle-sdk.git",
+                "reference": "29b7c81f8ccd039f49d62ef7427a4cc06369becc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/29b7c81f8ccd039f49d62ef7427a4cc06369becc",
+                "reference": "29b7c81f8ccd039f49d62ef7427a4cc06369becc",
+                "shasum": ""
+            },
+            "require-dev": {
+                "codeinwp/phpcs-ruleset": "dev-main"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "ThemeIsle team",
+                    "email": "friends@themeisle.com",
+                    "homepage": "https://themeisle.com"
+                }
+            ],
+            "description": "ThemeIsle SDK",
+            "homepage": "https://github.com/Codeinwp/themeisle-sdk",
+            "keywords": [
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.25"
+            },
+            "time": "2024-07-08T13:49:14+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.4"
+    },
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/196
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
The PR adds ThemeIsle SDK to Blocks Animation child-plugin.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure the SDK works and doesn't throw any issues when used with or without Otter.

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

