### PR TITLE
feat: add merge fields for Mailchimp

### DIFF
--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -343,6 +343,9 @@ class Form_Data_Response {
 	 * @since 2.1.7
 	 */
 	public function process_error_code() {
+		if ( ! $this->has_error() ) {
+			return;
+		}
 		$this->add_reason( self::get_error_code_message( $this->response['code'] ) );
 	}
 

--- a/inc/integrations/providers/class-mailchimp.php
+++ b/inc/integrations/providers/class-mailchimp.php
@@ -35,6 +35,13 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 	 */
 	protected $server_name = '';
 
+	/**
+	 * The form data.
+	 * 
+	 * @var Form_Data_Request|null
+	 */
+	protected $form_data = null;
+
 
 	/**
 	 * The default constructor.
@@ -110,16 +117,24 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 	 *
 	 * @param string $email The email address.
 	 * @return array|\WP_Error The response from Mailchimp.
+	 * 
+	 * @see https://mailchimp.com/developer/marketing/api/list-members/add-member-to-list/
 	 */
 	public function make_subscribe_request( $email ) {
 		$user_status = $this->get_new_user_status_mailchimp( $this->list_id );
 
 		$url = 'https://' . $this->server_name . '.api.mailchimp.com/3.0/lists/' . $this->list_id . '/members/' . md5( strtolower( $email ) );
-
+		
 		$payload = array(
 			'email_address' => $email,
 			'status'        => $user_status,
 		);
+		
+		$linked_merge_fields = $this->get_linked_merge_fields();
+		if ( ! empty( $linked_merge_fields ) ) {
+			$url                     = add_query_arg( 'skip_merge_validation', 'true', $url );
+			$payload['merge_fields'] = $linked_merge_fields;
+		}
 
 		$args = array(
 			'method'  => 'PUT',
@@ -141,9 +156,10 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 	 */
 	public function subscribe( $form_data ) {
 
-		$email    = $form_data->get_first_email_from_input_fields();
-		$response = $this->make_subscribe_request( $email );
-		$body     = json_decode( wp_remote_retrieve_body( $response ), true );
+		$this->form_data = $form_data;
+		$email           = $form_data->get_first_email_from_input_fields();
+		$response        = $this->make_subscribe_request( $email );
+		$body            = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 
@@ -283,5 +299,100 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 	 */
 	private function is_credential_error( $response_code ) {
 		return in_array( $response_code, array( 401, 403, 404, 500 ) );
+	}
+
+	/**
+	 * Get the merge fields from Mailchimp.
+	 *
+	 * @return array An array of merge fields, each containing:
+	 *               - string $tag The merge field's tag
+	 *               - string $type The merge field's type (e.g., 'text')
+	 * @since 2.7.0
+	 * 
+	 * @see https://mailchimp.com/developer/marketing/api/list-merges/list-merge-fields/
+	 */
+	public function get_merge_fields() {
+		$url  = 'https://' . $this->server_name . '.api.mailchimp.com/3.0/lists/' . $this->list_id . '/merge-fields';
+		$args = array(
+			'method'  => 'GET',
+			'headers' => array(
+				'Authorization' => 'Basic ' . base64_encode( 'user:' . $this->api_key ),
+			),
+		);
+		
+		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
+			$response = vip_safe_wp_remote_get( $url, '', 3, 1, 20, $args );
+		} else {
+			$response = wp_remote_get( $url, $args ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		}
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( ! isset( $body['merge_fields'] ) || empty( $body['merge_fields'] ) ) {
+			return array();
+		}
+
+		return array_filter(
+			$body['merge_fields'],
+			function( $item ) {
+				return ! empty( $item['tag'] );
+			}
+		);
+	}
+
+	/**
+	 * Link the form fields with their corresponding merge fields.
+	 * 
+	 * @return array The available merge fields to link with the form fields.
+	 * @since 2.7.0
+	 */
+	protected function get_linked_merge_fields() {
+
+		// Check if it is necessary to link the fields.
+		$form_fields = $this->form_data->get_fields();
+		if ( empty( $form_fields ) ) {
+			return array();
+		}
+
+		$available_fields_tags = array();
+
+		foreach ( $form_fields as $field ) {
+			if ( empty( $field['metadata']['mappedName'] ) ) {
+				continue;
+			}
+
+			$available_fields_tags[] = array(
+				'tag'   => strtoupper( $field['metadata']['mappedName'] ),
+				'value' => $field['value'],
+			);
+		}
+
+		if ( empty( $available_fields_tags ) ) {
+			return array();
+		}
+		
+
+		$merge_fields = $this->get_merge_fields();
+		if ( empty( $merge_fields ) ) {
+			return array();
+		}
+
+		// Link based on the tag of the merge fields.
+		$linked_fields = array();
+		foreach ( $available_fields_tags as $field ) {
+			foreach ( $merge_fields as $merge_field ) {
+				if ( $field['tag'] !== $merge_field['tag'] ) {
+					continue;
+				}
+
+				$linked_fields[ $merge_field['tag'] ] = $field['value'];
+			}
+		}
+
+		return $linked_fields;
 	}
 }

--- a/src/blocks/blocks/form/common.tsx
+++ b/src/blocks/blocks/form/common.tsx
@@ -234,7 +234,7 @@ export const selectAllFieldsFromForm = ( children: any[]) : ({ parentClientId: s
 
 export const mappedNameInfo = (
 	<Fragment>
-		{__( 'Allow easy identification of the field.', 'otter-blocks' )}
+		{__( 'Allow easy identification of the field in features like Webhooks.', 'otter-blocks' )}
 		<ExternalLink href='https://docs.themeisle.com/article/1878-how-to-use-webhooks-in-otter-forms#mapped-name'> { __( 'Learn More', 'otter-blocks' ) } </ExternalLink>
 	</Fragment>
 );

--- a/src/pro/blocks/form-stripe-field/inspector.js
+++ b/src/pro/blocks/form-stripe-field/inspector.js
@@ -84,7 +84,7 @@ const Inspector = ({
 
 				<TextControl
 					label={ __( 'Mapped Name', 'otter-blocks' ) }
-					help={ __( 'Allow easy identification of the field with features like: webhooks', 'otter-blocks' ) }
+					help={ __( 'Allow easy identification of the field in features like Webhooks.', 'otter-blocks' ) }
 					value={ attributes.mappedName }
 					onChange={ mappedName => setAttributes({ mappedName }) }
 					placeholder={ __( 'product', 'otter-blocks' ) }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/168
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Added the ability to link the value of the fields with **some** of the types for Mailchimp Merge Fields

> [!NOTE]
> The users are advised to mostly use the type `TEXT` for the linked fields.

Fields like File do not file, but the name of the files. Select type fields (e.g., checkbox) and send a string of values with the selected types.

This is not made to handle complex cases, uploading files to Mailchimp, and advanced selection to their dropdown.

![image](https://github.com/user-attachments/assets/38dbcdea-fb0e-45cd-9864-dab62ac6e388)

> [!WARNING]
> The validation is disabled, so wrong data might be sent if the Otter field is not properly set up based on the merge fields.

### Screenshots <!-- if applicable -->

#### Merge fields in Mailchimp Dashboard 

![image](https://github.com/user-attachments/assets/ec97b3f7-4c2f-4838-9fc5-304fd4fc1e51)

#### Connected Otter fields

![image](https://github.com/user-attachments/assets/91a59932-7e91-4983-9929-68b06e3e24c3)

![image](https://github.com/user-attachments/assets/08997d50-1b28-4f46-8482-866438115cd2)

#### Mailchimp Contact list with extra fields 

![image](https://github.com/user-attachments/assets/eada4ef0-718e-4fd6-9008-757c97fe8e47)

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

**Check if the tag in the Otter field MAPPED NAMED is sent to its corresponding tag in Mailchimp MERGE FIELDS.**

> [!NOTE]
> We only send the data to Mailchimp. Do not expect to send automatic replays with merged fields from the plugin -- this is done via Mailchimp if it is set up to do so.

References:
- https://mailchimp.com/help/getting-started-with-merge-tags/

![image](https://github.com/user-attachments/assets/fd354644-172d-4928-a850-c752ddc489e7)


<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

