### PR TITLE
feat: add label option to Add to Cart Block

### DIFF
--- a/plugins/otter-pro/inc/render/class-add-to-cart-button-block.php
+++ b/plugins/otter-pro/inc/render/class-add-to-cart-button-block.php
@@ -38,7 +38,7 @@ class Add_To_Cart_Button_Block {
 			'data-product_id'  => $product->get_id(),
 			'data-product_sku' => $product->get_sku(),
 			'rel'              => 'nofollow',
-			'class'            => 'wp-block-button__link add_to_cart_button',
+			'class'            => 'wp-block-button__link wp-element-button add_to_cart_button',
 		);
 
 		if (
@@ -53,7 +53,7 @@ class Add_To_Cart_Button_Block {
 			'<a href="%s" %s>%s</a>',
 			esc_url( $product->add_to_cart_url() ),
 			wc_implode_html_attributes( $attrs ),
-			esc_html( $product->add_to_cart_text() )
+			esc_html( isset( $attributes['label'] ) ? $attributes['label'] :$product->add_to_cart_text() )
 		);
 
 		return sprintf(

--- a/src/pro/blocks/add-to-cart-button/block.json
+++ b/src/pro/blocks/add-to-cart-button/block.json
@@ -10,7 +10,10 @@
     "attributes": {
         "product": {
             "type": "number"
-        }
+        },
+		"label": {
+			"type": "string"
+		}
     },
 	"styles": [
 		{

--- a/src/pro/blocks/add-to-cart-button/edit.js
+++ b/src/pro/blocks/add-to-cart-button/edit.js
@@ -19,6 +19,8 @@ import ServerSideRender from '@wordpress/server-side-render';
  */
 const { SelectProducts } = window.otterComponents;
 
+import Inspector from './inspector.js';
+
 /**
  * Add To Card Button component
  * @param {import('./types.js').AddToCartButtonProps} props
@@ -31,33 +33,40 @@ const Edit = ({
 	const blockProps = useBlockProps();
 
 	return (
-		<div { ...blockProps }>
-			{ attributes.product ? (
-				<Disabled>
-					<ServerSideRender
-						block="themeisle-blocks/add-to-cart-button"
-						attributes={ { ...attributes } }
-					/>
-				</Disabled>
-			) : (
-				<Placeholder
-					icon={ store }
-					label={ __( 'Add to Cart Button', 'otter-blocks' ) }
-					instructions={ __( 'Select a WooCommerce product for the Add to Cart button.', 'otter-blocks' ) }
-				>
-					<SelectProducts
-						label={ __( 'Select Product', 'otter-blocks' ) }
-						hideLabelFromVision
-						value={ attributes.product || '' }
-						onChange={ product => {
-							window.oTrk?.add({ feature: 'add-to-cart', featureComponent: 'product-changed' });
+		<>
+			<Inspector
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
 
-							setAttributes({ product: Number( product ) });
-						} }
-					/>
-				</Placeholder>
-			) }
-		</div>
+			<div { ...blockProps }>
+				{ attributes.product ? (
+					<Disabled>
+						<ServerSideRender
+							block="themeisle-blocks/add-to-cart-button"
+							attributes={ { ...attributes } }
+						/>
+					</Disabled>
+				) : (
+					<Placeholder
+						icon={ store }
+						label={ __( 'Add to Cart Button', 'otter-blocks' ) }
+						instructions={ __( 'Select a WooCommerce product for the Add to Cart button.', 'otter-blocks' ) }
+					>
+						<SelectProducts
+							label={ __( 'Select Product', 'otter-blocks' ) }
+							hideLabelFromVision
+							value={ attributes.product || '' }
+							onChange={ product => {
+								window.oTrk?.add({ feature: 'add-to-cart', featureComponent: 'product-changed' });
+
+								setAttributes({ product: Number( product ) });
+							} }
+						/>
+					</Placeholder>
+				) }
+			</div>
+		</>
 	);
 };
 

--- a/src/pro/blocks/add-to-cart-button/inspector.js
+++ b/src/pro/blocks/add-to-cart-button/inspector.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import { InspectorControls } from '@wordpress/block-editor';
+
+import {
+	PanelBody,
+	TextControl
+} from '@wordpress/components';
+
+const { SelectProducts } = window.otterComponents;
+
+const Inspector = ({
+	attributes,
+	setAttributes
+}) => {
+	if ( ! attributes.product ) {
+		return null;
+	}
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Settings', 'otter-blocks' ) }
+			>
+				<SelectProducts
+					label={ __( 'Select Product', 'otter-blocks' ) }
+					hideLabelFromVision
+					value={ attributes.product }
+					onChange={ product => {
+						window.oTrk?.add({ feature: 'add-to-cart', featureComponent: 'product-changed' });
+						setAttributes({ product: Number( product ) });
+					} }
+				/>
+
+				<TextControl
+					label={ __( 'Button Label', 'otter-blocks' ) }
+					help={ __( 'This overrides the default WooCommerce button label.', 'otter-blocks' ) }
+					value={ attributes.label }
+					onChange={ label => setAttributes({ label }) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default Inspector;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/199.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This adds an option to override the default label to the Add to Cart block. Closes https://github.com/Codeinwp/otter-internals/issues/199

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Confirm that adding the label overrides the default Woo label.
- And remove the label after that and confirm the default label shows up.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

