### PR TITLE
fix: increase the height for Popup in Editor on auto mode

### DIFF
--- a/src/blocks/blocks/popup/editor.scss
+++ b/src/blocks/blocks/popup/editor.scss
@@ -7,6 +7,7 @@
 
 	.otter-popup__modal_content {
 		margin-top: 65px;
+		min-height: 450px;
 	}
 }
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/217
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

I added a minimum height of `450px` in the Popup edit area.

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/12efb437-1da7-4d3e-adf3-201b899edc07)

![image](https://github.com/user-attachments/assets/be5b5dc8-5a1a-43c8-9141-79f5d32e86ba)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Insert a Popup Block, click the `Edit` button, and see if you find the new height more ergonomic.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

