### PR TITLE
feat: close popup on ESC key

### DIFF
--- a/src/blocks/frontend/popup/popup.ts
+++ b/src/blocks/frontend/popup/popup.ts
@@ -27,6 +27,7 @@ class PopupBlock {
 	init() {
 		this.bindOpen();
 		this.bindClose();
+		this.bindEscClose();
 	}
 
 	isDisabled() {
@@ -258,6 +259,14 @@ class PopupBlock {
 		if ( this.canLock ) {
 			document.body.classList.remove( 'o-lock-body' );
 		}
+	}
+
+	bindEscClose() {
+		document.addEventListener( 'keydown', ( event ) => {
+			if ( 'Escape' === event.key && this.happened ) {
+				this.closeModal();
+			}
+		});
 	}
 }
 

--- a/src/blocks/test/e2e/blocks/popup.spec.js
+++ b/src/blocks/test/e2e/blocks/popup.spec.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Popup', () => {
+	test.beforeEach( async({ admin }) => {
+		await admin.createNewPost();
+	});
+
+	test( 'close on escape', async({ editor, page }) => {
+
+		await editor.insertBlock({
+			name: 'themeisle-blocks/popup',
+			attributes: {
+
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Popup Content Test'
+					}
+				}
+			]
+		});
+
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${postId}` );
+
+		await expect( page.getByText( 'Popup Content Test' ) ).toBeVisible();
+		await page.keyboard.press( 'Escape' );
+		await expect( page.getByText( 'Popup Content Test' ) ).toBeHidden();
+	});
+});


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/204
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The popup will close on the ESC key press.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a Popup Block
2. Check in preview
3. Press on ESC key close it.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

