### PR TITLE
fix: pin down `@wordpress/script` to support WordPress 6.5 or earlier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "otter-blocks",
-			"version": "2.6.13",
+			"version": "3.0.2",
 			"license": "GPL-2.0+",
 			"dependencies": {
 				"@formbricks/js": "^1.6.5",
@@ -47,7 +47,7 @@
 				"@wordpress/e2e-tests": "^8.4.0",
 				"@wordpress/element": "^6.3.0",
 				"@wordpress/env": "^9.6.0",
-				"@wordpress/scripts": "^28.3.0",
+				"@wordpress/scripts": "27.9.0",
 				"conventional-changelog-simple-preset": "^1.0.24",
 				"eslint-config-wordpress": "^2.0.0",
 				"filemanager-webpack-plugin": "^6.1.7",
@@ -1764,15 +1764,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.24.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.7.tgz",
-			"integrity": "sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.4.tgz",
+			"integrity": "sha512-8hsyG+KUYGY0coX6KUCDancA0Vw225KJ2HJO0yCNr1vq5r+lJTleDaJf0K7iOhjw4SWhu03TMBzYTJ9krmzULQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.24.7",
-				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-plugin-utils": "^7.24.8",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.1",
+				"babel-plugin-polyfill-corejs3": "^0.10.6",
 				"babel-plugin-polyfill-regenerator": "^0.6.1",
 				"semver": "^6.3.1"
 			},
