### PR TITLE
feat: add tiled style to Posts Block

### DIFF
--- a/inc/css/blocks/class-posts-css.php
+++ b/inc/css/blocks/class-posts-css.php
@@ -209,6 +209,10 @@ class Posts_CSS extends Base_CSS {
 						},
 					),
 					array(
+						'property' => '--image-ratio',
+						'value'    => 'imageRatio',
+					),
+					array(
 						'property' => '--border-width',
 						'value'    => 'borderWidth',
 					),

--- a/inc/css/blocks/class-posts-css.php
+++ b/inc/css/blocks/class-posts-css.php
@@ -63,6 +63,10 @@ class Posts_CSS extends Base_CSS {
 						'value'    => 'backgroundColor',
 					),
 					array(
+						'property' => '--background-overlay',
+						'value'    => 'backgroundOverlay',
+					),
+					array(
 						'property' => '--border-color',
 						'value'    => 'borderColor',
 					),
@@ -395,6 +399,38 @@ class Posts_CSS extends Base_CSS {
 			)
 		);
 
+		if ( isset( $block['attrs']['cardBorderRadius'] ) && is_array( $block['attrs']['cardBorderRadius'] ) ) {
+			$border_radius_properties = array(
+				'top'    => '--border-radius-start-start',
+				'right'  => '--border-radius-start-end',
+				'bottom' => '--border-radius-end-start',
+				'left'   => '--border-radius-end-end',
+			);
+		
+			$properties = array_map(
+				function( $position, $css_variable ) {
+					return array(
+						'property'  => $css_variable,
+						'value'     => 'cardBorderRadius',
+						'format'    => function( $value, $attrs ) use ( $position ) {
+							return $value[ $position ];
+						},
+						'condition' => function( $attrs ) {
+							// @phpstan-ignore-next-line
+							return isset( $attrs['className'] ) && strpos( $attrs['className'], 'is-style-tiled' ) !== false;
+						},
+					);
+				},
+				array_keys( $border_radius_properties ),
+				$border_radius_properties
+			);
+		
+			$css->add_item(
+				array(
+					'properties' => $properties,
+				)
+			);
+		}
 
 		$style = $css->generate();
 

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -124,10 +124,6 @@ class Posts_Grid_Block {
 			$class .= ' o-posts-grid-columns-' . $attributes['columns'];
 		}
 
