### PR TITLE
fix: add more selectors for Advanced Heading

### DIFF
--- a/src/blocks/blocks/advanced-heading/style.scss
+++ b/src/blocks/blocks/advanced-heading/style.scss
@@ -2,7 +2,15 @@ span.wp-block-themeisle-blocks-advanced-heading {
 	display: block;
 }
 
-.wp-block-themeisle-blocks-advanced-heading {
+.wp-block-themeisle-blocks-advanced-heading,
+.is-layout-constrained > .wp-block-themeisle-blocks-advanced-heading:first-child, // We add these selectors to make sure the block is styled correctly. FSE themes not making things much easier.
+.is-layout-constrained > .wp-block-themeisle-blocks-advanced-heading,
+h1.wp-block-themeisle-blocks-advanced-heading,
+h2.wp-block-themeisle-blocks-advanced-heading,
+h3.wp-block-themeisle-blocks-advanced-heading,
+h4.wp-block-themeisle-blocks-advanced-heading,
+h5.wp-block-themeisle-blocks-advanced-heading,
+h6.wp-block-themeisle-blocks-advanced-heading {
 	--padding: 0px;
 	--padding-tablet: var(--padding);
 	--padding-mobile: var(--padding-tablet);

--- a/src/blocks/blocks/advanced-heading/style.scss
+++ b/src/blocks/blocks/advanced-heading/style.scss
@@ -3,14 +3,8 @@ span.wp-block-themeisle-blocks-advanced-heading {
 }
 
 .wp-block-themeisle-blocks-advanced-heading,
-.is-layout-constrained > .wp-block-themeisle-blocks-advanced-heading:first-child, // We add these selectors to make sure the block is styled correctly. FSE themes not making things much easier.
-.is-layout-constrained > .wp-block-themeisle-blocks-advanced-heading,
-h1.wp-block-themeisle-blocks-advanced-heading,
-h2.wp-block-themeisle-blocks-advanced-heading,
-h3.wp-block-themeisle-blocks-advanced-heading,
-h4.wp-block-themeisle-blocks-advanced-heading,
-h5.wp-block-themeisle-blocks-advanced-heading,
-h6.wp-block-themeisle-blocks-advanced-heading {
+.is-layout-constrained > :is( .wp-block-themeisle-blocks-advanced-heading, .wp-block-themeisle-blocks-advanced-heading:first-child ),  /* We add these selectors to make sure the block is styled correctly. FSE themes not making things much easier. */
+:is(h1, h2, h3, h4, h5, h6).wp-block-themeisle-blocks-advanced-heading {
 	--padding: 0px;
 	--padding-tablet: var(--padding);
 	--padding-mobile: var(--padding-tablet);


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2299.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Adds more selectors to make sure Heading block works better with more themes as some themes and Core has some styles that prevent the default styles from working.

---- 

### Checklist before the final review

- [] Included E2E or unit tests for the changes in this PR.
- [] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