@@ -1800,13 +1800,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.4.tgz",
-			"integrity": "sha512-25J6I8NGfa5YkCDogHRID3fVCadIR8/pGl1/spvCkzb6lVn6SR3ojpx9nOn9iEBcUsjY24AmdKm5khcfKdylcg==",
+			"version": "0.10.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.1",
-				"core-js-compat": "^3.36.1"
+				"@babel/helper-define-polyfill-provider": "^0.6.2",
+				"core-js-compat": "^3.38.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -3490,12 +3490,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-			"integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+			"version": "1.46.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
+			"integrity": "sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.45.3"
+				"playwright": "1.46.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -6649,10 +6649,22 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.41.0.tgz",
+			"integrity": "sha512-hYxj2Uobxk86ctlfaJou9v13XqXZ30yx4ZwRNu5cH5/LWXe2MIXBTPv7dUk6wqN/qFOjsFvP9jCB0NsW6MnkrA==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.12.9"
+			}
+		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.4.0.tgz",
-			"integrity": "sha512-BIbHlZxXGG6gEDrTUJ3s7wU2mAPbHFCkc7QkeTD+7GMIixEzEPr7IBbrpHkcwLIRWqEvc9LB69YPrWklUKJZmg==",
+			"version": "7.42.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-7.42.0.tgz",
+			"integrity": "sha512-AWSxWuEuzazt/nWomKiaVhYQeXuqxTniPCKhvks58wB3P4UXvSe3hRnO+nujz20IuxIk2xHT6x47HgpDZy30jw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
@@ -6661,26 +6673,31 @@
 				"@babel/preset-env": "^7.16.0",
 				"@babel/preset-typescript": "^7.16.0",
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/browserslist-config": "^6.4.0",
-				"@wordpress/warning": "^3.4.0",
+				"@wordpress/babel-plugin-import-jsx-pragma": "^4.41.0",
+				"@wordpress/browserslist-config": "^5.41.0",
+				"@wordpress/warning": "^2.58.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14"
+			}
+		},
+		"node_modules/@wordpress/babel-preset-default/node_modules/@wordpress/warning": {
+			"version": "2.58.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.58.0.tgz",
+			"integrity": "sha512-9bZlORhyMY2nbWozeyC5kqJsFzEPP4DCLhGmjtbv+YWGHttUrxUZEfrKdqO+rUODA8rP5zeIly1nCQOUnkw4Lg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.4.0.tgz",
-			"integrity": "sha512-W/Tazd2nhiMoUWtZD0rVRbByH2uXakOR6htnqM1NT2dbnwWS/NsT0AQVY5JMTIrGQ8p4BSgq68/+xb1r4DXxTw==",
-			"dev": true,
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-4.49.0.tgz",
+			"integrity": "sha512-yFRYqNtd26ULZ0oAHhCu/IcaA0XHI3E7kRCKajZqUvyRQj7YprXnpD3o0/pnwvF6ZFTXzCX8pXHjUc2TIv97ig==",
+			"dev": true
 		},
 		"node_modules/@wordpress/blob": {
 			"version": "4.3.0",
@@ -7028,13 +7045,12 @@
 			"dev": true
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.4.0.tgz",
-			"integrity": "sha512-6Uvh++K+UCOSSlE589uHtxVWa7vJmcFjDYHT7/VsdrHkwpCRwJd0UAUrmTBqiekGYo3NQzZW/ikODxR+lkORjw==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.41.0.tgz",
+			"integrity": "sha512-J7ejzzDpPZddVIiq2YiK8J/pNTJDy3X1s+5ZtwkwklCxBMZJurxf9pEhtbaf7us0Q6c1j8Ubv7Fpx3lqk2ypxA==",
 			"dev": true,
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14"
 			}
 		},
 		"node_modules/@wordpress/commands": {
@@ -7535,16 +7551,15 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.4.0.tgz",
-			"integrity": "sha512-9CmC+8SSQ4Oh/IghVg8YQjBIKpvuxn18m+Painq6SdJGseJhRgnFINVUwHCs1BRR1sB4BUTldnUlNiya43EK1w==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-5.9.0.tgz",
+			"integrity": "sha512-hXbCkbG1XES47t7hFSETRrLfaRSPyQPlCnhlCx7FfhYFD0wh1jVArApXX5dD+A6wTrayXX/a16MpfaNqE662XA==",
 			"dev": true,
 			"dependencies": {
 				"json2php": "^0.0.7"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=18"
 			},
 			"peerDependencies": {
 				"webpack": "^5.0.0"
@@ -7624,9 +7639,9 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.4.0.tgz",
-			"integrity": "sha512-kp88FLUU1SJAtxlRF5jNWYYmOSmpVrVLXuLTZmmXDMp/FFd0vzNDKwZ7TV6fd0B58cxyUydaG6e+hxLMeSYQtw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.6.0.tgz",
+			"integrity": "sha512-ncu9cgaysr4tYwMfWYAu0O6E6vV8iMGvHeMmZow965ogIldePkIonQIwLB3PdXz536/u5kgUAjqcTb+nhEB8lQ==",
 			"dev": true,
 			"dependencies": {
 				"change-case": "^4.1.2",
@@ -7675,6 +7690,144 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/type-utils": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@typescript-eslint/parser": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@typescript-eslint/types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/api-fetch": {
 			"version": "7.4.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.4.0.tgz",
@@ -7688,6 +7841,65 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/babel-preset-default": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.6.0.tgz",
+			"integrity": "sha512-g8Soek91qosZgF7GVuXu8MIe/T5HZh/sxjN2w7+XWwHpT3OqOOExKbPpfHRVa2kfvqyU0M5HOG3rWU9p5grAMw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.16.0",
+				"@babel/plugin-transform-react-jsx": "^7.16.0",
+				"@babel/plugin-transform-runtime": "^7.16.0",
+				"@babel/preset-env": "^7.16.0",
+				"@babel/preset-typescript": "^7.16.0",
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/browserslist-config": "^6.6.0",
+				"@wordpress/warning": "^3.6.0",
+				"browserslist": "^4.21.10",
+				"core-js": "^3.31.0",
+				"react": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/base-styles": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-5.6.0.tgz",
+			"integrity": "sha512-U+4ROBYaxzyf96bvFEJTzTJTaSS1igk3UxMJZIUa2Ixs+rBirywEkMPbbwto8uRCCEy4c0Gq/f+lmzfU02Vvpg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/browserslist-config": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.6.0.tgz",
+			"integrity": "sha512-godfjZwl9gZmgXKxUctl01MxX5uDGIgcGa7VrFxtoVX0YZPKuZob0LUOkENddfWTTRmPQfrQBMDA05XtPsmPcA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/dependency-extraction-webpack-plugin": {
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.6.0.tgz",
+			"integrity": "sha512-w3TqOnLnjmbBaZRea7uBoF3Uo5pH4ORdmGTiIigezl/tp7c14VIw0x9xJNs3an7hWX6yal8L5We6WR4ixSJXOQ==",
+			"dev": true,
+			"dependencies": {
+				"json2php": "^0.0.7"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"webpack": "^5.0.0"
 			}
 		},
 		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/e2e-test-utils": {
@@ -7713,6 +7925,49 @@
 				"puppeteer-core": ">=11"
 			}
 		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/eslint-plugin": {
+			"version": "20.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-20.3.0.tgz",
+			"integrity": "sha512-Y272ZtosmXPJJ0K5X7j0ufcpuDf1unEEDOmdyStHhYV3DGjfETPKgMBVjpmWIObu5oMlqqkTiiQaNb+lho3EIQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/eslint-parser": "^7.16.0",
+				"@typescript-eslint/eslint-plugin": "^6.4.1",
+				"@typescript-eslint/parser": "^6.4.1",
+				"@wordpress/babel-preset-default": "^8.6.0",
+				"@wordpress/prettier-config": "^4.6.0",
+				"cosmiconfig": "^7.0.0",
+				"eslint-config-prettier": "^8.3.0",
+				"eslint-plugin-import": "^2.25.2",
+				"eslint-plugin-jest": "^27.2.3",
+				"eslint-plugin-jsdoc": "^46.4.6",
+				"eslint-plugin-jsx-a11y": "^6.5.1",
+				"eslint-plugin-playwright": "^0.15.3",
+				"eslint-plugin-prettier": "^5.0.0",
+				"eslint-plugin-react": "^7.27.0",
+				"eslint-plugin-react-hooks": "^4.3.0",
+				"globals": "^13.12.0",
+				"requireindex": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7",
+				"eslint": ">=8",
+				"prettier": ">=3",
+				"typescript": ">=4"
+			},
+			"peerDependenciesMeta": {
+				"prettier": {
+					"optional": true
+				},
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/i18n": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.4.0.tgz",
@@ -7734,6 +7989,24 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/jest-preset-default": {
+			"version": "12.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.6.0.tgz",
+			"integrity": "sha512-02ZozKXzlBdJnr5fD4PKfNrDFmsA44KvPJa1zNOsIILxHk+C5ZfqcSL0q++k2dOsSpLuIZg+tNwKkOeluL+s3Q==",
+			"dev": true,
+			"dependencies": {
+				"@wordpress/jest-console": "^8.6.0",
+				"babel-jest": "^29.6.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7",
+				"jest": ">=29"
+			}
+		},
 		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/keycodes": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.4.0.tgz",
@@ -7748,6 +8021,168 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/npm-package-json-lint-config": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.6.0.tgz",
+			"integrity": "sha512-wJKEX0XC0eDQFTnvpuBQdV12KyJzWHJaAA8n6pyIgRWz8RjdeANEaKHAbdDK1aHOA5DbwuxZh7NUm4ngMaPBrA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"npm-package-json-lint": ">=6.0.0"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/postcss-plugins-preset": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.6.0.tgz",
+			"integrity": "sha512-r8QShU9dKd23nPcnOtW4Cvaf8LyZ9qyoIWw50lVNV4H9LAvaaXFN7kzID+B7bosLaqoB5vAe/H17n6/kxdDfHQ==",
+			"dev": true,
+			"dependencies": {
+				"@wordpress/base-styles": "^5.6.0",
+				"autoprefixer": "^10.2.5"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/prettier-config": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.6.0.tgz",
+			"integrity": "sha512-e43Ep9OiNt/zRkY0NAdPni3ac7Tf761lEZDVwxwSZdrm5N4u6SXqXJrHo5/AxcnLhq/21TG4Ry+g4zEA6L1aXA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"prettier": ">=3"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/scripts": {
+			"version": "28.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-28.6.0.tgz",
+			"integrity": "sha512-CBmmC3ftafLQ0hXXust5w9W/H1D14k28oQxCSYWQncAcCocGyOlALoEN27BGh+Hb79PZDqC/HB71ni6fQZOQTQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.16.0",
+				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
+				"@svgr/webpack": "^8.0.1",
+				"@wordpress/babel-preset-default": "^8.6.0",
+				"@wordpress/browserslist-config": "^6.6.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.6.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.6.0",
+				"@wordpress/eslint-plugin": "^20.3.0",
+				"@wordpress/jest-preset-default": "^12.6.0",
+				"@wordpress/npm-package-json-lint-config": "^5.6.0",
+				"@wordpress/postcss-plugins-preset": "^5.6.0",
+				"@wordpress/prettier-config": "^4.6.0",
+				"@wordpress/stylelint-config": "^22.6.0",
+				"adm-zip": "^0.5.9",
+				"babel-jest": "^29.6.2",
+				"babel-loader": "^8.2.3",
+				"browserslist": "^4.21.10",
+				"chalk": "^4.0.0",
+				"check-node-version": "^4.1.0",
+				"clean-webpack-plugin": "^3.0.0",
+				"copy-webpack-plugin": "^10.2.0",
+				"cross-spawn": "^5.1.0",
+				"css-loader": "^6.2.0",
+				"cssnano": "^6.0.1",
+				"cwd": "^0.10.0",
+				"dir-glob": "^3.0.1",
+				"eslint": "^8.3.0",
+				"expect-puppeteer": "^4.4.0",
+				"fast-glob": "^3.2.7",
+				"filenamify": "^4.2.0",
+				"jest": "^29.6.2",
+				"jest-dev-server": "^9.0.1",
+				"jest-environment-jsdom": "^29.6.2",
+				"jest-environment-node": "^29.6.2",
+				"markdownlint-cli": "^0.31.1",
+				"merge-deep": "^3.0.3",
+				"mini-css-extract-plugin": "^2.5.1",
+				"minimist": "^1.2.0",
+				"npm-package-json-lint": "^6.4.0",
+				"npm-packlist": "^3.0.0",
+				"postcss": "^8.4.5",
+				"postcss-loader": "^6.2.1",
+				"prettier": "npm:wp-prettier@3.0.3",
+				"puppeteer-core": "^13.2.0",
+				"react-refresh": "^0.14.0",
+				"read-pkg-up": "^7.0.1",
+				"resolve-bin": "^0.4.0",
+				"rtlcss-webpack-plugin": "^4.0.7",
+				"sass": "^1.35.2",
+				"sass-loader": "^12.1.0",
+				"schema-utils": "^4.2.0",
+				"source-map-loader": "^3.0.0",
+				"stylelint": "^14.2.0",
+				"terser-webpack-plugin": "^5.3.9",
+				"url-loader": "^4.1.1",
+				"webpack": "^5.88.2",
+				"webpack-bundle-analyzer": "^4.9.1",
+				"webpack-cli": "^5.1.4",
+				"webpack-dev-server": "^4.15.1"
+			},
+			"bin": {
+				"wp-scripts": "bin/wp-scripts.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@playwright/test": "^1.46.0",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/scripts/node_modules/puppeteer-core": {
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.7.0.tgz",
+			"integrity": "sha512-rXja4vcnAzFAP1OVLq/5dWNfwBGuzcOARJ6qGV7oAZhnLmVRU8G5MsdeQEAOy332ZhkIOnn9jp15R89LKHyp2Q==",
+			"dev": true,
+			"dependencies": {
+				"cross-fetch": "3.1.5",
+				"debug": "4.3.4",
+				"devtools-protocol": "0.0.981744",
+				"extract-zip": "2.0.1",
+				"https-proxy-agent": "5.0.1",
+				"pkg-dir": "4.2.0",
+				"progress": "2.0.3",
+				"proxy-from-env": "1.1.0",
+				"rimraf": "3.0.2",
+				"tar-fs": "2.1.1",
+				"unbzip2-stream": "1.4.3",
+				"ws": "8.5.0"
+			},
+			"engines": {
+				"node": ">=10.18.1"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/stylelint-config": {
+			"version": "22.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-22.6.0.tgz",
+			"integrity": "sha512-wtGdEbHp99Vh/ya4swP8AWKzZCDFHke1SYHvmgdbomSJ+C87APp9q4ggfk2VOk/tIcrHPK9oagDFH05B8H+VLA==",
+			"dev": true,
+			"dependencies": {
+				"stylelint-config-recommended": "^6.0.0",
+				"stylelint-config-recommended-scss": "^5.0.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"stylelint": "^14.2"
+			}
+		},
 		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/url": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.4.0.tgz",
@@ -7760,6 +8195,363 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/cross-fetch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"dev": true,
+			"dependencies": {
+				"node-fetch": "2.6.7"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/devtools-protocol": {
+			"version": "0.0.981744",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.981744.tgz",
+			"integrity": "sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==",
+			"dev": true
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/eslint-plugin-jest": {
+			"version": "27.9.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+			"integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/utils": "^5.10.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
+				"eslint": "^7.0.0 || ^8.0.0",
+				"jest": "*"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/eslint-plugin": {
+					"optional": true
+				},
+				"jest": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@types/json-schema": "^7.0.9",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"eslint-scope": "^5.1.1",
+				"semver": "^7.3.7"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.62.0",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/eslint-plugin-playwright": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
+			"integrity": "sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==",
+			"dev": true,
+			"peerDependencies": {
+				"eslint": ">=7",
+				"eslint-plugin-jest": ">=25"
+			},
+			"peerDependenciesMeta": {
+				"eslint-plugin-jest": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/globals": {
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/schema-utils": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+			"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.9.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.1.0"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/@wordpress/e2e-tests/node_modules/ws": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/element": {
@@ -7830,16 +8622,16 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "20.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-20.1.0.tgz",
-			"integrity": "sha512-2FVQsdvG92qiKKnXhR0JO4RVyjrdRVY5vS6C6OZjp4M+O/kC/k5sx/BsjOX09qyUGletXJyQRmy11uoCE9lmAA==",
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-18.1.0.tgz",
+			"integrity": "sha512-5eGpXEwaZsKbEh9040nVr4ggmrpPmltP+Ie4iGruWvCme6ZIFYw70CyWEV8S102IkqjH/BaH6d+CWg8tN7sc/g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.4.0",
-				"@wordpress/prettier-config": "^4.4.0",
+				"@wordpress/babel-preset-default": "^7.42.0",
+				"@wordpress/prettier-config": "^3.15.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
@@ -7854,8 +8646,8 @@
 				"requireindex": "^1.2.0"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14",
+				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {
 				"@babel/core": ">=7",
@@ -8331,9 +9123,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.4.0.tgz",
-			"integrity": "sha512-vwfpSmCWpOx2IyCfjNJu8Ior4JK4D43T5YhPF6UpjHE+T+h3t3SwqriKYFbExDz+cdYwjJt4mpUEk8vh3lcfdQ==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.6.0.tgz",
+			"integrity": "sha512-U680VvNbmg8oGcNpeovuFN8w2Y8iN/lVDyjvO+iT/hsM74qAzUfjb4EOhQiaSnT/GEGP8KAqw7FNSUSMLv+/YA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -8348,20 +9140,35 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.4.0.tgz",
-			"integrity": "sha512-HJNzQEW2bdznObUcU3lbkPAYaNZlZkrP3+ye+GG/m/iy6xg2n9rvOqI1s2JieiWLCbCAiLLBm1zqTWtuEaf0BQ==",
+			"version": "11.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.29.0.tgz",
+			"integrity": "sha512-7LA0ZS5t0Thn7xrdwPL3hLgjB9LKloneGhMwnnDUTgJP330lyfdDfJ+O6Lnz3iL+bg68mkA3AzrT9Fs9f3WKww==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/jest-console": "^8.4.0",
+				"@wordpress/jest-console": "^7.29.0",
 				"babel-jest": "^29.6.2"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"@babel/core": ">=7",
+				"jest": ">=29"
+			}
+		},
+		"node_modules/@wordpress/jest-preset-default/node_modules/@wordpress/jest-console": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.29.0.tgz",
+			"integrity": "sha512-/9PZJhyszdRX4mka7t1WzoooM+Q/DwC4jkNVtJxqci5lbL3Lrhy1cCJGCgMr1n/9w+zs7eLmExFBvV4v44iyNw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"jest-matcher-utils": "^29.6.2"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
 				"jest": ">=29"
 			}
 		},
@@ -8474,30 +9281,28 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.4.0.tgz",
-			"integrity": "sha512-5ADmUubsY9HK9qat87DpjMIEiGfVIL2xbmZiOyzQ9fiLDFLg9i9snhjbxqEnTqc/WilRg0Fd66k+E6yHV7YDoA==",
+			"version": "4.43.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.43.0.tgz",
+			"integrity": "sha512-XSb7AdDC7yGTBVYeRM4oqmOygEB+/+tk7lobLIGDmlZJs+M3F/NUvQq0Vcas1pojq2fyPYTUwOlu81ga33fNwQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"npm-package-json-lint": ">=6.0.0"
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.4.0.tgz",
-			"integrity": "sha512-nfH9yw1Xbzqf6/kKKXVl1gmuyqVs9vBoAuqyrVYMt2wxk6/G7EEHNqI141SVZ2+O7wlMc9UNZMAEcApTmQ9N8g==",
+			"version": "4.42.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-4.42.0.tgz",
+			"integrity": "sha512-5xmKF7IUsqS5JcmJlHKHq7RaR6ZpaLj3n9c+X0X0/Oo7ZCIGp6WeDQngx13sH4NJoKXrZ9g4n1rbzhEKeo/Wtg==",
 			"dev": true,
 			"dependencies": {
-				"@wordpress/base-styles": "^5.4.0",
+				"@wordpress/base-styles": "^4.49.0",
 				"autoprefixer": "^10.2.5"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"postcss": "^8.0.0"
@@ -8596,13 +9401,12 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.4.0.tgz",
-			"integrity": "sha512-etguLCGd8r0solW9pkUeBHGuqrsCGL+d2JzCB3APhDo3mYD+TK2PUg3EfXKOvJzHsQwHg73h0eW9/C5DU+ll+Q==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.15.0.tgz",
+			"integrity": "sha512-exC2rkEioTt//AnzPRyaaFv8FNYIvamPDytNol5bKQ6Qh65QSdZZE9V+GtRCrIPL7/Bq6xba03XuRVxl9TjtJg==",
 			"dev": true,
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"prettier": ">=3"
@@ -8771,24 +9575,24 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "28.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-28.4.0.tgz",
-			"integrity": "sha512-z15ytMLQZdQRbpaUFkkhAmGFVzD/bBCClQ/1HOINbJu1j8y+WGTuP0HFn45I/+B+ynOKBQjisOCf8ZI3s290/g==",
+			"version": "27.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-27.9.0.tgz",
+			"integrity": "sha512-ohiDHMnfTTBTi7qS7AVJZUi1dxwg0k3Aav1a8CzUoOE8YoT8tvMQ3W89H9XgqMgMTWUCdgTUBYLTJTivfVVbXQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.4.0",
-				"@wordpress/browserslist-config": "^6.4.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.4.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.4.0",
-				"@wordpress/eslint-plugin": "^20.1.0",
-				"@wordpress/jest-preset-default": "^12.4.0",
-				"@wordpress/npm-package-json-lint-config": "^5.4.0",
-				"@wordpress/postcss-plugins-preset": "^5.4.0",
-				"@wordpress/prettier-config": "^4.4.0",
-				"@wordpress/stylelint-config": "^22.4.0",
+				"@wordpress/babel-preset-default": "^7.42.0",
+				"@wordpress/browserslist-config": "^5.41.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
+				"@wordpress/e2e-test-utils-playwright": "^0.26.0",
+				"@wordpress/eslint-plugin": "^18.1.0",
+				"@wordpress/jest-preset-default": "^11.29.0",
+				"@wordpress/npm-package-json-lint-config": "^4.43.0",
+				"@wordpress/postcss-plugins-preset": "^4.42.0",
+				"@wordpress/prettier-config": "^3.15.0",
+				"@wordpress/stylelint-config": "^21.41.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "^29.6.2",
 				"babel-loader": "^8.2.3",
@@ -8826,7 +9630,6 @@
 				"rtlcss-webpack-plugin": "^4.0.7",
 				"sass": "^1.35.2",
 				"sass-loader": "^12.1.0",
-				"schema-utils": "^4.2.0",
 				"source-map-loader": "^3.0.0",
 				"stylelint": "^14.2.0",
 				"terser-webpack-plugin": "^5.3.9",
@@ -8840,41 +9643,36 @@
 				"wp-scripts": "bin/wp-scripts.js"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=18",
+				"npm": ">=6.14.4"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.45.1",
+				"@playwright/test": "^1.43.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+		"node_modules/@wordpress/scripts/node_modules/@wordpress/e2e-test-utils-playwright": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.26.0.tgz",
+			"integrity": "sha512-4KFyQ3IsYIJaIvOQ1qhAHhRISs9abNToF/bktfMNxQiEJsmbNn7lq/IbaY+shqwdBWVg8TQtLcL4MpSl0ISaxQ==",
 			"dev": true,
 			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
+				"@wordpress/api-fetch": "^6.55.0",
+				"@wordpress/keycodes": "^3.58.0",
+				"@wordpress/url": "^3.59.0",
+				"change-case": "^4.1.2",
+				"form-data": "^4.0.0",
+				"get-port": "^5.1.1",
+				"lighthouse": "^10.4.0",
+				"mime": "^3.0.0",
+				"web-vitals": "^3.5.0"
 			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/ajv-keywords": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-			"dev": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3"
+			"engines": {
+				"node": ">=12"
 			},
 			"peerDependencies": {
-				"ajv": "^8.8.2"
+				"@playwright/test": ">=1"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/cross-fetch": {
@@ -8927,12 +9725,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
-		},
 		"node_modules/@wordpress/scripts/node_modules/node-fetch": {
 			"version": "2.6.7",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -8976,29 +9768,16 @@
 				"node": ">=10.18.1"
 			}
 		},
-		"node_modules/@wordpress/scripts/node_modules/schema-utils": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-			"integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"ajv": "^8.9.0",
-				"ajv-formats": "^2.1.1",
-				"ajv-keywords": "^5.1.0"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
 		"node_modules/@wordpress/scripts/node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
+		},
+		"node_modules/@wordpress/scripts/node_modules/web-vitals": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+			"integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
 			"dev": true
 		},
 		"node_modules/@wordpress/scripts/node_modules/webidl-conversions": {
@@ -9067,17 +9846,16 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "22.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-22.4.0.tgz",
-			"integrity": "sha512-oi1+yLqyDU7zP1qLHm2iPihltSelSFzNb8UBvRdExsUROZF+xHxBBz5R1El+KSTTSBguRfvUMufJAMQTDAS7dA==",
+			"version": "21.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.41.0.tgz",
+			"integrity": "sha512-2wxFu8ICeRGF3Lxz7H7o2SU1u6pTI4mjuog39DgtCNb+v+f6yhgREDuNQEeti3Svb0rjj63AJ7r2CqLZk+EQIQ==",
 			"dev": true,
 			"dependencies": {
 				"stylelint-config-recommended": "^6.0.0",
 				"stylelint-config-recommended-scss": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"stylelint": "^14.2"
@@ -9137,9 +9915,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.4.0.tgz",
-			"integrity": "sha512-0LbBvyRLZVulwVcseH+WryDlnP//CFBwAq15+XzzoZc3s0ANlGsLPTlYamZ7eoyosGQZVKqG/yzP3DAlESj89w==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.6.0.tgz",
+			"integrity": "sha512-pm57z1LZkzfQsXsji6yxcP0XSymKbvP087vJLlMkmLf+MoNVyTD6UvFpXl8hRSH6C6pySoJSgGFXaH81CRuO2Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=18.12.0",
@@ -9850,9 +10628,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.19",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-			"integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+			"version": "10.4.20",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+			"integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
 			"dev": true,
 			"funding": [
 				{
@@ -9869,11 +10647,11 @@
 				}
 			],
 			"dependencies": {
-				"browserslist": "^4.23.0",
-				"caniuse-lite": "^1.0.30001599",
+				"browserslist": "^4.23.3",
+				"caniuse-lite": "^1.0.30001646",
 				"fraction.js": "^4.3.7",
 				"normalize-range": "^0.1.2",
-				"picocolors": "^1.0.0",
+				"picocolors": "^1.0.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"bin": {
@@ -10468,9 +11246,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-			"integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+			"version": "4.23.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+			"integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
 			"dev": true,
 			"funding": [
 				{
@@ -10487,10 +11265,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001587",
-				"electron-to-chromium": "^1.4.668",
-				"node-releases": "^2.0.14",
-				"update-browserslist-db": "^1.0.13"
+				"caniuse-lite": "^1.0.30001646",
+				"electron-to-chromium": "^1.5.4",
+				"node-releases": "^2.0.18",
+				"update-browserslist-db": "^1.1.0"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -10730,9 +11508,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001606",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
-			"integrity": "sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==",
+			"version": "1.0.30001651",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
+			"integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
 			"dev": true,
 			"funding": [
 				{
@@ -12080,9 +12858,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-			"integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+			"integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -12091,12 +12869,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.36.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-			"integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+			"version": "3.38.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+			"integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.23.0"
+				"browserslist": "^4.23.3"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -13588,9 +14366,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.701",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.701.tgz",
-			"integrity": "sha512-K3WPQ36bUOtXg/1+69bFlFOvdSm0/0bGqmsfPDLRXLanoKXdA+pIWuf/VbA9b+2CwBFuONgl4NEz4OEm+OJOKA==",
+			"version": "1.5.13",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+			"integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -13929,9 +14707,9 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -21533,9 +22311,9 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
 			"dev": true
 		},
 		"node_modules/nopt": {
@@ -25439,9 +26217,9 @@
 			"dev": true
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
 			"dev": true
 		},
 		"node_modules/picomatch": {
@@ -25652,12 +26430,12 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-			"integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+			"version": "1.46.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
+			"integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.45.3"
+				"playwright-core": "1.46.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -25670,9 +26448,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-			"integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+			"version": "1.46.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
+			"integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -26229,9 +27007,9 @@
 			}
 		},
 		"node_modules/postcss-resolve-nested-selector": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.4.tgz",
-			"integrity": "sha512-R6vHqZWgVnTAPq0C+xjyHfEZqfIYboCBVSy24MjxEDm+tIh1BU4O6o7DP7AA7kHzf136d+Qc5duI4tlpHjixDw==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
+			"integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
 			"dev": true
 		},
 		"node_modules/postcss-safe-parser": {
@@ -31265,9 +32043,9 @@
 			"dev": true
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+			"integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -31284,8 +32062,8 @@
 				}
 			],
 			"dependencies": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.1.2",
+				"picocolors": "^1.0.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"@wordpress/e2e-tests": "^8.4.0",
 		"@wordpress/element": "^6.3.0",
 		"@wordpress/env": "^9.6.0",
-		"@wordpress/scripts": "^28.3.0",
+		"@wordpress/scripts": "27.9.0",
 		"conventional-changelog-simple-preset": "^1.0.24",
 		"eslint-config-wordpress": "^2.0.0",
 		"filemanager-webpack-plugin": "^6.1.7",


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2349
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

The current version of our react scripts requires a new react package that contains the new runtime for React 19. This is present only on WP 6.6 or higher. Our script loading was ignored because of the missing package in the early versions. 

I downgraded and pinned the `@wordpress/scrips` to the latest version that supports WP 6.5 or earlier. Now, the build files should be working fine.

Reference: https://github.com/WordPress/gutenberg/blob/2cbba93a29600f09f6f95c09f690576b90e79e9f/packages/scripts/CHANGELOG.md#2800-2024-05-31


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Test if everything is working fine with the latest WP version and WP 6.5

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