-		if ( isset( $attributes['cropImage'] ) && true === $attributes['cropImage'] ) {
-			$class .= ' o-crop-img';
-		}
-
 		$wrapper_attributes = get_block_wrapper_attributes();
 
 		$block_content = sprintf(

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -25,6 +25,7 @@ class Posts_Grid_Block {
 
 		$has_pagination = isset( $attributes['hasPagination'] ) && $attributes['hasPagination'];
 		$page_number    = 1;
+		$is_tiled       = isset( $attributes['className'] ) && false !== strpos( $attributes['className'], 'is-style-tiled' );
 
 		if ( $has_pagination ) {
 			if ( ! empty( get_query_var( 'page' ) ) || ! empty( get_query_var( 'paged' ) ) ) {
@@ -71,10 +72,18 @@ class Posts_Grid_Block {
 			$size      = isset( $attributes['imageSize'] ) ? $attributes['imageSize'] : 'medium';
 			$thumb_id  = get_post_thumbnail_id( $id );
 			$thumbnail = wp_get_attachment_image_src( $thumb_id, $size );
+			$style     = '';
 
-			$list_items_markup .= '<div class="o-posts-grid-post-blog o-posts-grid-post-plain"><div class="o-posts-grid-post">';
+			if ( $is_tiled && $thumbnail ) {
+				$style = sprintf(
+					' style="background-image: url(%1$s); background-size: cover; background-position: center center;"',
+					esc_url( $thumbnail[0] )
+				);
+			}
 
-			if ( isset( $attributes['displayFeaturedImage'] ) && $attributes['displayFeaturedImage'] ) {
+			$list_items_markup .= '<div class="o-posts-grid-post-blog o-posts-grid-post-plain"' . $style . '><div class="o-posts-grid-post">';
+
+			if ( isset( $attributes['displayFeaturedImage'] ) && $attributes['displayFeaturedImage'] && ! $is_tiled ) {
 				if ( $thumbnail ) {
 					$image_alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
 
@@ -293,6 +302,9 @@ class Posts_Grid_Block {
 		$size      = isset( $attributes['imageSize'] ) ? $attributes['imageSize'] : 'medium';
 		$thumb_id  = get_post_thumbnail_id( $id );
 		$image_alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
+		$style     = '';
+		$image_url = wp_get_attachment_image_src( $thumb_id, $size );
+		$is_tiled  = isset( $attributes['className'] ) && false !== strpos( $attributes['className'], 'is-style-tiled' );
 
 		if ( ! $image_alt ) {
 			$image_alt = get_the_title( $id );
@@ -300,7 +312,7 @@ class Posts_Grid_Block {
 
 		$thumbnail = wp_get_attachment_image( $thumb_id, $size, false, array( 'alt' => $image_alt ) );
 
-		if ( $thumbnail ) {
+		if ( $image_url && ! $is_tiled ) {
 			$html .= sprintf(
 				'<div class="o-posts-grid-post-image"><a href="%1$s">%2$s</a></div>',
 				esc_url( get_the_permalink( $id ) ),
@@ -308,11 +320,18 @@ class Posts_Grid_Block {
 			);
 		}
 
+		if ( $is_tiled && $image_url ) {
+			$style = sprintf(
+				' style="background-image: url(%1$s); background-size: cover; background-position: center center;"',
+				esc_url( $image_url[0] )
+			);
+		}
+
 		$html .= '<div class="o-posts-grid-post-body' . ( $thumbnail && $attributes['displayFeaturedImage'] ? '' : ' is-full' ) . '">';
 
 		$html .= $this->get_post_fields( $id, $attributes );
 		$html .= '</div>';
-		return sprintf( '<div class="o-featured-container"><div class="o-featured-post">%1$s</div></div>', $html );
+		return sprintf( '<div class="o-featured-container"><div class="o-featured-post"' . $style . '>%1$s</div></div>', $html );
 	}
 
 	/**

--- a/src/blocks/blocks/posts/block.json
+++ b/src/blocks/blocks/posts/block.json
@@ -147,6 +147,9 @@
 		"backgroundColor": {
 			"type": "string"
 		},
+		"backgroundOverlay": {
+			"type": "string"
+		},
 		"borderColor": {
 			"type": "string"
 		},

--- a/src/blocks/blocks/posts/block.json
+++ b/src/blocks/blocks/posts/block.json
@@ -110,9 +110,8 @@
 			"type": "boolean",
 			"default": false
 		},
-		"cropImage": {
-			"type": "boolean",
-			"default": false
+		"imageRatio": {
+			"type": "string"
 		},
 		"customTitleFontSize": {
 			"type": [ "string", "number" ]

--- a/src/blocks/blocks/posts/components/layout/featured.js
+++ b/src/blocks/blocks/posts/components/layout/featured.js
@@ -14,7 +14,15 @@ import { applyFilters } from '@wordpress/hooks';
  * Internal dependencies
  */
 
-import Thumbnail from './thumbnail.js';
+
+import {
+	Thumbnail,
+	useThumbnail
+} from './thumbnail.js';
+
+import { getActiveStyle } from '../../../../helpers/helper-functions.js';
+
+import { styles } from '../../constants.js';
 
 import {
 	PostsCategory,
@@ -29,16 +37,34 @@ const FeaturedPost = ({
 	author,
 	categoriesList
 }) => {
+	const activeStyle = getActiveStyle( styles, attributes?.className );
+	const isTiled = 'tiled' === activeStyle;
+	const { featuredImage } = useThumbnail( post?.featured_media, post.title?.rendered, attributes?.imageSize );
+
 	if ( ! post  ) {
 		return '';
 	}
 
 	const category = categoriesList && 0 < post?.categories?.length ? categoriesList.find( item => item.id === post.categories[0]) : undefined;
 
+	const hasFeaturedImage = 0 !== post.featured_media && attributes.displayFeaturedImage;
+
+	const css = {
+		backgroundPosition: 'center center',
+		backgroundSize: 'cover'
+	};
+
+	if ( hasFeaturedImage && isTiled ) {
+		css.backgroundImage = `url(${ featuredImage })`;
+	}
+
 	return (
 		<div className="o-featured-container">
-			<div className="o-featured-post">
-				{ attributes.displayFeaturedImage && (
+			<div
+				className="o-featured-post"
+				style={ css }
+			>
+				{ ( attributes.displayFeaturedImage && ! isTiled ) && (
 					<Thumbnail
 						id={ post.featured_media }
 						link={ post.link }

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -49,17 +49,9 @@ const Layout = ({
 				'grid' === attributes.style ?
 					classnames(
 						'is-grid',
-						`o-posts-grid-columns-${ attributes.columns }`,
-						{
-							'o-crop-img': attributes.cropImage
-						}
+						`o-posts-grid-columns-${ attributes.columns }`
 					) :
-					classnames(
-						'is-list',
-						{
-							'o-crop-img': attributes.cropImage
-						}
-					)
+					'is-list'
 			}
 		>
 			{ postsToDisplay

--- a/src/blocks/blocks/posts/components/layout/index.js
+++ b/src/blocks/blocks/posts/components/layout/index.js
@@ -11,14 +11,25 @@ import {
 	sprintf
 } from '@wordpress/i18n';
 
+import { Placeholder } from '@wordpress/components';
+
 import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-import Thumbnail from './thumbnail.js';
-import { unescapeHTML, formatDate } from '../../../../helpers/helper-functions.js';
-import { Placeholder } from '@wordpress/components';
+import {
+	Thumbnail,
+	useThumbnail
+} from './thumbnail.js';
+
+import {
+	getActiveStyle,
+	unescapeHTML,
+	formatDate
+} from '../../../../helpers/helper-functions.js';
+
+import { styles } from '../../constants.js';
 
 const Layout = ({
 	attributes,
@@ -26,6 +37,8 @@ const Layout = ({
 	categoriesList,
 	authors
 }) => {
+	const activeStyle = getActiveStyle( styles, attributes?.className );
+	const isTiled = 'tiled' === activeStyle;
 
 	const postsToDisplay = posts
 		.filter( post => post );
@@ -52,52 +65,77 @@ const Layout = ({
 			{ postsToDisplay
 				.slice( attributes.enableFeaturedPost ? 1 : 0 )
 				.map( post => {
-					const category = categoriesList && 0 < post?.categories?.length ? categoriesList.find( item => item.id === post.categories[0]) : undefined;
-					const categories = categoriesList && 0 < post?.categories?.length ? categoriesList.filter( item => post.categories.includes( item.id ) ) : [];
-					const author = authors && post.author ? authors.find( item => item.id === post.author ) : undefined;
 					return (
-						<div
-							key={ post.link }
-							className="o-posts-grid-post-blog o-posts-grid-post-plain"
-						>
-							<div className={ classnames( 'o-posts-grid-post' ) }>
-								{ ( 0 !== post.featured_media && attributes.displayFeaturedImage ) && (
-									<Thumbnail
-										id={ post.featured_media }
-										link={ post.link }
-										alt={ post.title?.rendered }
-										size={ attributes.imageSize }
-										imgStyle={{
-											borderRadius: attributes.borderRadius !== undefined ? attributes.borderRadius + 'px' : undefined
-										}}
-									/>
-								) }
-
-								<div
-									className={ classnames(
-										'o-posts-grid-post-body',
-										{ 'is-full': ! attributes.displayFeaturedImage }
-									) }
-								>
-									{ attributes.template.map( element => {
-										switch ( element ) {
-										case 'category':
-											return <PostsCategory key={ element } attributes={ attributes } element={ element } category={ category } categoriesList={ categoriesList }/>;
-										case 'title':
-											return <PostsTitle key={ element } attributes={ attributes } element={ element } post={ post } />;
-										case 'meta':
-											return <PostsMeta key={ element } attributes={ attributes } element={ element } post={ post } author={ author } categories={ categories } />;
-										case 'description':
-											return <PostsDescription key={ element } attributes={ attributes } element={ element } post={ post } />;
-										default:
-											return applyFilters( 'otter.postsBlock.templateLoop', '', element, attributes );
-										}
-									}) }
-								</div>
-							</div>
-						</div>
+						<PostBody
+							key={ post.id }
+							post={ post }
+							attributes={ attributes }
+							categoriesList={ categoriesList }
+							authors={ authors }
+							isTiled={ isTiled }
+						/>
 					);
 				}) }
+		</div>
+	);
+};
+
+const PostBody = ({ post, attributes, categoriesList, authors, isTiled }) => {
+	const { featuredImage } = useThumbnail( post?.featured_media, post.title?.rendered, attributes?.imageSize );
+	const category = categoriesList && 0 < post?.categories?.length ? categoriesList.find( item => item.id === post.categories[0]) : undefined;
+	const categories = categoriesList && 0 < post?.categories?.length ? categoriesList.filter( item => post.categories.includes( item.id ) ) : [];
+	const author = authors && post.author ? authors.find( item => item.id === post.author ) : undefined;
+	const hasFeaturedImage = 0 !== post.featured_media && attributes.displayFeaturedImage;
+	const css = {
+		backgroundPosition: 'center center',
+		backgroundSize: 'cover'
+	};
+
+	if ( hasFeaturedImage && isTiled ) {
+		css.backgroundImage = `url(${ featuredImage })`;
+	}
+
+	return (
+		<div
+			key={ post.link }
+			className="o-posts-grid-post-blog o-posts-grid-post-plain"
+			style={ css }
+		>
+			<div className={ classnames( 'o-posts-grid-post' ) }>
+				{ ( hasFeaturedImage && ! isTiled ) && (
+					<Thumbnail
+						id={ post.featured_media }
+						link={ post.link }
+						alt={ post.title?.rendered }
+						size={ attributes.imageSize }
+						imgStyle={{
+							borderRadius: attributes.borderRadius !== undefined ? attributes.borderRadius + 'px' : undefined
+						}}
+					/>
+				) }
+
+				<div
+					className={ classnames(
+						'o-posts-grid-post-body',
+						{ 'is-full': ! attributes.displayFeaturedImage }
+					) }
+				>
+					{ attributes.template.map( element => {
+						switch ( element ) {
+						case 'category':
+							return <PostsCategory key={ element } attributes={ attributes } element={ element } category={ category } categoriesList={ categoriesList }/>;
+						case 'title':
+							return <PostsTitle key={ element } attributes={ attributes } element={ element } post={ post } />;
+						case 'meta':
+							return <PostsMeta key={ element } attributes={ attributes } element={ element } post={ post } author={ author } categories={ categories } />;
+						case 'description':
+							return <PostsDescription key={ element } attributes={ attributes } element={ element } post={ post } />;
+						default:
+							return applyFilters( 'otter.postsBlock.templateLoop', '', element, attributes );
+						}
+					}) }
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/src/blocks/blocks/posts/components/layout/thumbnail.js
+++ b/src/blocks/blocks/posts/components/layout/thumbnail.js
@@ -12,17 +12,18 @@ import { useSelect } from '@wordpress/data';
 
 import { isEmpty } from 'lodash';
 
-const Thumbnail = ({
-	id,
-	link,
-	alt,
-	size,
-	imgStyle
-}) => {
+export const useThumbnail = ( id, size, alt ) => {
 	const {
 		featuredImage,
 		altText
 	} = useSelect( select => {
+		if ( ! id ) {
+			return {
+				featuredImage: null,
+				altText: null
+			};
+		}
+
 		const image = select( 'core' ).getMedia( id, { context: 'view' });
 
 		const featuredImage = image ?
@@ -39,6 +40,20 @@ const Thumbnail = ({
 		};
 	}, [ size, id ]);
 
+	return {
+		featuredImage,
+		altText
+	};
+};
+
+export const Thumbnail = ({
+	id,
+	link,
+	alt,
+	size,
+	imgStyle
+}) => {
+	const { featuredImage, altText } = useThumbnail( id, size, alt );
 
 	if ( null === featuredImage ) {
 		return <Fragment />;
@@ -52,5 +67,3 @@ const Thumbnail = ({
 		</div>
 	);
 };
-
-export default Thumbnail;

--- a/src/blocks/blocks/posts/components/sortable.js
+++ b/src/blocks/blocks/posts/components/sortable.js
@@ -168,10 +168,38 @@ export const SortableItem = ({
 								onChange={ imageSize => setAttributes({ imageSize }) }
 							/>
 
-							<ToggleControl
-								label={ __( 'Crop Image to Fit', 'otter-blocks' ) }
-								checked={ attributes.cropImage }
-								onChange={ cropImage => setAttributes({ cropImage }) }
+							<SelectControl
+								label={ __( 'Image Ratio', 'otter-blocks' ) }
+								value={ attributes.imageRatio }
+								options={ [
+									{
+										label: __( 'Inherit', 'otter-blocks' ),
+										value: 'inherit'
+									},
+									{
+										label: '1:1',
+										value: '1/1'
+									},
+									{
+										label: '3:2',
+										value: '3/2'
+									},
+									{
+										label: '16:9',
+										value: '16/9'
+									},
+									{
+										label: '2:1',
+										value: '2/1'
+									}
+								] }
+								onChange={ imageRatio => {
+									if ( 'inherit' === imageRatio ) {
+										return setAttributes({ imageRatio: undefined });
+									}
+
+									setAttributes({ imageRatio });
+								} }
 							/>
 						</Fragment>
 					) }

--- a/src/blocks/blocks/posts/constants.js
+++ b/src/blocks/blocks/posts/constants.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+
+export const styles = [
+	{
+		label: __( 'Default', 'otter-blocks' ),
+		value: 'default',
+		isDefault: true
+	},
+	{
+		label: __( 'Boxed', 'otter-blocks' ),
+		value: 'boxed'
+	},
+	{
+		label: __( 'Tiled', 'otter-blocks' ),
+		value: 'tiled'
+	}
+];

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -59,18 +59,7 @@ import {
 import '../../components/store/index.js';
 import FeaturedPost from './components/layout/featured.js';
 import { domReady } from '../../helpers/frontend-helper-functions';
-
-const styles = [
-	{
-		label: __( 'Default', 'otter-blocks' ),
-		value: 'default',
-		isDefault: true
-	},
-	{
-		label: __( 'Boxed', 'otter-blocks' ),
-		value: 'boxed'
-	}
-];
+import { styles } from './constants.js';
 
 const { attributes: defaultAttributes } = metadata;
 
@@ -261,11 +250,16 @@ const Edit = ({
 		'--img-box-shadow': imageBoxShadow.active && `${ imageBoxShadow.horizontal }px ${ imageBoxShadow.vertical }px ${ imageBoxShadow.blur }px ${ imageBoxShadow.spread }px ${ hex2rgba( imageBoxShadow.color, imageBoxShadow.colorOpacity ) }`,
 		'--border-width': _px( attributes.borderWidth ),
 		'--border-radius': boxValues( attributes.cardBorderRadius ),
+		'--border-radius-start-start': _px( attributes.cardBorderRadius?.top ),
+		'--border-radius-start-end': _px( attributes.cardBorderRadius?.right ),
+		'--border-radius-end-start': _px( attributes.cardBorderRadius?.bottom ),
+		'--border-radius-end-end': _px( attributes.cardBorderRadius?.left ),
 		'--box-shadow': boxShadow.active && `${ boxShadow.horizontal }px ${ boxShadow.vertical }px ${ boxShadow.blur }px ${ boxShadow.spread }px ${ hex2rgba( boxShadow.color, boxShadow.colorOpacity ) }`,
 		'--vert-align': _align( attributes.verticalAlign ),
 		'--text-align': attributes.textAlign,
 		'--text-color': attributes.textColor,
 		'--background-color': attributes.backgroundColor,
+		'--background-overlay': attributes.backgroundOverlay || '#0000005e',
 		'--border-color': attributes.borderColor,
 		'--content-gap': attributes.contentGap,
 		'--img-width': responsiveGetAttributes([ _px( attributes.imageWidth ), attributes.imageWidthTablet, attributes.imageWidthMobile ]),

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -248,6 +248,7 @@ const Edit = ({
 	const inlineStyles = {
 		'--img-border-radius': isObject( attributes.borderRadius ) ? boxValues( attributes.borderRadius ) : _px( attributes.borderRadius ),
 		'--img-box-shadow': imageBoxShadow.active && `${ imageBoxShadow.horizontal }px ${ imageBoxShadow.vertical }px ${ imageBoxShadow.blur }px ${ imageBoxShadow.spread }px ${ hex2rgba( imageBoxShadow.color, imageBoxShadow.colorOpacity ) }`,
+		'--image-ratio': attributes.imageRatio,
 		'--border-width': _px( attributes.borderWidth ),
 		'--border-radius': boxValues( attributes.cardBorderRadius ),
 		'--border-radius-start-start': _px( attributes.cardBorderRadius?.top ),

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -51,18 +51,7 @@ import {
 import { useResponsiveAttributes } from '../../helpers/utility-hooks.js';
 import { useTabSwitch } from '../../helpers/block-utility';
 import { makeBox } from '../../plugins/copy-paste/utils';
-
-const styles = [
-	{
-		label: __( 'Default', 'otter-blocks' ),
-		value: 'default',
-		isDefault: true
-	},
-	{
-		label: __( 'Boxed', 'otter-blocks' ),
-		value: 'boxed'
-	}
-];
+import { styles } from './constants.js';
 
 const defaultFontSizes = [
 	{
@@ -104,6 +93,7 @@ const Inspector = ({
 	isLoading
 }) => {
 	const [ tab, setTab ] = useTabSwitch( attributes.id, 'settings' );
+	const style = getActiveStyle( styles, attributes?.className );
 
 	const {
 		slugs
@@ -443,6 +433,15 @@ const Inspector = ({
 								label: __( 'Border', 'otter-blocks' ),
 								isShownByDefault: false
 							},
+							...( 'tiled' === style ? [
+								{
+									value: attributes.backgroundOverlay,
+									onChange: backgroundOverlay => setAttributes({ backgroundOverlay }),
+									label: __( 'Background Overlay', 'otter-blocks' ),
+									enableAlpha: true,
+									isShownByDefault: false
+								}
+							] : []),
 							...( attributes.hasPagination ? [
 								{
 									value: attributes.pagColor,
@@ -644,6 +643,7 @@ const Inspector = ({
 							values={ attributes.cardBorderRadius ?? makeBox( '0px' )  }
 							onChange={ cardBorderRadius => setAttributes({ cardBorderRadius }) }
 							id="o-border-raduis-box"
+							allowReset={ false }
 						/>
 
 						{

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -6,8 +6,13 @@
 	--border-width: 0;
 	--text-color: inherit;
 	--background-color: inherit;
+	--background-overlay: #0000005e;
 	--border-color: inherit;
 	--border-radius: 0;
+	--border-radius-start-start: 0;
+	--border-radius-start-end: 0;
+	--border-radius-end-start: 0;
+	--border-radius-end-end: 0;
 	--box-shadow: none;
 	--content-gap: 10px;
 
@@ -64,11 +69,72 @@
 	}
 
 	&.is-style-boxed {
+		--background-color: rgb( 240, 245, 250);
 		--border-width: 1px;
 
 		.o-posts-grid-post-body {
 			padding: var( --content-padding, 20px );
-			background: rgb( 240, 245, 250);
+		}
+	}
+
+	&.is-style-tiled {
+		.o-posts-grid-post-blog {
+			background-color: var( --background-color );
+			border-width: var( --border-width );
+			border-style: solid;
+			border-color: var( --border-color );
+			border-radius: var( --border-radius );
+			box-shadow: var( --box-shadow );
+		}
+
+		.o-featured-post {
+			background-color: var( --background-color );
+
+			.o-posts-grid-post-body {
+				background: var( --background-overlay );
+				border-radius: calc( var( --border-radius-start-start ) - var( --border-width) ) calc( var( --border-radius-start-end ) - var( --border-width) ) calc( var( --border-radius-end-start ) - var( --border-width) ) calc( var( --border-radius-end-end ) - var( --border-width) );
+			}
+		}
+
+		.o-posts-grid-post {
+			width: 100%;
+			height: 100%;
+			display: flex;
+			justify-content: center;
+			align-items: end;
+			background: var( --background-overlay );
+			border-radius: calc( var( --border-radius-start-start ) - var( --border-width) ) calc( var( --border-radius-start-end ) - var( --border-width) ) calc( var( --border-radius-end-start ) - var( --border-width) ) calc( var( --border-radius-end-end ) - var( --border-width) );
+		}
+
+		.o-posts-grid-post,
+		.o-featured-post {
+			.o-posts-grid-post-body {
+				padding: var( --content-padding, 36px );
+				color: var( --text-color, #fff );
+
+				.o-posts-grid-post-title a {
+					color: var( --text-color, #fff );
+				}
+			}
+		}
+	}
+
+	&:not(.is-style-tiled) {
+		.o-posts-grid-post-blog {
+			.o-posts-grid-post {
+				background: var( --background-color );
+				border-width: var( --border-width );
+				border-style: solid;
+				border-color: var( --border-color );
+				border-radius: var( --border-radius );
+				box-shadow: var( --box-shadow );
+			}
+		}
+
+		.o-featured-container {
+			.o-featured-post {
+				background-color: var( --background-color );
+			}
 		}
 	}
 
@@ -156,12 +222,6 @@
 
 		.o-posts-grid-post {
 			overflow: hidden;
-			border-width: var( --border-width );
-			border-style: solid;
-			border-color: var( --border-color );
-			border-radius: var( --border-radius );
-			background: var( --background-color );
-			box-shadow: var( --box-shadow );
 		}
 	}
 
@@ -201,6 +261,11 @@
 			color: var( --text-color );
 			text-transform: capitalize;
 			margin: 0;
+
+			a {
+				font-size: var( --meta-text-size );
+				color: var( --text-color );
+			}
 		}
 
 		.o-posts-grid-post-title {
@@ -223,6 +288,11 @@
 			font-size: var( --meta-text-size );
 			color: var( --text-color );
 			margin: 0;
+
+			a {
+				font-size: var( --meta-text-size );
+				color: var( --text-color );
+			}
 		}
 
 		.o-posts-grid-post-description {
@@ -254,7 +324,6 @@
 			border-style: solid;
 			border-color: var( --border-color );
 			border-radius: var( --border-radius );
-			background-color: var( --background-color );
 			box-shadow: var( --box-shadow );
 			margin-bottom: var( --row-gap );
 

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -3,6 +3,7 @@
 	--vert-align: initial;
 	--img-border-radius: 0;
 	--img-box-shadow: none;
+	--image-ratio: inherit;
 	--border-width: 0;
 	--text-color: inherit;
 	--background-color: inherit;
@@ -182,7 +183,6 @@
 
 				img {
 					height: 100%;
-					object-fit: cover;
 				}
 			}
 
@@ -191,21 +191,6 @@
 
 				&.is-full {
 					flex-basis: 100%;
-				}
-			}
-		}
-	}
-
-	.o-crop-img {
-		.o-posts-grid-post-blog {
-			.o-posts-grid-post {
-				.o-posts-grid-post-image {
-					img {
-						width: 150px;
-						height: 150px;
-						object-fit: cover;
-						border-radius: var( --img-border-radius );
-					}
 				}
 			}
 		}
@@ -244,6 +229,9 @@
 			border-radius: 5px;
 			border-radius: var( --img-border-radius );
 			box-shadow: var( --img-box-shadow );
+			object-fit: cover;
+			object-position: center center;
+			aspect-ratio: var( --image-ratio );
 		}
 	}
 
@@ -334,6 +322,8 @@
 					width: 100%;
 					height: 250px;
 					object-fit: cover;
+					object-position: center center;
+					aspect-ratio: var( --image-ratio );
 				}
 			}
 

--- a/src/blocks/blocks/posts/types.d.ts
+++ b/src/blocks/blocks/posts/types.d.ts
@@ -26,7 +26,7 @@ type Attributes = {
 	displayComments: boolean
 	displayPostCategory: boolean
 	displayReadMoreLink: boolean
-	cropImage: boolean
+	imageRatio: string
 	customTitleFontSize: number
 	customTitleFontSizeTablet: number
 	customTitleFontSizeMobile: number

--- a/tests/test-post-grid-block.php
+++ b/tests/test-post-grid-block.php
@@ -53,7 +53,6 @@ class Test_Post_Grid_Block extends WP_UnitTestCase {
 		'displayComments' => true,
 		'displayPostCategory' => false,
 		'displayReadMoreLink' => false,
-		'cropImage' => false,
 		'boxShadow' => array(
 			'active' => false,
 			'colorOpacity' => 50,


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/218.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
Added a tiled style with overlay color and image as the background of the tiles as a new style to Posts Block.

### Screenshots <!-- if applicable -->

<img width="951" alt="Screenshot 2024-08-04 at 11 48 49 AM" src="https://github.com/user-attachments/assets/c44e5865-4398-47f9-96a6-bd7ab97bf08d">

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Just confirm everything works fine with the new style.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()