### PR TITLE
fix: Section block default inheritance for margin and padding

### DIFF
--- a/src/blocks/blocks/section/column/block.json
+++ b/src/blocks/blocks/section/column/block.json
@@ -21,22 +21,10 @@
 			}
 		},
 		"paddingTablet": {
-			"type": "object",
-			"default": {
-				"top": "0px",
-				"right": "0px",
-				"bottom": "0px",
-				"left": "0px"
-			}
+			"type": "object"
 		},
 		"paddingMobile": {
-			"type": "object",
-			"default": {
-				"top": "0px",
-				"right": "0px",
-				"bottom": "0px",
-				"left": "0px"
-			}
+			"type": "object"
 		},
 		"margin": {
 			"type": "object",
@@ -48,22 +36,10 @@
 			}
 		},
 		"marginTablet": {
-			"type": "object",
-			"default": {
-				"top": "0px",
-				"right": "0px",
-				"bottom": "0px",
-				"left": "0px"
-			}
+			"type": "object"
 		},
 		"marginMobile": {
-			"type": "object",
-			"default": {
-				"top": "0px",
-				"right": "0px",
-				"bottom": "0px",
-				"left": "0px"
-			}
+			"type": "object"
 		},
 		"color": {
 			"type": "string"

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -101,13 +101,14 @@ const Inspector = ({
 	};
 
 	const getPadding = () => {
+		const defaultValue = { ...metadata.attributes.padding.default };
 		switch ( getView ) {
 		case 'Desktop':
-			return getValue( 'padding' );
+			return merge( defaultValue, getValue( 'padding' ) );
 		case 'Tablet':
-			return merge({ ...getValue( 'padding' ) }, getValue( 'paddingTablet' ) );
+			return merge( defaultValue, { ...getValue( 'padding' ) }, getValue( 'paddingTablet' ) );
 		case 'Mobile':
-			return merge({ ...getValue( 'padding' ) }, getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) );
+			return merge( defaultValue, { ...getValue( 'padding' ) }, getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) );
 		default:
 			return undefined;
 		}
@@ -144,13 +145,14 @@ const Inspector = ({
 	};
 
 	const getMargin = () => {
+		const defaultValue = { ...metadata.attributes.margin.default };
 		switch ( getView ) {
 		case 'Desktop':
-			return getValue( 'margin' );
+			return merge( defaultValue, getValue( 'margin' ) );
 		case 'Tablet':
-			return merge({ ...getValue( 'margin' ) }, getValue( 'marginTablet' ) );
+			return merge( defaultValue, { ...getValue( 'margin' ) }, getValue( 'marginTablet' ) );
 		case 'Mobile':
-			return merge({ ...getValue( 'margin' ) }, getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
+			return merge( defaultValue, { ...getValue( 'margin' ) }, getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
 		default:
 			return undefined;
 		}
@@ -286,7 +288,6 @@ const Inspector = ({
 										max: 500
 									} }
 									onChange={ changePadding }
-									resetValues={ metadata.attributes.padding.default }
 								/>
 							</Disabled>
 
@@ -302,7 +303,6 @@ const Inspector = ({
 										max: 500
 									} }
 									onChange={ changeMargin }
-									resetValues={ metadata.attributes.margin.default }
 								/>
 							</Disabled>
 						</ResponsiveControl>

--- a/src/blocks/blocks/section/columns/block.json
+++ b/src/blocks/blocks/section/columns/block.json
@@ -35,22 +35,10 @@
 			}
 		},
 		"paddingTablet": {
-			"type": "object",
-			"default": {
-				"top": "0px",
-				"right": "0px",
-				"bottom": "0px",
-				"left": "0px"
-			}
+			"type": "object"
 		},
 		"paddingMobile": {
-			"type": "object",
-			"default": {
-				"top": "0px",
-				"right": "0px",
-				"bottom": "0px",
-				"left": "0px"
-			}
+			"type": "object"
 		},
 		"margin": {
 			"type": "object",
@@ -62,22 +50,10 @@
 			}
 		},
 		"marginTablet": {
-			"type": "object",
-			"default": {
-				"top": "0px",
-				"right": "0px",
-				"bottom": "0px",
-				"left": "0px"
-			}
+			"type": "object"
 		},
 		"marginMobile": {
-			"type": "object",
-			"default": {
-				"top": "0px",
-				"right": "0px",
-				"bottom": "0px",
-				"left": "0px"
-			}
+			"type": "object"
 		},
 		"columnsWidth": {
 			"type": [ "number", "string" ]

--- a/src/blocks/blocks/section/columns/inspector.js
+++ b/src/blocks/blocks/section/columns/inspector.js
@@ -143,13 +143,14 @@ const Inspector = ({
 	};
 
 	const getPadding = () => {
+		const defaultValue = { ...metadata.attributes.padding.default };
 		switch ( getView ) {
 		case 'Desktop':
-			return getValue( 'padding' );
+			return merge( defaultValue, getValue( 'padding' ) );
 		case 'Tablet':
-			return merge({ ...getValue( 'padding' ) }, getValue( 'paddingTablet' ) );
+			return merge( defaultValue, { ...getValue( 'padding' ) }, getValue( 'paddingTablet' ) );
 		case 'Mobile':
-			return merge({ ...getValue( 'padding' ) }, getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) ) ;
+			return merge( defaultValue, { ...getValue( 'padding' ) }, getValue( 'paddingTablet' ), getValue( 'paddingMobile' ) );
 		default:
 			return undefined;
 		}
@@ -186,13 +187,14 @@ const Inspector = ({
 	};
 
 	const getMargin = () => {
+		const defaultValue = { ...metadata.attributes.margin.default };
 		switch ( getView ) {
 		case 'Desktop':
-			return getValue( 'margin' );
+			return merge( defaultValue, getValue( 'margin' ) );
 		case 'Tablet':
-			return merge({ ...getValue( 'margin' ) }, getValue( 'marginTablet' ) );
+			return merge( defaultValue, { ...getValue( 'margin' ) }, getValue( 'marginTablet' ) );
 		case 'Mobile':
-			return merge({ ...getValue( 'margin' ) }, getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
+			return merge( defaultValue, { ...getValue( 'margin' ) }, getValue( 'marginTablet' ), getValue( 'marginMobile' ) );
 		default:
 			return undefined;
 		}
@@ -735,7 +737,6 @@ const Inspector = ({
 											max: 500
 										} }
 										onChange={ changePadding }
-										resetValues={ metadata.attributes.padding.default }
 									/>
 								</Disabled>
 
@@ -752,7 +753,6 @@ const Inspector = ({
 										} }
 										sides={ [ 'top', 'bottom' ] }
 										onChange={ changeMargin }
-										resetValues={ metadata.attributes.margin.default }
 									/>
 								</Disabled>
 							</ResponsiveControl>

--- a/src/blocks/test/e2e/blocks/section.spec.js
+++ b/src/blocks/test/e2e/blocks/section.spec.js
@@ -104,10 +104,10 @@ test.describe( 'Section Block', () => {
 		await page.getByRole( 'option', { name: 'Paragraph' }).click();
 		await page.getByLabel( 'Empty block; start writing or' ).fill( 'Test' );
 		await page.getByLabel( 'Document Overview' ).click();
-		await page.getByLabel( 'Section', { exact: true }).click();
+		await page.getByRole( 'link', { name: 'Section', exact: true }).click();
 
 		// Open Setting panel
-		await page.getByLabel( 'Settings', { exact: true }).click();
+		await page.getByRole( 'link', { name: 'Section', exact: true }).click;
 		await page.getByRole( 'button', { name: 'Style' }).click();
 
 		// Check Default values for Section Block
@@ -122,9 +122,13 @@ test.describe( 'Section Block', () => {
 		await expect( page.getByLabel( 'Padding' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '30' );
 		await expect( page.getByLabel( 'Margin' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '15' );
 
-		// Check Default values for Section Column Block
-		await page.getByLabel( 'Section Column', { exact: true }).click();
+		// Check Default values for Section Column Block after reset.
+		await page.getByRole( 'link', { name: 'Section', exact: true }).click();
 		await page.getByRole( 'button', { name: 'Style' }).click();
+
+		await page.getByLabel( 'Padding' ).getByRole( 'button', { name: 'Reset' }).click();
+		await page.getByLabel( 'Margin' ).getByRole( 'button', { name: 'Reset' }).click();
+
 		await expect( page.getByLabel( 'Padding' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '0' );
 		await expect( page.getByLabel( 'Margin' ).getByRole( 'textbox', { name: 'All sides' }) ).toHaveValue( '0' );
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/184
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Removed the default attributes value for table and mobile so users can use `0px` values
- Improved the inheritance behavior using a desktop default value for Inspector components to prevent a null state on the slider.

### Screenshots <!-- if applicable -->


https://github.com/user-attachments/assets/8c1ffc11-ef77-49c2-b97e-8a4ac8fd4e99



----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Section Block
2. Change the padding and margin in Desktop view
3. Go to Mobile view and set it to `0px`. It should work.
4. Reset and the values should be back to the one in Desktop view

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

