### PR TITLE
feat: add search within category to Live Search for Posts

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-live-search.php
+++ b/plugins/otter-pro/inc/plugins/class-live-search.php
@@ -45,6 +45,10 @@ class Live_Search {
 		$post_types_data = '';
 		if ( isset( $block['attrs']['otterSearchQuery']['post_type'] ) ) {
 			$post_types_data = 'data-post-types=' . wp_json_encode( $block['attrs']['otterSearchQuery']['post_type'] );
+
+			if ( count( $block['attrs']['otterSearchQuery']['post_type'] ) === 1 && in_array( 'post', $block['attrs']['otterSearchQuery']['post_type'] ) ) {
+				$post_types_data .= ' data-cat="' . esc_attr( $block['attrs']['otterSearchQuery']['cat'] ) . '"';
+			}
 		}
 
 		// Insert hidden fields to filter core's search results.
@@ -54,7 +58,7 @@ class Live_Search {
 				$query_params_markup .= sprintf(
 					'<input type="hidden" name="o_%s" value="%s" />',
 					esc_attr( $param ),
-					esc_attr( implode( ',', $value ) )
+					esc_attr( is_array( $value ) ? implode( ',', $value ) : $value )
 				);
 			}
 		}

--- a/plugins/otter-pro/inc/server/class-live-search-server.php
+++ b/plugins/otter-pro/inc/server/class-live-search-server.php
@@ -135,8 +135,10 @@ class Live_Search_Server {
 	 * @since 2.0.3
 	 */
 	public function search( WP_REST_Request $request ) {
+		$cat = $request->get_param( 'cat' ) ? sanitize_text_field( $request->get_param( 'cat' ) ) : '';
+
 		$query = new WP_Query(
-			$this->prepare_search_query( $request->get_param( 's' ), $request->get_param( 'post_type' ) )
+			$this->prepare_search_query( $request->get_param( 's' ), $request->get_param( 'post_type' ), $cat )
 		);
 
 		return new WP_REST_Response(
@@ -171,12 +173,13 @@ class Live_Search_Server {
 	 * 
 	 * @param string       $s Search query.
 	 * @param string|array $post_types Post type.
+	 * @param string       $cat Category.
 	 * 
 	 * @return array
 	 */
-	public function prepare_search_query( $s, $post_types ) {
-
-		$s = sanitize_text_field( $s );
+	public function prepare_search_query( $s, $post_types, $cat = '' ) {
+		$s   = sanitize_text_field( $s );
+		$cat = sanitize_text_field( $cat );
 
 		if ( is_array( $post_types ) ) {
 			$post_types = array_map( 'sanitize_text_field', $post_types );
@@ -205,12 +208,18 @@ class Live_Search_Server {
 			);
 		}
 
-		return array(
+		$params = array(
 			'posts_per_page' => 20,
 			's'              => $s,
 			'post_status'    => 'publish',
 			'post_type'      => $post_types,
 		);
+
+		if ( ! empty( $cat ) ) {
+			$params['category_name'] = $cat;
+		}
+
+		return $params;
 	}
 		
 	/**

--- a/src/blocks/components/index.js
+++ b/src/blocks/components/index.js
@@ -4,12 +4,14 @@
 import { useInspectorSlot } from './inspector-slot-fill';
 import Notice from './notice/index.js';
 import SelectProducts from './select-products-control/index.js';
+import { CategoriesFieldToken } from '../plugins/conditions/edit.js';
 
 window.otterComponents = {};
 
 window.otterComponents.SelectProducts = SelectProducts;
 window.otterComponents.Notice = Notice;
 window.otterComponents.useInspectorSlot = useInspectorSlot;
+window.otterComponents.CategoriesFieldToken = CategoriesFieldToken;
 
 export { default as BackgroundOverlayControl } from './background-overlay-control/index.js';
 export { default as BackgroundSelectorControl } from './background-selector-control/index.js';

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -229,7 +229,7 @@ const AuthorsFieldToken = ( props ) => {
 	);
 };
 
-const CategoriesFieldToken = ( props ) => {
+export const CategoriesFieldToken = ( props ) => {
 	const {
 		postCategories,
 		isLoading

--- a/tests/test-live-search.php
+++ b/tests/test-live-search.php
@@ -72,5 +72,8 @@ class TestLiveSearch extends WP_UnitTestCase
         $search_query = $live_search->prepare_search_query( 'test', array('otter_shop_product', 'otter_shop_coupon', 'otter_page') );
         $this->assertEquals( 'test', $search_query['s'] );
         $this->assertEquals( array('otter_shop_product'), $search_query['post_type'] ); // Keep only the public post type.
+
+        $search_query = $live_search->prepare_search_query( 'test', 'post', 'uncategorized' );
+        $this->assertEquals( 'uncategorized', $search_query['category_name'] );
     }
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/142.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Live Search now allows you to search posts within categories if the selected post type in Post. This doesn't work with CPTs or custom taxonomies, only Post.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Confirm the Search within category works fine if the Post type is selected.
- Also confirm it works when no types or random post types are selected.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

