### PR TITLE
Fixed PHP fatal error

### DIFF
--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -175,6 +175,10 @@ class Main {
 			'text-transform',
 			'transform',
 		);
+		// Return $props if $attr is not an array, addressing a specific edge case.
+		if ( ! is_array( $attr ) ) {
+			return $props;
+		}
 
 		$list = array_merge( $props, $attr );
 


### PR DESCRIPTION
Closes #2371

### Summary
In this PR, I’ve addressed and resolved a fatal error that was occurring with PHP 8 for a specific edge case.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()
