### PR TITLE
feat: add more Woo conditions to Block Conditions module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ license.json
 .phpunit.result.cache
 .fleet
 tests/assets/*_tmp
-wp-content
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ license.json
 .phpunit.result.cache
 .fleet
 tests/assets/*_tmp
+wp-content
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,15 @@
 	"description": "A set of awesome Gutenberg Blocks by ThemeIsle.",
 	"type": "wordpress-plugin",
 	"version": "2.6.13",
+    "repositories":[
+        {
+            "type":"composer",
+            "url":"https://wpackagist.org",
+            "only": [
+                "wpackagist-plugin/*"
+            ]
+        }
+    ],
 	"require-dev": {
 		"squizlabs/php_codesniffer": "^3.3",
 		"wp-coding-standards/wpcs": "^1",
@@ -15,7 +24,8 @@
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"php-stubs/woocommerce-stubs": "^9.1",
 		"php-stubs/acf-pro-stubs": "^6.0",
-		"spaze/phpstan-stripe": "^2.4"
+		"spaze/phpstan-stripe": "^2.4",
+		"wpackagist-plugin/woocommerce": "*"
 	},
 	"license": "GPL-2.0+",
 	"authors": [
@@ -37,11 +47,15 @@
 			"php": "7.4"
 		},
 		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"composer/installers": true
 		}
 	},
 	"extra": {
-		"installer-disable": "true"
+		"installer-disable": "true",
+		"installer-paths": {
+			"tests/wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
+		}
 	},
 	"autoload": {
 		"classmap": ["inc/"],

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
 	"extra": {
 		"installer-disable": "true",
 		"installer-paths": {
-			"tests/wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
+			"vendor/wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
 		}
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6e56fc952d074fb4d185530d7064785",
+    "content-hash": "07bb7e396bb66a7583b618065991d993",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
@@ -436,6 +436,152 @@
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
             "time": "2019-04-24T21:34:09+00:00"
+        },
+        {
+            "name": "composer/installers",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.10.27 || ^2.7",
+                "composer/semver": "^1.7.2 || ^3.4.0",
+                "phpstan/phpstan": "^1.11",
+                "phpstan/phpstan-phpunit": "^1",
+                "symfony/phpunit-bridge": "^7.1.1",
+                "symfony/process": "^5 || ^6 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                },
+                "plugin-modifies-install-path": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Starbug",
+                "Thelia",
+                "Whmcs",
+                "WolfCMS",
+                "agl",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "concreteCMS",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "known",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "matomo",
+                "mediawiki",
+                "miaoxing",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "pantheon",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "processwire",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "sylius",
+                "tastyigniter",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-06-24T20:46:46+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -2830,6 +2976,24 @@
                 "wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki"
             },
             "time": "2018-12-18T09:43:51+00:00"
+        },
+        {
+            "name": "wpackagist-plugin/woocommerce",
+            "version": "9.1.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/woocommerce/",
+                "reference": "tags/9.1.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/woocommerce.9.1.3.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/woocommerce/"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/inc/plugins/class-block-conditions.php
+++ b/inc/plugins/class-block-conditions.php
@@ -206,6 +206,16 @@ class Block_Conditions {
 			}
 		}
 
+		if ( 'postTag' === $condition['type'] ) {
+			if ( isset( $condition['tags'] ) ) {
+				if ( $visibility ) {
+					return has_tag( $condition['tags'] );
+				} else {
+					return ! has_tag( $condition['tags'] );
+				}
+			}
+		}
+
 		if ( 'screenSize' === $condition['type'] ) {
 			return true;
 		}

--- a/inc/plugins/class-block-conditions.php
+++ b/inc/plugins/class-block-conditions.php
@@ -151,83 +151,39 @@ class Block_Conditions {
 		$visibility = isset( $condition['visibility'] ) ? boolval( $condition['visibility'] ) : true;
 
 		if ( 'loggedInUser' === $condition['type'] ) {
-			if ( is_user_logged_in() ) {
-				return true;
-			} else {
-				return false;
-			}
+			return is_user_logged_in();
 		}
 
 		if ( 'loggedOutUser' === $condition['type'] ) {
-			if ( is_user_logged_in() ) {
-				return false;
-			} else {
-				return true;
-			}
+			return ! is_user_logged_in();
 		}
 
-		if ( 'userRoles' === $condition['type'] ) {
-			if ( isset( $condition['roles'] ) ) {
-				if ( $visibility ) {
-					return $this->has_user_roles( $condition['roles'] );
-				} else {
-					return ! $this->has_user_roles( $condition['roles'] );
-				}
-			}
+		if ( 'userRoles' === $condition['type'] && isset( $condition['roles'] ) ) {
+			return $visibility ? $this->has_user_roles( $condition['roles'] ) : ! $this->has_user_roles( $condition['roles'] );
 		}
 
-		if ( 'postAuthor' === $condition['type'] ) {
-			if ( isset( $condition['authors'] ) ) {
-				if ( $visibility ) {
-					return $this->has_author( $condition['authors'] );
-				} else {
-					return ! $this->has_author( $condition['authors'] );
-				}
-			}
+		if ( 'postAuthor' === $condition['type'] && isset( $condition['authors'] ) ) {
+			return $visibility ? $this->has_author( $condition['authors'] ) : ! $this->has_author( $condition['authors'] );
 		}
 
-		if ( 'postType' === $condition['type'] ) {
-			if ( isset( $condition['post_types'] ) ) {
-				if ( $visibility ) {
-					return $this->is_type( $condition['post_types'] );
-				} else {
-					return ! $this->is_type( $condition['post_types'] );
-				}
-			}
+		if ( 'postType' === $condition['type'] && isset( $condition['post_types'] ) ) {
+			return $visibility ? $this->is_type( $condition['post_types'] ) : ! $this->is_type( $condition['post_types'] );
 		}
 
-		if ( 'postCategory' === $condition['type'] ) {
-			if ( isset( $condition['categories'] ) ) {
-				if ( $visibility ) {
-					return $this->has_category( $condition['categories'] );
-				} else {
-					return ! $this->has_category( $condition['categories'] );
-				}
-			}
+		if ( 'postCategory' === $condition['type'] && isset( $condition['categories'] ) ) {
+			return $visibility ? $this->has_category( $condition['categories'] ) : ! $this->has_category( $condition['categories'] );
 		}
 
-		if ( 'postTag' === $condition['type'] ) {
-			if ( isset( $condition['tags'] ) ) {
-				if ( $visibility ) {
-					return has_tag( $condition['tags'] );
-				} else {
-					return ! has_tag( $condition['tags'] );
-				}
-			}
+		if ( 'postTag' === $condition['type'] && isset( $condition['tags'] ) ) {
+			return $visibility ? has_tag( $condition['tags'] ) : ! has_tag( $condition['tags'] );
 		}
 
 		if ( 'screenSize' === $condition['type'] ) {
 			return true;
 		}
 
-		if ( 'stripePurchaseHistory' === $condition['type'] ) {
-			if ( isset( $condition['product'] ) && Stripe_API::has_keys() ) {
-				if ( $visibility ) {
-					return $this->has_stripe_product( $condition['product'] );
-				} else {
-					return ! $this->has_stripe_product( $condition['product'] );
-				}
-			}
+		if ( 'stripePurchaseHistory' === $condition['type'] && isset( $condition['product'] ) && Stripe_API::has_keys() ) {
+			return $visibility ? $this->has_stripe_product( $condition['product'] ) : ! $this->has_stripe_product( $condition['product'] );
 		}
 
 		return apply_filters( 'otter_blocks_evaluate_condition', true, $condition, $visibility );

--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -41,162 +41,76 @@ class Block_Conditions {
 	 * @return bool
 	 */
 	public function evaluate_condition( $bool, $condition, $visibility ) {
-		if ( 'loggedInUserMeta' === $condition['type'] ) {
-			if ( isset( $condition['meta_key'] ) ) {
-				if ( $visibility ) {
-					return $this->has_meta( $condition, 'user' );
-				} else {
-					return ! $this->has_meta( $condition, 'user' );
-				}
-			}
+		if ( ! isset( $condition['type'] ) ) {
+			return true;
 		}
 
-		if ( 'postMeta' === $condition['type'] ) {
-			if ( isset( $condition['meta_key'] ) ) {
-				if ( $visibility ) {
-					return $this->has_meta( $condition, 'post' );
-				} else {
-					return ! $this->has_meta( $condition, 'post' );
-				}
-			}
+		if ( 'loggedInUserMeta' === $condition['type'] && isset( $condition['meta_key'] ) ) {
+			return $visibility ? $this->has_meta( $condition, 'user' ) : ! $this->has_meta( $condition, 'user' );
 		}
 
-		if ( 'queryString' === $condition['type'] ) {
-			if ( isset( $condition['query_string'] ) && isset( $condition['match'] ) ) {
-				if ( $visibility ) {
-					return $this->has_query_string( $condition );
-				} else {
-					return ! $this->has_query_string( $condition );
-				}
-			}
+		if ( 'postMeta' === $condition['type'] && isset( $condition['meta_key'] ) ) {
+			return $visibility ? $this->has_meta( $condition, 'post' ) : ! $this->has_meta( $condition, 'post' );
 		}
 
-		if ( 'country' === $condition['type'] ) {
-			if ( isset( $condition['value'] ) ) {
-				if ( $visibility ) {
-					return $this->has_country( $condition );
-				} else {
-					return ! $this->has_country( $condition );
-				}
-			}
+		if ( 'queryString' === $condition['type'] && isset( $condition['query_string'] ) && isset( $condition['match'] ) ) {
+			return $visibility ? $this->has_query_string( $condition ) : ! $this->has_query_string( $condition );
 		}
 
-		if ( 'cookie' === $condition['type'] ) {
-			if ( isset( $condition['cookie_key'] ) ) {
-				if ( $visibility ) {
-					return $this->has_cookie( $condition );
-				} else {
-					return ! $this->has_cookie( $condition );
-				}
-			}
+		if ( 'country' === $condition['type'] && isset( $condition['value'] ) ) {
+			return $visibility ? $this->has_country( $condition ) : ! $this->has_country( $condition );
 		}
 
-		if ( 'dateRange' === $condition['type'] ) {
-			if ( isset( $condition['start_date'] ) ) {
-				return $this->has_date_range( $condition );
-			}
+		if ( 'cookie' === $condition['type'] && isset( $condition['cookie_key'] ) ) {
+			return $visibility ? $this->has_cookie( $condition ) : ! $this->has_cookie( $condition );
 		}
 
-		if ( 'dateRecurring' === $condition['type'] ) {
-			if ( isset( $condition['days'] ) ) {
-				return $this->has_date_recurring( $condition['days'] );
-			}
+		if ( 'dateRange' === $condition['type'] && isset( $condition['start_date'] ) ) {
+			return $this->has_date_range( $condition );
 		}
 
-		if ( 'timeRecurring' === $condition['type'] ) {
-			if ( isset( $condition['start_time'] ) ) {
-				return $this->has_time_recurring( $condition );
-			}
+		if ( 'dateRecurring' === $condition['type'] && isset( $condition['days'] ) ) {
+			return $this->has_date_recurring( $condition['days'] );
 		}
 
-		if ( 'wooProductsInCart' === $condition['type'] && class_exists( 'WooCommerce' ) ) {
-			if ( isset( $condition['on'] ) ) {
-				if ( $visibility ) {
-					return $this->has_products_in_cart( $condition );
-				} else {
-					return ! $this->has_products_in_cart( $condition );
-				}
-			}
+		if ( 'timeRecurring' === $condition['type'] && isset( $condition['start_time'] ) ) {
+			return $this->has_time_recurring( $condition );
 		}
 
-		if ( 'wooTotalCartValue' === $condition['type'] && class_exists( 'WooCommerce' ) ) {
-			if ( isset( $condition['value'] ) ) {
-				if ( 'greater_than' === $condition['compare'] ) {
-					return $this->has_total_cart_value( $condition['value'] );
-				} else {
-					return ! $this->has_total_cart_value( $condition['value'] );
-				}
-			}
+		if ( 'wooProductsInCart' === $condition['type'] && class_exists( 'WooCommerce' ) && isset( $condition['on'] ) ) {
+			return $visibility ? $this->has_products_in_cart( $condition ) : ! $this->has_products_in_cart( $condition );
 		}
 
-		if ( 'wooPurchaseHistory' === $condition['type'] && class_exists( 'WooCommerce' ) ) {
-			if ( isset( $condition['products'] ) ) {
-				if ( $visibility ) {
-					return $this->has_products( $condition['products'] );
-				} else {
-					return ! $this->has_products( $condition['products'] );
-				}
-			}
+		if ( 'wooTotalCartValue' === $condition['type'] && class_exists( 'WooCommerce' ) && isset( $condition['value'] ) ) {
+			return 'greater_than' === $condition['compare'] ? $this->has_total_cart_value( $condition['value'] ) : ! $this->has_total_cart_value( $condition['value'] );
 		}
 
-		if ( 'wooTotalSpent' === $condition['type'] && class_exists( 'WooCommerce' ) ) {
-			if ( isset( $condition['value'] ) ) {
-				if ( 'greater_than' === $condition['compare'] ) {
-					return $this->has_total_spent( $condition['value'] );
-				} else {
-					return ! $this->has_total_spent( $condition['value'] );
-				}
-			}
+		if ( 'wooPurchaseHistory' === $condition['type'] && class_exists( 'WooCommerce' ) && isset( $condition['products'] ) ) {
+			return $visibility ? $this->has_products( $condition['products'] ) : ! $this->has_products( $condition['products'] );
 		}
 
-		if ( 'wooCategory' === $condition['type'] && class_exists( 'WooCommerce' ) ) {
-			if ( isset( $condition['categories'] ) ) {
-				if ( $visibility ) {
-					return $this->has_product_category( $condition['categories'] );
-				} else {
-					return ! $this->has_product_category( $condition['categories'] );
-				}
-			}
+		if ( 'wooTotalSpent' === $condition['type'] && class_exists( 'WooCommerce' ) && isset( $condition['value'] ) ) {
+			return 'greater_than' === $condition['compare'] ? $this->has_total_spent( $condition['value'] ) : ! $this->has_total_spent( $condition['value'] );
 		}
 
-		if ( 'wooTag' === $condition['type'] && class_exists( 'WooCommerce' ) ) {
-			if ( isset( $condition['tags'] ) ) {
-				if ( $visibility ) {
-					return $this->has_product_tag( $condition['tags'] );
-				} else {
-					return ! $this->has_product_tag( $condition['tags'] );
-				}
-			}
+		if ( 'wooCategory' === $condition['type'] && class_exists( 'WooCommerce' ) && isset( $condition['categories'] ) ) {
+			return $visibility ? $this->has_product_category( $condition['categories'] ) : ! $this->has_product_category( $condition['categories'] );
 		}
 
-		if ( 'wooAttribute' === $condition['type'] && class_exists( 'WooCommerce' ) ) {
-			if ( isset( $condition['attribute'] ) ) {
-				if ( $visibility ) {
-					return $this->has_product_attribute( $condition );
-				} else {
-					return ! $this->has_product_attribute( $condition );
-				}
-			}
+		if ( 'wooTag' === $condition['type'] && class_exists( 'WooCommerce' ) && isset( $condition['tags'] ) ) {
+			return $visibility ? $this->has_product_tag( $condition['tags'] ) : ! $this->has_product_tag( $condition['tags'] );
 		}
 
-		if ( 'learnDashPurchaseHistory' === $condition['type'] && defined( 'LEARNDASH_VERSION' ) ) {
-			if ( isset( $condition['on'] ) ) {
-				if ( $visibility ) {
-					return $this->has_courses_or_groups( $condition );
-				} else {
-					return ! $this->has_courses_or_groups( $condition );
-				}
-			}
+		if ( 'wooAttribute' === $condition['type'] && class_exists( 'WooCommerce' ) && isset( $condition['attribute'] ) ) {
+			return $visibility ? $this->has_product_attribute( $condition ) : ! $this->has_product_attribute( $condition );
 		}
 
-		if ( 'learnDashCourseStatus' === $condition['type'] && defined( 'LEARNDASH_VERSION' ) ) {
-			if ( isset( $condition['course'] ) ) {
-				if ( $visibility ) {
-					return $this->has_course_status( $condition );
-				} else {
-					return ! $this->has_course_status( $condition );
-				}
-			}
+		if ( 'learnDashPurchaseHistory' === $condition['type'] && defined( 'LEARNDASH_VERSION' ) && isset( $condition['on'] ) ) {
+			return $visibility ? $this->has_courses_or_groups( $condition ) : ! $this->has_courses_or_groups( $condition );
+		}
+
+		if ( 'learnDashCourseStatus' === $condition['type'] && defined( 'LEARNDASH_VERSION' ) && isset( $condition['course'] ) ) {
+			return $visibility ? $this->has_course_status( $condition ) : ! $this->has_course_status( $condition );
 		}
 
 		return $bool;
@@ -499,13 +413,10 @@ class Block_Conditions {
 	 * @access public
 	 */
 	public function has_products_in_cart( $condition ) {
-		$in_cart = false;
-
 		if ( 'products' === $condition['on'] && isset( $condition['products'] ) ) {
 			foreach ( \WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 				if ( in_array( $cart_item['product_id'], $condition['products'], true ) ) {
-					$in_cart = true;
-					break;
+					return true;
 				}
 			}
 		}
@@ -514,24 +425,19 @@ class Block_Conditions {
 			foreach ( \WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 				$terms = get_the_terms( $cart_item['product_id'], 'product_cat' );
 
-				if ( gettype( $terms ) !== 'array' ) {
+				if ( ! is_array( $terms ) ) {
 					continue;
 				}
 
 				foreach ( $terms as $term ) {
 					if ( in_array( $term->term_id, $condition['categories'], true ) ) {
-						$in_cart = true;
-						break;
+						return true;
 					}
-				}
-
-				if ( $in_cart ) {
-					break;
 				}
 			}
 		}
 
-		return $in_cart;
+		return false;
 	}
 
 	/**
@@ -583,17 +489,15 @@ class Block_Conditions {
 	 * @access public
 	 */
 	public function has_products( $products ) {
-		$bought       = false;
 		$current_user = wp_get_current_user();
 
 		foreach ( $products as $product ) {
 			if ( wc_customer_bought_product( $current_user->user_email, $current_user->ID, $product ) ) {
-				$bought = true;
-				break;
+				return true;
 			};
 		}
 
-		return $bought;
+		return false;
 	}
 
 	/**
@@ -605,8 +509,6 @@ class Block_Conditions {
 	 * @access public
 	 */
 	public function has_product_category( $categories ) {
-		$in_category = false;
-
 		global $product;
 
 		if ( ! $product instanceof \WC_Product ) {
@@ -615,18 +517,17 @@ class Block_Conditions {
 
 		$terms = get_the_terms( $product->get_id(), 'product_cat' );
 
-		if ( gettype( $terms ) !== 'array' ) {
+		if ( ! is_array( $terms ) ) {
 			return false;
 		}
 
 		foreach ( $terms as $term ) {
 			if ( in_array( $term->term_id, $categories, true ) ) {
-				$in_category = true;
-				break;
+				return true;
 			}
 		}
 
-		return $in_category;
+		return false;
 	}
 
 	/**
@@ -638,8 +539,6 @@ class Block_Conditions {
 	 * @access public
 	 */
 	public function has_product_tag( $tags ) {
-		$in_tag = false;
-
 		global $product;
 
 		if ( ! $product instanceof \WC_Product ) {
@@ -648,18 +547,17 @@ class Block_Conditions {
 
 		$terms = get_the_terms( $product->get_id(), 'product_tag' );
 
-		if ( gettype( $terms ) !== 'array' ) {
+		if ( ! is_array( $terms ) ) {
 			return false;
 		}
 
 		foreach ( $terms as $term ) {
 			if ( in_array( $term->term_id, $tags, true ) ) {
-				$in_tag = true;
-				break;
+				return true;
 			}
 		}
 
-		return $in_tag;
+		return false;
 	}
 
 	/**
@@ -678,7 +576,6 @@ class Block_Conditions {
 		$attribute     = $condition['attribute'];
 		$terms         = isset( $condition['terms'] ) ? $condition['terms'] : false;
 		$has_attribute = false;
-		$in_attribute  = false;
 
 		global $product;
 
@@ -712,12 +609,11 @@ class Block_Conditions {
 
 		foreach ( $attribute_terms as $term ) {
 			if ( in_array( $term->slug, $terms, true ) ) {
-				$in_attribute = true;
-				break;
+				return true;
 			}
 		}
 
-		return $in_attribute;
+		return false;
 	}
 
 	/**
@@ -729,14 +625,12 @@ class Block_Conditions {
 	 * @access public
 	 */
 	public function has_courses_or_groups( $condition ) {
-		$bought       = false;
 		$current_user = wp_get_current_user();
 
 		if ( 'courses' === $condition['on'] && isset( $condition['courses'] ) ) {
 			foreach ( $condition['courses'] as $course ) {
 				if ( ld_course_check_user_access( $course, $current_user->ID ) ) {
-					$bought = true;
-					break;
+					return true;
 				};
 			}
 		}
@@ -746,17 +640,12 @@ class Block_Conditions {
 				$users = learndash_get_groups_user_ids( $group );
 
 				if ( in_array( $current_user->ID, $users, true ) ) {
-					$bought = true;
-					break;
-				}
-
-				if ( $bought ) {
-					break;
+					return true;
 				}
 			}
 		}
 
-		return $bought;
+		return false;
 	}
 
 	/**

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -85,6 +85,12 @@ const defaultConditions = {
 				toogleVisibility: true
 			},
 			{
+				value: 'postTag',
+				label: __( 'Post Tag', 'otter-blocks' ),
+				help: __( 'The selected block will be visible based on selected post tags.' ),
+				toogleVisibility: true
+			},
+			{
 				value: 'postMeta',
 				label: __( 'Post Meta (Pro)', 'otter-blocks' ),
 				help: __( 'The selected block will be visible based on post meta condition.' ),
@@ -173,6 +179,29 @@ const defaultConditions = {
 			}
 		]
 	},
+	'woocommerceProduct': {
+		label: __( 'WooCommerce Product', 'otter-blocks' ),
+		conditions: [
+			{
+				value: 'wooCategory',
+				label: __( 'Product Category (Pro)', 'otter-blocks' ),
+				help: __( 'The selected block will be visible based on the product category.' ),
+				isDisabled: true
+			},
+			{
+				value: 'wooTag',
+				label: __( 'Product Tag (Pro)', 'otter-blocks' ),
+				help: __( 'The selected block will be visible based on the product tag.' ),
+				isDisabled: true
+			},
+			{
+				value: 'wooAttribute',
+				label: __( 'Product Attribute (Pro)', 'otter-blocks' ),
+				help: __( 'The selected block will be visible based on the product attribute.' ),
+				isDisabled: true
+			}
+		]
+	},
 	'stripe': {
 		label: __( 'Stripe', 'otter-blocks' ),
 		conditions: [
@@ -250,6 +279,31 @@ const CategoriesFieldToken = ( props ) => {
 			suggestions={ postCategories }
 			__experimentalExpandOnFocus={ true }
 			__experimentalValidateInput={ newValue => postCategories.includes( newValue ) }
+		/>
+	);
+};
+
+const TagsFieldToken = ( props ) => {
+	const {
+		postTags,
+		isLoading
+	} = useSelect( select => {
+		const { getEntityRecords, isResolving } = select( 'core' );
+
+		return {
+			postTags: ( getEntityRecords( 'taxonomy', 'post_tag', { 'per_page': -1, context: 'view' }) ?? []).map( tag => tag.slug ),
+			isLoading: isResolving( 'getEntityRecords', [ 'taxonomy', 'post_tag', { 'per_page': -1, context: 'view' }])
+		};
+	}, [ ]);
+
+	return isLoading ? (
+		<Placeholder><Spinner /></Placeholder>
+	) : (
+		<FormTokenField
+			{ ...props }
+			suggestions={ postTags }
+			__experimentalExpandOnFocus={ true }
+			__experimentalValidateInput={ newValue => postTags.includes( newValue ) }
 		/>
 	);
 };
@@ -505,6 +559,14 @@ const Edit = ({
 											label={ __( 'Post Category', 'otter-blocks' ) }
 											value={ condObj.categories }
 											onChange={ categories => changeArrayValue( categories, index, condIdx, 'categories' ) }
+										/>
+									) }
+
+									{ 'postTag' === condObj.type && (
+										<TagsFieldToken
+											label={ __( 'Post Tag', 'otter-blocks' ) }
+											value={ condObj.tags }
+											onChange={ tags => changeArrayValue( tags, index, condIdx, 'tags' ) }
 										/>
 									) }
 

--- a/src/pro/plugins/conditions/edit.js
+++ b/src/pro/plugins/conditions/edit.js
@@ -112,7 +112,7 @@ const Multiselect = ({
 			label={ label }
 			value={ ( values && 'object' === typeof values ) ? values.map( id => {
 				const obj = items.find( item => Number( id ) === Number( item.value ) );
-				return `${ obj.value }. ${ obj.label }`;
+				return `${ obj?.value }. ${ obj?.label }`;
 			}) : undefined }
 			suggestions={ items.map( item => `${ item.value }. ${ item.label }` ) }
 			onChange={ onChange }
@@ -164,7 +164,7 @@ const ProductsMultiselect = ( props ) => {
 		<Placeholder><Spinner /></Placeholder>
 	) : (
 		<Multiselect
-			{...props}
+			{ ...props }
 			items={ products }
 		/>
 	);
@@ -207,8 +207,100 @@ const CategoriesMultiselect = ( props ) => {
 		<Placeholder><Spinner /></Placeholder>
 	) : (
 		<Multiselect
-			{...props}
+			{ ...props }
 			items={ categories }
+		/>
+	);
+};
+
+const TagsMultiselect = ( props ) => {
+	const {
+		tags,
+		isLoading
+	} = useSelect( select => {
+		if ( ! Boolean( window.otterPro.hasWooCommerce ) ) {
+			return {
+				tags: [],
+				isLoading: false
+			};
+		}
+
+		const { COLLECTIONS_STORE_KEY } = window?.wc?.wcBlocksData;
+		const {
+			getCollection,
+			getCollectionError,
+			isResolving
+		} = select( COLLECTIONS_STORE_KEY );
+
+		// eslint-disable-next-line camelcase
+		const tagsError = getCollectionError( '/wc/store', 'products/tags' );
+
+		const tags = tagsError ? [] : ( getCollection( '/wc/store', 'products/tags' ) ?? [])?.map( result => ({
+			value: result.id,
+			label: decodeEntities( result.name )
+		}) );
+
+		return {
+			tags,
+			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products/tags' ])
+		};
+	}, []);
+
+	return isLoading ? (
+		<Placeholder><Spinner /></Placeholder>
+	) : (
+		<Multiselect
+			{ ...props }
+			items={ tags }
+		/>
+	);
+};
+
+const WooAttributes = ( props ) => {
+	const {
+		attributes,
+		isLoading
+	} = useSelect( select => {
+		if ( ! Boolean( window.otterPro.hasWooCommerce ) ) {
+			return {
+				attributes: [],
+				isLoading: false
+			};
+		}
+
+		const { COLLECTIONS_STORE_KEY } = window?.wc?.wcBlocksData;
+		const {
+			getCollection,
+			getCollectionError,
+			isResolving
+		} = select( COLLECTIONS_STORE_KEY );
+
+		// eslint-disable-next-line camelcase
+		const attributesError = getCollectionError( '/wc/store', 'products/attributes' );
+
+		const attributes = attributesError ? [] : ( getCollection( '/wc/store', 'products/attributes' ) ?? [])?.map( result => ({
+			value: result.id,
+			label: decodeEntities( result.name )
+		}) );
+
+		return {
+			attributes,
+			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products/attributes' ])
+		};
+	}, []);
+
+	return isLoading ? (
+		<Placeholder><Spinner /></Placeholder>
+	) : (
+		<SelectControl
+			{ ...props }
+			options={ [
+				{
+					value: '',
+					label: __( 'Select an attribute', 'otter-blocks' )
+				},
+				...attributes
+			] }
 		/>
 	);
 };
@@ -236,7 +328,7 @@ const CoursesMultiselect = ( props ) => {
 		<Placeholder><Spinner /></Placeholder>
 	) : (
 		<Multiselect
-			{...props}
+			{ ...props }
 			items={ courses }
 		/>
 	);
@@ -306,7 +398,7 @@ const GroupsMultiselect = ( props ) => {
 		<Placeholder><Spinner /></Placeholder>
 	) : (
 		<Multiselect
-			{...props}
+			{ ...props }
 			items={ groups }
 		/>
 	);
@@ -320,6 +412,11 @@ const Edit = ({
 	setAttributes,
 	changeValue
 }) => {
+	const changeArrayValue = ( value, index, key, type ) => {
+		const otterConditions = [ ...conditions ];
+		otterConditions[ index ][ key ][ type ] = value;
+		setAttributes({ otterConditions });
+	};
 
 	const changeDays = ( value, groupIndex, key ) => {
 		const otterConditions = [ ...conditions ];
@@ -362,6 +459,31 @@ const Edit = ({
 
 		const otterConditions = [ ...conditions ];
 		otterConditions[ index ][ key ].categories = values;
+		setAttributes({ otterConditions });
+	};
+
+	const changeTags = ( values, index, key ) => {
+		const regex = /^([^.]+)/;
+
+		values.forEach( ( value, key ) => {
+			const m = regex.exec( value );
+			null !== m ? values[ key ] = Number( m[0]) : value;
+		});
+
+		const otterConditions = [ ...conditions ];
+		otterConditions[ index ][ key ].tags = values;
+		setAttributes({ otterConditions });
+	};
+
+	const changeAttribute = ( values, index, key ) => {
+		const otterConditions = [ ...conditions ];
+
+		if ( ! values ) {
+			delete otterConditions[ index ][ key ].attribute;
+		} else {
+			otterConditions[ index ][ key ].attribute = values;
+		}
+
 		setAttributes({ otterConditions });
 	};
 
@@ -795,6 +917,40 @@ const Edit = ({
 					/>
 				</Fragment>
 			) }
+
+			{ 'wooCategory' === item.type && (
+				<CategoriesMultiselect
+					label={ __( 'Categories', 'otter-blocks' ) }
+					values={ item.categories }
+					onChange={ values => changeCategories( values, groupIndex, itemIndex ) }
+				/>
+			) }
+			{ 'wooTag' === item.type && (
+				<TagsMultiselect
+					label={ __( 'Tags', 'otter-blocks' ) }
+					values={ item.tags }
+					onChange={ values => changeTags( values, groupIndex, itemIndex ) }
+				/>
+			)}
+
+			{ 'wooAttribute' === item.type && (
+				<Fragment>
+					<WooAttributes
+						label={ __( 'Attribute', 'otter-blocks' ) }
+						value={ item.attribute }
+						onChange={ values => changeAttribute( values, groupIndex, itemIndex ) }
+					/>
+
+					{ !! item.attribute && (
+						<FormTokenField
+							label={ __( 'Terms', 'otter-blocks' ) }
+							placeholder={ __( 'List the terms by their slug.', 'otter-blocks' ) }
+							value={ item.terms }
+							onChange={ terms => changeArrayValue( terms, groupIndex, itemIndex, 'terms' ) }
+						/>
+					) }
+				</Fragment>
+			)}
 
 			{ 'learnDashPurchaseHistory' === item.type && (
 				<Fragment>

--- a/src/pro/plugins/conditions/index.js
+++ b/src/pro/plugins/conditions/index.js
@@ -115,6 +115,32 @@ const applyProConditions = conditions => {
 				}
 			]
 		},
+		'woocommerceProduct': {
+			label: __( 'WooCommerce Product', 'otter-blocks' ),
+			conditions: [
+				{
+					value: 'wooCategory',
+					label: __( 'Product Categories', 'otter-blocks' ),
+					help: __( 'The selected block will be visible based on the product categories.' ),
+					toogleVisibility: true,
+					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
+				},
+				{
+					value: 'wooTag',
+					label: __( 'Product Tags', 'otter-blocks' ),
+					help: __( 'The selected block will be visible based on the product tags.' ),
+					toogleVisibility: true,
+					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
+				},
+				{
+					value: 'wooAttribute',
+					label: __( 'Product Attributes', 'otter-blocks' ),
+					help: __( 'The selected block will be visible based on the product attribute.' ),
+					toogleVisibility: true,
+					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
+				}
+			]
+		},
 		'learndash': {
 			label: __( 'LearnDash', 'otter-blocks' ),
 			conditions: [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,7 @@ require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/otter-blocks.php';
-	require dirname( dirname( __FILE__ ) ) . '/tests/wp-content/plugins/woocommerce/woocommerce.php';
+	require dirname( dirname( __FILE__ ) ) . '/vendor/wp-content/plugins/woocommerce/woocommerce.php';
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,7 @@ require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/otter-blocks.php';
+	require dirname( dirname( __FILE__ ) ) . '/tests/wp-content/plugins/woocommerce/woocommerce.php';
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
@@ -36,6 +37,8 @@ if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
 require dirname( dirname( __FILE__ ) ) . '/tests/stripe-http-client-mock.php';
 
 activate_plugin( 'otter-blocks/otter-blocks.php' );
+activate_plugin( 'woocommerce/woocommerce.php' );
+
 global $current_user;
 $current_user = new WP_User( 1 );
 $current_user->set_role( 'administrator' );

--- a/tests/test-block-conditions.php
+++ b/tests/test-block-conditions.php
@@ -41,11 +41,13 @@ class TestBlockConditions extends WP_UnitTestCase
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->block_conditions            = new Block_Conditions();
-		$this->otter_pro_blocks_conditions = new \ThemeIsle\OtterPro\Plugins\Block_Conditions();
-		$this->user_id                     = wp_create_user( 'test_user_deletion', 'userlogin', 'test@userrecover.com' );
+		$this->block_conditions = new Block_Conditions();
+		$this->pro_conditions   = new \ThemeIsle\OtterPro\Plugins\Block_Conditions();
+		$this->user_id          = wp_create_user( 'test_user_deletion', 'userlogin', 'test@userrecover.com' );
 
 		$this->block_conditions->init();
+
+		add_filter( 'otter_blocks_evaluate_condition', array( $this->pro_conditions, 'evaluate_condition' ), 10, 3 );
 
 		/**
 		 * Create a test post.
@@ -256,7 +258,7 @@ class TestBlockConditions extends WP_UnitTestCase
 			'meta_compare' => 'is_true',
 		);
 
-		$result = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+		$result = $this->block_conditions->evaluate_condition( $condition );
 
 		$this->assertTrue( $result );
 	}
@@ -273,7 +275,7 @@ class TestBlockConditions extends WP_UnitTestCase
 			'meta_compare' => 'is_true',
 		);
 
-		$result = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+		$result = $this->block_conditions->evaluate_condition( $condition );
 
 		$this->assertFalse( $result );
 	}
@@ -290,7 +292,7 @@ class TestBlockConditions extends WP_UnitTestCase
 			'meta_compare' => 'is_true',
 		);
 
-		$result = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+		$result = $this->block_conditions->evaluate_condition( $condition );
 
 		$this->assertTrue( $result );
 	}
@@ -307,7 +309,7 @@ class TestBlockConditions extends WP_UnitTestCase
 			'meta_compare' => 'is_true',
 		);
 
-		$result = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+		$result = $this->block_conditions->evaluate_condition( $condition );
 
 		$this->assertFalse( $result );
 	}
@@ -323,7 +325,7 @@ class TestBlockConditions extends WP_UnitTestCase
 			'end_date'   => '2030-12-31',
 		);
 
-		$result = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+		$result = $this->block_conditions->evaluate_condition( $condition );
 
 		$this->assertTrue( $result );
 	}
@@ -339,7 +341,7 @@ class TestBlockConditions extends WP_UnitTestCase
 			'end_date'   => '2020-12-31',
 		);
 
-		$result = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+		$result = $this->block_conditions->evaluate_condition( $condition );
 
 		$this->assertFalse( $result );
 	}
@@ -353,7 +355,7 @@ class TestBlockConditions extends WP_UnitTestCase
 			'days' => array( 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday' ),
 		);
 
-		$result = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+		$result = $this->block_conditions->evaluate_condition( $condition );
 
 		$this->assertTrue( $result );
 	}

--- a/tests/test-woo-conditions.php
+++ b/tests/test-woo-conditions.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Class CSS
+ *
+ * @package gutenberg-blocks
+ */
+
+use ThemeIsle\GutenbergBlocks\Registration;
+use ThemeIsle\GutenbergBlocks\Plugins\Block_Conditions;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsCanonicalizing;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertNotEqualsCanonicalizing;
+
+/**
+ * Dynamic Content Test Case.
+ */
+class TestWooConditions extends WP_UnitTestCase
+{
+	/**
+	 * The block conditions instance.
+	 *
+	 * @var Block_Conditions
+	 */
+	protected $block_conditions;
+
+	/**
+	 * The test user ID.
+	 *
+	 * @var int
+	 */
+	protected $user_id;
+
+	/**
+	 * The test post ID.
+	 *
+	 * @var int
+	 */
+	protected $post_id;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->block_conditions            = new Block_Conditions();
+		$this->otter_pro_blocks_conditions = new \ThemeIsle\OtterPro\Plugins\Block_Conditions();
+		$this->user_id                     = wp_create_user( 'test_user_deletion', 'userlogin', 'test@userrecover.com' );
+
+		$this->block_conditions->init();
+
+		$this->category_id_1 = wp_insert_term( 'test-category-1', 'product_cat' );
+		$this->category_id_2 = wp_insert_term( 'test-category-2', 'product_cat' );
+
+		$this->tag_id_1 = wp_insert_term( 'test-tag-1', 'product_tag' );
+		$this->tag_id_2 = wp_insert_term( 'test-tag-2', 'product_tag' );
+
+		/**
+		 * Crete two new WooCommerce product.
+		 */
+		$this->product_id_1 = wp_insert_post(
+			array(
+				'post_title'   => 'Test Product 1',
+				'post_content' => 'Test Product 1 Description',
+				'post_status'  => 'publish',
+				'post_type'    => 'product',
+			)
+		);
+
+		$this->product_id_2 = wp_insert_post(
+			array(
+				'post_title'   => 'Test Product 2',
+				'post_content' => 'Test Product 2 Description',
+				'post_status'  => 'publish',
+				'post_type'    => 'product',
+			)
+		);
+
+		// Add the categories and tags to the products.
+		wp_set_object_terms( $this->product_id_1, $this->category_id_1, 'product_cat' );
+		wp_set_object_terms( $this->product_id_1, $this->tag_id_1, 'product_tag' );
+
+		wp_set_object_terms( $this->product_id_2, $this->category_id_2, 'product_cat' );
+		wp_set_object_terms( $this->product_id_2, $this->tag_id_2, 'product_tag' );
+	}
+
+	public function tear_down()
+	{
+		wp_delete_user( $this->user_id, true );
+		wp_delete_post( $this->post_id, true );
+		wp_delete_term( $this->category_id_1, 'product_cat' );
+		wp_delete_term( $this->category_id_2, 'product_cat' );
+		wp_delete_term( $this->tag_id_1, 'product_tag' );
+		wp_delete_term( $this->tag_id_2, 'product_tag' );
+		wp_delete_post( $this->product_id_1, true );
+		wp_delete_post( $this->product_id_2, true );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test Woo Category condition.
+	 */
+	public function test_woo_category() {
+		global $product;
+
+		$condition = array(
+			'type'       => 'wooCategory',
+			'categories' => array( $this->category_id_1['term_id'] ),
+		);
+
+		$product = wc_get_product( $this->product_id_1 );
+		$result  = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+
+		$this->assertTrue( $result );
+
+		$product = wc_get_product( $this->product_id_2 );
+		$result  = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test Woo Tag condition.
+	 */
+	public function test_woo_tag() {
+		global $product;
+
+		$condition = array(
+			'type' => 'wooTag',
+			'tags' => array( $this->tag_id_1['term_id'] ),
+		);
+
+		$product = wc_get_product( $this->product_id_1 );
+		$result  = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+
+		$this->assertTrue( $result );
+
+		$product = wc_get_product( $this->product_id_2 );
+		$result  = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
+
+		$this->assertFalse( $result );
+
+		$condition['visibility'] = false;
+		$result = $this->block_conditions->evaluate_condition( $condition );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test Condition without type.
+	 */
+	public function test_condition_without_type() {
+		$condition = array(
+			'categories' => array( $this->category_id_1['term_id'] ),
+		);
+
+		$result = $this->block_conditions->evaluate_condition( $condition );
+		$this->assertTrue( $result );
+	}
+}

--- a/tests/test-woo-conditions.php
+++ b/tests/test-woo-conditions.php
@@ -41,11 +41,13 @@ class TestWooConditions extends WP_UnitTestCase
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->block_conditions            = new Block_Conditions();
-		$this->otter_pro_blocks_conditions = new \ThemeIsle\OtterPro\Plugins\Block_Conditions();
-		$this->user_id                     = wp_create_user( 'test_user_deletion', 'userlogin', 'test@userrecover.com' );
+		$this->block_conditions = new Block_Conditions();
+		$this->pro_conditions   = new \ThemeIsle\OtterPro\Plugins\Block_Conditions();
+		$this->user_id          = wp_create_user( 'test_user_deletion', 'userlogin', 'test@userrecover.com' );
 
 		$this->block_conditions->init();
+
+		add_filter( 'otter_blocks_evaluate_condition', array( $this->pro_conditions, 'evaluate_condition' ), 10, 3 );
 
 		$this->category_id_1 = wp_insert_term( 'test-category-1', 'product_cat' );
 		$this->category_id_2 = wp_insert_term( 'test-category-2', 'product_cat' );
@@ -108,13 +110,11 @@ class TestWooConditions extends WP_UnitTestCase
 		);
 
 		$product = wc_get_product( $this->product_id_1 );
-		$result  = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
-
+		$result  = $this->block_conditions->evaluate_condition( $condition );
 		$this->assertTrue( $result );
 
 		$product = wc_get_product( $this->product_id_2 );
-		$result  = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
-
+		$result  = $this->block_conditions->evaluate_condition( $condition );
 		$this->assertFalse( $result );
 	}
 
@@ -130,13 +130,11 @@ class TestWooConditions extends WP_UnitTestCase
 		);
 
 		$product = wc_get_product( $this->product_id_1 );
-		$result  = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
-
+		$result  = $this->block_conditions->evaluate_condition( $condition );
 		$this->assertTrue( $result );
 
 		$product = wc_get_product( $this->product_id_2 );
-		$result  = $this->otter_pro_blocks_conditions->evaluate_condition( true, $condition, true );
-
+		$result  = $this->block_conditions->evaluate_condition( $condition );
 		$this->assertFalse( $result );
 
 		$condition['visibility'] = false;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/198.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This PR adds:

- Product Category
- Product Tag
- Product Attribute

conditions to Block Conditions module.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- You can import WooCommerce's sample data to get a good set of products.
- Confirm all the conditions work when the taxonomy is present/absent.
- There are no debugging errors.
- This is made for Product Page, so you must be using a FSE theme for being able to customize the Single Product Template.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

