### PR TITLE
fix: enable additional modules by default

### DIFF
--- a/src/animation/index.js
+++ b/src/animation/index.js
@@ -31,7 +31,7 @@ const excludedBlocks = [ 'themeisle-blocks/popup' ];
 const BlockAnimation = ( el, props ) => {
 	if ( hasBlockSupport( props.name, 'customClassName', true ) && ! excludedBlocks.includes( props.name ) ) {
 
-		const showAsDefault = Boolean( select( 'core/preferences' )?.get( 'themeisle/otter-blocks', 'show-animations' ) );
+		const showAsDefault = Boolean( select( 'core/preferences' )?.get( 'themeisle/otter-blocks', 'show-animations' ) ?? true );
 
 		return (
 			<Fragment>

--- a/src/blocks/plugins/conditions/index.js
+++ b/src/blocks/plugins/conditions/index.js
@@ -37,7 +37,7 @@ const addAttribute = ( props ) => {
 };
 
 const BlockConditions = ( el, props ) => {
-	const showAsDefault = Boolean( select( 'core/preferences' )?.get( 'themeisle/otter-blocks', 'show-block-conditions' ) );
+	const showAsDefault = Boolean( select( 'core/preferences' )?.get( 'themeisle/otter-blocks', 'show-block-conditions' ) ?? true );
 
 	return (
 		<Fragment>

--- a/src/blocks/plugins/options/index.js
+++ b/src/blocks/plugins/options/index.js
@@ -324,7 +324,7 @@ const Sidebar = () => {
 											<ToggleControl
 												className="o-sidebar-toggle"
 												label={__( 'Custom CSS', 'otter-blocks' )}
-												checked={get?.( 'themeisle/otter-blocks', 'show-custom-css' )}
+												checked={get?.( 'themeisle/otter-blocks', 'show-custom-css' ) ?? true }
 												disabled={'loading' === preferenceStatus}
 												onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-custom-css', value ) )}
 											/>
@@ -338,7 +338,7 @@ const Sidebar = () => {
 											<ToggleControl
 												className="o-sidebar-toggle"
 												label={__( 'Animation', 'otter-blocks' )}
-												checked={get?.( 'themeisle/otter-blocks', 'show-animations' ) ?? false}
+												checked={get?.( 'themeisle/otter-blocks', 'show-animations' ) ?? true }
 												disabled={'loading' === preferenceStatus}
 												onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-animations', value ) )}
 											/>
@@ -352,7 +352,7 @@ const Sidebar = () => {
 											<ToggleControl
 												className="o-sidebar-toggle"
 												label={__( 'Visibility Condition', 'otter-blocks' )}
-												checked={get?.( 'themeisle/otter-blocks', 'show-block-conditions' ) ?? false }
+												checked={get?.( 'themeisle/otter-blocks', 'show-block-conditions' ) ?? true }
 												disabled={'loading' === preferenceStatus}
 												onChange={( value ) => updatedWithStatus( dispatch( 'core/preferences' )?.set( 'themeisle/otter-blocks', 'show-block-conditions', value ) )}
 											/>

--- a/src/css/index.js
+++ b/src/css/index.js
@@ -77,7 +77,7 @@ const Edit = ({
 
 const BlockCSSWrapper = ( el, props ) => {
 	if ( hasBlockSupport( props.name, 'customClassName', true ) ) {
-		const showAsDefault = Boolean( select( 'core/preferences' )?.get( 'themeisle/otter-blocks', 'show-custom-css' ) );
+		const showAsDefault = Boolean( select( 'core/preferences' )?.get( 'themeisle/otter-blocks', 'show-custom-css' ) ?? true );
 
 		return (
 			<Fragment>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/183
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Made additional the modules enabled again.

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/9eb84d44-f62b-48af-966d-f5f22cc83585)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Check if the modules are enabled again.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

