### PR TITLE
fix: incorrect name for background size on Flip Block php css

### DIFF
--- a/inc/css/blocks/class-flip-css.php
+++ b/inc/css/blocks/class-flip-css.php
@@ -179,7 +179,7 @@ class Flip_CSS extends Base_CSS {
 								},
 							),
 							'size'       => array(
-								'value'   => 'backgroundSize',
+								'value'   => 'frontBackgroundSize',
 								'default' => 'auto',
 							),
 						),
@@ -241,7 +241,7 @@ class Flip_CSS extends Base_CSS {
 								},
 							),
 							'size'       => array(
-								'value'   => 'backgroundSize',
+								'value'   => 'backBackgroundSize',
 								'default' => 'auto',
 							),
 						),


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/187
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fix incorrect name for variable identification for image background size on Flip Block PHP CSS.

### Screenshots <!-- if applicable -->

#### Editor

![image](https://github.com/user-attachments/assets/1767a8ca-34ed-4100-b76c-fd023793c351)

#### Front/User

![image](https://github.com/user-attachments/assets/38e96748-592f-473c-a4ba-952ae9045400)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Flip Block
2. Add **small images** as background for the front and back sides
3. Check if the settings are applied.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

