### PR TITLE
chore: change Otter Patterns button order & Premium Designs appearance

### DIFF
--- a/src/blocks/plugins/patterns-library/library.js
+++ b/src/blocks/plugins/patterns-library/library.js
@@ -28,7 +28,7 @@ import {
 	useState
 } from '@wordpress/element';
 
-import { grid } from '@wordpress/icons';
+import { external, grid, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -213,6 +213,16 @@ const Library = ({
 							{ __( 'My Favorites', 'otter-blocks' ) }
 						</Button>
 
+						{tcCategories.length < 1 && (
+							<Button
+								icon="open-folder"
+								isPressed={ 'cloud-empty' === selectedCategory }
+								onClick={ () => setSelectedCategory( CLOUD_EMPTY_CATEGORY ) }
+							>
+								{ __( 'Cloud Libraries', 'otter-blocks' ) }
+							</Button>
+						) }
+
 						{ ( ! Boolean( window.themeisleGutenberg.hasPro ) ) && (
 							<Button
 								icon="lock"
@@ -220,6 +230,7 @@ const Library = ({
 								target="_blank"
 							>
 								{ __( 'Premium Designs', 'otter-blocks' ) }
+								<Icon icon={external} size={15} />
 							</Button>
 						) }
 
@@ -244,15 +255,6 @@ const Library = ({
 								</ul>
 							</>
 						)}
-						{tcCategories.length < 1 && (
-							<Button
-								icon="lock"
-								isPressed={ 'cloud-empty' === selectedCategory }
-								onClick={ () => setSelectedCategory( CLOUD_EMPTY_CATEGORY ) }
-							>
-								{ __( 'Cloud Libraries', 'otter-blocks' ) }
-							</Button>
-						) }
 
 						<p className="o-library__modal__sidebar__heading">
 							{ __( 'Categories', 'otter-blocks' ) }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2456.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
change Otter Patterns button order & Premium Designs appearance
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->
![image](https://github.com/user-attachments/assets/327e54b1-a0e1-4d4c-b093-ce365392a2b7)

----

### Test instructions
- Open the otter patterns modal in the free version;
- The Premium Designs button should have a folder icon and the external link icon after the text;
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

