### PR TITLE
feat: use post title as alt if no image alt available in Posts Block

### DIFF
--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -69,16 +69,23 @@ class Posts_Grid_Block {
 			}
 
 			$size      = isset( $attributes['imageSize'] ) ? $attributes['imageSize'] : 'medium';
-			$thumbnail = wp_get_attachment_image_src( get_post_thumbnail_id( $id ), $size );
+			$thumb_id  = get_post_thumbnail_id( $id );
+			$thumbnail = wp_get_attachment_image_src( $thumb_id, $size );
 
 			$list_items_markup .= '<div class="o-posts-grid-post-blog o-posts-grid-post-plain"><div class="o-posts-grid-post">';
 
 			if ( isset( $attributes['displayFeaturedImage'] ) && $attributes['displayFeaturedImage'] ) {
 				if ( $thumbnail ) {
+					$image_alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
+
+					if ( ! $image_alt ) {
+						$image_alt = get_the_title( $id );
+					}
+
 					$list_items_markup .= sprintf(
 						'<div class="o-posts-grid-post-image"><a href="%1$s">%2$s</a></div>',
 						esc_url( get_the_permalink( $id ) ),
-						wp_get_attachment_image( get_post_thumbnail_id( $id ), $size )
+						wp_get_attachment_image( $thumb_id, $size, false, array( 'alt' => $image_alt ) )
 					);
 				}
 			}
@@ -284,7 +291,14 @@ class Posts_Grid_Block {
 		$html      = '';
 		$id        = $post instanceof \WP_Post ? $post->ID : $post;
 		$size      = isset( $attributes['imageSize'] ) ? $attributes['imageSize'] : 'medium';
-		$thumbnail = wp_get_attachment_image( get_post_thumbnail_id( $id ), $size );
+		$thumb_id  = get_post_thumbnail_id( $id );
+		$image_alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
+
+		if ( ! $image_alt ) {
+			$image_alt = get_the_title( $id );
+		}
+
+		$thumbnail = wp_get_attachment_image( $thumb_id, $size, false, array( 'alt' => $image_alt ) );
 
 		if ( $thumbnail ) {
 			$html .= sprintf(


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/128.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Like Core, we use the post title as the default alt for the Featured Images if the image doesn't have an alt specified.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure the behavior specified in the description is followed. The image alt gets the priority over post title.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

