### PR TITLE
fix: disallow anchor control for using empty ID

### DIFF
--- a/src/blocks/blocks/advanced-heading/edit.js
+++ b/src/blocks/blocks/advanced-heading/edit.js
@@ -56,7 +56,7 @@ const Edit = ({
 }) => {
 
 	useEffect( () => {
-		googleFontsLoader.attach( );
+		googleFontsLoader.attach();
 		const unsubscribe = blockInit( clientId, defaultAttributes );
 		return () => unsubscribe( attributes.id );
 	}, [ attributes.id ]);

--- a/src/blocks/components/html-anchor-control/index.js
+++ b/src/blocks/components/html-anchor-control/index.js
@@ -62,7 +62,7 @@ const HTMLAnchorControl = ({
 						icon={ isEditing ? 'yes' : 'edit' }
 						label={ isEditing ? __( 'Save', 'otter-blocks' ) : __( 'Edit', 'otter-blocks' ) }
 						showTooltip={ true }
-						disabled={ isInvalid ? true : false }
+						disabled={ isInvalid || ! ID }
 						className={ classnames(
 							'o-html-anchor-control-button',
 							{ 'is-saved': ! isEditing }
@@ -86,6 +86,16 @@ const HTMLAnchorControl = ({
 					className="o-html-anchor-control-notice"
 				>
 					{ __( 'This ID has already been used in this page. Please consider using a different ID to avoid conflict.', 'otter-blocks' ) }
+				</Notice>
+			) }
+
+			{ ! ID && (
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					className="o-html-anchor-control-notice"
+				>
+					{ __( 'Please enter an ID to use as an anchor.', 'otter-blocks' ) }
 				</Notice>
 			) }
 		</InspectorAdvancedControls>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/201.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This disallows the Anchor Control from allowing an empty ID, as well as some changes in the blockInit function to rewrite existing empty IDs with a unique one.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Confirm you can't change the ID of Section or Advanced Heading Block to an empty field.
- Confirm if you upgrade from an older version and open the editor, all empty sections get an unique ID.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

