### PR TITLE
Added whitespace support to form's submit button

### DIFF
--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -1044,9 +1044,8 @@ const Edit = ({
 											submitLabel = submitLabel.replace( /<br\s*\/?>/gi, ' ' );
 											setAttributes({ submitLabel });
 										} }
-										multiline={ false }
 										multiple={ false }
-										tagName="button"
+										tagName="span"
 										type='submit'
 										onClick={ e => e.preventDefault() }
 									/>

--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -69,6 +69,7 @@
 				border: 0px;
 				transition: background-color 0.15s linear;
 				max-width: max-content;
+				white-space: normal !important;
 
 				@media ( min-width:640px ) and ( max-width: 1024px ) {
 					padding: var(--btn-pad-tablet);


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2429

### Summary
Added whitespace support

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()