### PR TITLE
Fixed dynamic image view issue with unauthetnicated users

### DIFF
--- a/inc/server/class-dynamic-content-server.php
+++ b/inc/server/class-dynamic-content-server.php
@@ -167,6 +167,7 @@ class Dynamic_Content_Server {
 
 			$fallback           = sanitize_text_field( $fallback );
 			$feedback_full_path = realpath( $fallback );
+			$feedback_full_path = str_contains( $feedback_full_path, WP_CONTENT_DIR );
 
 			if ( false !== $feedback_full_path && @getimagesize( $fallback ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 				$path = $feedback_full_path;


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-internals/issues/243

### Summary
I’ve added a restriction to use the fallback image only if it exists in the `wp-content` folder.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()
