### PR TITLE
feat: add 7 days notice for upsell

### DIFF
--- a/otter-blocks.php
+++ b/otter-blocks.php
@@ -50,6 +50,18 @@ add_filter(
 );
 
 add_filter(
+	'otter_blocks_welcome_metadata',
+	function() {
+		return [
+			'is_enabled' => ! defined( 'OTTER_PRO_VERSION' ),
+			'pro_name'   => __( 'Otter Blocks Pro', 'otter-blocks' ),
+			'logo'       => OTTER_BLOCKS_URL . '/assets/images/logo-alt.png',
+			'cta_link'   => tsdk_utmify( 'https://themeisle.com/plugins/otter-blocks/upgrade/?discount=LOYALUSER583&dvalue=60#pricing', 'otter-welcome', 'notice' ),
+		];
+	}
+);
+
+add_filter(
 	'themeisle_sdk_compatibilities/' . basename( OTTER_BLOCKS_PATH ),
 	function ( $compatibilities ) {
 		$compatibilities['OtterBlocksPRO'] = array(


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/210
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added Welcome Upsell notice from SDK.

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/1e665653-2b54-4173-8e3b-8fd92a2f6fa5)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Install Otter
2. Make the Otter plugin install time to be older than 7 days and newer than 14 days.
3. Check if the notices shows up

#### Tips

You can directly edit the install date in `/admin/options.php`. You can this website to generate the date value: https://www.nexcess.net/web-tools/unix-timestamp-converter/ (Set the date with 8 days back from the current one)

<img width="1101" alt="Screenshot 2024-07-26 at 12 44 42" src="https://github.com/user-attachments/assets/64b5b75f-b6a0-4fcf-8fa2-19b59bd0eac6">


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

