### PR TITLE
fix: button block appearance in latest wp version

### DIFF
--- a/src/blocks/blocks/button-group/button/edit.js
+++ b/src/blocks/blocks/button-group/button/edit.js
@@ -42,7 +42,6 @@ const { attributes: defaultAttributes } = metadata;
  * @returns
  */
 const Edit = ( props ) => {
-
 	const {
 		attributes,
 		setAttributes,
@@ -118,9 +117,7 @@ const Edit = ( props ) => {
 					}
 				</style>
 				{ 'none' !== attributes.iconType ? (
-					<a
-						className="wp-block-button__link"
-					>
+					<div className="wp-block-button__link">
 						{ ( 'left' === attributes.iconType || 'only' === attributes.iconType ) && (
 							'themeisle-icons' === attributes.library && attributes.icon ? (
 								<Icon
@@ -160,11 +157,9 @@ const Edit = ( props ) => {
 								<i className={ `${ attributes.prefix } fa-fw fa-${ attributes.icon } margin-left` }></i>
 							)
 						) }
-					</a>
+					</div>
 				) : (
-					<a
-						className="wp-block-button__link"
-					>
+					<div className="wp-block-button__link">
 						<RichText
 							placeholder={ __( 'Add text…', 'otter-blocks' ) }
 							value={ attributes.text }
@@ -172,7 +167,7 @@ const Edit = ( props ) => {
 							tagName="span"
 							withoutInteractiveFormatting
 						/>
-					</a>
+					</div>
 				) }
 			</div>
 		</Fragment>

--- a/src/blocks/blocks/button-group/style.scss
+++ b/src/blocks/blocks/button-group/style.scss
@@ -137,14 +137,23 @@ $device-map: (desktop: '1200px', tablet: '960px', mobile: '600px');
 		}
 
 		&.wp-block-button {
-			&:is(.is-style-plain, .is-style-outline) :is(.wp-block-button__link, .wp-block-button__link:hover) {
-				background: transparent;
-			}
-			
 			&:is(.is-style-plain) :is(.wp-block-button__link, .wp-block-button__link:hover) {
+				background: transparent;
+				color: #000;
 				border-width: 0px;
 				padding: 0px;
 				box-shadow: unset;
+			}
+
+			&:is(.is-style-outline) .wp-block-button__link {
+				background: transparent;
+				color: #111111;
+				border: 1px solid #111111;
+
+				&:hover {
+					background: #111111;
+					color: #ffffff;
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/223.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This PR adds a default style for the block variations to prevent them from looking bad in the editor/front after the latest WordPress update. This breaks the history of the button inheriting the styles, which isn't possible after the latest WordPress update.

By adding the default styles, we ensure the buttons look at least presentable for users so they can customize them as needed.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure the buttons look good in some of the most popular themes.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

