### PR TITLE
feat: add Otter notice in FSE editor for Blocks CSS

### DIFF
--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -82,7 +82,7 @@ class Blocks_CSS {
 						admin_url( 'update.php' )
 					),
 					'install-plugin_otter-blocks'
-				)
+				),
 			)
 		);
 

--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -72,7 +72,17 @@ class Blocks_CSS {
 			'otter-css',
 			'blocksCSS',
 			array(
-				'hasOtter' => defined( 'OTTER_BLOCKS_VERSION' ),
+				'hasOtter'     => defined( 'OTTER_BLOCKS_VERSION' ),
+				'installOtter' => wp_nonce_url(
+					add_query_arg(
+						array(
+							'action' => 'install-plugin',
+							'plugin' => 'otter-blocks',
+						),
+						admin_url( 'update.php' )
+					),
+					'install-plugin_otter-blocks'
+				)
 			)
 		);
 

--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -16,6 +16,8 @@ import {
 	useState
 } from '@wordpress/element';
 
+import { select } from '@wordpress/data';
+
 let inputTimeout = null;
 
 window.otterCSSLintIgnored = [];
@@ -132,6 +134,25 @@ const CSSEditor = ({
 
 	return (
 		<Fragment>
+			{ ( ! Boolean( window?.blocksCSS?.hasOtter ) && !! select( 'core/edit-site' ) ) && (
+				<Notice
+					status="info"
+					isDismissible={ false }
+				>
+					{ __( 'Blocks CSS is not fully compatible with the Site Editor. We recommend installing Otter for Site Builder compatibility.', 'otter-blocks' ) }
+
+					<br/><br/>
+
+					<Button
+						variant="primary"
+						href={ window?.blocksCSS?.installOtter }
+						target="_blank"
+					>
+						{ __( 'Install Otter', 'otter-blocks' ) }
+					</Button>
+				</Notice>
+			) }
+
 			<p>{__( 'Add your custom CSS.', 'otter-blocks' )}</p>
 
 			<div id="o-css-editor" className="o-css-editor" />

--- a/src/css/index.js
+++ b/src/css/index.js
@@ -16,6 +16,8 @@ import {
 
 import { createHigherOrderComponent } from '@wordpress/compose';
 
+import { select } from '@wordpress/data';
+
 import { Fragment } from '@wordpress/element';
 
 import {
@@ -33,7 +35,6 @@ import CSSEditor from './editor.js';
 import './inject-css.js';
 
 import { onDeselect } from './inject-css.js';
-import { select } from '@wordpress/data';
 
 const addAttribute = ( settings ) => {
 	if ( hasBlockSupport( settings, 'customClassName', true ) ) {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/120 and https://github.com/Codeinwp/otter-internals/issues/194.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This adds a Notice to Site Editor when Blocks CSS is being used alone. Clicking on the button installs to Otter in a new tab.

### Screenshots <!-- if applicable -->
<img width="1680" alt="Screenshot 2024-08-01 at 2 20 30 AM" src="https://github.com/user-attachments/assets/2e3ab9fd-1bfa-42a7-a395-c8b21cc58414">

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Confirm the notice appears if:
  - When using Blocks CSS in Site Editor
  - Not inside normal Post Editor or when used as part of Otter 

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

