### PR TITLE
Fixed post images with WP 6.7

### DIFF
--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -23,6 +23,7 @@ class Posts_Grid_Block {
 	 */
 	public function render( $attributes ) {
 
+		add_filter( 'wp_img_tag_add_auto_sizes', '__return_false' );
 		$has_pagination = isset( $attributes['hasPagination'] ) && $attributes['hasPagination'];
 		$page_number    = 1;
 		$is_tiled       = isset( $attributes['className'] ) && false !== strpos( $attributes['className'], 'is-style-tiled' );

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -64,7 +64,6 @@
 	--pag-cont-margin: 10px 0 0 0;
 
 	border: none;
-	max-width: inherit !important;
 
 	&.has-dark-bg {
 		--text-color: #fff;

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -64,6 +64,7 @@
 	--pag-cont-margin: 10px 0 0 0;
 
 	border: none;
+	max-width: inherit !important;
 
 	&.has-dark-bg {
 		--text-color: #fff;
@@ -230,7 +231,6 @@
 			box-shadow: var( --img-box-shadow );
 			object-fit: cover;
 			object-position: center center;
-			aspect-ratio: var( --image-ratio );
 		}
 	}
 

--- a/src/blocks/blocks/posts/style.scss
+++ b/src/blocks/blocks/posts/style.scss
@@ -231,6 +231,7 @@
 			box-shadow: var( --img-box-shadow );
 			object-fit: cover;
 			object-position: center center;
+			aspect-ratio: var( --image-ratio );
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2457

### Summary
In this PR, I've fixed the post images issue with the latest version of WordPress.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()
