### PR TITLE
fix: auto scroll for tabs and accordion on opening

### DIFF
--- a/src/blocks/frontend/accordion/index.js
+++ b/src/blocks/frontend/accordion/index.js
@@ -1,11 +1,17 @@
 /**
  * Internal dependencies
  */
-import { domReady } from '../../helpers/frontend-helper-functions.js';
+import { domReady, scrollIntoViewIfNeeded } from '../../helpers/frontend-helper-functions.js';
 
 domReady( () => {
 	const accordions = document.querySelectorAll( '.wp-block-themeisle-blocks-accordion' );
 
+	/**
+	 *	Handle the opening of the accordion items.
+	 *
+	 * @param {HTMLDetailsElement} accordion The accordion root element.
+	 * @returns
+	 */
 	const handleItemOpening = accordion => {
 		if ( ! accordion.classList.contains( 'exclusive' ) ) {
 			return;
@@ -25,6 +31,9 @@ domReady( () => {
 				openSibling.forEach( sibling => {
 					sibling.removeAttribute( 'open' );
 				});
+
+				const title = item.querySelector( ':scope > .wp-block-themeisle-blocks-accordion-item__title' );
+				scrollIntoViewIfNeeded( title );
 			});
 		});
 	};

--- a/src/blocks/frontend/tabs/index.js
+++ b/src/blocks/frontend/tabs/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { domReady } from '../../helpers/frontend-helper-functions.js';
+import { domReady, scrollIntoViewIfNeeded } from '../../helpers/frontend-helper-functions.js';
 
 domReady( () => {
 	const tabs = document.querySelectorAll( '.wp-block-themeisle-blocks-tabs' );
@@ -57,6 +57,10 @@ domReady( () => {
 					h.classList.toggle( 'hidden', idx !== index );
 					h.setAttribute( 'aria-selected', idx === index );
 				});
+
+				if ( idx === index && headerMobile ) {
+					scrollIntoViewIfNeeded( headerMobile );
+				}
 			};
 
 			headerItem.addEventListener( 'click', () => items.forEach( toggleTabs ) );

--- a/src/blocks/helpers/frontend-helper-functions.js
+++ b/src/blocks/helpers/frontend-helper-functions.js
@@ -185,3 +185,27 @@ export const rgb2hsl = ( color, asArray = true ) => {
 
 	return `hsl( ${h * 360}, ${s * 100}, ${l * 100} )`;
 };
+
+/**
+ *	Scrolls the element into view if it's not fully visible.
+ *
+ * @param {HTMLElement} element The element to scroll into view.
+ * @param {*} options The options for the scrollIntoView method.
+ */
+export const scrollIntoViewIfNeeded = ( element, options = {}) => {
+	if ( ! element ) {
+		return;
+	}
+
+	const rect = element.getBoundingClientRect();
+	const isFullyVisible = (
+		0 <= rect.top &&
+		0 <= rect.left &&
+		rect.bottom <= ( window.innerHeight || document.documentElement.clientHeight ) &&
+		rect.right <= ( window.innerWidth || document.documentElement.clientWidth )
+	);
+
+	if ( ! isFullyVisible ) {
+		element.scrollIntoView( options );
+	}
+};


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/193
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

If the tab that is going to be open is not visible after the others are closed, scroll to it.

### Screenshots <!-- if applicable -->

#### Before



https://github.com/user-attachments/assets/da76e3df-3a96-4289-8fad-aaac75199b88


#### After

https://github.com/user-attachments/assets/553cd180-dde1-428b-ad43-d6190f31e8be



----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert some huge paragraphs.
2. In the middle add an accordion and a tab block
3. Fill him also with huge content.
4. When you open a tab, it should make sure that the beginning is always visible like in the video

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

