### PR TITLE
feat(column): add support for tablet width

### DIFF
--- a/inc/css/blocks/class-advanced-column-css.php
+++ b/inc/css/blocks/class-advanced-column-css.php
@@ -266,6 +266,14 @@ class Advanced_Column_CSS extends Base_CSS {
 				'query'      => '@media ( max-width: 960px )',
 				'properties' => array(
 					array(
+						'property' => 'flex-basis',
+						'value'    => 'columnWidthTablet',
+						'unit'     => '%',
+						'format'   => function( $value, $attrs ) {
+							return floatval( $value );
+						},
+					),
+					array(
 						'property'  => 'padding-top',
 						'value'     => 'paddingTablet',
 						'format'    => function( $value, $attrs ) {

--- a/src/blocks/blocks/section/column/block.json
+++ b/src/blocks/blocks/section/column/block.json
@@ -187,6 +187,9 @@
 		"columnWidth": {
 			"type": "string"
 		},
+		"columnWidthTablet": {
+			"type": "string"
+		},
 		"verticalAlign": {
 			"type": "string"
 		},

--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -170,6 +170,7 @@ const Edit = ({
 	let background, overlayBackground, borderStyle, borderRadiusStyle, boxShadowStyle;
 
 	let	stylesheet = {
+		flexBasis: `${ getValue( 'columnWidth' ) }%`,
 		paddingTop: getValue( 'padding' )?.top,
 		paddingRight: getValue( 'padding' )?.right,
 		paddingBottom: getValue( 'padding' )?.bottom,
@@ -183,6 +184,7 @@ const Edit = ({
 
 	if ( isTablet || isMobile ) {
 		const tabletStyle = pickBy({
+			flexBasis: getValue( 'columnWidthTablet' ) ? `${ getValue( 'columnWidthTablet' ) }%` : '50%',
 			paddingTop: getValue( 'paddingTablet' )?.top,
 			paddingRight: getValue( 'paddingTablet' )?.right,
 			paddingBottom: getValue( 'paddingTablet' )?.bottom,
@@ -265,7 +267,6 @@ const Edit = ({
 	};
 
 	const style = {
-		flexBasis: `${ attributes.columnWidth }%`,
 		...stylesheet,
 		...background,
 		...borderStyle,

--- a/src/blocks/blocks/section/column/inspector.js
+++ b/src/blocks/blocks/section/column/inspector.js
@@ -76,14 +76,39 @@ const Inspector = ({
 
 	const [ tab, setTab ] = useTabSwitch( attributes.id, 'layout' );
 
+	const getWidthField = () => {
+		switch ( getView ) {
+		case 'Desktop':
+			return 'columnWidth';
+		case 'Tablet':
+			return 'columnWidthTablet';
+		default:
+			return undefined;
+		}
+	};
+
+	const getWidth = () => {
+		switch ( getView ) {
+		case 'Desktop':
+			return getValue( 'columnWidth' );
+		case 'Tablet':
+			return getValue( 'columnWidthTablet' ) ?? 50;
+		default:
+			return undefined;
+		}
+	};
+
 	const changeColumnWidth = value => {
 		const width = value || 10;
 		const nextWidth = ( Number( currentBlockWidth.current ) - width ) + Number( nextBlockWidth.current );
 		currentBlockWidth.current = width;
 		nextBlockWidth.current = nextWidth;
-		setAttributes({ columnWidth: width.toFixed( 2 ) });
+
+		const attributeTag = getWidthField();
+
+		setAttributes({ [attributeTag]: width.toFixed( 2 ) });
 		updateBlockAttributes( nextBlock.current, {
-			columnWidth: nextWidth.toFixed( 2 )
+			[attributeTag]: nextWidth.toFixed( 2 )
 		});
 	};
 
@@ -226,14 +251,19 @@ const Inspector = ({
 						title={ __( 'Column Structure', 'otter-blocks' ) }
 					>
 						{ ( 1 < parentBlock.innerBlocks.length ) && (
-							<RangeControl
-								label={ __( 'Column Width', 'otter-blocks' ) }
-								value={ Number( attributes.columnWidth ) }
-								onChange={ changeColumnWidth }
-								step={ 0.1 }
-								min={ 10 }
-								max={ ( Number( attributes.columnWidth ) + Number( nextBlockWidth.current ) ) - 10 }
-							/>
+							<ResponsiveControl
+								label={ __( 'Screen Type', 'otter-blocks' ) }
+							>
+								<RangeControl
+									label={ __( 'Column Width', 'otter-blocks' ) }
+									value={ Number( getWidth() ) }
+									onChange={ changeColumnWidth }
+									step={ 0.1 }
+									min={ 10 }
+									max={ 100 }
+									disabled={ 'Mobile' === getView }
+								/>
+							</ResponsiveControl>
 						) }
 
 						<SelectControl

--- a/src/blocks/blocks/section/style.scss
+++ b/src/blocks/blocks/section/style.scss
@@ -31,6 +31,7 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 .wp-block-themeisle-blocks-advanced-columns {
 	--background: transparent;
 	--columns-width: 100%;
+	--columns-width-tablet: 50%;
 	--horizontal-align: unset;
 
 	background: var( --background );
@@ -346,7 +347,7 @@ html[lang="ja"], html[lang="ko"], html[lang="zh"], html[lang="zh-Hans"], html[la
 			display: flex;
 			flex-basis: 100%;
 			word-break: keep-all;
-			max-width: var( --columns-width );
+			max-width: var( --columns-width-tablet );
 
 			.wp-block-themeisle-blocks-advanced-column {
 				position: relative;


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/200
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Add custom width support for Section Column

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/2d386ae1-cd9b-41fd-ba8d-3bd2cb6ac975)


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Insert a Section Block
2. Check if you can change the column with for Tablet
3. MObile should be disabled

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

