### PR TITLE
fix: AI Block container alignment

### DIFF
--- a/src/blocks/components/prompt/editor.scss
+++ b/src/blocks/components/prompt/editor.scss
@@ -88,6 +88,7 @@
 	width: auto;
 	max-width: 1200px;
 	padding: 10px;
+	margin: 0 auto;
 
 	.prompt-result__header {
 		display: flex;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/117
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

On the wide mode, center the block. 

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/107af335-89cb-47cf-bf2f-5e8576c5a2ac)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert an AI Block
2. Set the block to `Wide` using the toolbar
3. Check if it centered

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

