### PR TITLE
 fix: slider breaking when inside a Section Column 

### DIFF
--- a/src/blocks/blocks/slider/editor.scss
+++ b/src/blocks/blocks/slider/editor.scss
@@ -8,12 +8,13 @@
 	--border-radius: 0;
 	--width: auto;
 
-
 	.glide--carousel, &> div {
 		width: var( --width );
 		border: var( --border-width ) solid var( --border-color );
 		border-radius: var( --border-radius );
 		overflow: hidden;
+
+		display: grid;
 	}
 
 	.glide__slides {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/190.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This fixes the issue with Slider not working properly in the editor when added inside the Section's Column.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add a section block with 2 columns
- In the first column, add a slider block
- In the second one, add a paragraph block
- Save and check the page
- Also, adjust the column width and check again

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

