### PR TITLE
feat: use translation in block patterns

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-patterns.php
+++ b/plugins/otter-pro/inc/plugins/class-patterns.php
@@ -91,7 +91,7 @@ class Patterns {
 		} else {
 			$response = wp_remote_get( esc_url_raw( $url ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		}
-		
+
 		$response = wp_remote_retrieve_body( $response );
 		$response = json_decode( $response, true );
 

--- a/src/blocks/plugins/patterns-library/library.js
+++ b/src/blocks/plugins/patterns-library/library.js
@@ -142,7 +142,7 @@ const Library = ({
 		const currentCategory = 'favorites' === selectedCategory ? patterns.filter( pattern => getFavorites.includes( pattern.name ) ) : patterns.filter( pattern => pattern.categories.includes( selectedCategory ) );
 
 		if ( searchInput ) {
-			return currentCategory.filter( pattern => pattern.name.toLowerCase().includes( searchInput.toLowerCase() ) );
+			return currentCategory.filter( pattern => pattern.title.toLowerCase().includes( searchInput.toLowerCase() ) );
 		}
 
 		return currentCategory;

--- a/tests/test-patterns-class.php
+++ b/tests/test-patterns-class.php
@@ -18,27 +18,56 @@ class TestPatterns extends WP_UnitTestCase {
 	 */
 	 public function test_fetch_patterns() {
 
-		 $json_data = file_get_contents( dirname( dirname( __FILE__ ) ) . '/license.json' );
-		 $array_data = json_decode( $json_data, true );
+		$json_data = file_get_contents( dirname( dirname( __FILE__ ) ) . '/license.json' );
+		$array_data = json_decode( $json_data, true );
 
-		 $url = add_query_arg(
-			 array(
-				 'site_url'   => get_site_url(),
-				 'license_id' => $array_data['key'],
-				 'cache'      => time(),
-			 ),
-			 'https://api.themeisle.com/templates-cloud/otter-patterns'
-		 );
+		$url = add_query_arg(
+			array(
+				'site_url'   => get_site_url(),
+				'license_id' => $array_data['key'],
+				'cache'      => time(),
+			),
+			ThemeIsle\OtterPro\Plugins\Patterns::PATTERNS_ENDPOINT
+		);
 
-		 $response = wp_remote_get( $url );
-		 $response = wp_remote_retrieve_body( $response );
+		$response = wp_remote_get( $url );
+		$response = wp_remote_retrieve_body( $response );
 
-		 $this->assertTrue( 2000 < strlen( $response ) );
+		$this->assertTrue( 2000 < strlen( $response ) );
 
-		 $response = json_decode( $response, true );
+		$response = json_decode( $response, true );
 
-		 $this->assertIsArray( $response );
+		$this->assertIsArray( $response );
 
-		 $this->assertArrayHasKey( 'slug', $response[0] );
-	 }
+		$this->assertArrayHasKey( 'slug', $response[0] );
+	}
+
+	public function test_prepare_block_pattern() {
+		$patterns_instance = new ThemeIsle\OtterPro\Plugins\Patterns();
+
+		$block_pattern = array(
+			'slug' => 'test-pattern',
+			'title' => 'Default Title',
+			'title_es' => 'Título en Español',
+			'title_fr' => 'Titre en Français',
+			'title_de' => 'Titel auf Deutsch',
+			'content' => '<!-- wp:paragraph --><p>Test content</p><!-- /wp:paragraph -->',
+			'categories' => array( 'test-category' ),
+			'minimum' => '5.0',
+		);
+
+		// Test with German locale
+		$prepared_pattern = $patterns_instance->prepare_block_pattern( $block_pattern, 'de_DE' );
+		$this->assertEquals( 'Titel auf Deutsch', $prepared_pattern['title'] );
+		$this->assertArrayNotHasKey( 'title_es', $prepared_pattern );
+		$this->assertArrayNotHasKey( 'title_fr', $prepared_pattern );
+		$this->assertArrayNotHasKey( 'title_de', $prepared_pattern );
+
+		// Test with default locale (no translation)
+		$prepared_pattern = $patterns_instance->prepare_block_pattern( $block_pattern, 'en_US' );
+		$this->assertEquals( 'Default Title', $prepared_pattern['title'] );
+		$this->assertArrayNotHasKey( 'title_es', $prepared_pattern );
+		$this->assertArrayNotHasKey( 'title_fr', $prepared_pattern );
+		$this->assertArrayNotHasKey( 'title_de', $prepared_pattern );
+	}
 }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/templates-cloud/issues/82
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Swap the title of the registered pattern with its translated version if available. 

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

