### PR TITLE
fix: styles not applying on blocks added to widgets

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -1054,20 +1054,13 @@ class Registration {
 			return $content;
 		}
 
-		global $wp_registered_widgets;
 		$valid_widgets = array();
 		$widget_data   = get_option( 'widget_block', array() );
 
-		// Loop through all widgets, and add any that are active.
-		foreach ( $wp_registered_widgets as $widget_name => $widget ) {
-			if ( ! in_array( $widget['id'], self::$widget_used, true ) ) {
-				continue;
-			}
-
-			$key = $widget['params'][0]['number'];
-
-			if ( isset( $widget_data[ $key ] ) ) {
-				$valid_widgets[] = (object) $widget_data[ $key ];
+		foreach ( self::$widget_used as $widget_id ) {
+			$widget_id = str_replace( 'block-', '', $widget_id );
+			if ( isset( $widget_data[ $widget_id ] ) ) {
+				$valid_widgets[] = (object) $widget_data[ $widget_id ];
 			}
 		}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/121.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This fixes the issue with CSS not being applied instantly to blocks added to Widgets in the Customizer or Widgets area.

Previously, it worked if you made another change and Published your changes from the Customizer, but the current block status wasn't taken into consideration.

We remove the previously implemented `wp_registered_widgets` check as we are already using `$widgets_used` to check for inactive widgets.
### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add some blocks as widgets from Customizer and publish the change.
- Confirm the CSS is applied properly after the very first publish attempt.
- Also confirm in the generated CSS file that no CSS is generated if the block is part of Inactive Widgets screen.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

