### PR TITLE
feat: posts block improvements

### DIFF
--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -420,7 +420,7 @@ class Posts_Grid_Block {
 		$tag = sanitize_key( $tag );
 		
 		if ( ! in_array( $tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ), true ) ) {
-			$tag = 'h5';
+			$tag = 'h4';
 		}
 
 		return sprintf(

--- a/src/blocks/blocks/posts/block.json
+++ b/src/blocks/blocks/posts/block.json
@@ -40,7 +40,7 @@
 		},
 		"postsToShow": {
 			"type": "number",
-			"default": 5
+			"default": 6
 		},
 		"order": {
 			"type": "string",
@@ -72,7 +72,7 @@
 		},
 		"titleTag": {
 			"type": "string",
-			"default": "h5"
+			"default": "h4"
 		},
 		"displayMeta": {
 			"type": "boolean",

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -115,7 +115,7 @@ export const PostsTitle = ({ attributes, element, post }) => {
 		return '';
 	}
 
-	const Tag = ! [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes( attributes.titleTag ) ? 'h5' : attributes.titleTag;
+	const Tag = ! [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ].includes( attributes.titleTag ) ? 'h4' : attributes.titleTag;
 
 	return (
 		<Tag key={ element } className="o-posts-grid-post-title">

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -48,6 +48,7 @@ import {
 	_align,
 	_px,
 	boxValues,
+	changeActiveStyle,
 	getCustomPostTypeSlugs,
 	hex2rgba
 } from '../../helpers/helper-functions.js';
@@ -58,6 +59,18 @@ import {
 import '../../components/store/index.js';
 import FeaturedPost from './components/layout/featured.js';
 import { domReady } from '../../helpers/frontend-helper-functions';
+
+const styles = [
+	{
+		label: __( 'Default', 'otter-blocks' ),
+		value: 'default',
+		isDefault: true
+	},
+	{
+		label: __( 'Boxed', 'otter-blocks' ),
+		value: 'boxed'
+	}
+];
 
 const { attributes: defaultAttributes } = metadata;
 
@@ -212,8 +225,22 @@ const Edit = ({
 	const { responsiveGetAttributes } = useResponsiveAttributes();
 
 	useEffect( () => {
+		let isNew = false;
+		if ( undefined === attributes.id ) {
+			isNew = true;
+		}
+
 		const fetch = async() => {
 			setSlugs( await getCustomPostTypeSlugs() );
+
+			if ( isNew ) {
+
+				// We want to set the default style to boxed for new blocks.
+				// We keep it inside async function as keeping it outside was not updating the block style.
+				// Ref: https://github.com/Codeinwp/otter-internals/issues/220
+				const classes = changeActiveStyle( attributes?.className, styles, 'boxed' );
+				setAttributes({ className: classes });
+			}
 		};
 		fetch();
 	}, []);

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -359,7 +359,7 @@ const Inspector = ({
 					>
 						<SelectControl
 							label={ __( 'Title Tag', 'otter-blocks' ) }
-							value={ attributes.titleTag || 'h5' }
+							value={ attributes.titleTag || 'h4' }
 							options={ [
 								{ label: __( 'H1', 'otter-blocks' ), value: 'h1' },
 								{ label: __( 'H2', 'otter-blocks' ), value: 'h2' },

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -64,10 +64,11 @@
 	}
 
 	&.is-style-boxed {
-		--border-width: 3px;
+		--border-width: 1px;
 
 		.o-posts-grid-post-body {
 			padding: var( --content-padding, 20px );
+			background: rgb( 240, 245, 250);
 		}
 	}
 

--- a/tests/test-post-grid-block.php
+++ b/tests/test-post-grid-block.php
@@ -121,7 +121,7 @@ class Test_Post_Grid_Block extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $output );
 
 		// We expect the titleTag to be sanitized.
-		$expected = '<h5 class="o-posts-grid-post-title"><a href="http://www.example.com">Title</a></h5>';
+		$expected = '<h4 class="o-posts-grid-post-title"><a href="http://www.example.com">Title</a></h4>';
 		$output = $this->post_grid_block->render_post_title( $malformed_attributes['titleTag'], 'www.example.com', 'Title' );
 
 		$this->assertEquals( $expected, $output );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/220.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
- Change default block style to Boxed
- Change default heading to h4
- Change the default color, border, and number of posts

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Confirm all the described changes
- Most importantly, make sure the default style of new block is Boxed but it shouldn't affect existing blocks.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

