### PR TITLE
feat: display a mix of free/pro in autocomplete

### DIFF
--- a/src/blocks/plugins/dynamic-content/value/autocompleter.js
+++ b/src/blocks/plugins/dynamic-content/value/autocompleter.js
@@ -21,8 +21,6 @@ let autocompleteOptions = [];
 
 Object.keys( options ).forEach( option => autocompleteOptions.push( ...options[option].options ) );
 
-autocompleteOptions =  [ ...autocompleteOptions.filter( i => true !== i.isDisabled ), ...autocompleteOptions.filter( i => true === i.isDisabled ) ];
-
 const dynamicValue = {
 	name: 'dynamic-value',
 	triggerPrefix: '%',


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/207
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This changes the current autocomplete behavior for Dynamic Value from displaying Free first and Pro later to mix them.

### Screenshots <!-- if applicable -->
<img width="476" alt="Screenshot 2024-07-25 at 10 28 53 AM" src="https://github.com/user-attachments/assets/a6205738-095a-4846-a77a-606f468fb22a">

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Confirm the feature works as before, and you see a mix of Free/Pro by default.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

