### PR TITLE
chore: disable copy/paste styles feature

### DIFF
--- a/src/blocks/plugins/registerPlugin.tsx
+++ b/src/blocks/plugins/registerPlugin.tsx
@@ -23,7 +23,9 @@ import './galley-extension/index.js';
 import './masonry-extension/index.js';
 import './image-extension/index.js';
 import './menu-icons/index.js';
-import './copy-paste/index.js';
+
+// We disable the copy-paste plugin for now.
+// import './copy-paste/index.js';
 import './sticky/index.js';
 import './dynamic-content/index.js';
 import './welcome-guide/index.js';


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/213.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
As we discussed, this PR disables Copy/Paste Styles features for the time being. We still keep the code inside, just disable the feature.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Confirm Copy/Paste styles toolbar doesn't appear anymore.

---- 

### Checklist before the final review

- [] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

