### PR TITLE
fix: separate domain based on plugin

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,6 +5,7 @@
 .jshintrc
 Gruntfile.js
 phpcs.xml
+phpcs.export.xml
 phpstan.neon
 .eslintrc
 .gitattributes

--- a/.eslintrc
+++ b/.eslintrc
@@ -86,6 +86,9 @@
 		"jsx-a11y/alt-text": "warn",
 		"jsx-a11y/anchor-is-valid": "warn",
 		"jsx-a11y/no-noninteractive-element-interactions": "warn",
-		"jsx-a11y/no-autofocus": "warn"
+		"jsx-a11y/no-autofocus": "warn",
+		"@wordpress/i18n-text-domain": ["error", {
+			"allowedTextDomain": ["otter-blocks", "otter-pro", "blocks-export-import", "blocks-css", "blocks-animation"]
+		}]
 	}
 }

--- a/.github/workflows/create-build-url.yml
+++ b/.github/workflows/create-build-url.yml
@@ -2,7 +2,7 @@ name: Build and publish the ZIP build file
 
 on:
   pull_request:
-    types: [ opened, synchronize, ready_for_review ]
+    types: [opened, synchronize, ready_for_review]
     branches-ignore:
       - "update_dependencies"
 jobs:
@@ -31,6 +31,8 @@ jobs:
         run: composer install --no-dev --prefer-dist --no-progress --no-suggest
       - name: Install npm deps
         run: npm ci
+      - name: Set version to Stable Tag
+        run: npm run grunt:version
       - name: Build files
         run: npm run build
       - name: Create zip

--- a/.github/workflows/deploy-stagging.yml
+++ b/.github/workflows/deploy-stagging.yml
@@ -33,6 +33,8 @@ jobs:
               run: composer install --no-dev --prefer-dist --no-progress --no-suggest
             - name: Install npm deps
               run: npm ci
+            - name: Set version to Stable Tag
+              run: npm run grunt:version
             - name: Build files
               run: npm run build
             - name: Zip files

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
         run: composer install --no-dev --prefer-dist --no-progress --no-suggest
       - name: Install npm deps
         run: npm ci
+      - name: Set version to Stable Tag
+        run: npm run grunt:version
       - name: Build files
         run: npm run build
       - name: Build zip

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ license.json
 .fleet
 tests/assets/*_tmp
 .phpunit.result.cache
+languages

--- a/.wp-env.override.json
+++ b/.wp-env.override.json
@@ -9,6 +9,7 @@
     "FS_METHOD": "direct",
     "WP_DEFAULT_THEME": "twentytwentythree"
   },
+  "phpVersion": "7.4",
   "env": {
     "development": {
       "themes": [ "./test/emptytheme" ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,18 @@ module.exports = function( grunt ) {
 					flags: ''
 				},
 				src: [ 'plugins/otter-pro/otter-pro.php' ]
-			}
+			},
+			readmetxt: {
+				options: {
+					prefix: 'Stable tag:\\s*'
+				},
+				src: [
+					'readme.txt',
+					'plugins/blocks-animation/readme.txt',
+					'plugins/blocks-css/readme.txt',
+					'plugins/blocks-export-import/readme.txt',
+				]
+			},
 		},
 		wp_readme_to_markdown: {
 			plugin: {

--- a/bin/dist.sh
+++ b/bin/dist.sh
@@ -25,6 +25,9 @@ fi
 # Take all the files, filter the dev ones (e.g. node_modules, src), and save the result to './dist'
 rsync -rc --exclude-from ".distignore" "./" "dist/$DIST_FOLDER"
 
+# Change the individual sub-text-domain for the included sub-plugins in the main one.
+composer run format-dist -- "dist/$DIST_FOLDER"
+
 cd dist
 
 # Create a zip file in './artifact' from the filtered files in the './dist'

--- a/bin/dist.sh
+++ b/bin/dist.sh
@@ -22,11 +22,14 @@ else
   DIST_FOLDER=$BUILD_NAME
 fi
 
+
 # Take all the files, filter the dev ones (e.g. node_modules, src), and save the result to './dist'
 rsync -rc --exclude-from ".distignore" "./" "dist/$DIST_FOLDER"
 
 # Change the individual sub-text-domain for the included sub-plugins in the main one.
-composer run format-dist -- "dist/$DIST_FOLDER"
+composer install --prefer-dist --no-progress --no-suggest
+composer run format-dist -- "./dist/$DIST_FOLDER"
+composer install --no-dev --prefer-dist --no-progress --no-suggest
 
 cd dist
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
 		"lint": "phpcs",
 		"format": "phpcbf",
 		"phpunit": "phpunit",
-		"phpstan": "phpstan analyse --memory-limit 2G"
+		"phpstan": "phpstan analyse --memory-limit 2G",
+		"format-dist": "phpcbf --standard=phpcs.export.xml $1"
 	},
 	"prefer-stable": true,
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"format": "phpcbf",
 		"phpunit": "phpunit",
 		"phpstan": "phpstan analyse --memory-limit 2G",
-		"format-dist": "phpcbf --standard=phpcs.export.xml $1"
+		"format-dist": "phpcbf --standard=phpcs.export.xml"
 	},
 	"prefer-stable": true,
 	"config": {

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -281,17 +281,17 @@ class Blocks_Animation {
 		);
 
 		$notice_html  = '<div class="notice notice-info otter-animation-welcome-notice">';
-		$notice_html .= '<button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button>';
+		$notice_html .= '<button type="button" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__( 'Dismiss this notice.', 'blocks-animation' ) . '</span></button>';
 		$notice_html .= '<div class="notice-content">';
 
-		$notice_html .= '<img class="otter-preview" style="max-height: 300px;" src="' . esc_url( BLOCKS_ANIMATION_URL . '/assets/images/welcome-notice.png' ) . '" alt="' . esc_attr__( 'Otter Blocks preview', 'otter-blocks' ) . '"/>';
+		$notice_html .= '<img class="otter-preview" style="max-height: 300px;" src="' . esc_url( BLOCKS_ANIMATION_URL . '/assets/images/welcome-notice.png' ) . '" alt="' . esc_attr__( 'Otter Blocks preview', 'blocks-animation' ) . '"/>';
 
 		$notice_html .= '<div class="notice-copy">';
 
 		$notice_html .= '<h1 class="notice-title">';
 		$notice_html .= sprintf(
 			/* translators: %1$s: Add-on Blocks, %2$s: Enhanced Animations, %3$s: Visibility Conditions */
-			__( 'Power Up Your Site with %1$s, %2$s, %3$s, and more!', 'otter-blocks' ), 
+			__( 'Power Up Your Site with %1$s, %2$s, %3$s, and more!', 'blocks-animation' ), 
 			'<span>' . __( 'Add-on Blocks', 'blocks-animation' ) . '</span>', 
 			'<span>' . __( 'Enhanced Animations', 'blocks-animation' ) . '</span>', 
 			'<span>' . __( 'Visibility Conditions', 'blocks-animation' ) . '</span>' 
@@ -316,7 +316,7 @@ class Blocks_Animation {
 		$notice_html .= '</button>';
 
 		$notice_html .= '<a href="https://wordpress.org/plugins/otter-blocks/" target="_blank" class="button button-secondary button-hero">';
-		$notice_html .= '<span>' . __( 'blocks-animation', 'otter-blocks' ) . '</span>';
+		$notice_html .= '<span>' . __( 'Learn More', 'blocks-animation' ) . '</span>';
 		$notice_html .= '<span class="dashicons dashicons-external"></span>';
 		$notice_html .= '</a>';
 

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -92,7 +92,11 @@ class Blocks_Animation {
 			)
 		);
 
-		wp_set_script_translations( 'otter-animation', 'blocks-animation' );
+		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
+			wp_set_script_translations( 'otter-animation', 'otter-blocks' );
+		} else {
+			wp_set_script_translations( 'otter-animation', 'blocks-animation' );
+		}
 
 		$asset_file = include BLOCKS_ANIMATION_PATH . '/build/animation/anim-count.asset.php';
 		wp_enqueue_script(
@@ -104,7 +108,12 @@ class Blocks_Animation {
 		);
 
 		wp_script_add_data( 'otter-count', 'defer', true );
-		wp_set_script_translations( 'otter-count', 'blocks-animation' );
+
+		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
+			wp_set_script_translations( 'otter-count', 'otter-blocks' );
+		} else {
+			wp_set_script_translations( 'otter-count', 'blocks-animation' );
+		}
 
 		wp_enqueue_script(
 			'otter-typing',
@@ -115,7 +124,12 @@ class Blocks_Animation {
 		);
 
 		wp_script_add_data( 'otter-typing', 'defer', true );
-		wp_set_script_translations( 'otter-typing', 'blocks-animation' );
+
+		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
+			wp_set_script_translations( 'otter-typing', 'otter-blocks' );
+		} else {
+			wp_set_script_translations( 'otter-typing', 'blocks-animation' );
+		}
 	}
 
 	/**
@@ -253,7 +267,11 @@ class Blocks_Animation {
 			true
 		);
 
-		wp_set_script_translations( 'otter-animation-welcome-notice-scripts', 'blocks-animation' );
+		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
+			wp_set_script_translations( 'otter-animation-welcome-notice-scripts', 'otter-blocks' );
+		} else {
+			wp_set_script_translations( 'otter-animation-welcome-notice-scripts', 'blocks-animation' );
+		}
 
 		wp_localize_script(
 			'otter-animation-welcome-notice-scripts',

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -104,6 +104,7 @@ class Blocks_Animation {
 		);
 
 		wp_script_add_data( 'otter-count', 'defer', true );
+		wp_set_script_translations( 'otter-count', 'blocks-animation' );
 
 		wp_enqueue_script(
 			'otter-typing',
@@ -114,6 +115,7 @@ class Blocks_Animation {
 		);
 
 		wp_script_add_data( 'otter-typing', 'defer', true );
+		wp_set_script_translations( 'otter-typing', 'blocks-animation' );
 	}
 
 	/**

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -44,6 +44,7 @@ class Blocks_Animation {
 		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
 			define( 'BLOCKS_ANIMATION_URL', OTTER_BLOCKS_URL );
 			define( 'BLOCKS_ANIMATION_PATH', OTTER_BLOCKS_PATH );
+			define( 'BLOCKS_ANIMATION_OTTER', true );
 		}
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
@@ -63,7 +64,8 @@ class Blocks_Animation {
 	 * @access  public
 	 */
 	public function enqueue_editor_assets() {
-		$asset_file = include BLOCKS_ANIMATION_PATH . '/build/animation/index.asset.php';
+		$asset_file           = include BLOCKS_ANIMATION_PATH . '/build/animation/index.asset.php';
+		$is_using_otter_files = defined( 'BLOCKS_ANIMATION_OTTER' );
 
 		wp_enqueue_style(
 			'otter-animation',
@@ -92,11 +94,7 @@ class Blocks_Animation {
 			)
 		);
 
-		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
-			wp_set_script_translations( 'otter-animation', 'otter-blocks' );
-		} else {
-			wp_set_script_translations( 'otter-animation', 'blocks-animation' );
-		}
+		wp_set_script_translations( 'otter-animation', $is_using_otter_files ? 'otter-blocks' : 'blocks-animation' );
 
 		$asset_file = include BLOCKS_ANIMATION_PATH . '/build/animation/anim-count.asset.php';
 		wp_enqueue_script(
@@ -109,11 +107,7 @@ class Blocks_Animation {
 
 		wp_script_add_data( 'otter-count', 'defer', true );
 
-		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
-			wp_set_script_translations( 'otter-count', 'otter-blocks' );
-		} else {
-			wp_set_script_translations( 'otter-count', 'blocks-animation' );
-		}
+		wp_set_script_translations( 'otter-count', $is_using_otter_files ? 'otter-blocks' : 'blocks-animation' );
 
 		wp_enqueue_script(
 			'otter-typing',
@@ -125,11 +119,7 @@ class Blocks_Animation {
 
 		wp_script_add_data( 'otter-typing', 'defer', true );
 
-		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
-			wp_set_script_translations( 'otter-typing', 'otter-blocks' );
-		} else {
-			wp_set_script_translations( 'otter-typing', 'blocks-animation' );
-		}
+		wp_set_script_translations( 'otter-typing', $is_using_otter_files ? 'otter-blocks' : 'blocks-animation' );
 	}
 
 	/**
@@ -267,11 +257,10 @@ class Blocks_Animation {
 			true
 		);
 
-		if ( ! defined( 'BLOCKS_ANIMATION_URL' ) ) {
-			wp_set_script_translations( 'otter-animation-welcome-notice-scripts', 'otter-blocks' );
-		} else {
-			wp_set_script_translations( 'otter-animation-welcome-notice-scripts', 'blocks-animation' );
-		}
+		wp_set_script_translations( 
+			'otter-animation-welcome-notice-scripts', 
+			defined( 'BLOCKS_ANIMATION_OTTER' ) ? 'otter-blocks' : 'blocks-animation' 
+		);
 
 		wp_localize_script(
 			'otter-animation-welcome-notice-scripts',

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -251,7 +251,7 @@ class Blocks_Animation {
 			true
 		);
 
-		wp_set_script_translations( 'otter-animation-welcome-notice-scripts', 'otter-blocks' );
+		wp_set_script_translations( 'otter-animation-welcome-notice-scripts', 'blocks-animation' );
 
 		wp_localize_script(
 			'otter-animation-welcome-notice-scripts',
@@ -272,9 +272,9 @@ class Blocks_Animation {
 						admin_url( 'plugins.php' )
 					)
 				),
-				'activating'    => __( 'Activating', 'otter-blocks' ) . '&hellip;',
-				'installing'    => __( 'Installing', 'otter-blocks' ) . '&hellip;',
-				'done'          => __( 'Done', 'otter-blocks' ),
+				'activating'    => __( 'Activating', 'blocks-animation' ) . '&hellip;',
+				'installing'    => __( 'Installing', 'blocks-animation' ) . '&hellip;',
+				'done'          => __( 'Done', 'blocks-animation' ),
 			)
 		);
 
@@ -290,14 +290,14 @@ class Blocks_Animation {
 		$notice_html .= sprintf(
 			/* translators: %1$s: Add-on Blocks, %2$s: Enhanced Animations, %3$s: Visibility Conditions */
 			__( 'Power Up Your Site with %1$s, %2$s, %3$s, and more!', 'otter-blocks' ), 
-			'<span>' . __( 'Add-on Blocks', 'otter-blocks' ) . '</span>', 
-			'<span>' . __( 'Enhanced Animations', 'otter-blocks' ) . '</span>', 
-			'<span>' . __( 'Visibility Conditions', 'otter-blocks' ) . '</span>' 
+			'<span>' . __( 'Add-on Blocks', 'blocks-animation' ) . '</span>', 
+			'<span>' . __( 'Enhanced Animations', 'blocks-animation' ) . '</span>', 
+			'<span>' . __( 'Visibility Conditions', 'blocks-animation' ) . '</span>' 
 		);
 
 		$notice_html .= '</h1>';
 
-		$notice_html .= '<p class="description">' . __( 'Otter is a Gutenberg Blocks page builder plugin that adds extra functionality to the WordPress Block Editor (also known as Gutenberg) for a better page building experience without the need for traditional page builders.', 'otter-blocks' ) . '</p>';
+		$notice_html .= '<p class="description">' . __( 'Otter is a Gutenberg Blocks page builder plugin that adds extra functionality to the WordPress Block Editor (also known as Gutenberg) for a better page building experience without the need for traditional page builders.', 'blocks-animation' ) . '</p>';
 
 		$notice_html .= '<div class="actions">';
 
@@ -307,14 +307,14 @@ class Blocks_Animation {
 		$notice_html .= '<span class="text">';
 		$notice_html .= 'installed' === $otter_status ?
 			/* translators: %s: Otter Blocks */
-			sprintf( __( 'Activate %s', 'otter-blocks' ), 'Otter Blocks' ) :
+			sprintf( __( 'Activate %s', 'blocks-animation' ), 'Otter Blocks' ) :
 			/* translators: %s: Otter Blocks */
-			sprintf( __( 'Install & Activate %s', 'otter-blocks' ), 'Otter Blocks' );
+			sprintf( __( 'Install & Activate %s', 'blocks-animation' ), 'Otter Blocks' );
 		$notice_html .= '</span>';
 		$notice_html .= '</button>';
 
 		$notice_html .= '<a href="https://wordpress.org/plugins/otter-blocks/" target="_blank" class="button button-secondary button-hero">';
-		$notice_html .= '<span>' . __( 'Learn More', 'otter-blocks' ) . '</span>';
+		$notice_html .= '<span>' . __( 'blocks-animation', 'otter-blocks' ) . '</span>';
 		$notice_html .= '<span class="dashicons dashicons-external"></span>';
 		$notice_html .= '</a>';
 

--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -67,7 +67,6 @@ class Blocks_CSS {
 			$asset_file['version'],
 			true
 		);
-		wp_set_script_translations( 'otter-css', 'blocks-css' );
 
 		wp_localize_script(
 			'otter-css',
@@ -87,7 +86,11 @@ class Blocks_CSS {
 			)
 		);
 
-		wp_set_script_translations( 'otter-css', 'blocks-css' );
+		if ( ! defined( 'BLOCKS_CSS_URL' ) ) {
+			wp_set_script_translations( 'otter-css', 'otter-blocks' );
+		} else {
+			wp_set_script_translations( 'otter-css', 'blocks-css' );
+		}
 
 		wp_enqueue_style(
 			'otter-css',

--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -67,6 +67,7 @@ class Blocks_CSS {
 			$asset_file['version'],
 			true
 		);
+		wp_set_script_translations( 'otter-css', 'blocks-css' );
 
 		wp_localize_script(
 			'otter-css',

--- a/inc/class-blocks-css.php
+++ b/inc/class-blocks-css.php
@@ -26,6 +26,7 @@ class Blocks_CSS {
 		if ( ! defined( 'BLOCKS_CSS_URL' ) ) {
 			define( 'BLOCKS_CSS_URL', OTTER_BLOCKS_URL );
 			define( 'BLOCKS_CSS_PATH', OTTER_BLOCKS_PATH );
+			define( 'BLOCKS_CSS_OTTER', true );
 		}
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ), 1 );
@@ -86,11 +87,7 @@ class Blocks_CSS {
 			)
 		);
 
-		if ( ! defined( 'BLOCKS_CSS_URL' ) ) {
-			wp_set_script_translations( 'otter-css', 'otter-blocks' );
-		} else {
-			wp_set_script_translations( 'otter-css', 'blocks-css' );
-		}
+		wp_set_script_translations( 'otter-css', defined( 'BLOCKS_CSS_OTTER' ) ? 'otter-blocks' : 'blocks-css' );
 
 		wp_enqueue_style(
 			'otter-css',

--- a/inc/class-blocks-export-import.php
+++ b/inc/class-blocks-export-import.php
@@ -47,8 +47,12 @@ class Blocks_Export_Import {
 			$asset_file['version'],
 			true
 		);
-	
-		wp_set_script_translations( 'blocks-export-import', 'blocks-export-import' );
+
+		if ( ! defined( 'BLOCKS_EXPORT_IMPORT_URL' ) ) {
+			wp_set_script_translations( 'blocks-export-import', 'otter-blocks' );
+		} else {
+			wp_set_script_translations( 'blocks-export-import', 'blocks-export-import' );
+		}
 	}
 
 	/**

--- a/inc/class-blocks-export-import.php
+++ b/inc/class-blocks-export-import.php
@@ -26,6 +26,7 @@ class Blocks_Export_Import {
 		if ( ! defined( 'BLOCKS_EXPORT_IMPORT_URL' ) ) {
 			define( 'BLOCKS_EXPORT_IMPORT_URL', OTTER_BLOCKS_URL );
 			define( 'BLOCKS_EXPORT_IMPORT_PATH', OTTER_BLOCKS_PATH );
+			define( 'BLOCKS_EXPORT_OTTER', true );
 		}
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ), 1 );
@@ -48,11 +49,7 @@ class Blocks_Export_Import {
 			true
 		);
 
-		if ( ! defined( 'BLOCKS_EXPORT_IMPORT_URL' ) ) {
-			wp_set_script_translations( 'blocks-export-import', 'otter-blocks' );
-		} else {
-			wp_set_script_translations( 'blocks-export-import', 'blocks-export-import' );
-		}
+		wp_set_script_translations( 'blocks-export-import', defined( 'BLOCKS_EXPORT_OTTER' ) ? 'otter-blocks' : 'blocks-export-import' );
 	}
 
 	/**

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -582,7 +582,7 @@ class Main {
 			'logo'             => esc_url_raw( OTTER_BLOCKS_URL . 'assets/images/logo-alt.png' ),
 			'has_upgrade_menu' => ! DEFINED( 'OTTER_PRO_VERSION' ),
 			'upgrade_link'     => tsdk_translate_link( tsdk_utmify( Pro::get_url(), 'editor', Pro::get_reference() ) ),
-			'upgrade_text'     => __( 'Get Otter Pro', 'blocks-animation' ),
+			'upgrade_text'     => __( 'Get Otter Pro', 'otter-blocks' ),
 		);
 	}
 

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -582,7 +582,7 @@ class Main {
 			'logo'             => esc_url_raw( OTTER_BLOCKS_URL . 'assets/images/logo-alt.png' ),
 			'has_upgrade_menu' => ! DEFINED( 'OTTER_PRO_VERSION' ),
 			'upgrade_link'     => tsdk_translate_link( tsdk_utmify( Pro::get_url(), 'editor', Pro::get_reference() ) ),
-			'upgrade_text'     => __( 'Get Otter Pro', 'otter-blocks' ),
+			'upgrade_text'     => __( 'Get Otter Pro', 'blocks-animation' ),
 		);
 	}
 

--- a/inc/class-pro.php
+++ b/inc/class-pro.php
@@ -207,7 +207,7 @@ class Pro {
 	public function register_metabox( $post_type ) {
 		add_meta_box(
 			'otter_woo_builder',
-			__( 'WooCommerce Builder by Otter', 'otter-pro' ),
+			__( 'WooCommerce Builder by Otter', 'otter-blocks' ),
 			array( $this, 'render_metabox_upsell' ),
 			'product',
 			'side',
@@ -241,17 +241,17 @@ class Pro {
 				}
 			</style>
 			<div class="clear o-upsell">
-				<p><?php _e( 'Unlock the full power of WooCommerce Builder with Otter Pro:', 'otter-pro' ); ?></p>
+				<p><?php _e( 'Unlock the full power of WooCommerce Builder with Otter Pro:', 'otter-blocks' ); ?></p>
 
 				<ul>
-					<li><?php _e( 'WooCommerce Block Builder', 'otter-pro' ); ?></li>
-					<li><?php _e( 'Add to Cart Block', 'otter-pro' ); ?></li>
-					<li><?php _e( 'Review Comparison  Block', 'otter-pro' ); ?></li>
-					<li><?php _e( 'Priority Support', 'otter-pro' ); ?></li>
+					<li><?php _e( 'WooCommerce Block Builder', 'otter-blocks' ); ?></li>
+					<li><?php _e( 'Add to Cart Block', 'otter-blocks' ); ?></li>
+					<li><?php _e( 'Review Comparison  Block', 'otter-blocks' ); ?></li>
+					<li><?php _e( 'Priority Support', 'otter-blocks' ); ?></li>
 				</ul>
 
 				<a href="<?php echo esc_url_raw( tsdk_translate_link( tsdk_utmify( self::get_url(), 'woobuilder', 'wooproducteditor' ) ) ); ?>" target="_blank" class="button button-primary">
-					<?php _e( 'Discover Otter Pro', 'otter-pro' ); ?>
+					<?php _e( 'Discover Otter Pro', 'otter-blocks' ); ?>
 				</a>
 			</div>
 			<?php
@@ -260,10 +260,10 @@ class Pro {
 
 		?>
 		<div class="clear">
-			<p><?php _e( 'Unlock the full power of WooCommerce Builder by activating Otter Pro license.', 'otter-pro' ); ?></p>
+			<p><?php _e( 'Unlock the full power of WooCommerce Builder by activating Otter Pro license.', 'otter-blocks' ); ?></p>
 
 			<a href="<?php echo esc_url( admin_url( 'admin.php?page=otter' ) ); ?>" target="_blank" class="button button-primary">
-				<?php _e( 'Activate License', 'otter-pro' ); ?>
+				<?php _e( 'Activate License', 'otter-blocks' ); ?>
 			</a>
 		</div>
 		<?php
@@ -276,15 +276,15 @@ class Pro {
 	 * @access  public
 	 */
 	public function old_neve_notice() {
-		$plugin_name = __( 'Block Editor Booster', 'otter-pro' );
-		$message     = __( 'You need to make sure Neve & Neve Pro Addons are updated to the latest version to continue using Block Editor Booster.', 'otter-pro' );
+		$plugin_name = __( 'Block Editor Booster', 'otter-blocks' );
+		$message     = __( 'You need to make sure Neve & Neve Pro Addons are updated to the latest version to continue using Block Editor Booster.', 'otter-blocks' );
 
 		printf(
 			'<div class="error"><p><b>%1$s</b> %2$s <a href="%3$s">%4$s</a></p></div>',
 			esc_html( $plugin_name ),
 			esc_html( $message ),
 			esc_url( admin_url( 'update-core.php' ) ),
-			esc_html__( 'Update', 'otter-pro' )
+			esc_html__( 'Update', 'otter-blocks' )
 		);
 	}
 
@@ -320,8 +320,8 @@ class Pro {
 			jQuery( document ).ready( () => disableNotice( jQuery ) );
 		</script>
 		<?php
-		$prefix  = __( 'You\'re using Otter!', 'otter-pro' );
-		$message = __( 'Enhance your WordPress site building with Otter Pro.', 'otter-pro' );
+		$prefix  = __( 'You\'re using Otter!', 'otter-blocks' );
+		$message = __( 'Enhance your WordPress site building with Otter Pro.', 'otter-blocks' );
 		$notice  = printf(
 			'<div class="o-notice notice notice-info is-dismissible">
 				<svg style="float: left; margin: .5em 0; padding: 2px; padding-right: 10px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 32" width="20" height="20" class"otter-icon"><path d="M19.831 7.877c0.001-0.003 0.001-0.005 0.001-0.009s-0-0.006-0.001-0.009l0 0c-0.047-0.081-0.092-0.164-0.132-0.247l-0.057-0.115c-0.277-0.498-0.381-0.99-1.033-1.064h-0.045c-0.001 0-0.002 0-0.003 0-0.486 0-0.883 0.382-0.908 0.862l-0 0.002c0.674 0.126 1.252 0.278 1.813 0.468l-0.092-0.027 0.283 0.096 0.147 0.053s0.028 0 0.028-0.011z" /><path d="M23.982 13.574c-0.008-2.41-0.14-4.778-0.39-7.112l0.026 0.299 0.070-0.019c0.459-0.139 0.787-0.558 0.787-1.053 0-0.479-0.307-0.887-0.735-1.037l-0.008-0.002h-0.026c-0.479-0.164-0.874-0.468-1.149-0.861l-0.005-0.007c-2.7-3.96-8.252-3.781-8.252-3.781s-5.55-0.179-8.25 3.781c-0.28 0.401-0.676 0.704-1.14 0.862l-0.016 0.005c-0.441 0.148-0.754 0.557-0.754 1.040 0 0.009 0 0.017 0 0.026l-0-0.001c-0 0.010-0.001 0.022-0.001 0.034 0 0.493 0.335 0.907 0.789 1.029l0.007 0.002 0.045 0.011c-0.224 2.034-0.356 4.403-0.364 6.801l-0 0.012s-9.493 13.012-1.277 17.515c4.733 2.431 6.881-0.769 6.881-0.769s1.397-1.661-1.784-3.355v-4.609c0.006-0.344 0.282-0.621 0.625-0.628h1.212v-0.59c0-0.275 0.223-0.498 0.498-0.498v0h1.665c0.274 0.001 0.496 0.224 0.496 0.498 0 0 0 0 0 0v0 0.59h2.721v-0.59c0-0.275 0.223-0.498 0.498-0.498v0h1.665c0.271 0.005 0.49 0.226 0.49 0.498 0 0 0 0 0 0v0 0.59h1.209c0 0 0 0 0 0 0.349 0 0.633 0.28 0.639 0.627v4.584c-3.193 1.703-1.784 3.355-1.784 3.355s2.148 3.193 6.879 0.769c8.222-4.503-1.269-17.515-1.269-17.515zM22.586 10.261c-0.097 1.461-0.67 2.772-1.563 3.797l0.007-0.008c-1.703 2.010-4.407 3.249-6.721 4.432v0c-2.325-1.177-5.026-2.416-6.736-4.432-0.883-1.019-1.455-2.329-1.555-3.769l-0.001-0.020c-0.126-2.22 0.583-5.929 3.044-6.74 2.416-0.788 3.947 1.288 4.494 2.227 0.152 0.258 0.429 0.428 0.745 0.428s0.593-0.17 0.743-0.424l0.002-0.004c0.551-0.932 2.080-3.008 4.494-2.22 2.474 0.805 3.174 4.513 3.046 6.734z" /><path d="M19.463 10.087h-0.028c-0.192 0.026-0.121 0.251-0.047 0.356 0.254 0.349 0.407 0.787 0.407 1.26 0 0.006-0 0.012-0 0.018v-0.001c-0.001 0.469-0.255 0.878-0.633 1.1l-0.006 0.003c-0.739 0.426-1.377-0.145-2.054-0.398-0.72-0.269-1.552-0.434-2.42-0.455l-0.009-0v-1.033c1.020-0.233 1.894-0.76 2.551-1.486l0.004-0.004c0.151-0.163 0.244-0.383 0.244-0.623 0-0.316-0.159-0.595-0.402-0.76l-0.003-0.002c-0.768-0.551-1.728-0.881-2.764-0.881-1.054 0-2.029 0.341-2.819 0.92l0.013-0.009c-0.224 0.166-0.367 0.429-0.367 0.726 0 0.226 0.083 0.433 0.221 0.591l-0.001-0.001c0.665 0.751 1.55 1.295 2.553 1.53l0.033 0.007v1.050c-0.742 0.021-1.448 0.14-2.118 0.343l0.057-0.015c-0.341 0.103-0.631 0.219-0.908 0.358l0.033-0.015c-0.519 0.26-1.037 0.436-1.58 0.121-0.371-0.213-0.617-0.607-0.617-1.058 0-0.002 0-0.004 0-0.007v0c0-0.002 0-0.004 0-0.007 0-0.47 0.153-0.905 0.411-1.257l-0.004 0.006c0.047-0.068 0.089-0.17 0.026-0.241s-0.189 0-0.27 0.030c-0.189 0.099-0.348 0.227-0.479 0.381l-0.002 0.002c-0.245 0.296-0.394 0.679-0.394 1.097 0 0.004 0 0.007 0 0.011v-0.001c0.008 0.706 0.393 1.321 0.964 1.651l0.009 0.005c0.296 0.178 0.654 0.283 1.036 0.283 0.364 0 0.706-0.095 1.001-0.263l-0.010 0.005c0.877-0.461 1.917-0.731 3.019-0.731 0.069 0 0.137 0.001 0.206 0.003l-0.010-0h0.030c1.277 0 2.382 0.266 3.266 0.775 0.27 0.159 0.594 0.253 0.94 0.253 0.001 0 0.002 0 0.003 0h-0c0.355-0.002 0.688-0.098 0.974-0.265l-0.009 0.005c0.606-0.357 1.007-1.007 1.007-1.75 0-0.001 0-0.003 0-0.004v0c0.001-0.026 0.002-0.056 0.002-0.086 0-0.625-0.34-1.171-0.846-1.462l-0.008-0.004c-0.056-0.040-0.125-0.065-0.199-0.070l-0.001-0zM13.101 8.831c-0.238 0.213-0.468 0.581-0.832 0.345-0.061-0.041-0.114-0.086-0.161-0.136l-0-0c-0.063-0.063-0.101-0.15-0.101-0.247 0-0.133 0.074-0.248 0.182-0.308l0.002-0.001c0.594-0.309 1.203-0.543 1.884-0.49-0.324 0.281-0.649 0.56-0.973 0.837z" /><path d="M15.89 13.578c-0.367 0.483-0.941 0.792-1.588 0.792s-1.221-0.309-1.585-0.787l-0.004-0.005c-0.064-0.103-0.177-0.171-0.306-0.171-0.199 0-0.36 0.161-0.36 0.36 0 0.091 0.034 0.174 0.090 0.238l-0-0c0.499 0.659 1.283 1.080 2.164 1.080s1.665-0.421 2.159-1.073l0.005-0.007c0.043-0.059 0.068-0.132 0.068-0.212 0-0.116-0.055-0.22-0.14-0.286l-0.001-0.001c-0.059-0.045-0.134-0.072-0.215-0.072-0.117 0-0.221 0.056-0.286 0.143l-0.001 0.001z" /><path d="M18.507 11.707c0 0.194-0.157 0.351-0.351 0.351s-0.351-0.157-0.351-0.351c0-0.194 0.157-0.351 0.351-0.351s0.351 0.157 0.351 0.351z" /><path d="M17.389 11.049c0 0.194-0.157 0.351-0.351 0.351s-0.351-0.157-0.351-0.351c0-0.194 0.157-0.351 0.351-0.351s0.351 0.157 0.351 0.351z" /><path d="M10.798 11.707c0 0.194-0.157 0.351-0.351 0.351s-0.351-0.157-0.351-0.351c0-0.194 0.157-0.351 0.351-0.351s0.351 0.157 0.351 0.351z" /><path d="M11.918 11.049c0 0.194-0.157 0.351-0.351 0.351s-0.351-0.157-0.351-0.351c0-0.194 0.157-0.351 0.351-0.351s0.351 0.157 0.351 0.351z" /><path d="M8.773 7.877c-0.001-0.003-0.002-0.005-0.002-0.009s0.001-0.006 0.002-0.009l-0 0c0.047-0.081 0.089-0.164 0.132-0.247 0.019-0.038 0.036-0.079 0.057-0.115 0.275-0.498 0.379-0.99 1.033-1.064h0.045c0 0 0.001 0 0.001 0 0.487 0 0.884 0.382 0.91 0.862l0 0.002c-0.678 0.124-1.261 0.277-1.827 0.468l0.092-0.027-0.275 0.096-0.1 0.036-0.045 0.017s-0.023 0-0.023-0.011z" /></svg>
@@ -369,7 +369,7 @@ class Pro {
 	public function add_cron_schedules( $schedules = array() ) {
 		// Adds once monthly to the existing schedules.
 		$schedules['monthly'] = array(
-			'display'  => __( 'Monthly', 'otter-pro' ),
+			'display'  => __( 'Monthly', 'otter-blocks' ),
 			'interval' => 2635200,
 		);
 
@@ -420,7 +420,7 @@ class Pro {
 		$links[] = sprintf(
 			'<a href="%s" target="_blank" style="color:#ed6f57;font-weight:bold;">%s</a>',
 			esc_url_raw( tsdk_utmify( self::get_url(), 'pluginspage', 'action' ) ),
-			__( 'Get Otter Pro', 'otter-pro' )
+			__( 'Get Otter Pro', 'otter-blocks' )
 		);
 
 		return $links;

--- a/inc/class-pro.php
+++ b/inc/class-pro.php
@@ -207,7 +207,7 @@ class Pro {
 	public function register_metabox( $post_type ) {
 		add_meta_box(
 			'otter_woo_builder',
-			__( 'WooCommerce Builder by Otter', 'otter-blocks' ),
+			__( 'WooCommerce Builder by Otter', 'otter-pro' ),
 			array( $this, 'render_metabox_upsell' ),
 			'product',
 			'side',
@@ -241,17 +241,17 @@ class Pro {
 				}
 			</style>
 			<div class="clear o-upsell">
-				<p><?php _e( 'Unlock the full power of WooCommerce Builder with Otter Pro:', 'otter-blocks' ); ?></p>
+				<p><?php _e( 'Unlock the full power of WooCommerce Builder with Otter Pro:', 'otter-pro' ); ?></p>
 
 				<ul>
-					<li><?php _e( 'WooCommerce Block Builder', 'otter-blocks' ); ?></li>
-					<li><?php _e( 'Add to Cart Block', 'otter-blocks' ); ?></li>
-					<li><?php _e( 'Review Comparison  Block', 'otter-blocks' ); ?></li>
-					<li><?php _e( 'Priority Support', 'otter-blocks' ); ?></li>
+					<li><?php _e( 'WooCommerce Block Builder', 'otter-pro' ); ?></li>
+					<li><?php _e( 'Add to Cart Block', 'otter-pro' ); ?></li>
+					<li><?php _e( 'Review Comparison  Block', 'otter-pro' ); ?></li>
+					<li><?php _e( 'Priority Support', 'otter-pro' ); ?></li>
 				</ul>
 
 				<a href="<?php echo esc_url_raw( tsdk_translate_link( tsdk_utmify( self::get_url(), 'woobuilder', 'wooproducteditor' ) ) ); ?>" target="_blank" class="button button-primary">
-					<?php _e( 'Discover Otter Pro', 'otter-blocks' ); ?>
+					<?php _e( 'Discover Otter Pro', 'otter-pro' ); ?>
 				</a>
 			</div>
 			<?php
@@ -260,10 +260,10 @@ class Pro {
 
 		?>
 		<div class="clear">
-			<p><?php _e( 'Unlock the full power of WooCommerce Builder by activating Otter Pro license.', 'otter-blocks' ); ?></p>
+			<p><?php _e( 'Unlock the full power of WooCommerce Builder by activating Otter Pro license.', 'otter-pro' ); ?></p>
 
 			<a href="<?php echo esc_url( admin_url( 'admin.php?page=otter' ) ); ?>" target="_blank" class="button button-primary">
-				<?php _e( 'Activate License', 'otter-blocks' ); ?>
+				<?php _e( 'Activate License', 'otter-pro' ); ?>
 			</a>
 		</div>
 		<?php
@@ -276,15 +276,15 @@ class Pro {
 	 * @access  public
 	 */
 	public function old_neve_notice() {
-		$plugin_name = __( 'Block Editor Booster', 'otter-blocks' );
-		$message     = __( 'You need to make sure Neve & Neve Pro Addons are updated to the latest version to continue using Block Editor Booster.', 'otter-blocks' );
+		$plugin_name = __( 'Block Editor Booster', 'otter-pro' );
+		$message     = __( 'You need to make sure Neve & Neve Pro Addons are updated to the latest version to continue using Block Editor Booster.', 'otter-pro' );
 
 		printf(
 			'<div class="error"><p><b>%1$s</b> %2$s <a href="%3$s">%4$s</a></p></div>',
 			esc_html( $plugin_name ),
 			esc_html( $message ),
 			esc_url( admin_url( 'update-core.php' ) ),
-			esc_html__( 'Update', 'otter-blocks' )
+			esc_html__( 'Update', 'otter-pro' )
 		);
 	}
 
@@ -320,8 +320,8 @@ class Pro {
 			jQuery( document ).ready( () => disableNotice( jQuery ) );
 		</script>
 		<?php
-		$prefix  = __( 'You\'re using Otter!', 'otter-blocks' );
-		$message = __( 'Enhance your WordPress site building with Otter Pro.', 'otter-blocks' );
+		$prefix  = __( 'You\'re using Otter!', 'otter-pro' );
+		$message = __( 'Enhance your WordPress site building with Otter Pro.', 'otter-pro' );
 		$notice  = printf(
 			'<div class="o-notice notice notice-info is-dismissible">
 				<svg style="float: left; margin: .5em 0; padding: 2px; padding-right: 10px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 32" width="20" height="20" class"otter-icon"><path d="M19.831 7.877c0.001-0.003 0.001-0.005 0.001-0.009s-0-0.006-0.001-0.009l0 0c-0.047-0.081-0.092-0.164-0.132-0.247l-0.057-0.115c-0.277-0.498-0.381-0.99-1.033-1.064h-0.045c-0.001 0-0.002 0-0.003 0-0.486 0-0.883 0.382-0.908 0.862l-0 0.002c0.674 0.126 1.252 0.278 1.813 0.468l-0.092-0.027 0.283 0.096 0.147 0.053s0.028 0 0.028-0.011z" /><path d="M23.982 13.574c-0.008-2.41-0.14-4.778-0.39-7.112l0.026 0.299 0.070-0.019c0.459-0.139 0.787-0.558 0.787-1.053 0-0.479-0.307-0.887-0.735-1.037l-0.008-0.002h-0.026c-0.479-0.164-0.874-0.468-1.149-0.861l-0.005-0.007c-2.7-3.96-8.252-3.781-8.252-3.781s-5.55-0.179-8.25 3.781c-0.28 0.401-0.676 0.704-1.14 0.862l-0.016 0.005c-0.441 0.148-0.754 0.557-0.754 1.040 0 0.009 0 0.017 0 0.026l-0-0.001c-0 0.010-0.001 0.022-0.001 0.034 0 0.493 0.335 0.907 0.789 1.029l0.007 0.002 0.045 0.011c-0.224 2.034-0.356 4.403-0.364 6.801l-0 0.012s-9.493 13.012-1.277 17.515c4.733 2.431 6.881-0.769 6.881-0.769s1.397-1.661-1.784-3.355v-4.609c0.006-0.344 0.282-0.621 0.625-0.628h1.212v-0.59c0-0.275 0.223-0.498 0.498-0.498v0h1.665c0.274 0.001 0.496 0.224 0.496 0.498 0 0 0 0 0 0v0 0.59h2.721v-0.59c0-0.275 0.223-0.498 0.498-0.498v0h1.665c0.271 0.005 0.49 0.226 0.49 0.498 0 0 0 0 0 0v0 0.59h1.209c0 0 0 0 0 0 0.349 0 0.633 0.28 0.639 0.627v4.584c-3.193 1.703-1.784 3.355-1.784 3.355s2.148 3.193 6.879 0.769c8.222-4.503-1.269-17.515-1.269-17.515zM22.586 10.261c-0.097 1.461-0.67 2.772-1.563 3.797l0.007-0.008c-1.703 2.010-4.407 3.249-6.721 4.432v0c-2.325-1.177-5.026-2.416-6.736-4.432-0.883-1.019-1.455-2.329-1.555-3.769l-0.001-0.020c-0.126-2.22 0.583-5.929 3.044-6.74 2.416-0.788 3.947 1.288 4.494 2.227 0.152 0.258 0.429 0.428 0.745 0.428s0.593-0.17 0.743-0.424l0.002-0.004c0.551-0.932 2.080-3.008 4.494-2.22 2.474 0.805 3.174 4.513 3.046 6.734z" /><path d="M19.463 10.087h-0.028c-0.192 0.026-0.121 0.251-0.047 0.356 0.254 0.349 0.407 0.787 0.407 1.26 0 0.006-0 0.012-0 0.018v-0.001c-0.001 0.469-0.255 0.878-0.633 1.1l-0.006 0.003c-0.739 0.426-1.377-0.145-2.054-0.398-0.72-0.269-1.552-0.434-2.42-0.455l-0.009-0v-1.033c1.020-0.233 1.894-0.76 2.551-1.486l0.004-0.004c0.151-0.163 0.244-0.383 0.244-0.623 0-0.316-0.159-0.595-0.402-0.76l-0.003-0.002c-0.768-0.551-1.728-0.881-2.764-0.881-1.054 0-2.029 0.341-2.819 0.92l0.013-0.009c-0.224 0.166-0.367 0.429-0.367 0.726 0 0.226 0.083 0.433 0.221 0.591l-0.001-0.001c0.665 0.751 1.55 1.295 2.553 1.53l0.033 0.007v1.050c-0.742 0.021-1.448 0.14-2.118 0.343l0.057-0.015c-0.341 0.103-0.631 0.219-0.908 0.358l0.033-0.015c-0.519 0.26-1.037 0.436-1.58 0.121-0.371-0.213-0.617-0.607-0.617-1.058 0-0.002 0-0.004 0-0.007v0c0-0.002 0-0.004 0-0.007 0-0.47 0.153-0.905 0.411-1.257l-0.004 0.006c0.047-0.068 0.089-0.17 0.026-0.241s-0.189 0-0.27 0.030c-0.189 0.099-0.348 0.227-0.479 0.381l-0.002 0.002c-0.245 0.296-0.394 0.679-0.394 1.097 0 0.004 0 0.007 0 0.011v-0.001c0.008 0.706 0.393 1.321 0.964 1.651l0.009 0.005c0.296 0.178 0.654 0.283 1.036 0.283 0.364 0 0.706-0.095 1.001-0.263l-0.010 0.005c0.877-0.461 1.917-0.731 3.019-0.731 0.069 0 0.137 0.001 0.206 0.003l-0.010-0h0.030c1.277 0 2.382 0.266 3.266 0.775 0.27 0.159 0.594 0.253 0.94 0.253 0.001 0 0.002 0 0.003 0h-0c0.355-0.002 0.688-0.098 0.974-0.265l-0.009 0.005c0.606-0.357 1.007-1.007 1.007-1.75 0-0.001 0-0.003 0-0.004v0c0.001-0.026 0.002-0.056 0.002-0.086 0-0.625-0.34-1.171-0.846-1.462l-0.008-0.004c-0.056-0.040-0.125-0.065-0.199-0.070l-0.001-0zM13.101 8.831c-0.238 0.213-0.468 0.581-0.832 0.345-0.061-0.041-0.114-0.086-0.161-0.136l-0-0c-0.063-0.063-0.101-0.15-0.101-0.247 0-0.133 0.074-0.248 0.182-0.308l0.002-0.001c0.594-0.309 1.203-0.543 1.884-0.49-0.324 0.281-0.649 0.56-0.973 0.837z" /><path d="M15.89 13.578c-0.367 0.483-0.941 0.792-1.588 0.792s-1.221-0.309-1.585-0.787l-0.004-0.005c-0.064-0.103-0.177-0.171-0.306-0.171-0.199 0-0.36 0.161-0.36 0.36 0 0.091 0.034 0.174 0.090 0.238l-0-0c0.499 0.659 1.283 1.080 2.164 1.080s1.665-0.421 2.159-1.073l0.005-0.007c0.043-0.059 0.068-0.132 0.068-0.212 0-0.116-0.055-0.22-0.14-0.286l-0.001-0.001c-0.059-0.045-0.134-0.072-0.215-0.072-0.117 0-0.221 0.056-0.286 0.143l-0.001 0.001z" /><path d="M18.507 11.707c0 0.194-0.157 0.351-0.351 0.351s-0.351-0.157-0.351-0.351c0-0.194 0.157-0.351 0.351-0.351s0.351 0.157 0.351 0.351z" /><path d="M17.389 11.049c0 0.194-0.157 0.351-0.351 0.351s-0.351-0.157-0.351-0.351c0-0.194 0.157-0.351 0.351-0.351s0.351 0.157 0.351 0.351z" /><path d="M10.798 11.707c0 0.194-0.157 0.351-0.351 0.351s-0.351-0.157-0.351-0.351c0-0.194 0.157-0.351 0.351-0.351s0.351 0.157 0.351 0.351z" /><path d="M11.918 11.049c0 0.194-0.157 0.351-0.351 0.351s-0.351-0.157-0.351-0.351c0-0.194 0.157-0.351 0.351-0.351s0.351 0.157 0.351 0.351z" /><path d="M8.773 7.877c-0.001-0.003-0.002-0.005-0.002-0.009s0.001-0.006 0.002-0.009l-0 0c0.047-0.081 0.089-0.164 0.132-0.247 0.019-0.038 0.036-0.079 0.057-0.115 0.275-0.498 0.379-0.99 1.033-1.064h0.045c0 0 0.001 0 0.001 0 0.487 0 0.884 0.382 0.91 0.862l0 0.002c-0.678 0.124-1.261 0.277-1.827 0.468l0.092-0.027-0.275 0.096-0.1 0.036-0.045 0.017s-0.023 0-0.023-0.011z" /></svg>
@@ -369,7 +369,7 @@ class Pro {
 	public function add_cron_schedules( $schedules = array() ) {
 		// Adds once monthly to the existing schedules.
 		$schedules['monthly'] = array(
-			'display'  => __( 'Monthly', 'otter-blocks' ),
+			'display'  => __( 'Monthly', 'otter-pro' ),
 			'interval' => 2635200,
 		);
 
@@ -420,7 +420,7 @@ class Pro {
 		$links[] = sprintf(
 			'<a href="%s" target="_blank" style="color:#ed6f57;font-weight:bold;">%s</a>',
 			esc_url_raw( tsdk_utmify( self::get_url(), 'pluginspage', 'action' ) ),
-			__( 'Get Otter Pro', 'otter-blocks' )
+			__( 'Get Otter Pro', 'otter-pro' )
 		);
 
 		return $links;

--- a/inc/css/class-block-frontend.php
+++ b/inc/css/class-block-frontend.php
@@ -700,7 +700,7 @@ class Block_Frontend extends Base_CSS {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'blocks-css' ), '1.0.0' );
 	}
 
 	/**
@@ -712,6 +712,6 @@ class Block_Frontend extends Base_CSS {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'blocks-css' ), '1.0.0' );
 	}
 }

--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -136,7 +136,7 @@ class CSS_Handler extends Base_CSS {
 						'id' => array(
 							'type'              => 'integer',
 							'required'          => true,
-							'description'       => __( 'ID of the Post.', 'otter-blocks' ),
+							'description'       => __( 'ID of the Post.', 'blocks-css' ),
 							'validate_callback' => function ( $param, $request, $key ) {
 								return is_numeric( $param );
 							},
@@ -160,7 +160,7 @@ class CSS_Handler extends Base_CSS {
 						'id' => array(
 							'type'              => 'integer',
 							'required'          => true,
-							'description'       => __( 'ID of the Reusable Block.', 'otter-blocks' ),
+							'description'       => __( 'ID of the Reusable Block.', 'blocks-css' ),
 							'validate_callback' => function ( $param, $request, $key ) {
 								return is_numeric( $param );
 							},
@@ -224,7 +224,7 @@ class CSS_Handler extends Base_CSS {
 
 		self::mark_review_block_metadata( $post_id );
 
-		return rest_ensure_response( array( 'message' => __( 'CSS updated.', 'otter-blocks' ) ) );
+		return rest_ensure_response( array( 'message' => __( 'CSS updated.', 'blocks-css' ) ) );
 	}
 
 	/**
@@ -311,7 +311,7 @@ class CSS_Handler extends Base_CSS {
 
 		self::mark_review_block_metadata( $post_id );
 
-		return rest_ensure_response( array( 'message' => __( 'CSS updated.', 'otter-blocks' ) ) );
+		return rest_ensure_response( array( 'message' => __( 'CSS updated.', 'blocks-css' ) ) );
 	}
 
 	/**
@@ -598,7 +598,7 @@ class CSS_Handler extends Base_CSS {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'blocks-css' ), '1.0.0' );
 	}
 
 	/**
@@ -610,6 +610,6 @@ class CSS_Handler extends Base_CSS {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'blocks-css' ), '1.0.0' );
 	}
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"lint:php": "wp-env run --env-cwd='wp-content/plugins/otter-blocks' cli composer run-script lint",
 		"format:php": "wp-env run --env-cwd='wp-content/plugins/otter-blocks' cli composer run-script format",
 		"wp-env": "wp-env",
-		"build:makepot": "docker run --user root --rm --volume \"$(pwd):/var/www/html/otter-blocks\" wordpress:cli bash -c 'php -d memory_limit=512M \"$(which wp)\" --version --allow-root && wp i18n make-pot otter-blocks ./otter-blocks/languages/otter-pro.pot --include=src/pro,otter-pro,build/pro --allow-root --domain=otter-pro --headers={\\\"Last-Translator\\\":\\\"friends@themeisle.com\\\"\\,\\\"Report-Msgid-Bugs-To\\\":\\\"https://github.com/Codeinwp/otter-blocks/issues\\\"\\,\\\"Project-Id-Version\\\":\\\"Otter-Blocks\\\"\\,\\\"POT-Creation-Date\\\":\\\"\\\"}'"
+		"build:makepot": "docker run --user root --rm --volume \"$(pwd):/var/www/html/otter-blocks\" wordpress:cli bash -c 'php -d memory_limit=512M \"$(which wp)\" --version --allow-root && wp i18n make-pot otter-blocks ./otter-blocks/languages/otter-pro.pot --include=\"otter-pro,build/pro,inc\" --allow-root --domain=otter-pro --headers={\\\"Last-Translator\\\":\\\"friends@themeisle.com\\\"\\,\\\"Report-Msgid-Bugs-To\\\":\\\"https://github.com/Codeinwp/otter-blocks/issues\\\"\\,\\\"Project-Id-Version\\\":\\\"Otter-Blocks\\\"\\,\\\"POT-Creation-Date\\\":\\\"\\\"}'"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"prod:lite": "wp-scripts build --config webpack.config.js",
 		"prod:pro": "wp-scripts build --config webpack.config.pro.js",
 		"prod:grunt": "grunt build",
+		"grunt:version": "grunt version",
 		"start": "rm -rf build && npm-run-all --parallel dev:*",
 		"dev:lite": "wp-scripts start --config webpack.config.js",
 		"dev:pro": "wp-scripts start --config webpack.config.pro.js",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"lint:php": "wp-env run --env-cwd='wp-content/plugins/otter-blocks' cli composer run-script lint",
 		"format:php": "wp-env run --env-cwd='wp-content/plugins/otter-blocks' cli composer run-script format",
 		"wp-env": "wp-env",
-		"build:makepot": "docker run --user root --rm --volume \"$(pwd):/var/www/html/otter-blocks\" wordpress:cli bash -c 'php -d memory_limit=512M \"$(which wp)\" --version --allow-root && wp i18n make-pot otter-blocks ./otter-blocks/languages/otter-pro.pot --include=src/pro,otter-pro,build/pro --allow-root --headers={\\\"Last-Translator\\\":\\\"friends@themeisle.com\\\"\\,\\\"Report-Msgid-Bugs-To\\\":\\\"https://github.com/Codeinwp/otter-blocks/issues\\\"\\,\\\"Project-Id-Version\\\":\\\"Otter-Blocks\\\"\\,\\\"POT-Creation-Date\\\":\\\"\\\"}'"
+		"build:makepot": "docker run --user root --rm --volume \"$(pwd):/var/www/html/otter-blocks\" wordpress:cli bash -c 'php -d memory_limit=512M \"$(which wp)\" --version --allow-root && wp i18n make-pot otter-blocks ./otter-blocks/languages/otter-pro.pot --include=src/pro,otter-pro,build/pro --allow-root --domain=otter-pro --headers={\\\"Last-Translator\\\":\\\"friends@themeisle.com\\\"\\,\\\"Report-Msgid-Bugs-To\\\":\\\"https://github.com/Codeinwp/otter-blocks/issues\\\"\\,\\\"Project-Id-Version\\\":\\\"Otter-Blocks\\\"\\,\\\"POT-Creation-Date\\\":\\\"\\\"}'"
 	},
 	"repository": {
 		"type": "git",

--- a/phpcs.export.xml
+++ b/phpcs.export.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<ruleset name="">
+    <description>ThemeIsle ruleset</description>
+    <rule ref="WordPress-VIP-Go" />
+
+    <rule ref="WordPress-Core" />
+
+    <rule ref="WordPress-Docs" />
+
+    <rule ref="WordPress-Extra">
+        <!-- Forget about file names -->
+        <exclude name="WordPress.Files.FileName" />
+    </rule>
+
+
+    <config name="testVersion" value="5.6-" />
+
+    <rule ref="PHPCompatibility" />
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="otter-blocks" />
+            </property>
+        </properties>
+    </rule>
+
+    <rule ref="WordPress.Utils.I18nTextDomainFixer">
+        <properties>
+            <property name="old_text_domain" type="array">
+                <element value="blocks-animation" />
+                <element value="blocks-import-export" />
+                <element value="otter-pro" />
+                <element value="blocks-css" />
+            </property>
+            <property name="new_text_domain" value="otter-blocks" />
+        </properties>
+    </rule>
+
+
+    <arg name="extensions" value="php" />
+    <arg value="s" />
+
+    <file>.</file>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>build/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
+    <exclude-pattern>Gruntfile.js</exclude-pattern>
+    <exclude-pattern>cypress</exclude-pattern>
+    <exclude-pattern>artifact/*</exclude-pattern>
+    <exclude-pattern>assets/*</exclude-pattern>
+</ruleset>

--- a/phpcs.export.xml
+++ b/phpcs.export.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="">
     <description>ThemeIsle ruleset</description>
+
     <rule ref="WordPress-VIP-Go" />
 
     <rule ref="WordPress-Core" />
@@ -16,6 +17,7 @@
     <config name="testVersion" value="5.6-" />
 
     <rule ref="PHPCompatibility" />
+
     <rule ref="WordPress.WP.I18n">
         <properties>
             <property name="text_domain" type="array">
@@ -26,27 +28,12 @@
 
     <rule ref="WordPress.Utils.I18nTextDomainFixer">
         <properties>
-            <property name="old_text_domain" type="array">
-                <element value="blocks-animation" />
-                <element value="blocks-import-export" />
-                <element value="otter-pro" />
-                <element value="blocks-css" />
-            </property>
+            <property name="old_text_domain"
+                value="blocks-animation,blocks-import-export,otter-pro,blocks-css" />
             <property name="new_text_domain" value="otter-blocks" />
         </properties>
     </rule>
 
-
-    <arg name="extensions" value="php" />
-    <arg value="s" />
-
-    <file>.</file>
-    <exclude-pattern>node_modules/*</exclude-pattern>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>build/*</exclude-pattern>
-    <exclude-pattern>tests/*</exclude-pattern>
-    <exclude-pattern>Gruntfile.js</exclude-pattern>
-    <exclude-pattern>cypress</exclude-pattern>
-    <exclude-pattern>artifact/*</exclude-pattern>
-    <exclude-pattern>assets/*</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,23 +9,28 @@
 
     <rule ref="WordPress-Extra">
         <!-- Forget about file names -->
-        <exclude name="WordPress.Files.FileName"/>
+        <exclude name="WordPress.Files.FileName" />
     </rule>
 
 
-    <config name="testVersion" value="5.6-"/>
+    <config name="testVersion" value="5.6-" />
 
     <rule ref="PHPCompatibility" />
     <rule ref="WordPress.WP.I18n">
         <properties>
-            <property name="text_domain" value="otter-blocks" />
+            <property name="text_domain" type="array">
+                <element value="otter-blocks" />
+                <element value="blocks-animation" />
+                <element value="blocks-import-export" />
+                <element value="otter-pro" />
+                <element value="blocks-css" />
+            </property>
         </properties>
-
     </rule>
 
 
-    <arg name="extensions" value="php"/>
-    <arg value="s"/>
+    <arg name="extensions" value="php" />
+    <arg value="s" />
 
     <file>.</file>
     <exclude-pattern>node_modules/*</exclude-pattern>

--- a/plugins/otter-pro/inc/class-main.php
+++ b/plugins/otter-pro/inc/class-main.php
@@ -275,7 +275,7 @@ class Main {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -287,6 +287,6 @@ class Main {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/class-main.php
+++ b/plugins/otter-pro/inc/class-main.php
@@ -221,6 +221,8 @@ class Main {
 				$asset_file['version'],
 				true
 			);
+
+			wp_set_script_translations( 'otter-blocks-woocommerce', 'otter-pro' );
 		}
 	}
 
@@ -243,6 +245,8 @@ class Main {
 			$asset_file['version'],
 			true
 		);
+
+		wp_set_script_translations( 'otter-dashboard-scripts', 'otter-pro' );
 	}
 
 	/**

--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -697,7 +697,7 @@ class Block_Conditions {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -709,6 +709,6 @@ class Block_Conditions {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-dynamic-content.php
+++ b/plugins/otter-pro/inc/plugins/class-dynamic-content.php
@@ -246,7 +246,7 @@ class Dynamic_Content {
 		}
 
 		if ( false === $meta || true === $meta ) {
-			$meta = $meta ? __( 'Yes', 'otter-blocks' ) : __( 'No', 'otter-blocks' );
+			$meta = $meta ? __( 'Yes', 'otter-pro' ) : __( 'No', 'otter-pro' );
 		}
 
 		if ( empty( $meta ) || ! is_string( $meta ) ) {
@@ -615,7 +615,7 @@ class Dynamic_Content {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -627,6 +627,6 @@ class Dynamic_Content {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-fonts-module.php
+++ b/plugins/otter-pro/inc/plugins/class-fonts-module.php
@@ -110,7 +110,7 @@ class Fonts_Module {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -122,6 +122,6 @@ class Fonts_Module {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-form-emails-storing.php
+++ b/plugins/otter-pro/inc/plugins/class-form-emails-storing.php
@@ -92,20 +92,20 @@ class Form_Emails_Storing {
 			self::FORM_RECORD_TYPE,
 			array(
 				'labels'          => array(
-					'name'               => esc_html_x( 'Form Submissions', '', 'otter-blocks' ),
-					'singular_name'      => esc_html_x( 'Form Submission', '', 'otter-blocks' ),
-					'search_items'       => esc_html__( 'Search Submissions', 'otter-blocks' ),
-					'all_items'          => esc_html__( 'Form Submissions', 'otter-blocks' ),
-					'view_item'          => esc_html__( 'View Submission', 'otter-blocks' ),
-					'update_item'        => esc_html__( 'Update Submission', 'otter-blocks' ),
-					'not_found'          => esc_html__( 'No submissions found', 'otter-blocks' ),
-					'not_found_in_trash' => esc_html__( 'No submissions found in the Trash', 'otter-blocks' ),
+					'name'               => esc_html_x( 'Form Submissions', '', 'otter-pro' ),
+					'singular_name'      => esc_html_x( 'Form Submission', '', 'otter-pro' ),
+					'search_items'       => esc_html__( 'Search Submissions', 'otter-pro' ),
+					'all_items'          => esc_html__( 'Form Submissions', 'otter-pro' ),
+					'view_item'          => esc_html__( 'View Submission', 'otter-pro' ),
+					'update_item'        => esc_html__( 'Update Submission', 'otter-pro' ),
+					'not_found'          => esc_html__( 'No submissions found', 'otter-pro' ),
+					'not_found_in_trash' => esc_html__( 'No submissions found in the Trash', 'otter-pro' ),
 				),
 				'capability_type' => self::FORM_RECORD_TYPE,
 				'capabilities'    => array(
 					'create_posts' => 'create_otter_form_records',
 				),
-				'description'     => __( 'Holds the data from the form submissions', 'otter-blocks' ),
+				'description'     => __( 'Holds the data from the form submissions', 'otter-pro' ),
 				'public'          => false,
 				'show_ui'         => true,
 				'show_in_rest'    => false,
@@ -116,7 +116,7 @@ class Form_Emails_Storing {
 		register_post_status(
 			'read',
 			array(
-				'label'                     => _x( 'Read', 'otter-form-record', 'otter-blocks' ),
+				'label'                     => _x( 'Read', 'otter-form-record', 'otter-pro' ),
 				'public'                    => true,
 				'exclude_from_search'       => false,
 				'show_in_admin_all_list'    => true,
@@ -125,7 +125,7 @@ class Form_Emails_Storing {
 				'label_count'               => _n_noop(
 					'Read <span class="count">(%s)</span>',
 					'Read <span class="count">(%s)</span>',
-					'otter-blocks'
+					'otter-pro'
 				),
 			)
 		);
@@ -133,7 +133,7 @@ class Form_Emails_Storing {
 		register_post_status(
 			'unread',
 			array(
-				'label'                     => _x( 'Unread', 'otter-form-record', 'otter-blocks' ),
+				'label'                     => _x( 'Unread', 'otter-form-record', 'otter-pro' ),
 				'public'                    => true,
 				'exclude_from_search'       => false,
 				'show_in_admin_all_list'    => true,
@@ -142,7 +142,7 @@ class Form_Emails_Storing {
 				'label_count'               => _n_noop(
 					'Unread <span class="count">(%s)</span>',
 					'Unread <span class="count">(%s)</span>',
-					'otter-blocks'
+					'otter-pro'
 				),
 			)
 		);
@@ -213,7 +213,7 @@ class Form_Emails_Storing {
 			array(
 				'ID'         => $post_id,
 				/* translators: %s the ID of the submission */
-				'post_title' => sprintf( __( 'Submission #%s', 'otter-blocks' ), $post_id ),
+				'post_title' => sprintf( __( 'Submission #%s', 'otter-pro' ), $post_id ),
 			)
 		);
 
@@ -223,19 +223,19 @@ class Form_Emails_Storing {
 
 		$meta = array(
 			'form'     => array(
-				'label' => __( 'Form', 'otter-blocks' ),
+				'label' => __( 'Form', 'otter-pro' ),
 				'value' => $form_data->get_data_from_payload( 'formId' ),
 			),
 			'post_url' => array(
-				'label' => __( 'Post URL', 'otter-blocks' ),
+				'label' => __( 'Post URL', 'otter-pro' ),
 				'value' => $form_data->get_data_from_payload( 'postUrl' ),
 			),
 			'post_id'  => array(
-				'label' => __( 'Post ID', 'otter-blocks' ),
+				'label' => __( 'Post ID', 'otter-pro' ),
 				'value' => $form_data->get_data_from_payload( 'postId' ),
 			),
 			'dump'     => array(
-				'label' => __( 'Dumped data', 'otter-blocks' ),
+				'label' => __( 'Dumped data', 'otter-pro' ),
 				'value' => $form_data->is_temporary() ? $form_data->dump_data() : array(),
 			),
 		);
@@ -326,11 +326,11 @@ class Form_Emails_Storing {
 	public function form_record_columns() {
 		return array(
 			'cb'              => '<input type="checkbox" />',
-			'title'           => __( 'Title', 'otter-blocks' ),
-			'form'            => __( 'Form ID', 'otter-blocks' ),
-			'post_url'        => __( 'Post', 'otter-blocks' ),
-			'ID'              => __( 'ID', 'otter-blocks' ),
-			'submission_date' => __( 'Submission Date', 'otter-blocks' ),
+			'title'           => __( 'Title', 'otter-pro' ),
+			'form'            => __( 'Form ID', 'otter-pro' ),
+			'post_url'        => __( 'Post', 'otter-pro' ),
+			'ID'              => __( 'ID', 'otter-pro' ),
+			'submission_date' => __( 'Submission Date', 'otter-pro' ),
 		);
 	}
 
@@ -341,9 +341,9 @@ class Form_Emails_Storing {
 	 */
 	public function form_record_sortable_columns() {
 		return array(
-			'title'           => __( 'Title', 'otter-blocks' ),
-			'ID'              => __( 'ID', 'otter-blocks' ),
-			'submission_date' => __( 'Submission Date', 'otter-blocks' ),
+			'title'           => __( 'Title', 'otter-pro' ),
+			'ID'              => __( 'ID', 'otter-pro' ),
+			'submission_date' => __( 'Submission Date', 'otter-pro' ),
 		);
 	}
 
@@ -357,18 +357,18 @@ class Form_Emails_Storing {
 		$bulk_actions = array();
 
 		if ( 'trash' !== $status ) {
-			$bulk_actions['trash'] = __( 'Move to Trash', 'otter-blocks' );
+			$bulk_actions['trash'] = __( 'Move to Trash', 'otter-pro' );
 
 			if ( 'unread' !== $status ) {
-				$bulk_actions['unread'] = __( 'Mark as Unread', 'otter-blocks' );
+				$bulk_actions['unread'] = __( 'Mark as Unread', 'otter-pro' );
 			}
 
 			if ( 'read' !== $status ) {
-				$bulk_actions['read'] = __( 'Mark as Read', 'otter-blocks' );
+				$bulk_actions['read'] = __( 'Mark as Read', 'otter-pro' );
 			}
 		} else {
-			$bulk_actions['untrash'] = __( 'Restore', 'otter-blocks' );
-			$bulk_actions['delete']  = __( 'Delete Permanently', 'otter-blocks' );
+			$bulk_actions['untrash'] = __( 'Restore', 'otter-pro' );
+			$bulk_actions['delete']  = __( 'Delete Permanently', 'otter-pro' );
 		}
 
 		return $bulk_actions;
@@ -395,7 +395,7 @@ class Form_Emails_Storing {
 			$actions['view'] = sprintf(
 				'<a href="%s">%s</a>',
 				get_edit_post_link( $post->ID ),
-				__( 'View', 'otter-blocks' )
+				__( 'View', 'otter-pro' )
 			);
 		}
 
@@ -405,7 +405,7 @@ class Form_Emails_Storing {
 				'row-read',
 				$post->ID,
 				wp_create_nonce( 'read-' . self::FORM_RECORD_TYPE . '_' . $post->ID ),
-				__( 'Mark as Read', 'otter-blocks' )
+				__( 'Mark as Read', 'otter-pro' )
 			);
 		} elseif ( 'trash' !== $status ) {
 			$actions['unread'] = sprintf(
@@ -413,7 +413,7 @@ class Form_Emails_Storing {
 				'row-unread',
 				$post->ID,
 				wp_create_nonce( 'unread-' . self::FORM_RECORD_TYPE . '_' . $post->ID ),
-				__( 'Mark as Unread', 'otter-blocks' )
+				__( 'Mark as Unread', 'otter-pro' )
 			);
 		}
 
@@ -637,8 +637,8 @@ class Form_Emails_Storing {
 
 		add_submenu_page(
 			'otter',
-			__( 'Submissions', 'otter-blocks' ),
-			__( 'Submissions', 'otter-blocks' ),
+			__( 'Submissions', 'otter-pro' ),
+			__( 'Submissions', 'otter-pro' ),
 			'manage_options',
 			'edit.php?post_type=' . self::FORM_RECORD_TYPE
 		);
@@ -652,7 +652,7 @@ class Form_Emails_Storing {
 	public function add_form_record_meta_box() {
 		add_meta_box(
 			'field_values_meta_box',
-			esc_html__( 'Submission Data', 'otter-blocks' ),
+			esc_html__( 'Submission Data', 'otter-pro' ),
 			array( $this, 'fields_meta_box_markup' ),
 			self::FORM_RECORD_TYPE
 		);
@@ -660,7 +660,7 @@ class Form_Emails_Storing {
 		// this will replace the default publish box, that's why it's using its id.
 		add_meta_box(
 			'submitpost',
-			esc_html__( 'Update', 'otter-blocks' ),
+			esc_html__( 'Update', 'otter-pro' ),
 			array( $this, 'update_meta_box_markup' ),
 			self::FORM_RECORD_TYPE,
 			'side'
@@ -689,11 +689,11 @@ class Form_Emails_Storing {
 		}
 
 		if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['_wpnonce'] ) ), 'update-post_' . $post->ID ) ) {
-			wp_die( esc_html__( 'Nonce not verified.', 'otter-blocks' ) );
+			wp_die( esc_html__( 'Nonce not verified.', 'otter-pro' ) );
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			wp_die( esc_html__( 'User cannot edit this post.', 'otter-blocks' ) );
+			wp_die( esc_html__( 'User cannot edit this post.', 'otter-pro' ) );
 		}
 
 		$meta = get_post_meta( $post_id, self::FORM_RECORD_META_KEY, true );
@@ -868,12 +868,12 @@ class Form_Emails_Storing {
 				</div>
 				<div>
 					<span class="dashicons dashicons-admin-page"></span>
-					<?php echo esc_html__( 'Post', 'otter-blocks' ); ?>:
-					<a href="<?php echo esc_url( $meta['post_url']['value'] ); ?>"><?php echo esc_html__( 'View', 'otter-blocks' ); ?></a>
+					<?php echo esc_html__( 'Post', 'otter-pro' ); ?>:
+					<a href="<?php echo esc_url( $meta['post_url']['value'] ); ?>"><?php echo esc_html__( 'View', 'otter-pro' ); ?></a>
 				</div>
 				<div>
 					<span class="dashicons dashicons-calendar"></span>
-					<?php echo esc_html__( 'Submitted on', 'otter-blocks' ); ?>:
+					<?php echo esc_html__( 'Submitted on', 'otter-pro' ); ?>:
 					<span><strong><?php echo esc_html( get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post ) ); ?></strong></span>
 				</div>
 			</div>
@@ -885,7 +885,7 @@ class Form_Emails_Storing {
 						'trash',
 						intval( $post->ID ),
 						esc_attr( wp_create_nonce( 'trash-post_' . $post->ID ) ),
-						esc_html__( 'Move to Trash', 'otter-blocks' )
+						esc_html__( 'Move to Trash', 'otter-pro' )
 					);
 					?>
 				</div>
@@ -894,7 +894,7 @@ class Form_Emails_Storing {
 					<?php
 					echo sprintf(
 						'<input type="submit" class="button button-primary button-large" value="%s"/>',
-						esc_html__( 'Update', 'otter-blocks' )
+						esc_html__( 'Update', 'otter-pro' )
 					);
 					?>
 				</div>
@@ -956,19 +956,19 @@ class Form_Emails_Storing {
 		$post = get_post( $id );
 
 		if ( empty( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) ), $action . '-' . self::FORM_RECORD_TYPE . '_' . $id ) ) {
-			wp_die( esc_html__( 'Security check failed', 'otter-blocks' ) );
+			wp_die( esc_html__( 'Security check failed', 'otter-pro' ) );
 		}
 
 		if ( ! isset( $_REQUEST[ self::FORM_RECORD_TYPE ] ) ) {
-			wp_die( esc_html__( 'Post ID is required', 'otter-blocks' ) );
+			wp_die( esc_html__( 'Post ID is required', 'otter-pro' ) );
 		}
 
 		if ( ! $post ) {
-			wp_die( esc_html__( 'Invalid post ID', 'otter-blocks' ) );
+			wp_die( esc_html__( 'Invalid post ID', 'otter-pro' ) );
 		}
 
 		if ( self::FORM_RECORD_TYPE !== $post->post_type ) {
-			wp_die( esc_html__( 'Invalid post type', 'otter-blocks' ) );
+			wp_die( esc_html__( 'Invalid post type', 'otter-pro' ) );
 		}
 
 		return $id;
@@ -1079,7 +1079,7 @@ class Form_Emails_Storing {
 		?>
 		<label for="filter-by-form"></label>
 		<select name="form" id="filter-by-form">
-			<option value=""><?php esc_html_e( 'All Forms', 'otter-blocks' ); ?></option>
+			<option value=""><?php esc_html_e( 'All Forms', 'otter-pro' ); ?></option>
 			<?php foreach ( $forms as $form_id => $form_name ) : ?>
 				<option value="<?php echo esc_attr( $form_id ); ?>" <?php selected( $form, $form_id ); ?>><?php echo esc_html( $form_name ); ?></option>
 			<?php endforeach; ?>
@@ -1105,7 +1105,7 @@ class Form_Emails_Storing {
 		?>
 		<label for="filter-by-post"></label>
 		<select name="post" id="filter-by-post">
-			<option value=""><?php esc_html_e( 'All Posts', 'otter-blocks' ); ?></option>
+			<option value=""><?php esc_html_e( 'All Posts', 'otter-pro' ); ?></option>
 			<?php foreach ( $posts as $post_id => $post_title ) : ?>
 				<option value="<?php echo esc_attr( $post_id ); ?>" <?php selected( $post, $post_id ); ?>><?php echo esc_html( $post_title ); ?></option>
 			<?php endforeach; ?>
@@ -1333,7 +1333,7 @@ class Form_Emails_Storing {
 	public function export_submissions() {
 		$nonce = isset( $_POST['_nonce'] ) ? sanitize_text_field( $_POST['_nonce'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		if ( ! wp_verify_nonce( $nonce, 'otter_form_export_submissions' ) ) {
-			wp_die( esc_html( __( 'Invalid nonce.', 'otter-blocks' ) ) );
+			wp_die( esc_html( __( 'Invalid nonce.', 'otter-pro' ) ) );
 		}
 
 		// Export submissions.
@@ -1374,7 +1374,7 @@ class Form_Emails_Storing {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -1385,6 +1385,6 @@ class Form_Emails_Storing {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -417,7 +417,7 @@ class Form_Pro_Features {
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						// TODO: use logger.
 						// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-						error_log( __( '[Otter Webhook]', 'otter-blocks' ) . $response->get_error_message() );
+						error_log( __( '[Otter Webhook]', 'otter-pro' ) . $response->get_error_message() );
 					}
 				}
 			}
@@ -707,7 +707,7 @@ class Form_Pro_Features {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -719,6 +719,6 @@ class Form_Pro_Features {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-license.php
+++ b/plugins/otter-pro/inc/plugins/class-license.php
@@ -194,7 +194,7 @@ class License {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -206,6 +206,6 @@ class License {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-live-search.php
+++ b/plugins/otter-pro/inc/plugins/class-live-search.php
@@ -90,6 +90,7 @@ class Live_Search {
 			$asset_file['version'],
 			true
 		);
+		
 		wp_localize_script(
 			'otter-live-search',
 			'liveSearchData',
@@ -104,6 +105,8 @@ class Live_Search {
 				),
 			)
 		);
+
+		wp_set_script_translations( 'otter-live-search', 'otter-pro' );
 
 		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/live-search-style.asset.php';
 		wp_enqueue_style( 'otter-live-search-style', OTTER_BLOCKS_URL . 'build/blocks/live-search-style.css', $asset_file['dependencies'], $asset_file['version'] );

--- a/plugins/otter-pro/inc/plugins/class-live-search.php
+++ b/plugins/otter-pro/inc/plugins/class-live-search.php
@@ -99,8 +99,8 @@ class Live_Search {
 				'permalinkStructure' => get_option( 'permalink_structure' ),
 				'strings'            => array(
 					/* translators: This is followed by the search string */
-					'noResults' => __( 'No results for', 'otter-blocks' ),
-					'noTitle'   => sprintf( '(%s)', __( 'no title', 'otter-blocks' ) ),
+					'noResults' => __( 'No results for', 'otter-pro' ),
+					'noTitle'   => sprintf( '(%s)', __( 'no title', 'otter-pro' ) ),
 				),
 			)
 		);
@@ -139,7 +139,7 @@ class Live_Search {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -151,6 +151,6 @@ class Live_Search {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-options-settings.php
+++ b/plugins/otter-pro/inc/plugins/class-options-settings.php
@@ -38,7 +38,7 @@ class Options_Settings {
 			'otter_inherited_autoactivate',
 			array(
 				'type'         => 'boolean',
-				'description'  => __( 'Inherit license from Neve Pro.', 'otter-blocks' ),
+				'description'  => __( 'Inherit license from Neve Pro.', 'otter-pro' ),
 				'show_in_rest' => true,
 				'default'      => false,
 			)
@@ -49,7 +49,7 @@ class Options_Settings {
 			'otter_offload_fonts',
 			array(
 				'type'         => 'boolean',
-				'description'  => __( 'Store Google Fonts Offline.', 'otter-blocks' ),
+				'description'  => __( 'Store Google Fonts Offline.', 'otter-pro' ),
 				'show_in_rest' => true,
 				'default'      => true === boolval( get_option( 'nv_pro_enable_local_fonts', false ) ) ? true : false,
 			)
@@ -60,7 +60,7 @@ class Options_Settings {
 			'otter_iphub_api_key',
 			array(
 				'type'              => 'string',
-				'description'       => __( 'IPHub API Key.', 'otter-blocks' ),
+				'description'       => __( 'IPHub API Key.', 'otter-pro' ),
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 				'default'           => '',
@@ -98,7 +98,7 @@ class Options_Settings {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -110,6 +110,6 @@ class Options_Settings {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-posts-acf-integration.php
+++ b/plugins/otter-pro/inc/plugins/class-posts-acf-integration.php
@@ -109,7 +109,7 @@ class Posts_ACF_Integration {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -121,6 +121,6 @@ class Posts_ACF_Integration {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-review-woo-integration.php
+++ b/plugins/otter-pro/inc/plugins/class-review-woo-integration.php
@@ -62,7 +62,7 @@ class Review_Woo_Integration {
 
 		$attributes['links'] = array(
 			array(
-				'label'       => __( 'Buy Now', 'otter-blocks' ),
+				'label'       => __( 'Buy Now', 'otter-pro' ),
 				'href'        => method_exists( $product, 'get_product_url' ) ? $product->get_product_url() : $product->get_permalink(),
 				'isSponsored' => method_exists( $product, 'get_product_url' ),
 			),
@@ -101,7 +101,7 @@ class Review_Woo_Integration {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -113,6 +113,6 @@ class Review_Woo_Integration {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-stripe-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-stripe-pro-features.php
@@ -100,7 +100,7 @@ class Stripe_Pro_Features {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -112,6 +112,6 @@ class Stripe_Pro_Features {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-woocommerce-builder.php
+++ b/plugins/otter-pro/inc/plugins/class-woocommerce-builder.php
@@ -50,7 +50,7 @@ class WooCommerce_Builder {
 
 		add_meta_box(
 			'otter_woo_builder',
-			__( 'WooCommerce Builder by Otter', 'otter-blocks' ),
+			__( 'WooCommerce Builder by Otter', 'otter-pro' ),
 			array( $this, 'render_metabox' ),
 			'product',
 			'side',
@@ -72,20 +72,20 @@ class WooCommerce_Builder {
 		if ( boolval( $woo_builder_enabled ) ) {
 			?>
 			<div class="clear">
-				<p><?php _e( 'You can go back to the regular editor from this option.', 'otter-blocks' ); ?></p>
+				<p><?php _e( 'You can go back to the regular editor from this option.', 'otter-pro' ); ?></p>
 
 				<a href="<?php echo esc_url( add_query_arg( 'otter-woo-builder', 0 ) ); ?>" class="button button-primary" id="otter-woo-builder">
-					<?php _e( 'Disable WooCommerce Builder', 'otter-blocks' ); ?>
+					<?php _e( 'Disable WooCommerce Builder', 'otter-pro' ); ?>
 				</a>
 			</div>
 			<?php
 		} else {
 			?>
 			<div class="clear">
-				<p><?php _e( 'Use WooCommerce Builder by Otter to build a custom page for your WooCommerce products.', 'otter-blocks' ); ?></p>
+				<p><?php _e( 'Use WooCommerce Builder by Otter to build a custom page for your WooCommerce products.', 'otter-pro' ); ?></p>
 
 				<a href="<?php echo esc_url( add_query_arg( 'otter-woo-builder', 1 ) ); ?>" class="button button-primary" id="otter-woo-builder">
-					<?php _e( 'Enable WooCommerce Builder', 'otter-blocks' ); ?>
+					<?php _e( 'Enable WooCommerce Builder', 'otter-pro' ); ?>
 				</a>
 			</div>
 			<?php
@@ -221,7 +221,7 @@ class WooCommerce_Builder {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -233,6 +233,6 @@ class WooCommerce_Builder {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/plugins/class-woocommerce-builder.php
+++ b/plugins/otter-pro/inc/plugins/class-woocommerce-builder.php
@@ -150,6 +150,8 @@ class WooCommerce_Builder {
 
 			if ( has_block( 'themeisle-blocks/product-image', get_the_ID() ) ) {
 				wp_enqueue_script( 'wc-single-product' );
+
+				wp_set_script_translations( 'wc-single-product', 'otter-pro' );
 			}
 
 			if ( class_exists( '\Neve\Views\Product_Layout' ) && class_exists( '\Neve_Pro\Modules\Woocommerce_Booster\Views\Single_Product' ) ) {

--- a/plugins/otter-pro/inc/render/class-form-file-block.php
+++ b/plugins/otter-pro/inc/render/class-form-file-block.php
@@ -30,7 +30,7 @@ class Form_File_Block {
 		}
 
 		$id                 = isset( $attributes['id'] ) ? esc_attr( $attributes['id'] ) : '';
-		$label              = isset( $attributes['label'] ) ? esc_html( $attributes['label'] ) : __( 'Select option', 'otter-blocks' );
+		$label              = isset( $attributes['label'] ) ? esc_html( $attributes['label'] ) : __( 'Select option', 'otter-pro' );
 		$help_text          = isset( $attributes['helpText'] ) ? esc_html( $attributes['helpText'] ) : '';
 		$is_required        = isset( $attributes['isRequired'] ) && boolval( $attributes['isRequired'] );
 		$has_multiple_files = isset( $attributes['multipleFiles'] ) && boolval( $attributes['multipleFiles'] ) && ( ! isset( $attributes['maxFilesNumber'] ) || intval( $attributes['maxFilesNumber'] ) > 1 );

--- a/plugins/otter-pro/inc/render/class-form-hidden-block.php
+++ b/plugins/otter-pro/inc/render/class-form-hidden-block.php
@@ -30,7 +30,7 @@ class Form_Hidden_Block {
 		}
 
 		$id            = isset( $attributes['id'] ) ? esc_attr( $attributes['id'] ) : '';
-		$label         = isset( $attributes['label'] ) ? esc_html( $attributes['label'] ) : __( 'Hidden Field', 'otter-blocks' );
+		$label         = isset( $attributes['label'] ) ? esc_html( $attributes['label'] ) : __( 'Hidden Field', 'otter-pro' );
 		$param_name    = isset( $attributes['paramName'] ) ? esc_attr( $attributes['paramName'] ) : '';
 		$mapped_name   = isset( $attributes['mappedName'] ) ? esc_attr( $attributes['mappedName'] ) : 'field-' . $id;
 		$default_value = isset( $attributes['defaultValue'] ) ? esc_attr( $attributes['defaultValue'] ) : '';

--- a/plugins/otter-pro/inc/render/class-form-stripe-block.php
+++ b/plugins/otter-pro/inc/render/class-form-stripe-block.php
@@ -43,7 +43,7 @@ class Form_Stripe_Block {
 			return sprintf(
 				'<div %1$s><div class="o-stripe-checkout">%2$s</div></div>',
 				get_block_wrapper_attributes(),
-				__( 'An error occurred! Could not retrieve product information!', 'otter-blocks' ) . $this->format_error( $product )
+				__( 'An error occurred! Could not retrieve product information!', 'otter-pro' ) . $this->format_error( $product )
 			);
 		}
 
@@ -59,7 +59,7 @@ class Form_Stripe_Block {
 			return sprintf(
 				'<div %1$s><div class="o-stripe-checkout">%2$s</div></div>',
 				get_block_wrapper_attributes(),
-				__( 'An error occurred! Could not retrieve the price of the product!', 'otter-blocks' ) . $this->format_error( $price )
+				__( 'An error occurred! Could not retrieve the price of the product!', 'otter-pro' ) . $this->format_error( $price )
 			);
 		}
 
@@ -90,7 +90,7 @@ class Form_Stripe_Block {
 	 */
 	private function format_error( $error ) {
 		return defined( 'WP_DEBUG' ) && WP_DEBUG ? (
-			'<span><strong>' . __( 'Error message: ', 'otter-blocks' ) . '</strong> ' . $error->get_error_message() . '</span>'
+			'<span><strong>' . __( 'Error message: ', 'otter-pro' ) . '</strong> ' . $error->get_error_message() . '</span>'
 		) : '';
 	}
 }

--- a/plugins/otter-pro/inc/render/class-review-comparison-block.php
+++ b/plugins/otter-pro/inc/render/class-review-comparison-block.php
@@ -73,7 +73,7 @@ class Review_Comparison_Block {
 
 				$block['attrs']['links'] = array(
 					array(
-						'label'       => __( 'Buy Now', 'otter-blocks' ),
+						'label'       => __( 'Buy Now', 'otter-pro' ),
 						'href'        => method_exists( $product, 'get_product_url' ) ? $product->get_product_url() : $product->get_permalink(),
 						'isSponsored' => method_exists( $product, 'get_product_url' ),
 					),
@@ -82,19 +82,19 @@ class Review_Comparison_Block {
 
 			$features = array(
 				array(
-					'title'  => __( 'Stability', 'otter-blocks' ),
+					'title'  => __( 'Stability', 'otter-pro' ),
 					'rating' => 9,
 				),
 				array(
-					'title'  => __( 'Ease of Use', 'otter-blocks' ),
+					'title'  => __( 'Ease of Use', 'otter-pro' ),
 					'rating' => 4,
 				),
 				array(
-					'title'  => __( 'Look & Feel', 'otter-blocks' ),
+					'title'  => __( 'Look & Feel', 'otter-pro' ),
 					'rating' => 9,
 				),
 				array(
-					'title'  => __( 'Price', 'otter-blocks' ),
+					'title'  => __( 'Price', 'otter-pro' ),
 					'rating' => 7,
 				),
 			);
@@ -112,7 +112,7 @@ class Review_Comparison_Block {
 			$table_title .= '<td>';
 			if ( isset( $block['attrs']['title'] ) ) {
 				$table_title .= '<a href="' . get_the_permalink( intval( $id[0] ) ) . '" target="_blank">';
-				$table_title .= $block['attrs']['title'] ? $block['attrs']['title'] : __( 'Untitled review', 'otter-blocks' );
+				$table_title .= $block['attrs']['title'] ? $block['attrs']['title'] : __( 'Untitled review', 'otter-pro' );
 				$table_title .= '</a>';
 			}
 			$table_title .= '</td>';
@@ -150,12 +150,12 @@ class Review_Comparison_Block {
 
 			$links = array(
 				array(
-					'label'       => __( 'Buy on Amazon', 'otter-blocks' ),
+					'label'       => __( 'Buy on Amazon', 'otter-pro' ),
 					'href'        => '',
 					'isSponsored' => false,
 				),
 				array(
-					'label'       => __( 'Buy on eBay', 'otter-blocks' ),
+					'label'       => __( 'Buy on eBay', 'otter-pro' ),
 					'href'        => '',
 					'isSponsored' => false,
 				),
@@ -195,32 +195,32 @@ class Review_Comparison_Block {
 
 		$html .= '	<tbody>';
 		$html .= '		<tr>';
-		$html .= '			<th>' . __( 'Name', 'otter-blocks' ) . '</th>';
+		$html .= '			<th>' . __( 'Name', 'otter-pro' ) . '</th>';
 		$html .= $table_title;
 		$html .= '		</tr>';
 
 		$html .= '		<tr>';
-		$html .= '			<th>' . __( 'Price', 'otter-blocks' ) . '</th>';
+		$html .= '			<th>' . __( 'Price', 'otter-pro' ) . '</th>';
 		$html .= $table_price;
 		$html .= '		</tr>';
 
 		$html .= '		<tr>';
-		$html .= '			<th>' . __( 'Rating', 'otter-blocks' ) . '</th>';
+		$html .= '			<th>' . __( 'Rating', 'otter-pro' ) . '</th>';
 		$html .= $table_ratings;
 		$html .= '		</tr>';
 
 		$html .= '		<tr>';
-		$html .= '			<th>' . __( 'Description', 'otter-blocks' ) . '</th>';
+		$html .= '			<th>' . __( 'Description', 'otter-pro' ) . '</th>';
 		$html .= $table_description;
 		$html .= '		</tr>';
 
 		$html .= '		<tr>';
-		$html .= '			<th>' . __( 'Statistics', 'otter-blocks' ) . '</th>';
+		$html .= '			<th>' . __( 'Statistics', 'otter-pro' ) . '</th>';
 		$html .= $table_features;
 		$html .= '		</tr>';
 
 		$html .= '		<tr>';
-		$html .= '			<th>' . __( 'Buy this product', 'otter-blocks' ) . '</th>';
+		$html .= '			<th>' . __( 'Buy this product', 'otter-pro' ) . '</th>';
 		$html .= $table_links;
 		$html .= '		</tr>';
 		$html .= '	</tbody>';

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-rating-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-rating-block.php
@@ -37,7 +37,7 @@ class Product_Rating_Block {
 		$output = ob_get_clean();
 
 		if ( empty( $output ) ) {
-			$output = __( 'Your product ratings will display here.', 'otter-blocks' );
+			$output = __( 'Your product ratings will display here.', 'otter-pro' );
 		}
 		return $output;
 	}

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-stock-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-stock-block.php
@@ -34,7 +34,7 @@ class Product_Stock_Block {
 		$output = wc_get_stock_html( $product );
 
 		if ( empty( $output ) ) {
-			$output = __( 'Your product stock will display here.', 'otter-blocks' );
+			$output = __( 'Your product stock will display here.', 'otter-pro' );
 		}
 		return $output;
 	}

--- a/plugins/otter-pro/inc/server/class-dashboard-server.php
+++ b/plugins/otter-pro/inc/server/class-dashboard-server.php
@@ -125,7 +125,7 @@ class Dashboard_Server {
 		if ( ! isset( $fields['key'] ) || ! isset( $fields['action'] ) ) {
 			return new \WP_REST_Response(
 				array(
-					'message' => __( 'Invalid Action. Please refresh the page and try again.', 'otter-blocks' ),
+					'message' => __( 'Invalid Action. Please refresh the page and try again.', 'otter-pro' ),
 					'success' => false,
 				)
 			);
@@ -145,7 +145,7 @@ class Dashboard_Server {
 		return new \WP_REST_Response(
 			array(
 				'success' => true,
-				'message' => 'activate' === $fields['action'] ? __( 'Activated.', 'otter-blocks' ) : __( 'Deactivated', 'otter-blocks' ),
+				'message' => 'activate' === $fields['action'] ? __( 'Activated.', 'otter-pro' ) : __( 'Deactivated', 'otter-pro' ),
 				'license' => array(
 					'key'        => apply_filters( 'product_otter_license_key', 'free' ),
 					'valid'      => apply_filters( 'product_otter_license_status', false ),
@@ -185,7 +185,7 @@ class Dashboard_Server {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -197,6 +197,6 @@ class Dashboard_Server {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/server/class-filter-blocks-server.php
+++ b/plugins/otter-pro/inc/server/class-filter-blocks-server.php
@@ -57,7 +57,7 @@ class Filter_Blocks_Server {
 						'block' => array(
 							'type'        => 'string',
 							'required'    => true,
-							'description' => __( 'Block namespace.', 'otter-blocks' ),
+							'description' => __( 'Block namespace.', 'otter-pro' ),
 						),
 					),
 					'permission_callback' => function () {
@@ -161,7 +161,7 @@ class Filter_Blocks_Server {
 
 						$post_block['attrs']['links'] = array(
 							array(
-								'label'       => __( 'Buy Now', 'otter-blocks' ),
+								'label'       => __( 'Buy Now', 'otter-pro' ),
 								'href'        => method_exists( $product, 'get_product_url' ) ? $product->get_product_url() : $product->get_permalink(),
 								'isSponsored' => method_exists( $product, 'get_product_url' ),
 							),
@@ -216,7 +216,7 @@ class Filter_Blocks_Server {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -228,6 +228,6 @@ class Filter_Blocks_Server {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/server/class-live-search-server.php
+++ b/plugins/otter-pro/inc/server/class-live-search-server.php
@@ -234,7 +234,7 @@ class Live_Search_Server {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -246,6 +246,6 @@ class Live_Search_Server {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/inc/server/class-posts-acf-server.php
+++ b/plugins/otter-pro/inc/server/class-posts-acf-server.php
@@ -76,7 +76,7 @@ class Posts_ACF_Server {
 		);
 
 		if ( ! ( function_exists( 'acf_get_field_groups' ) && function_exists( 'acf_get_fields' ) ) ) {
-			$return['error']     = esc_html__( 'ACF is not installed!', 'otter-blocks' );
+			$return['error']     = esc_html__( 'ACF is not installed!', 'otter-pro' );
 			$return['eror_code'] = 1;
 			return rest_ensure_response( $return );
 		}
@@ -132,7 +132,7 @@ class Posts_ACF_Server {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 
 	/**
@@ -144,6 +144,6 @@ class Posts_ACF_Server {
 	 */
 	public function __wakeup() {
 		// Unserializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-blocks' ), '1.0.0' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'otter-pro' ), '1.0.0' );
 	}
 }

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -65,7 +65,7 @@ if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
 	add_action(
 		'admin_notices',
 		function() {
-			$message = __( 'You need to install Otter – Page Builder Blocks & Extensions for Gutenberg plugin to use Otter Pro.', 'otter-blocks' );
+			$message = __( 'You need to install Otter – Page Builder Blocks & Extensions for Gutenberg plugin to use Otter Pro.', 'otter-pro' );
 			$link    = wp_nonce_url(
 				add_query_arg(
 					array(
@@ -81,7 +81,7 @@ if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
 				'<div class="error"><p>%1$s <a href="%2$s">%3$s</a></p></div>',
 				esc_html( $message ),
 				esc_url( $link ),
-				esc_html__( 'Install', 'otter-blocks' )
+				esc_html__( 'Install', 'otter-pro' )
 			);
 		}
 	);
@@ -91,7 +91,7 @@ if ( defined( 'OTTER_BLOCKS_VERSION' ) && ! defined( 'OTTER_BLOCKS_PRO_SUPPORT' 
 	add_action(
 		'admin_notices',
 		function() {
-			$message = __( 'You need to update Otter – Page Builder Blocks & Extensions for Gutenberg to the latest version to use Otter Pro.', 'otter-blocks' );
+			$message = __( 'You need to update Otter – Page Builder Blocks & Extensions for Gutenberg to the latest version to use Otter Pro.', 'otter-pro' );
 
 			printf(
 				'<div class="error"><p>%1$s</p></div>',

--- a/src/animation/components/animation-popover.js
+++ b/src/animation/components/animation-popover.js
@@ -71,7 +71,7 @@ function AnimationPopover({
 	const id = `inspector-o-animations-control-${ instanceId }`;
 
 	return (
-		<BaseControl label={ __( 'Animation', 'otter-blocks' ) } id={ id }>
+		<BaseControl label={ __( 'Animation', 'blocks-animation' ) } id={ id }>
 			<Dropdown
 				contentClassName="o-animations-control__popover"
 				position="bottom center"
@@ -86,9 +86,9 @@ function AnimationPopover({
 					</Button>
 				) }
 				renderContent={ ({ onToggle }) => (
-					<MenuGroup label={ __( 'Animations', 'otter-blocks' ) }>
+					<MenuGroup label={ __( 'Animations', 'blocks-animation' ) }>
 						<TextControl
-							placeholder={ __( 'Search', 'otter-blocks' ) }
+							placeholder={ __( 'Search', 'blocks-animation' ) }
 							value={ currentInput }
 							onChange={ ( e ) => {
 								setCurrentInput( e );
@@ -121,7 +121,7 @@ function AnimationPopover({
 								<div>
 									{ __(
 										'Nothing found. Try searching for something else!',
-										'otter-blocks'
+										'blocks-animation'
 									) }
 								</div>
 							) }

--- a/src/animation/count/index.js
+++ b/src/animation/count/index.js
@@ -26,7 +26,7 @@ const name = 'themeisle-blocks/count-animation';
 
 export const format = {
 	name,
-	title: __( 'Count Animation', 'otter-blocks' ),
+	title: __( 'Count Animation', 'blocks-animation' ),
 	tagName: 'o-anim-count',
 	className: null,
 
@@ -48,7 +48,7 @@ export const format = {
 			<Fragment>
 				<RichTextToolbarButton
 					icon={ brush }
-					title={ __( 'Count Animation', 'otter-blocks' ) }
+					title={ __( 'Count Animation', 'blocks-animation' ) }
 					isDisabled={ ! isActive && null === regex.exec( value.text.substring( value.start, value.end ) ) }
 					onClick={ onToggle }
 					isActive={ isActive }

--- a/src/animation/count/inline-controls.js
+++ b/src/animation/count/inline-controls.js
@@ -96,17 +96,17 @@ const InlineControls = ({
 			focusOnMount={ false }
 			className="o-animation-popover"
 		>
-			<Heading level={ 4 }>{ __( 'Count Animation', 'otter-blocks' ) }</Heading>
+			<Heading level={ 4 }>{ __( 'Count Animation', 'blocks-animation' ) }</Heading>
 
 			<SelectControl
-				label={ __( 'Delay', 'otter-blocks' ) }
+				label={ __( 'Delay', 'blocks-animation' ) }
 				value={ countDelay || 'none' }
 				options={ delayListInline }
 				onChange={ value => updateAnimConfig( 'count', countDelay, value, () => setCountDelay( value ), attributes, setAttributes ) }
 			/>
 
 			<SelectControl
-				label={ __( 'Speed', 'otter-blocks' ) }
+				label={ __( 'Speed', 'blocks-animation' ) }
 				value={ countSpeed || 'none' }
 				options={ speedListInline }
 				onChange={ value => updateAnimConfig( 'count', countSpeed, value, () => setCountSpeed( value ), attributes, setAttributes ) }

--- a/src/animation/data.js
+++ b/src/animation/data.js
@@ -5,270 +5,270 @@ import { __ } from '@wordpress/i18n';
 
 export const animationsList = [
 	{
-		label: __( 'None', 'otter-blocks' ),
+		label: __( 'None', 'blocks-animation' ),
 		value: 'none'
 	},
 	{
-		label: __( 'Back In Down', 'otter-blocks' ),
+		label: __( 'Back In Down', 'blocks-animation' ),
 		value: 'backInDown'
 	},
 	{
-		label: __( 'Back In Left', 'otter-blocks' ),
+		label: __( 'Back In Left', 'blocks-animation' ),
 		value: 'backInLeft'
 	},
 	{
-		label: __( 'Back In Right', 'otter-blocks' ),
+		label: __( 'Back In Right', 'blocks-animation' ),
 		value: 'backInRight'
 	},
 	{
-		label: __( 'Back In Up', 'otter-blocks' ),
+		label: __( 'Back In Up', 'blocks-animation' ),
 		value: 'backInUp'
 	},
 	{
-		label: __( 'Bounce', 'otter-blocks' ),
+		label: __( 'Bounce', 'blocks-animation' ),
 		value: 'bounce'
 	},
 	{
-		label: __( 'Bounce In', 'otter-blocks' ),
+		label: __( 'Bounce In', 'blocks-animation' ),
 		value: 'bounceIn'
 	},
 	{
-		label: __( 'Bounce In Down', 'otter-blocks' ),
+		label: __( 'Bounce In Down', 'blocks-animation' ),
 		value: 'bounceInDown'
 	},
 	{
-		label: __( 'Bounce In Left', 'otter-blocks' ),
+		label: __( 'Bounce In Left', 'blocks-animation' ),
 		value: 'bounceInLeft'
 	},
 	{
-		label: __( 'Bounce In Right', 'otter-blocks' ),
+		label: __( 'Bounce In Right', 'blocks-animation' ),
 		value: 'bounceInRight'
 	},
 	{
-		label: __( 'Bounce In Up', 'otter-blocks' ),
+		label: __( 'Bounce In Up', 'blocks-animation' ),
 		value: 'bounceInUp'
 	},
 	{
-		label: __( 'Fade In', 'otter-blocks' ),
+		label: __( 'Fade In', 'blocks-animation' ),
 		value: 'fadeIn'
 	},
 	{
-		label: __( 'Fade In Down', 'otter-blocks' ),
+		label: __( 'Fade In Down', 'blocks-animation' ),
 		value: 'fadeInDown'
 	},
 	{
-		label: __( 'Fade In Down Big', 'otter-blocks' ),
+		label: __( 'Fade In Down Big', 'blocks-animation' ),
 		value: 'fadeInDownBig'
 	},
 	{
-		label: __( 'Fade In Left', 'otter-blocks' ),
+		label: __( 'Fade In Left', 'blocks-animation' ),
 		value: 'fadeInLeft'
 	},
 	{
-		label: __( 'Fade In Left Big', 'otter-blocks' ),
+		label: __( 'Fade In Left Big', 'blocks-animation' ),
 		value: 'fadeInLeftBig'
 	},
 	{
-		label: __( 'Fade In Right', 'otter-blocks' ),
+		label: __( 'Fade In Right', 'blocks-animation' ),
 		value: 'fadeInRight'
 	},
 	{
-		label: __( 'Fade In Right Big', 'otter-blocks' ),
+		label: __( 'Fade In Right Big', 'blocks-animation' ),
 		value: 'fadeInRightBig'
 	},
 	{
-		label: __( 'Fade In Up', 'otter-blocks' ),
+		label: __( 'Fade In Up', 'blocks-animation' ),
 		value: 'fadeInUp'
 	},
 	{
-		label: __( 'Fade In Top Left', 'otter-blocks' ),
+		label: __( 'Fade In Top Left', 'blocks-animation' ),
 		value: 'fadeInTopLeft'
 	},
 	{
-		label: __( 'Fade In Top Right', 'otter-blocks' ),
+		label: __( 'Fade In Top Right', 'blocks-animation' ),
 		value: 'fadeInTopRight'
 	},
 	{
-		label: __( 'Fade In Bottom Left', 'otter-blocks' ),
+		label: __( 'Fade In Bottom Left', 'blocks-animation' ),
 		value: 'fadeInBottomLeft'
 	},
 	{
-		label: __( 'Fade In Bottom Right', 'otter-blocks' ),
+		label: __( 'Fade In Bottom Right', 'blocks-animation' ),
 		value: 'fadeInBottomRight'
 	},
 	{
-		label: __( 'Flip', 'otter-blocks' ),
+		label: __( 'Flip', 'blocks-animation' ),
 		value: 'flip'
 	},
 	{
-		label: __( 'Flip In X', 'otter-blocks' ),
+		label: __( 'Flip In X', 'blocks-animation' ),
 		value: 'flipInX'
 	},
 	{
-		label: __( 'Flip In Y', 'otter-blocks' ),
+		label: __( 'Flip In Y', 'blocks-animation' ),
 		value: 'flipInY'
 	},
 	{
-		label: __( 'Rotate In', 'otter-blocks' ),
+		label: __( 'Rotate In', 'blocks-animation' ),
 		value: 'rotateIn'
 	},
 	{
-		label: __( 'Rotate In Down Left', 'otter-blocks' ),
+		label: __( 'Rotate In Down Left', 'blocks-animation' ),
 		value: 'rotateInDownLeft'
 	},
 	{
-		label: __( 'Rotate In Down Right', 'otter-blocks' ),
+		label: __( 'Rotate In Down Right', 'blocks-animation' ),
 		value: 'rotateInDownRight'
 	},
 	{
-		label: __( 'Rotate In Up Left', 'otter-blocks' ),
+		label: __( 'Rotate In Up Left', 'blocks-animation' ),
 		value: 'rotateInUpLeft'
 	},
 	{
-		label: __( 'Rotate In Up Right', 'otter-blocks' ),
+		label: __( 'Rotate In Up Right', 'blocks-animation' ),
 		value: 'rotateInUpRight'
 	},
 	{
-		label: __( 'Slide In Down', 'otter-blocks' ),
+		label: __( 'Slide In Down', 'blocks-animation' ),
 		value: 'slideInDown'
 	},
 	{
-		label: __( 'Slide In Left', 'otter-blocks' ),
+		label: __( 'Slide In Left', 'blocks-animation' ),
 		value: 'slideInLeft'
 	},
 	{
-		label: __( 'Slide In Right', 'otter-blocks' ),
+		label: __( 'Slide In Right', 'blocks-animation' ),
 		value: 'slideInRight'
 	},
 	{
-		label: __( 'Slide In Up', 'otter-blocks' ),
+		label: __( 'Slide In Up', 'blocks-animation' ),
 		value: 'slideInUp'
 	},
 	{
-		label: __( 'Zoom In', 'otter-blocks' ),
+		label: __( 'Zoom In', 'blocks-animation' ),
 		value: 'zoomIn'
 	},
 	{
-		label: __( 'Zoom In Down', 'otter-blocks' ),
+		label: __( 'Zoom In Down', 'blocks-animation' ),
 		value: 'zoomInDown'
 	},
 	{
-		label: __( 'Zoom In Left', 'otter-blocks' ),
+		label: __( 'Zoom In Left', 'blocks-animation' ),
 		value: 'zoomInLeft'
 	},
 	{
-		label: __( 'Zoom In Right', 'otter-blocks' ),
+		label: __( 'Zoom In Right', 'blocks-animation' ),
 		value: 'zoomInRight'
 	},
 	{
-		label: __( 'Zoom In Up', 'otter-blocks' ),
+		label: __( 'Zoom In Up', 'blocks-animation' ),
 		value: 'zoomInUp'
 	},
 	{
-		label: __( 'Roll In', 'otter-blocks' ),
+		label: __( 'Roll In', 'blocks-animation' ),
 		value: 'rollIn'
 	},
 	{
-		label: __( 'Light Speed In Right', 'otter-blocks' ),
+		label: __( 'Light Speed In Right', 'blocks-animation' ),
 		value: 'lightSpeedInRight'
 	},
 	{
-		label: __( 'Light Speed In Left', 'otter-blocks' ),
+		label: __( 'Light Speed In Left', 'blocks-animation' ),
 		value: 'lightSpeedInLeft'
 	},
 	{
-		label: __( 'Flash', 'otter-blocks' ),
+		label: __( 'Flash', 'blocks-animation' ),
 		value: 'flash'
 	},
 	{
-		label: __( 'Pulse', 'otter-blocks' ),
+		label: __( 'Pulse', 'blocks-animation' ),
 		value: 'pulse'
 	},
 	{
-		label: __( 'Rubber Band', 'otter-blocks' ),
+		label: __( 'Rubber Band', 'blocks-animation' ),
 		value: 'rubberBand'
 	},
 	{
-		label: __( 'Shake X', 'otter-blocks' ),
+		label: __( 'Shake X', 'blocks-animation' ),
 		value: 'shakeX'
 	},
 	{
-		label: __( 'Shake Y', 'otter-blocks' ),
+		label: __( 'Shake Y', 'blocks-animation' ),
 		value: 'shakeY'
 	},
 	{
-		label: __( 'Head Shake', 'otter-blocks' ),
+		label: __( 'Head Shake', 'blocks-animation' ),
 		value: 'headShake'
 	},
 	{
-		label: __( 'Swing', 'otter-blocks' ),
+		label: __( 'Swing', 'blocks-animation' ),
 		value: 'swing'
 	},
 	{
-		label: __( 'TaDa', 'otter-blocks' ),
+		label: __( 'TaDa', 'blocks-animation' ),
 		value: 'tada'
 	},
 	{
-		label: __( 'Wobble', 'otter-blocks' ),
+		label: __( 'Wobble', 'blocks-animation' ),
 		value: 'wobble'
 	},
 	{
-		label: __( 'Jello', 'otter-blocks' ),
+		label: __( 'Jello', 'blocks-animation' ),
 		value: 'jello'
 	},
 	{
-		label: __( 'Heart Beat', 'otter-blocks' ),
+		label: __( 'Heart Beat', 'blocks-animation' ),
 		value: 'heartBeat'
 	},
 	{
-		label: __( 'Hinge', 'otter-blocks' ),
+		label: __( 'Hinge', 'blocks-animation' ),
 		value: 'hinge'
 	},
 	{
-		label: __( 'Jack In The Box', 'otter-blocks' ),
+		label: __( 'Jack In The Box', 'blocks-animation' ),
 		value: 'jackInTheBox'
 	}
 ];
 
 export const categories = [
 	{
-		label: __( 'Backing', 'otter-blocks' ),
+		label: __( 'Backing', 'blocks-animation' ),
 		value: 'backInDown'
 	},
 	{
-		label: __( 'Bouncing', 'otter-blocks' ),
+		label: __( 'Bouncing', 'blocks-animation' ),
 		value: 'bounce'
 	},
 	{
-		label: __( 'Fading', 'otter-blocks' ),
+		label: __( 'Fading', 'blocks-animation' ),
 		value: 'fadeIn'
 	},
 	{
-		label: __( 'Flipping', 'otter-blocks' ),
+		label: __( 'Flipping', 'blocks-animation' ),
 		value: 'flip'
 	},
 	{
-		label: __( 'Rotating', 'otter-blocks' ),
+		label: __( 'Rotating', 'blocks-animation' ),
 		value: 'rotateIn'
 	},
 	{
-		label: __( 'Sliding', 'otter-blocks' ),
+		label: __( 'Sliding', 'blocks-animation' ),
 		value: 'slideInDown'
 	},
 	{
-		label: __( 'Zooming', 'otter-blocks' ),
+		label: __( 'Zooming', 'blocks-animation' ),
 		value: 'zoomIn'
 	},
 	{
-		label: __( 'Rolling', 'otter-blocks' ),
+		label: __( 'Rolling', 'blocks-animation' ),
 		value: 'rollIn'
 	},
 	{
-		label: __( 'Light Speed', 'otter-blocks' ),
+		label: __( 'Light Speed', 'blocks-animation' ),
 		value: 'lightSpeedInRight'
 	},
 	{
-		label: __( 'Other', 'otter-blocks' ),
+		label: __( 'Other', 'blocks-animation' ),
 		value: 'flash'
 	}
 ];
@@ -319,70 +319,70 @@ export const outAnimation = [
 
 export const delayList = [
 	{
-		label: __( 'None', 'otter-blocks' ),
+		label: __( 'None', 'blocks-animation' ),
 		value: 'none'
 	},
 	{
-		label: __( '100 Milliseconds', 'otter-blocks' ),
+		label: __( '100 Milliseconds', 'blocks-animation' ),
 		value: 'delay-100ms'
 	},
 	{
-		label: __( '200 Milliseconds', 'otter-blocks' ),
+		label: __( '200 Milliseconds', 'blocks-animation' ),
 		value: 'delay-200ms'
 	},
 	{
-		label: __( '500 Milliseconds', 'otter-blocks' ),
+		label: __( '500 Milliseconds', 'blocks-animation' ),
 		value: 'delay-500ms'
 	},
 	{
-		label: __( 'One Second', 'otter-blocks' ),
+		label: __( 'One Second', 'blocks-animation' ),
 		value: 'delay-1s'
 	},
 	{
-		label: __( 'Two Second', 'otter-blocks' ),
+		label: __( 'Two Second', 'blocks-animation' ),
 		value: 'delay-2s'
 	},
 	{
-		label: __( 'Three Second', 'otter-blocks' ),
+		label: __( 'Three Second', 'blocks-animation' ),
 		value: 'delay-3s'
 	},
 	{
-		label: __( 'Four Second', 'otter-blocks' ),
+		label: __( 'Four Second', 'blocks-animation' ),
 		value: 'delay-4s'
 	},
 	{
-		label: __( 'Five Second', 'otter-blocks' ),
+		label: __( 'Five Second', 'blocks-animation' ),
 		value: 'delay-5s'
 	},
 	{
-		label: __( 'Custom', 'otter-blocks' ),
+		label: __( 'Custom', 'blocks-animation' ),
 		value: 'o-anim-custom-delay'
 	}
 ];
 
 export const speedList = [
 	{
-		label: __( 'Slow', 'otter-blocks' ),
+		label: __( 'Slow', 'blocks-animation' ),
 		value: 'slow'
 	},
 	{
-		label: __( 'Slower', 'otter-blocks' ),
+		label: __( 'Slower', 'blocks-animation' ),
 		value: 'slower'
 	},
 	{
-		label: __( 'Default', 'otter-blocks' ),
+		label: __( 'Default', 'blocks-animation' ),
 		value: 'none'
 	},
 	{
-		label: __( 'Fast', 'otter-blocks' ),
+		label: __( 'Fast', 'blocks-animation' ),
 		value: 'fast'
 	},
 	{
-		label: __( 'Faster', 'otter-blocks' ),
+		label: __( 'Faster', 'blocks-animation' ),
 		value: 'faster'
 	},
 	{
-		label: __( 'Custom', 'otter-blocks' ),
+		label: __( 'Custom', 'blocks-animation' ),
 		value: 'o-anim-custom-speed'
 	}
 ];

--- a/src/animation/editor.js
+++ b/src/animation/editor.js
@@ -457,7 +457,7 @@ function AnimationControls({
 			>
 				<img
 					src={ typingPlaceholder }
-					alt={ _( 'Using Count Animation in the Block Editor', 'blocks-animation' ) }
+					alt={ __( 'Using Count Animation in the Block Editor', 'blocks-animation' ) }
 					className="otter-animations-count-image"
 				/>
 
@@ -470,7 +470,7 @@ function AnimationControls({
 			>
 				<img
 					src={ countPlaceholder }
-					alt={ _( 'Using Typing Animation in the Block Editor', 'blocks-animation' ) }
+					alt={ __( 'Using Typing Animation in the Block Editor', 'blocks-animation' ) }
 					className="otter-animations-count-image"
 				/>
 

--- a/src/animation/editor.js
+++ b/src/animation/editor.js
@@ -122,7 +122,7 @@ function AnimationControls({
 	const [ animation, setAnimation ] = useState( 'none' );
 	const [ delay, setDelay ] = useState( 'none' );
 	const [ speed, setSpeed ] = useState( 'none' );
-	const [ currentAnimationLabel, setCurrentAnimationLabel ] = useState( __( 'None', 'otter-blocks' ) );
+	const [ currentAnimationLabel, setCurrentAnimationLabel ] = useState( __( 'None', 'blocks-animation' ) );
 	const [ customDelayValue, setCustomDelayValue ] = useState( 0 );
 	const [ customSpeedValue, setCustomSpeedValue ] = useState( 0 );
 	const [ playOnHover, setPlayOnHover ] = useState( false );
@@ -315,7 +315,7 @@ function AnimationControls({
 
 	return (
 		<PanelBody
-			title={ __( 'Animations', 'otter-blocks' ) }
+			title={ __( 'Animations', 'blocks-animation' ) }
 			initialOpen={ false }
 		>
 			<div className="o-animations-control">
@@ -329,7 +329,7 @@ function AnimationControls({
 				{ 'none' !== animation && (
 					<Fragment>
 						<SelectControl
-							label={ __( 'Delay', 'otter-blocks' ) }
+							label={ __( 'Delay', 'blocks-animation' ) }
 							value={ delay || 'none' }
 							options={ delayList }
 							onChange={  value => updateAnimConfig( AnimationType.default, delay, value, () => setDelay( value ), attributes, setAttributes ) }
@@ -338,7 +338,7 @@ function AnimationControls({
 						{
 							'o-anim-custom-delay' === delay && (
 								<UnitControl
-									label={ __( 'Value', 'otter-blocks' ) }
+									label={ __( 'Value', 'blocks-animation' ) }
 									value={ customDelayValue }
 									onChange={ value => updateAnimConfig( AnimationType.default, 'o-anim-value-delay-', value ? `o-anim-value-delay-${value}` : undefined, () => setCustomDelayValue( value ), attributes, setAttributes ) }
 									min={ 0 }
@@ -347,11 +347,11 @@ function AnimationControls({
 									units={
 										[
 											{
-												label: __( 'S', 'otter-blocks' ),
+												label: __( 'S', 'blocks-animation' ),
 												value: 's'
 											},
 											{
-												label: __( 'MS', 'otter-blocks' ),
+												label: __( 'MS', 'blocks-animation' ),
 												value: 'ms'
 											}
 										]
@@ -361,7 +361,7 @@ function AnimationControls({
 						}
 
 						<SelectControl
-							label={ __( 'Speed', 'otter-blocks' ) }
+							label={ __( 'Speed', 'blocks-animation' ) }
 							value={ speed || 'none' }
 							options={ speedList }
 							onChange={ value => updateAnimConfig( AnimationType.default, speed, value, () => setSpeed( value ), attributes, setAttributes ) }
@@ -370,7 +370,7 @@ function AnimationControls({
 						{
 							'o-anim-custom-speed' === speed && (
 								<UnitControl
-									label={ __( 'Value', 'otter-blocks' ) }
+									label={ __( 'Value', 'blocks-animation' ) }
 									value={ customSpeedValue }
 									onChange={ value => updateAnimConfig( AnimationType.default, 'o-anim-value-speed-', `o-anim-value-speed-${value}`, () => setCustomSpeedValue( value ), attributes, setAttributes ) }
 									min={ 0 }
@@ -379,11 +379,11 @@ function AnimationControls({
 									units={
 										[
 											{
-												label: __( 'S', 'otter-blocks' ),
+												label: __( 'S', 'blocks-animation' ),
 												value: 's'
 											},
 											{
-												label: __( 'MS', 'otter-blocks' ),
+												label: __( 'MS', 'blocks-animation' ),
 												value: 'ms'
 											}
 										]
@@ -393,14 +393,14 @@ function AnimationControls({
 						}
 
 						<ToggleControl
-							label={ __( 'Play on Hover', 'otter-blocks' ) }
+							label={ __( 'Play on Hover', 'blocks-animation' ) }
 							checked={ playOnHover }
 							onChange={ value  => updateAnimConfig( AnimationType.default, 'o-anim-hover', value ? 'o-anim-hover' : '', () => setPlayOnHover( value ), attributes, setAttributes ) }
 
 						/>
 
 						<ToggleControl
-							label={ __( 'Trigger Offset', 'otter-blocks' ) }
+							label={ __( 'Trigger Offset', 'blocks-animation' ) }
 							checked={ Boolean( triggerOffset ) }
 							onChange={
 								value  => updateAnimConfig(
@@ -414,13 +414,13 @@ function AnimationControls({
 									setAttributes
 								)
 							}
-							help={ __( 'This will offset the trigger of animation relative to the screen.', 'otter-blocks' ) }
+							help={ __( 'This will offset the trigger of animation relative to the screen.', 'blocks-animation' ) }
 						/>
 
 						{
 							Boolean( triggerOffset ) && (
 								<UnitControl
-									label={ __( 'Height Trigger Offset', 'otter-blocks' ) }
+									label={ __( 'Height Trigger Offset', 'blocks-animation' ) }
 									value={ triggerOffsetValue }
 									onChange={ setTriggerOffsetValue }
 									step={ 0.1 }
@@ -428,16 +428,16 @@ function AnimationControls({
 									units={
 										[
 											{
-												label: __( 'px', 'otter-blocks' ),
+												label: __( 'px', 'blocks-animation' ),
 												value: 'px'
 											},
 											{
-												label: __( '%', 'otter-blocks' ),
+												label: __( '%', 'blocks-animation' ),
 												value: '%'
 											}
 										]
 									}
-									help={ triggerOffsetValue?.endsWith( '%' ) ? __( 'Is the percentage of the screen height. E.g: with 50% the animation will trigger after passing the middle of screen.', 'otter-blocks' ) : '' }
+									help={ triggerOffsetValue?.endsWith( '%' ) ? __( 'Is the percentage of the screen height. E.g: with 50% the animation will trigger after passing the middle of screen.', 'blocks-animation' ) : '' }
 								/>
 							)
 						}
@@ -446,36 +446,36 @@ function AnimationControls({
 							variant="secondary"
 							onClick={ replayAnimation }
 						>
-							{ __( 'Replay Animation', 'otter-blocks' ) }
+							{ __( 'Replay Animation', 'blocks-animation' ) }
 						</Button>
 					</Fragment>
 				) }
 			</div>
 
 			<ControlPanelControl
-				label={ __( 'Count Animations', 'otter-blocks' ) }
+				label={ __( 'Count Animations', 'blocks-animation' ) }
 			>
 				<img
 					src={ typingPlaceholder }
-					alt={ _( 'Using Count Animation in the Block Editor', 'otter-blocks' ) }
+					alt={ _( 'Using Count Animation in the Block Editor', 'blocks-animation' ) }
 					className="otter-animations-count-image"
 				/>
 
-				<p>{ __( 'You can add counting animation from the format toolbar of this block.', 'otter-blocks' ) }</p>
-				<p>{ __( 'Note: This feature is not available in all the blocks.', 'otter-blocks' ) }</p>
+				<p>{ __( 'You can add counting animation from the format toolbar of this block.', 'blocks-animation' ) }</p>
+				<p>{ __( 'Note: This feature is not available in all the blocks.', 'blocks-animation' ) }</p>
 			</ControlPanelControl>
 
 			<ControlPanelControl
-				label={ __( 'Typing Animations', 'otter-blocks' ) }
+				label={ __( 'Typing Animations', 'blocks-animation' ) }
 			>
 				<img
 					src={ countPlaceholder }
-					alt={ _( 'Using Typing Animation in the Block Editor', 'otter-blocks' ) }
+					alt={ _( 'Using Typing Animation in the Block Editor', 'blocks-animation' ) }
 					className="otter-animations-count-image"
 				/>
 
-				<p>{ __( 'You can add typing animation from the format toolbar of this block.', 'otter-blocks' ) }</p>
-				<p>{ __( 'Note: This feature is not available in all the blocks.', 'otter-blocks' ) }</p>
+				<p>{ __( 'You can add typing animation from the format toolbar of this block.', 'blocks-animation' ) }</p>
+				<p>{ __( 'Note: This feature is not available in all the blocks.', 'blocks-animation' ) }</p>
 			</ControlPanelControl>
 
 			<div className="o-fp-wrap">

--- a/src/animation/index.js
+++ b/src/animation/index.js
@@ -39,7 +39,7 @@ const BlockAnimation = ( el, props ) => {
 
 				<ToolsPanelItem
 					hasValue={ () => Boolean( props?.attributes?.className?.includes( 'animated' ) ) }
-					label={ __( 'Animations', 'otter-blocks' ) }
+					label={ __( 'Animations', 'blocks-animation' ) }
 					onDeselect={ () => window?.blocksAnimation?.removeAnimation() }
 					isShownByDefault={ showAsDefault }
 				>

--- a/src/animation/typing/index.js
+++ b/src/animation/typing/index.js
@@ -26,7 +26,7 @@ const name = 'themeisle-blocks/typing-animation';
 
 export const format = {
 	name,
-	title: __( 'Typing Animation', 'otter-blocks' ),
+	title: __( 'Typing Animation', 'blocks-animation' ),
 	tagName: 'o-anim-typing',
 	className: null,
 
@@ -44,7 +44,7 @@ export const format = {
 			<Fragment>
 				<RichTextToolbarButton
 					icon={ brush }
-					title={ __( 'Typing Animation', 'otter-blocks' ) }
+					title={ __( 'Typing Animation', 'blocks-animation' ) }
 					onClick={ onToggle }
 					isActive={ isActive }
 				/>

--- a/src/animation/typing/inline-controls.js
+++ b/src/animation/typing/inline-controls.js
@@ -96,17 +96,17 @@ const InlineControls = ({
 			focusOnMount={ false }
 			className="o-animation-popover"
 		>
-			<Heading level={ 4 }>{ __( 'Typing Animation', 'otter-blocks' ) }</Heading>
+			<Heading level={ 4 }>{ __( 'Typing Animation', 'blocks-animation' ) }</Heading>
 
 			<SelectControl
-				label={ __( 'Delay', 'otter-blocks' ) }
+				label={ __( 'Delay', 'blocks-animation' ) }
 				value={ typingDelay || 'none' }
 				options={ delayListInline }
 				onChange={ value => updateAnimConfig( 'typing', typingDelay, value, () => setTypingDelay( value ), attributes, setAttributes ) }
 			/>
 
 			<SelectControl
-				label={ __( 'Speed', 'otter-blocks' ) }
+				label={ __( 'Speed', 'blocks-animation' ) }
 				value={ typingSpeed || 'none' }
 				options={ speedListInline }
 				onChange={ value => updateAnimConfig( 'typing', typingSpeed, value, () => setTypingSpeed( value ), attributes, setAttributes ) }

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -448,7 +448,7 @@ const Inspector = ({
 						) }
 
 						<ToolsPanel
-							label={ __( 'Form Options' ) }
+							label={ __( 'Form Options', 'otter-blocks' ) }
 							className="o-form-options"
 						>
 							{ 'loading' === loadingState?.formOptions && (
@@ -709,7 +709,7 @@ const Inspector = ({
 								placeholder={ __( 'Error. Please try again.', 'otter-blocks' ) }
 								value={ formOptions.errorMessage }
 								onChange={ errorMessage =>  setFormOption({ errorMessage })  }
-								help={ __( 'This message will be displayed when there is a problem with the server.' ) }
+								help={ __( 'This message will be displayed when there is a problem with the server.', 'otter-blocks' ) }
 							/>
 						</PanelBody>
 

--- a/src/blocks/blocks/google-map/inspector.js
+++ b/src/blocks/blocks/google-map/inspector.js
@@ -174,7 +174,7 @@ const Inspector = ({
 						title={ __( 'Location', 'otter-blocks' ) }
 					>
 						<BaseControl
-							label={ __( 'Location' ) }
+							label={ __( 'Location', 'otter-blocks' ) }
 							id="wp-block-themeisle-blocks-google-map-search"
 						>
 							<input

--- a/src/blocks/blocks/review/inspector.js
+++ b/src/blocks/blocks/review/inspector.js
@@ -483,7 +483,7 @@ const Inspector = ({
 
 								<TextareaControl
 									label={ __( 'Description', 'otter-blocks' ) }
-									placeholder={ __( 'Feature Description' ) }
+									placeholder={ __( 'Feature Description', 'otter-blocks' ) }
 									value={ feature.description }
 									onChange={ description =>  onChangeFeature({ action: 'update', index, value: { description }}) }
 								/>

--- a/src/blocks/blocks/section/columns/index.js
+++ b/src/blocks/blocks/section/columns/index.js
@@ -46,9 +46,8 @@ registerBlockType( name, {
 					{
 						name: 'core/paragraph',
 						attributes: {
-							content: __(
-								'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.'
-							)
+							content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.',
+							
 						}
 					},
 					{
@@ -60,9 +59,7 @@ registerBlockType( name, {
 					{
 						name: 'core/paragraph',
 						attributes: {
-							content: __(
-								'Suspendisse commodo neque lacus, a dictum orci interdum et.'
-							)
+							content: 'Suspendisse commodo neque lacus, a dictum orci interdum et.'
 						}
 					}
 				]
@@ -78,17 +75,13 @@ registerBlockType( name, {
 					{
 						name: 'core/paragraph',
 						attributes: {
-							content: __(
-								'Etiam et egestas lorem. Vivamus sagittis sit amet dolor quis lobortis. Integer sed fermentum arcu, id vulputate lacus. Etiam fermentum sem eu quam hendrerit.'
-							)
+							content: 'Etiam et egestas lorem. Vivamus sagittis sit amet dolor quis lobortis. Integer sed fermentum arcu, id vulputate lacus. Etiam fermentum sem eu quam hendrerit.'
 						}
 					},
 					{
 						name: 'core/paragraph',
 						attributes: {
-							content: __(
-								'Nam risus massa, ullamcorper consectetur eros fermentum, porta aliquet ligula. Sed vel mauris nec enim.'
-							)
+							content: 'Nam risus massa, ullamcorper consectetur eros fermentum, porta aliquet ligula. Sed vel mauris nec enim.'
 						}
 					}
 				]

--- a/src/blocks/blocks/sharing-icons/inspector.js
+++ b/src/blocks/blocks/sharing-icons/inspector.js
@@ -53,7 +53,7 @@ const Inspector = ({
 			</PanelBody>
 
 			<PanelColorSettings
-				title={ __( 'Color Settings' ) }
+				title={ __( 'Color Settings', 'otter-blocks' ) }
 				className='ott-color-controls'
 				initialOpen={ false }
 				colorSettings={

--- a/src/blocks/blocks/stripe-checkout/inspector.js
+++ b/src/blocks/blocks/stripe-checkout/inspector.js
@@ -167,7 +167,7 @@ const Inspector = ({
 
 				{ isOpen && (
 					<Modal
-						title={ __( 'Stripe Messages' ) }
+						title={ __( 'Stripe Messages', 'otter-blocks' ) }
 						onRequestClose={() => setOpen( false )}
 						shouldCloseOnClickOutside={ false }
 					>

--- a/src/blocks/components/block-appender-button/index.tsx
+++ b/src/blocks/components/block-appender-button/index.tsx
@@ -32,7 +32,7 @@ type BlockAppenderButtonProps = {
  * @param {Object} params.props        - Additional button props.
  */
 const BlockAppender = ({
-	buttonText = __( 'Add Item' ),
+	buttonText = __( 'Add Item', 'otter-blocks' ),
 	clientId,
 	allowedBlock,
 	...props

--- a/src/blocks/components/responsive-control/index.js
+++ b/src/blocks/components/responsive-control/index.js
@@ -80,7 +80,7 @@ const ResponsiveControl = ({
 						<ButtonGroup>
 							<Button
 								icon={ desktop }
-								label={ __( 'Desktop' ) }
+								label={ __( 'Desktop', 'otter-blocks' ) }
 								onClick={ () => setView( 'Desktop' ) }
 								className={ classnames({
 									'is-selected': 'Desktop' === getView
@@ -88,7 +88,7 @@ const ResponsiveControl = ({
 							/>
 							<Button
 								icon={ tablet }
-								label={ __( 'Tablet' ) }
+								label={ __( 'Tablet', 'otter-blocks' ) }
 								onClick={ () => setView( 'Tablet' ) }
 								className={ classnames({
 									'is-selected': 'Tablet' === getView
@@ -96,7 +96,7 @@ const ResponsiveControl = ({
 							/>
 							<Button
 								icon={ mobile }
-								label={ __( 'Mobile' ) }
+								label={ __( 'Mobile', 'otter-blocks' ) }
 								onClick={ () => setView( 'Mobile' ) }
 								className={ classnames({
 									'is-selected': 'Mobile' === getView

--- a/src/blocks/plugins/ai-content/index.tsx
+++ b/src/blocks/plugins/ai-content/index.tsx
@@ -333,7 +333,7 @@ const withConditions = createHigherOrderComponent( BlockEdit => {
 							<Toolbar label={__( 'AI Block', 'otter-blocks' )}>
 								<DropdownMenu
 									icon={ aiGeneration }
-									label={ __( 'Otter AI Content' ) }
+									label={ __( 'Otter AI Content', 'otter-blocks' ) }
 								>
 									{
 										({ onClose }) => (

--- a/src/blocks/plugins/feedback/feedback-form.js
+++ b/src/blocks/plugins/feedback/feedback-form.js
@@ -36,7 +36,7 @@ const collectedInfo = [
 ];
 
 const helpTextByStatus = {
-	error: __( 'There has been an error. Your feedback couldn\'t be sent.' ),
+	error: __( 'There has been an error. Your feedback couldn\'t be sent.', 'otter-blocks' ),
 	emptyFeedback: __( 'Please provide a feedback before submitting the form.', 'otter-blocks' )
 };
 

--- a/src/blocks/plugins/otter-tools-inspector/index.tsx
+++ b/src/blocks/plugins/otter-tools-inspector/index.tsx
@@ -40,7 +40,7 @@ const FeaturePanel = ({ props }) => {
 
 	return (
 		<ToolsPanel
-			label={ __( 'Block Tools' ) }
+			label={ __( 'Block Tools', 'otter-blocks' ) }
 			className="o-block-tools"
 		>
 			{ applyFilters( 'otter.blockTools', '', props ) }

--- a/src/blocks/plugins/sticky/edit.tsx
+++ b/src/blocks/plugins/sticky/edit.tsx
@@ -105,7 +105,7 @@ const ProFeatures = () => {
 
 			<ToggleControl
 				label={ __( 'Enable on Mobile', 'otter-blocks' ) }
-				help={ __( 'Make the sticky mode active for mobile users.' ) }
+				help={ __( 'Make the sticky mode active for mobile users.', 'otter-blocks' ) }
 
 				// @ts-ignore
 				disabled={ true }

--- a/src/css/editor.js
+++ b/src/css/editor.js
@@ -139,7 +139,7 @@ const CSSEditor = ({
 					status="info"
 					isDismissible={ false }
 				>
-					{ __( 'Blocks CSS is not fully compatible with the Site Editor. We recommend installing Otter for Site Builder compatibility.', 'otter-blocks' ) }
+					{ __( 'Blocks CSS is not fully compatible with the Site Editor. We recommend installing Otter for Site Builder compatibility.', 'blocks-css' ) }
 
 					<br/><br/>
 
@@ -148,12 +148,12 @@ const CSSEditor = ({
 						href={ window?.blocksCSS?.installOtter }
 						target="_blank"
 					>
-						{ __( 'Install Otter', 'otter-blocks' ) }
+						{ __( 'Install Otter', 'blocks-css' ) }
 					</Button>
 				</Notice>
 			) }
 
-			<p>{__( 'Add your custom CSS.', 'otter-blocks' )}</p>
+			<p>{__( 'Add your custom CSS.', 'blocks-css' )}</p>
 
 			<div id="o-css-editor" className="o-css-editor" />
 
@@ -163,7 +163,7 @@ const CSSEditor = ({
 						status="error"
 						isDismissible={ false }
 					>
-						{ __( 'Attention needed! We found following errors with your code:', 'otter-blocks' ) }
+						{ __( 'Attention needed! We found following errors with your code:', 'blocks-css' ) }
 					</Notice>
 
 					<pre>
@@ -183,20 +183,20 @@ const CSSEditor = ({
 						onClick={() => checkInput( editorRef.current, true )}
 						style={{ width: 'max-content', marginBottom: '20px' }}
 					>
-						{ __( 'Override', 'otter-blocks' ) }
+						{ __( 'Override', 'blocks-css' ) }
 					</Button>
 				</div>
 			) }
 
-			<p>{__( 'Use', 'otter-blocks' )} <code>selector</code> {__( 'to target block wrapper.', 'otter-blocks' )}</p>
+			<p>{__( 'Use', 'blocks-css' )} <code>selector</code> {__( 'to target block wrapper.', 'blocks-css' )}</p>
 			<br />
-			<p>{__( 'Example:', 'otter-blocks' )}</p>
+			<p>{__( 'Example:', 'blocks-css' )}</p>
 
 			<pre className="o-css-editor-help">
 				{'selector {\n    background: #000;\n}\n\nselector img {\n    border-radius: 100%;\n}'}
 			</pre>
 
-			<p>{__( 'You can also use other CSS syntax here, such as media queries.', 'otter-blocks' )}</p>
+			<p>{__( 'You can also use other CSS syntax here, such as media queries.', 'blocks-css' )}</p>
 		</Fragment>
 	);
 };

--- a/src/css/index.js
+++ b/src/css/index.js
@@ -60,7 +60,7 @@ const Edit = ({
 }) => {
 	return (
 		<PanelBody
-			title={ __( 'Custom CSS', 'otter-blocks' ) }
+			title={ __( 'Custom CSS', 'blocks-css' ) }
 			initialOpen={ false }
 		>
 			<CSSEditor
@@ -87,7 +87,7 @@ const BlockCSSWrapper = ( el, props ) => {
 
 				<ToolsPanelItem
 					hasValue={ () => Boolean( props.attributes?.hasCustomCSS ) }
-					label={ __( 'Custom CSS', 'otter-blocks' ) }
+					label={ __( 'Custom CSS', 'blocks-css' ) }
 					onDeselect={ () => {
 						props.setAttributes({
 							hasCustomCSS: false,

--- a/src/export-import/exporter.js
+++ b/src/export-import/exporter.js
@@ -110,7 +110,7 @@ const BlocksExporter = () => {
 
 		createNotice(
 			'success',
-			__( 'Blocks exported.', 'otter-blocks' ),
+			__( 'Blocks exported.', 'blocks-export-import' ),
 			{
 				type: 'snackbar'
 			}
@@ -126,7 +126,7 @@ const BlocksExporter = () => {
 					icon={ external }
 					onClick={ exportBlocks }
 				>
-					{ __( 'Export as JSON', 'otter-blocks' ) }
+					{ __( 'Export as JSON', 'blocks-export-import' ) }
 				</MenuItem>
 			) }
 		</BlockSettingsMenuControls>

--- a/src/export-import/importer.js
+++ b/src/export-import/importer.js
@@ -52,7 +52,7 @@ const BlocksImporter = ({
 				': ',
 				__(
 					'Sorry, only JSON files are supported here.',
-					'otter-blocks'
+					'blocks-export-import'
 				)
 			];
 			noticeOperations.removeAllNotices();
@@ -70,7 +70,7 @@ const BlocksImporter = ({
 			} catch ( error ) {
 				noticeOperations.removeAllNotices();
 				noticeOperations.createErrorNotice(
-					__( 'Invalid JSON file', 'otter-blocks' )
+					__( 'Invalid JSON file', 'blocks-export-import' )
 				);
 				setLoading( false );
 				return;
@@ -92,7 +92,7 @@ const BlocksImporter = ({
 							data.title ||
 							__(
 								'Untitled Reusable Block',
-								'otter-blocks'
+								'blocks-export-import'
 							),
 						content: data.content,
 						status: 'publish'
@@ -105,7 +105,7 @@ const BlocksImporter = ({
 					noticeOperations.createErrorNotice(
 						__(
 							'Invalid Reusable Block JSON file',
-							'otter-blocks'
+							'blocks-export-import'
 						)
 					);
 					setLoading( false );
@@ -138,10 +138,10 @@ const BlocksImporter = ({
 	return (
 		<div { ...blockProps }>
 			<Placeholder
-				label={ __( 'Import Blocks from JSON', 'otter-blocks' ) }
+				label={ __( 'Import Blocks from JSON', 'blocks-export-import' ) }
 				instructions={ __(
 					'Upload JSON file from your device.',
-					'otter-blocks'
+					'blocks-export-import'
 				) }
 				icon="category"
 				notices={ noticeUI }
@@ -151,11 +151,11 @@ const BlocksImporter = ({
 					onChange={ ( e ) => uploadImport( e.target.files ) }
 					isSecondary
 				>
-					{ __( 'Upload' ) }
+					{ __( 'Upload', 'blocks-export-import' ) }
 				</FormFileUpload>
 
 				<DropZone
-					label={ __( 'Import from JSON', 'otter-blocks' ) }
+					label={ __( 'Import from JSON', 'blocks-export-import' ) }
 					onFilesDrop={ uploadImport }
 				/>
 			</Placeholder>

--- a/src/export-import/index.js
+++ b/src/export-import/index.js
@@ -18,7 +18,7 @@ import edit from './importer.js';
 
 registerBlockType( 'themeisle-blocks/importer', {
 	apiVersion: 2,
-	title: __( 'Import Blocks from JSON', 'otter-blocks' ),
+	title: __( 'Import Blocks from JSON', 'blocks-export-import' ),
 	description: __(
 		'Allows you import blocks from a JSON file.',
 		'blocks-export-import'
@@ -26,8 +26,8 @@ registerBlockType( 'themeisle-blocks/importer', {
 	icon: 'category',
 	category: 'widgets',
 	keywords: [
-		__( 'JSON', 'otter-blocks' ),
-		__( 'Importer', 'otter-blocks' ),
+		__( 'JSON', 'blocks-export-import' ),
+		__( 'Importer', 'blocks-export-import' ),
 		__( 'Import', 'blocks-export-import' )
 	],
 	attributes: {

--- a/src/pro/blocks/add-to-cart-button/block.json
+++ b/src/pro/blocks/add-to-cart-button/block.json
@@ -6,7 +6,7 @@
 	"category": "themeisle-blocks",
     "description": "Display an Add to Cart button for your WooCommerce products. Powered by Otter.",
     "keywords": [ "woocommerce", "add to cart", "products" ],
-	"textdomain": "otter-blocks",
+	"textdomain": "otter-pro",
     "attributes": {
         "product": {
             "type": "number"

--- a/src/pro/blocks/add-to-cart-button/edit.js
+++ b/src/pro/blocks/add-to-cart-button/edit.js
@@ -50,11 +50,11 @@ const Edit = ({
 				) : (
 					<Placeholder
 						icon={ store }
-						label={ __( 'Add to Cart Button', 'otter-blocks' ) }
-						instructions={ __( 'Select a WooCommerce product for the Add to Cart button.', 'otter-blocks' ) }
+						label={ __( 'Add to Cart Button', 'otter-pro' ) }
+						instructions={ __( 'Select a WooCommerce product for the Add to Cart button.', 'otter-pro' ) }
 					>
 						<SelectProducts
-							label={ __( 'Select Product', 'otter-blocks' ) }
+							label={ __( 'Select Product', 'otter-pro' ) }
 							hideLabelFromVision
 							value={ attributes.product || '' }
 							onChange={ product => {

--- a/src/pro/blocks/add-to-cart-button/index.js
+++ b/src/pro/blocks/add-to-cart-button/index.js
@@ -30,9 +30,9 @@ if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	}
 
 	registerBlockType( name, {
-		title: __( 'Add to Cart Button', 'otter-blocks' ),
+		title: __( 'Add to Cart Button', 'otter-pro' ),
 		...metadata,
-		description: __( 'Display an Add to Cart button for your WooCommerce products. Powered by Otter.', 'otter-blocks' ),
+		description: __( 'Display an Add to Cart button for your WooCommerce products. Powered by Otter.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',
@@ -45,16 +45,16 @@ if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 		styles: [
 			{
 				name: 'default',
-				label: __( 'Default', 'otter-blocks' ),
+				label: __( 'Default', 'otter-pro' ),
 				isDefault: true
 			},
 			{
 				name: 'primary',
-				label: __( 'Primary', 'otter-blocks' )
+				label: __( 'Primary', 'otter-pro' )
 			},
 			{
 				name: 'secondary',
-				label: __( 'Secondary', 'otter-blocks' )
+				label: __( 'Secondary', 'otter-pro' )
 			}
 		],
 		edit,
@@ -63,8 +63,8 @@ if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 } else {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Add to Cart Button', 'otter-blocks' ),
-		description: __( 'Display an Add to Cart button for your WooCommerce products. Powered by Otter.', 'otter-blocks' ),
+		title: __( 'Add to Cart Button', 'otter-pro' ),
+		description: __( 'Display an Add to Cart button for your WooCommerce products. Powered by Otter.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',
@@ -74,7 +74,7 @@ if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 		supports: {
 			inserter: false
 		},
-		edit: () => <div { ...useBlockProps() }><Placeholder>{ __( 'You need to have WooCommerce installed to edit Add to Cart Button block.', 'otter-blocks' ) }</Placeholder></div>,
+		edit: () => <div { ...useBlockProps() }><Placeholder>{ __( 'You need to have WooCommerce installed to edit Add to Cart Button block.', 'otter-pro' ) }</Placeholder></div>,
 		save: () => null
 	});
 }

--- a/src/pro/blocks/add-to-cart-button/inspector.js
+++ b/src/pro/blocks/add-to-cart-button/inspector.js
@@ -23,10 +23,10 @@ const Inspector = ({
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Settings', 'otter-blocks' ) }
+				title={ __( 'Settings', 'otter-pro' ) }
 			>
 				<SelectProducts
-					label={ __( 'Select Product', 'otter-blocks' ) }
+					label={ __( 'Select Product', 'otter-pro' ) }
 					hideLabelFromVision
 					value={ attributes.product }
 					onChange={ product => {
@@ -36,8 +36,8 @@ const Inspector = ({
 				/>
 
 				<TextControl
-					label={ __( 'Button Label', 'otter-blocks' ) }
-					help={ __( 'This overrides the default WooCommerce button label.', 'otter-blocks' ) }
+					label={ __( 'Button Label', 'otter-pro' ) }
+					help={ __( 'This overrides the default WooCommerce button label.', 'otter-pro' ) }
 					value={ attributes.label }
 					onChange={ label => setAttributes({ label }) }
 				/>

--- a/src/pro/blocks/business-hours/edit.js
+++ b/src/pro/blocks/business-hours/edit.js
@@ -107,7 +107,7 @@ const Edit = ({
 						className="otter-business-hour__title"
 					>
 						<RichText
-							placeholder={ __( 'Opening Hours', 'otter-blocks' ) }
+							placeholder={ __( 'Opening Hours', 'otter-pro' ) }
 							value={ attributes.title }
 							onChange={ title => {
 								setAttributes({ title });
@@ -126,51 +126,51 @@ const Edit = ({
 								[
 									'themeisle-blocks/business-hours-item',
 									{
-										label: __( 'Monday', 'otter-blocks' ),
-										time: __( '09:00 AM - 05:00 PM', 'otter-blocks' )
+										label: __( 'Monday', 'otter-pro' ),
+										time: __( '09:00 AM - 05:00 PM', 'otter-pro' )
 									}
 								],
 								[
 									'themeisle-blocks/business-hours-item',
 									{
-										label: __( 'Tuesday', 'otter-blocks' ),
-										time: __( '09:00 AM - 05:00 PM', 'otter-blocks' )
+										label: __( 'Tuesday', 'otter-pro' ),
+										time: __( '09:00 AM - 05:00 PM', 'otter-pro' )
 									}
 								],
 								[
 									'themeisle-blocks/business-hours-item',
 									{
-										label: __( 'Wednesday', 'otter-blocks' ),
-										time: __( '09:00 AM - 05:00 PM', 'otter-blocks' )
+										label: __( 'Wednesday', 'otter-pro' ),
+										time: __( '09:00 AM - 05:00 PM', 'otter-pro' )
 									}
 								],
 								[
 									'themeisle-blocks/business-hours-item',
 									{
-										label: __( 'Thursday', 'otter-blocks' ),
-										time: __( '09:00 AM - 05:00 PM', 'otter-blocks' )
+										label: __( 'Thursday', 'otter-pro' ),
+										time: __( '09:00 AM - 05:00 PM', 'otter-pro' )
 									}
 								],
 								[
 									'themeisle-blocks/business-hours-item',
 									{
-										label: __( 'Friday', 'otter-blocks' ),
-										time: __( '09:00 AM - 05:00 PM', 'otter-blocks' )
+										label: __( 'Friday', 'otter-pro' ),
+										time: __( '09:00 AM - 05:00 PM', 'otter-pro' )
 									}
 								],
 								[
 									'themeisle-blocks/business-hours-item',
 									{
-										label: __( 'Saturday', 'otter-blocks' ),
-										time: __( 'Closed', 'otter-blocks' ),
+										label: __( 'Saturday', 'otter-pro' ),
+										time: __( 'Closed', 'otter-pro' ),
 										timeColor: '#F8002A'
 									}
 								],
 								[
 									'themeisle-blocks/business-hours-item',
 									{
-										label: __( 'Sunday', 'otter-blocks' ),
-										time: __( 'Closed', 'otter-blocks' ),
+										label: __( 'Sunday', 'otter-pro' ),
+										time: __( 'Closed', 'otter-pro' ),
 										timeColor: '#F8002A'
 									}
 								]

--- a/src/pro/blocks/business-hours/index.js
+++ b/src/pro/blocks/business-hours/index.js
@@ -30,8 +30,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'Business Hours', 'otter-blocks' ),
-	description: __( 'Display your business schedule on your website. Powered by Otter.', 'otter-blocks' ),
+	title: __( 'Business Hours', 'otter-pro' ),
+	description: __( 'Display your business schedule on your website. Powered by Otter.', 'otter-pro' ),
 	icon,
 	keywords: [
 		'business',
@@ -45,12 +45,12 @@ registerBlockType( name, {
 	styles: [
 		{
 			name: 'default',
-			label: __( 'Default', 'otter-blocks' ),
+			label: __( 'Default', 'otter-pro' ),
 			isDefault: true
 		},
 		{
 			name: 'black-white',
-			label: __( 'Black & White', 'otter-blocks' )
+			label: __( 'Black & White', 'otter-pro' )
 		}
 	],
 	edit,

--- a/src/pro/blocks/business-hours/inspector.js
+++ b/src/pro/blocks/business-hours/inspector.js
@@ -26,10 +26,10 @@ const Inspector = ({
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Settings', 'otter-blocks' ) }
+				title={ __( 'Settings', 'otter-pro' ) }
 			>
 				<RangeControl
-					label={ __( 'Gap', 'otter-blocks' ) }
+					label={ __( 'Gap', 'otter-pro' ) }
 					value={ attributes.gap }
 					onChange={ value => setAttributes({ gap: Number( value ) }) }
 					min={ 0 }
@@ -37,7 +37,7 @@ const Inspector = ({
 				/>
 
 				<RangeControl
-					label={ __( 'Title Font Size', 'otter-blocks' ) }
+					label={ __( 'Title Font Size', 'otter-pro' ) }
 					value={ attributes.titleFontSize }
 					onChange={ value => setAttributes({ titleFontSize: Number( value ) }) }
 					step={ 0.1 }
@@ -46,7 +46,7 @@ const Inspector = ({
 				/>
 
 				<RangeControl
-					label={ __( 'Items Font Size', 'otter-blocks' ) }
+					label={ __( 'Items Font Size', 'otter-pro' ) }
 					value={ attributes.itemsFontSize }
 					onChange={ value => setAttributes({ itemsFontSize: Number( value ) }) }
 					step={ 0.1 }
@@ -55,7 +55,7 @@ const Inspector = ({
 				/>
 
 				<RangeControl
-					label={ __( 'Border Radius', 'otter-blocks' ) }
+					label={ __( 'Border Radius', 'otter-pro' ) }
 					value={ attributes.borderRadius }
 					onChange={ value => setAttributes({ borderRadius: Number( value ) }) }
 					step={ 0.1 }
@@ -64,7 +64,7 @@ const Inspector = ({
 				/>
 
 				<RangeControl
-					label={ __( 'Border Width', 'otter-blocks' ) }
+					label={ __( 'Border Width', 'otter-pro' ) }
 					value={ attributes.borderWidth }
 					onChange={ value => setAttributes({ borderWidth: Number( value ) }) }
 					step={ 0.1 }
@@ -74,25 +74,25 @@ const Inspector = ({
 			</PanelBody>
 
 			<PanelColorSettings
-				title={ __( 'Color', 'otter-blocks' ) }
+				title={ __( 'Color', 'otter-pro' ) }
 				initialOpen={ false }
 				colorSettings={ [
 					{
 						value: attributes.titleColor,
 						onChange: titleColor => setAttributes({ titleColor }),
-						label: __( 'Title', 'otter-blocks' ),
+						label: __( 'Title', 'otter-pro' ),
 						isShownByDefault: true
 					},
 					{
 						value: attributes.backgroundColor,
 						onChange: backgroundColor => setAttributes({ backgroundColor }),
-						label: __( 'Background', 'otter-blocks' ),
+						label: __( 'Background', 'otter-pro' ),
 						isShownByDefault: true
 					},
 					{
 						value: attributes.borderColor,
 						onChange: borderColor => setAttributes({ borderColor }),
-						label: __( 'Border', 'otter-blocks' ),
+						label: __( 'Border', 'otter-pro' ),
 						isShownByDefault: true
 					}
 				] }

--- a/src/pro/blocks/business-hours/item/edit.js
+++ b/src/pro/blocks/business-hours/item/edit.js
@@ -65,7 +65,7 @@ const Edit = ({
 					} }
 				>
 					<RichText
-						placeholder={ __( 'Day', 'otter-blocks' ) }
+						placeholder={ __( 'Day', 'otter-pro' ) }
 						value={ attributes.label }
 						onChange={ label => {
 							setAttributes({ label });
@@ -81,7 +81,7 @@ const Edit = ({
 					} }
 				>
 					<RichText
-						placeholder={ __( 'Opening Hours', 'otter-blocks' ) }
+						placeholder={ __( 'Opening Hours', 'otter-pro' ) }
 						value={ attributes.time }
 						onChange={ time => {
 							setAttributes({ time });

--- a/src/pro/blocks/business-hours/item/index.js
+++ b/src/pro/blocks/business-hours/item/index.js
@@ -18,8 +18,8 @@ const { name } = metadata;
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'Business Hours Item', 'otter-blocks' ),
-	description: __( 'Item used by Business Hours block to display the time. Powered by Otter.', 'otter-blocks' ),
+	title: __( 'Business Hours Item', 'otter-pro' ),
+	description: __( 'Item used by Business Hours block to display the time. Powered by Otter.', 'otter-pro' ),
 	icon,
 	parent: [ 'themeisle-blocks/business-hours' ],
 	category: 'themeisle-blocks',

--- a/src/pro/blocks/business-hours/item/inspector.js
+++ b/src/pro/blocks/business-hours/item/inspector.js
@@ -16,25 +16,25 @@ const Inspector = ({
 	return (
 		<InspectorControls>
 			<PanelColorSettings
-				title={ __( 'Color', 'otter-blocks' ) }
+				title={ __( 'Color', 'otter-pro' ) }
 				initialOpen={ false }
 				colorSettings={ [
 					{
 						value: attributes.backgroundColor,
 						onChange: backgroundColor => setAttributes({ backgroundColor }),
-						label: __( 'Background', 'otter-blocks' ),
+						label: __( 'Background', 'otter-pro' ),
 						isShownByDefault: true
 					},
 					{
 						value: attributes.labelColor,
 						onChange: labelColor => setAttributes({ labelColor }),
-						label: __( 'Label', 'otter-blocks' ),
+						label: __( 'Label', 'otter-pro' ),
 						isShownByDefault: true
 					},
 					{
 						value: attributes.timeColor,
 						onChange: timeColor => setAttributes({ timeColor }),
-						label: __( 'Time', 'otter-blocks' ),
+						label: __( 'Time', 'otter-pro' ),
 						isShownByDefault: true
 					}
 				] }

--- a/src/pro/blocks/file/block.json
+++ b/src/pro/blocks/file/block.json
@@ -7,7 +7,7 @@
 	"description": "Display a contact form for your clients.",
 	"keywords": [ "input", "file", "field" ],
 	"ancestor": [ "themeisle-blocks/form" ],
-	"textdomain": "otter-blocks",
+	"textdomain": "otter-pro",
 	"attributes": {
 		"id": {
 			"type": "string"

--- a/src/pro/blocks/file/edit.js
+++ b/src/pro/blocks/file/edit.js
@@ -102,13 +102,13 @@ const Edit = ({
 				}
 			}, ( res, error ) => {
 				if ( error ) {
-					createNotice( 'error', __( 'Error saving File Field settings.', 'otter-blocks' ), {
+					createNotice( 'error', __( 'Error saving File Field settings.', 'otter-pro' ), {
 						isDismissible: true,
 						type: 'snackbar',
 						id: 'file-field-option-error'
 					});
 				} else {
-					createNotice( 'info', __( 'File Field settings saved.', 'otter-blocks' ), {
+					createNotice( 'info', __( 'File Field settings saved.', 'otter-pro' ), {
 						isDismissible: true,
 						type: 'snackbar',
 						id: 'file-field-option-success'
@@ -141,7 +141,7 @@ const Edit = ({
 					className="otter-form-input-label"
 				>
 					<RichText
-						placeholder={ __( 'Type here…', 'otter-blocks' ) }
+						placeholder={ __( 'Type here…', 'otter-pro' ) }
 						className="otter-form-input-label__label"
 						value={ attributes.label }
 						onChange={ label => setAttributes({ label }) }

--- a/src/pro/blocks/file/index.js
+++ b/src/pro/blocks/file/index.js
@@ -30,8 +30,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'File Field', 'otter-blocks' ),
-	description: __( 'Display a file field for uploading.', 'otter-blocks' ),
+	title: __( 'File Field', 'otter-pro' ),
+	description: __( 'Display a file field for uploading.', 'otter-pro' ),
 	icon,
 	keywords: [
 		'input',

--- a/src/pro/blocks/file/inspector.js
+++ b/src/pro/blocks/file/inspector.js
@@ -37,7 +37,7 @@ const ProPreview = ({ attributes }) => {
 			<Disabled>
 
 				<TextControl
-					label={ __( 'Label', 'otter-blocks' ) }
+					label={ __( 'Label', 'otter-pro' ) }
 					value={ attributes.label }
 					onChange={ () => {} }
 				/>
@@ -45,51 +45,51 @@ const ProPreview = ({ attributes }) => {
 				<HideFieldLabelToggle attributes={ attributes } setAttributes={ () => {} } />
 
 				<TextControl
-					label={ __( 'Max File Size in MB', 'otter-blocks' ) }
+					label={ __( 'Max File Size in MB', 'otter-pro' ) }
 					type="number"
 					value={ attributes.maxFileSize }
 					onChange={ () => {} }
-					help={ __( 'You may need to contact your hosting provider to increase file sizes.', 'otter-blocks' ) }
+					help={ __( 'You may need to contact your hosting provider to increase file sizes.', 'otter-pro' ) }
 				/>
 
 				<FormTokenField
-					label={ __( 'Allowed File Types', 'otter-blocks' ) }
+					label={ __( 'Allowed File Types', 'otter-pro' ) }
 					value={ attributes.allowedFileTypes }
 					onChange={ () => {}  }
-					help={ __( 'Add the allowed files types that can be loaded. E.g.: jpg, zip, pdf.', 'otter-blocks' ) }
+					help={ __( 'Add the allowed files types that can be loaded. E.g.: jpg, zip, pdf.', 'otter-pro' ) }
 				/>
 
 				<TextControl
-					label={ __( 'Help Text', 'otter-blocks' ) }
+					label={ __( 'Help Text', 'otter-pro' ) }
 					value={ attributes.helpText }
 					onChange={ () => {} }
 				/>
 
 				<ToggleControl
-					label={ __( 'Required', 'otter-blocks' ) }
-					help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
+					label={ __( 'Required', 'otter-pro' ) }
+					help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-pro' ) }
 					checked={ attributes.isRequired }
 					onChange={ () => {} }
 				/>
 
 				<ToggleControl
-					label={ __( 'Allow multiple file uploads', 'otter-blocks' ) }
+					label={ __( 'Allow multiple file uploads', 'otter-pro' ) }
 					checked={ attributes.multipleFiles }
 					onChange={ () => {} }
 				/>
 
 				<TextControl
-					label={ __( 'Mapped Name', 'otter-blocks' ) }
+					label={ __( 'Mapped Name', 'otter-pro' ) }
 					help={ mappedNameInfo }
 					value={ attributes.mappedName }
 					onChange={ () => {} }
-					placeholder={ __( 'photos', 'otter-blocks' ) }
+					placeholder={ __( 'photos', 'otter-pro' ) }
 				/>
 
 				{
 					attributes.multipleFiles && (
 						<TextControl
-							label={ __( 'Maximum number of files', 'otter-blocks' ) }
+							label={ __( 'Maximum number of files', 'otter-pro' ) }
 							type="number"
 							value={ attributes.maxFilesNumber ?? 10 }
 							onChange={ () => {} }
@@ -98,8 +98,8 @@ const ProPreview = ({ attributes }) => {
 				}
 
 				<ToggleControl
-					label={ __( 'Save to Media Library', 'otter-blocks' ) }
-					help={ __( 'If enabled, the files will be saved to Media Library instead of adding them as attachments to email.', 'otter-blocks' ) }
+					label={ __( 'Save to Media Library', 'otter-pro' ) }
+					help={ __( 'If enabled, the files will be saved to Media Library instead of adding them as attachments to email.', 'otter-pro' ) }
 					checked={ 'media-library' === attributes.saveFiles }
 					onChange={ () => {} }
 				/>
@@ -107,7 +107,7 @@ const ProPreview = ({ attributes }) => {
 			</Disabled>
 			{ ! Boolean( window.themeisleGutenberg.hasPro ) && (
 				<Notice
-					notice={ <ExternalLink href={ setUtm( window.themeisleGutenberg.upgradeLink, 'formfileblock' )}>{ __( 'Get more options with Otter Pro.', 'otter-blocks' ) }</ExternalLink> }
+					notice={ <ExternalLink href={ setUtm( window.themeisleGutenberg.upgradeLink, 'formfileblock' )}>{ __( 'Get more options with Otter Pro.', 'otter-pro' ) }</ExternalLink> }
 					variant="upsell"
 				/> ) }
 		</Fragment>
@@ -134,18 +134,18 @@ const Inspector = ({
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Field Settings', 'otter-blocks' ) }
+				title={ __( 'Field Settings', 'otter-pro' ) }
 			>
 				<Button
 					isSecondary
 					variant="secondary"
 					onClick={ () => selectForm?.() }
 				>
-					{ __( 'Back to the Form', 'otter-blocks' ) }
+					{ __( 'Back to the Form', 'otter-pro' ) }
 				</Button>
 
 				<SelectControl
-					label={ __( 'Field Type', 'otter-blocks' ) }
+					label={ __( 'Field Type', 'otter-pro' ) }
 					value={ attributes.type }
 					options={ fieldTypesOptions() }
 					onChange={ type => {
@@ -168,13 +168,13 @@ const Inspector = ({
 			</PanelBody>
 
 			<PanelColorSettings
-				title={ __( 'Color', 'otter-blocks' ) }
+				title={ __( 'Color', 'otter-pro' ) }
 				initialOpen={ false }
 				colorSettings={ [
 					{
 						value: attributes.labelColor,
 						onChange: labelColor => setAttributes({ labelColor }),
-						label: __( 'Label Color', 'otter-blocks' )
+						label: __( 'Label Color', 'otter-pro' )
 					}
 				] }
 			/>

--- a/src/pro/blocks/form-hidden-field/block.json
+++ b/src/pro/blocks/form-hidden-field/block.json
@@ -6,7 +6,7 @@
 	"category": "themeisle-blocks",
 	"description": "A field used for adding extra metadata to the Form via URL params.",
 	"keywords": [ "metadata", "hidden", "field" ],
-	"textdomain": "otter-blocks",
+	"textdomain": "otter-pro",
 	"ancestor": [ "themeisle-blocks/form" ],
 	"attributes": {
 		"id": {

--- a/src/pro/blocks/form-hidden-field/edit.js
+++ b/src/pro/blocks/form-hidden-field/edit.js
@@ -46,7 +46,7 @@ const Edit = ({
 
 	const placeholder = attributes.paramName ? sprintf(
 		/* translators: %s: URL parameter name */
-		__( 'Get the value of the URL param: %s', 'otter-blocks' ),
+		__( 'Get the value of the URL param: %s', 'otter-pro' ),
 		attributes.paramName
 	) : '';
 
@@ -71,10 +71,10 @@ const Edit = ({
 					className="otter-form-input-label"
 				>
 					<span className="o-hidden-field-mark">
-						{ __( 'Hidden Field', 'otter-blocks' ) }
+						{ __( 'Hidden Field', 'otter-pro' ) }
 					</span>
 					<RichText
-						placeholder={ __( 'Type here…', 'otter-blocks' ) }
+						placeholder={ __( 'Type here…', 'otter-pro' ) }
 						className="otter-form-input-label__label"
 						value={ attributes.label }
 						onChange={ label  => setAttributes({ label }) }

--- a/src/pro/blocks/form-hidden-field/index.js
+++ b/src/pro/blocks/form-hidden-field/index.js
@@ -34,8 +34,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'Hidden Field', 'otter-blocks' ),
-	description: __( 'A field used for adding extra metadata to the Form via URL params.', 'otter-blocks' ),
+	title: __( 'Hidden Field', 'otter-pro' ),
+	description: __( 'A field used for adding extra metadata to the Form via URL params.', 'otter-pro' ),
 	icon,
 	edit,
 	save: () => null,

--- a/src/pro/blocks/form-hidden-field/inspector.js
+++ b/src/pro/blocks/form-hidden-field/inspector.js
@@ -45,18 +45,18 @@ const Inspector = ({
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Field Settings', 'otter-blocks' ) }
+				title={ __( 'Field Settings', 'otter-pro' ) }
 			>
 				<Button
 					isSecondary
 					variant="secondary"
 					onClick={ () => selectForm?.() }
 				>
-					{ __( 'Back to the Form', 'otter-blocks' ) }
+					{ __( 'Back to the Form', 'otter-pro' ) }
 				</Button>
 
 				<SelectControl
-					label={ __( 'Field Type', 'otter-blocks' ) }
+					label={ __( 'Field Type', 'otter-pro' ) }
 					value={ attributes.type ?? 'hidden' }
 					options={ fieldTypesOptions() }
 					onChange={ type => {
@@ -67,44 +67,44 @@ const Inspector = ({
 				/>
 
 				<TextControl
-					label={ __( 'Label', 'otter-blocks' ) }
+					label={ __( 'Label', 'otter-pro' ) }
 					value={ attributes.label }
 					onChange={ label => setAttributes({ label }) }
-					help={ __( 'The label will be used as the field name.', 'otter-blocks' ) }
+					help={ __( 'The label will be used as the field name.', 'otter-pro' ) }
 					disabled={! Boolean( window?.otterPro?.isActive )}
 				/>
 
 				<TextControl
-					label={ __( 'Query Param', 'otter-blocks' ) }
+					label={ __( 'Query Param', 'otter-pro' ) }
 					value={ attributes.paramName }
 					onChange={ paramName => setAttributes({ paramName }) }
-					help={ __( 'The query parameter name that is used in URL. If the param is present, its value will be extracted and send with the Form.', 'otter-blocks' ) }
-					placeholder={ __( 'e.g. utm_source', 'otter-blocks' ) }
+					help={ __( 'The query parameter name that is used in URL. If the param is present, its value will be extracted and send with the Form.', 'otter-pro' ) }
+					placeholder={ __( 'e.g. utm_source', 'otter-pro' ) }
 					disabled={! Boolean( window?.otterPro?.isActive )}
 				/>
 
 				<TextControl
-					label={ __( 'Default Value', 'otter-blocks' ) }
+					label={ __( 'Default Value', 'otter-pro' ) }
 					value={ attributes.defaultValue }
 					onChange={ defaultValue => setAttributes({ defaultValue }) }
-					placeholder={ __( 'e.g. medium', 'otter-blocks' ) }
+					placeholder={ __( 'e.g. medium', 'otter-pro' ) }
 					disabled={! Boolean( window?.otterPro?.isActive )}
 				/>
 
 				<TextControl
-					label={ __( 'Mapped Name', 'otter-blocks' ) }
+					label={ __( 'Mapped Name', 'otter-pro' ) }
 					help={ mappedNameInfo }
 					value={ attributes.mappedName }
 					onChange={ mappedName => setAttributes({ mappedName }) }
-					placeholder={ __( 'car_type', 'otter-blocks' ) }
+					placeholder={ __( 'car_type', 'otter-pro' ) }
 					disabled={! Boolean( window?.otterPro?.isActive )}
 				/>
 
 				{ ! Boolean( window?.otterPro?.isActive ) && (
 					<Fragment>
 						<OtterNotice
-							notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-							instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-blocks' ) }
+							notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+							instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-pro' ) }
 						/>
 					</Fragment>
 				)

--- a/src/pro/blocks/form-stripe-field/block.json
+++ b/src/pro/blocks/form-stripe-field/block.json
@@ -6,7 +6,7 @@
 	"category": "themeisle-blocks",
 	"description": "A field used for adding Stripe products to the form.",
 	"keywords": [ "product", "stripe", "field" ],
-	"textdomain": "otter-blocks",
+	"textdomain": "otter-pro",
 	"ancestor": [ "themeisle-blocks/form" ],
 	"attributes": {
 		"id": {

--- a/src/pro/blocks/form-stripe-field/edit.js
+++ b/src/pro/blocks/form-stripe-field/edit.js
@@ -167,7 +167,7 @@ const Edit = ({
 
 	const saveApiKey = () => {
 		setCanRetrieveProducts( false );
-		updateOption( 'themeisle_stripe_api_key', apiKey?.replace?.( /\s/g, '' ), __( 'Stripe API Key saved!', 'otter-blocks' ), 'stripe-api-key', reset );
+		updateOption( 'themeisle_stripe_api_key', apiKey?.replace?.( /\s/g, '' ), __( 'Stripe API Key saved!', 'otter-pro' ), 'stripe-api-key', reset );
 	};
 
 
@@ -188,7 +188,7 @@ const Edit = ({
 				if ( error ) {
 					createNotice(
 						'info',
-						__( 'Error saving Stripe product on Form.', 'otter-blocks' ),
+						__( 'Error saving Stripe product on Form.', 'otter-pro' ),
 						{
 							type: 'snackbar',
 							isDismissible: true,
@@ -198,7 +198,7 @@ const Edit = ({
 				} else {
 					createNotice(
 						'success',
-						__( 'Form Stripe product saved.', 'otter-blocks' ),
+						__( 'Form Stripe product saved.', 'otter-pro' ),
 						{
 							type: 'snackbar',
 							isDismissible: true,
@@ -259,13 +259,13 @@ const Edit = ({
 
 				<Placeholder
 					icon={ store }
-					label={ __( 'Stripe Checkout', 'otter-blocks' ) }
+					label={ __( 'Stripe Checkout', 'otter-pro' ) }
 				>
 					{
 						( 'loading' === status || 'saving' === status ) && (
 							<div style={{ width: '100%' }}>
 								<Spinner />
-								{ __( 'Checking the API Key…', 'otter-blocks' ) }
+								{ __( 'Checking the API Key…', 'otter-pro' ) }
 								<br /><br />
 							</div>
 						)
@@ -295,9 +295,9 @@ const Edit = ({
 							<div style={{ display: 'flex', flexDirection: 'column' }}>
 
 								<TextControl
-									label={ __( 'Stripe API Key', 'otter-blocks' ) }
+									label={ __( 'Stripe API Key', 'otter-pro' ) }
 									type="text"
-									placeholder={ __( 'Type here the Stripe API Key', 'otter-blocks' ) }
+									placeholder={ __( 'Type here the Stripe API Key', 'otter-pro' ) }
 									value={ apiKey }
 									className="components-placeholder__input"
 									onChange={ setAPIKey }
@@ -310,13 +310,13 @@ const Edit = ({
 										type="submit"
 										onClick={ saveApiKey }
 									>
-										{ __( 'Save', 'otter-blocks' ) }
+										{ __( 'Save', 'otter-pro' ) }
 									</Button>
 								</div>
 
 								<br />
 
-								<ExternalLink href={ window.themeisleGutenberg.optionsPath }>{ __( 'You can also set it from Dashboard', 'otter-blocks' ) }</ExternalLink>
+								<ExternalLink href={ window.themeisleGutenberg.optionsPath }>{ __( 'You can also set it from Dashboard', 'otter-pro' ) }</ExternalLink>
 							</div>
 						)
 					}
@@ -324,7 +324,7 @@ const Edit = ({
 					{
 						'error' === status && (
 							<Fragment>
-								{__( 'An error occurred during API Key checking.', 'otter-blocks' )}
+								{__( 'An error occurred during API Key checking.', 'otter-pro' )}
 							</Fragment>
 						)
 					}
@@ -334,11 +334,11 @@ const Edit = ({
 							<Fragment>
 								{ ! isLoadingProducts && (
 									<SelectControl
-										label={ __( 'Select a product to display.', 'otter-blocks' ) }
+										label={ __( 'Select a product to display.', 'otter-pro' ) }
 										value={ attributes.product }
 										options={ [
 											{
-												label: __( 'Select a product', 'otter-blocks' ),
+												label: __( 'Select a product', 'otter-pro' ),
 												value: 'none'
 											},
 											...productsList
@@ -351,11 +351,11 @@ const Edit = ({
 
 								{ ( ! isLoadingPrices && attributes.product ) && (
 									<SelectControl
-										label={ __( 'Select the price you want to display.', 'otter-blocks' ) }
+										label={ __( 'Select the price you want to display.', 'otter-pro' ) }
 										value={ attributes.price }
 										options={ [
 											{
-												label: __( 'Select a price', 'otter-blocks' ),
+												label: __( 'Select a price', 'otter-pro' ),
 												value: 'none'
 											},
 											...pricesList
@@ -419,8 +419,8 @@ const Edit = ({
 					</Fragment>
 				)}
 
-				{ 'success' === view && ( attributes.successMessage || __( 'Your payment was successful. If you have any questions, please email orders@example.com.', 'otter-blocks' ) ) }
-				{ 'cancel' === view && ( attributes.cancelMessage || __( 'Your payment was unsuccessful. If you have any questions, please email orders@example.com.', 'otter-blocks' ) ) }
+				{ 'success' === view && ( attributes.successMessage || __( 'Your payment was successful. If you have any questions, please email orders@example.com.', 'otter-pro' ) ) }
+				{ 'cancel' === view && ( attributes.cancelMessage || __( 'Your payment was unsuccessful. If you have any questions, please email orders@example.com.', 'otter-pro' ) ) }
 			</div>
 		</Fragment>
 	);

--- a/src/pro/blocks/form-stripe-field/index.js
+++ b/src/pro/blocks/form-stripe-field/index.js
@@ -34,8 +34,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'Stripe Field', 'otter-blocks' ),
-	description: __( 'A field used for adding Stripe products to the form.', 'otter-blocks' ),
+	title: __( 'Stripe Field', 'otter-pro' ),
+	description: __( 'A field used for adding Stripe products to the form.', 'otter-pro' ),
 	icon,
 	edit,
 	save: () => null,

--- a/src/pro/blocks/form-stripe-field/inspector.js
+++ b/src/pro/blocks/form-stripe-field/inspector.js
@@ -59,18 +59,18 @@ const Inspector = ({
 		<InspectorControls>
 
 			<PanelBody
-				title={ __( 'Field Settings', 'otter-blocks' ) }
+				title={ __( 'Field Settings', 'otter-pro' ) }
 			>
 				<Button
 					isSecondary
 					variant="secondary"
 					onClick={ () => selectForm?.() }
 				>
-					{ __( 'Back to the Form', 'otter-blocks' ) }
+					{ __( 'Back to the Form', 'otter-pro' ) }
 				</Button>
 
 				<SelectControl
-					label={ __( 'Field Type', 'otter-blocks' ) }
+					label={ __( 'Field Type', 'otter-pro' ) }
 					value={ attributes.type ?? 'stripe' }
 					options={ fieldTypesOptions() }
 					onChange={ type => {
@@ -83,18 +83,18 @@ const Inspector = ({
 				<FieldInputWidth attributes={ attributes } setAttributes={ setAttributes } />
 
 				<TextControl
-					label={ __( 'Mapped Name', 'otter-blocks' ) }
-					help={ __( 'Allow easy identification of the field in features like Webhooks.', 'otter-blocks' ) }
+					label={ __( 'Mapped Name', 'otter-pro' ) }
+					help={ __( 'Allow easy identification of the field in features like Webhooks.', 'otter-pro' ) }
 					value={ attributes.mappedName }
 					onChange={ mappedName => setAttributes({ mappedName }) }
-					placeholder={ __( 'product', 'otter-blocks' ) }
+					placeholder={ __( 'product', 'otter-pro' ) }
 				/>
 
 				{ ! Boolean( window?.otterPro?.isActive ) && (
 					<Fragment>
 						<OtterNotice
-							notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-							instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Form Block.', 'otter-blocks' ) }
+							notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+							instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Form Block.', 'otter-pro' ) }
 						/>
 					</Fragment>
 				)
@@ -110,15 +110,15 @@ const Inspector = ({
 			</PanelBody>
 
 			<PanelBody
-				title={ __( 'Stripe Product', 'otter-blocks' ) }
+				title={ __( 'Stripe Product', 'otter-pro' ) }
 			>
 				{ ! isLoadingProducts && (
 					<SelectControl
-						label={ __( 'Select a product to display.', 'otter-blocks' ) }
+						label={ __( 'Select a product to display.', 'otter-pro' ) }
 						value={ attributes.product }
 						options={ [
 							{
-								label: __( 'Select a product', 'otter-blocks' ),
+								label: __( 'Select a product', 'otter-pro' ),
 								value: 'none'
 							},
 							...productsList
@@ -135,11 +135,11 @@ const Inspector = ({
 
 				{ ( ! isLoadingPrices && attributes.product ) && (
 					<SelectControl
-						label={ __( 'Select the price you want to display.', 'otter-blocks' ) }
+						label={ __( 'Select the price you want to display.', 'otter-pro' ) }
 						value={ attributes.price }
 						options={ [
 							{
-								label: __( 'Select a price', 'otter-blocks' ),
+								label: __( 'Select a price', 'otter-pro' ),
 								value: 'none'
 							},
 							...pricesList
@@ -156,51 +156,51 @@ const Inspector = ({
 
 
 			<PanelColorSettings
-				title={ __( 'Color', 'otter-blocks' ) }
+				title={ __( 'Color', 'otter-pro' ) }
 				initialOpen={ false }
 				colorSettings={ [
 					{
 						value: attributes.labelColor,
 						onChange: labelColor => setAttributes({ labelColor }),
-						label: __( 'Label Color', 'otter-blocks' )
+						label: __( 'Label Color', 'otter-pro' )
 					},
 					{
 						value: attributes.borderColor,
 						onChange: borderColor => setAttributes({ borderColor }),
-						label: __( 'Border Color', 'otter-blocks' )
+						label: __( 'Border Color', 'otter-pro' )
 					}
 				] }
 			/>
 			<PanelBody
-				title={ __( 'Border', 'otter-blocks' ) }
+				title={ __( 'Border', 'otter-pro' ) }
 				initialOpen={ false }
 			>
 				<BoxControl
-					label={ __( 'Border Width', 'otter-blocks' ) }
+					label={ __( 'Border Width', 'otter-pro' ) }
 					values={ attributes.borderWidth }
 					onChange={ borderWidth => setAttributes({ borderWidth }) }
 				/>
 
 				<BoxControl
-					label={ __( 'Border Radius', 'otter-blocks' ) }
+					label={ __( 'Border Radius', 'otter-pro' ) }
 					values={ attributes.borderRadius }
 					onChange={ borderRadius => setAttributes({ borderRadius }) }
 				/>
 			</PanelBody>
 
 			<PanelBody
-				title={ __( 'Global Settings', 'otter-blocks' ) }
+				title={ __( 'Global Settings', 'otter-pro' ) }
 				initialOpen={ false }
 			>
 				<TextControl
-					label={ __( 'Change Stripe API Key', 'otter-blocks' ) }
+					label={ __( 'Change Stripe API Key', 'otter-pro' ) }
 					type="text"
-					placeholder={ __( 'Type a new Stripe API Key', 'otter-blocks' ) }
+					placeholder={ __( 'Type a new Stripe API Key', 'otter-pro' ) }
 					value={ apiKey }
 					className="components-placeholder__input"
 					autoComplete='off'
 					onChange={ setAPIKey }
-					help={ __( 'Changing the API key effects all Stripe Checkout blocks. You will have to refresh the page after changing your API keys.', 'otter-blocks' ) }
+					help={ __( 'Changing the API key effects all Stripe Checkout blocks. You will have to refresh the page after changing your API keys.', 'otter-pro' ) }
 				/>
 
 				<Button
@@ -209,7 +209,7 @@ const Inspector = ({
 					onClick={ saveApiKey }
 					isBusy={ 'loading' === status }
 				>
-					{ __( 'Save API Key', 'otter-blocks' ) }
+					{ __( 'Save API Key', 'otter-pro' ) }
 				</Button>
 			</PanelBody>
 

--- a/src/pro/blocks/modal/block.json
+++ b/src/pro/blocks/modal/block.json
@@ -6,7 +6,7 @@
 	"category": "themeisle-blocks",
 	"description": "Display your content in beautiful Modal with many customization options. Powered by Otter.",
 	"keywords": [ "modal", "lightbox" ],
-	"textdomain": "otter-blocks",
+	"textdomain": "otter-pro",
 	"attributes": {
 		"id": {
 			"type": "string"

--- a/src/pro/blocks/modal/edit.js
+++ b/src/pro/blocks/modal/edit.js
@@ -179,7 +179,7 @@ const Edit = ({
 				createBlock(
 					'core/button',
 					{
-						text: __( 'Open Modal', 'otter-blocks' ),
+						text: __( 'Open Modal', 'otter-pro' ),
 						anchor: modalAnchor
 					}
 				)
@@ -204,7 +204,7 @@ const Edit = ({
 						icon={ external }
 						onClick={ () => setEditing( true ) }
 					>
-						{ __( 'Edit Modal', 'otter-blocks' ) }
+						{ __( 'Edit Modal', 'otter-pro' ) }
 					</Button>
 
 					{ isEditing && (
@@ -242,8 +242,8 @@ const Edit = ({
 											},
 											[
 												[ 'core/image', { height: '150px' }],
-												[ 'core/heading', { placeholder: __( 'Modal Title' ) }],
-												[ 'core/paragraph', { placeholder: __( 'Modal Content' ) }]
+												[ 'core/heading', { placeholder: __( 'Modal Title', 'otter-pro'  ) }],
+												[ 'core/paragraph', { placeholder: __( 'Modal Content', 'otter-pro'  ) }]
 											]
 										]
 									]} />

--- a/src/pro/blocks/modal/index.js
+++ b/src/pro/blocks/modal/index.js
@@ -28,8 +28,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'Modal', 'otter-blocks' ),
-	description: __( 'Display your content in beautiful Modal with many customization options. Powered by Otter.', 'otter-blocks' ),
+	title: __( 'Modal', 'otter-pro' ),
+	description: __( 'Display your content in beautiful Modal with many customization options. Powered by Otter.', 'otter-pro' ),
 	icon,
 	keywords: [
 		'modal',

--- a/src/pro/blocks/modal/inspector.js
+++ b/src/pro/blocks/modal/inspector.js
@@ -69,13 +69,13 @@ const Inspector = ({
 		return (
 			<Fragment>
 				<ToggleControl
-					label={ __( 'Show Close Button', 'otter-blocks' ) }
+					label={ __( 'Show Close Button', 'otter-pro' ) }
 					checked={ attributes.showClose }
 					onChange={ () => setAttributes({ showClose: ! attributes.showClose }) }
 				/>
 
 				<ToggleControl
-					label={ __( 'Close on Click Outside', 'otter-blocks' ) }
+					label={ __( 'Close on Click Outside', 'otter-pro' ) }
 					checked={ attributes.outsideClose }
 					onChange={ () => setAttributes({ outsideClose: ! attributes.outsideClose }) }
 				/>
@@ -85,17 +85,17 @@ const Inspector = ({
 
 	return (
 		<InspectorControls>
-			{ applyFilters( 'otter.feedback', '', 'popup-block', __( 'Help us improve this block', 'otter-blocks' ) ) }
+			{ applyFilters( 'otter.feedback', '', 'popup-block', __( 'Help us improve this block', 'otter-pro' ) ) }
 
 			<InspectorHeader
 				value={ tab }
 				options={[
 					{
-						label: __( 'Settings', 'otter-blocks' ),
+						label: __( 'Settings', 'otter-pro' ),
 						value: 'settings'
 					},
 					{
-						label: __( 'Style', 'otter-blocks' ),
+						label: __( 'Style', 'otter-pro' ),
 						value: 'style'
 					}
 				]}
@@ -106,25 +106,25 @@ const Inspector = ({
 				{ 'settings' === tab && (
 					<Fragment>
 						<PanelBody
-							title={ __( 'Modal Settings', 'otter-blocks' )}
+							title={ __( 'Modal Settings', 'otter-pro' )}
 							initialOpen={ true }
 						>
 							<TextControl
-								label={ __( 'Anchor', 'otter-blocks' ) }
-								help={ __( 'You can use this anchor as an anchor link anywhere on the page to open the popup.', 'otter-blocks' ) }
+								label={ __( 'Anchor', 'otter-pro' ) }
+								help={ __( 'You can use this anchor as an anchor link anywhere on the page to open the popup.', 'otter-pro' ) }
 								value={ attributes.anchor }
 								onChange={ anchor => setAttributes({ anchor }) }
 							/>
 							<ToggleControl
-								label={ __( 'Close On Anchor Click', 'otter-blocks' ) }
+								label={ __( 'Close On Anchor Click', 'otter-pro' ) }
 								checked={ attributes.anchorClose }
 								onChange={ () => setAttributes({ anchorClose: ! attributes.anchorClose }) }
 							/>
 
 							{ attributes.anchorClose && (
 								<TextControl
-									label={ __( 'Close Anchor', 'otter-blocks' ) }
-									help={ __( 'You can use this anchor as an anchor link anywhere on the page to close the popup.', 'otter-blocks' ) }
+									label={ __( 'Close Anchor', 'otter-pro' ) }
+									help={ __( 'You can use this anchor as an anchor link anywhere on the page to close the popup.', 'otter-pro' ) }
 									value={ attributes.closeAnchor }
 									onChange={ closeAnchor => setAttributes({ closeAnchor }) }
 								/>
@@ -132,11 +132,11 @@ const Inspector = ({
 						</PanelBody>
 
 						<PanelBody
-							title={ __( 'Modal Position', 'otter-blocks' )}
+							title={ __( 'Modal Position', 'otter-pro' )}
 							initialOpen={ false }
 						>
 							<ResponsiveControl
-								label={ __( 'Screen Type', 'otter-blocks' ) }
+								label={ __( 'Screen Type', 'otter-pro' ) }
 							>
 								<div className="o-position-picker">
 									<AlignmentMatrixControl
@@ -162,10 +162,10 @@ const Inspector = ({
 				{ 'style' === tab && (
 					<Fragment>
 						<PanelBody
-							title={ __( 'Dimensions', 'otter-blocks' ) }
+							title={ __( 'Dimensions', 'otter-pro' ) }
 						>
 							<ResponsiveControl
-								label={ __( 'Width', 'otter-blocks' ) }
+								label={ __( 'Width', 'otter-pro' ) }
 							>
 								<UnitControl
 
@@ -181,14 +181,14 @@ const Inspector = ({
 							</ResponsiveControl>
 
 							<SelectControl
-								label={ __( 'Height', 'otter-blocks' ) }
+								label={ __( 'Height', 'otter-pro' ) }
 								options={ [
 									{
-										label: __( 'Fit Content', 'otter-blocks' ),
+										label: __( 'Fit Content', 'otter-pro' ),
 										value: 'none'
 									},
 									{
-										label: __( 'Custom', 'otter-blocks' ),
+										label: __( 'Custom', 'otter-pro' ),
 										value: 'custom'
 									}
 								] }
@@ -199,7 +199,7 @@ const Inspector = ({
 							{
 								'custom' === attributes.heightMode && (
 									<ResponsiveControl
-										label={ __( 'Custom Height', 'otter-blocks' ) }
+										label={ __( 'Custom Height', 'otter-pro' ) }
 									>
 										<UnitControl
 											value={ responsiveGetAttributes([
@@ -217,7 +217,7 @@ const Inspector = ({
 
 							<ResponsiveControl>
 								<BoxControl
-									label={ __( 'Padding', 'otter-blocks' ) }
+									label={ __( 'Padding', 'otter-pro' ) }
 									values={ responsiveGetAttributes([
 										attributes.padding,
 										attributes.paddingTablet,
@@ -234,41 +234,41 @@ const Inspector = ({
 						</PanelBody>
 
 						<PanelColorSettings
-							title={ __( 'Color', 'otter-blocks' ) }
+							title={ __( 'Color', 'otter-pro' ) }
 							initialOpen={ false }
 							colorSettings={ [
 								{
 									value: attributes.backgroundColor,
 									onChange: backgroundColor => setAttributes({ backgroundColor }),
-									label: __( 'Background', 'otter-blocks' ),
+									label: __( 'Background', 'otter-pro' ),
 									isShownByDefault: false
 								},
 								{
 									value: attributes.closeColor,
 									onChange: closeColor => setAttributes({ closeColor }),
-									label: __( 'Close Button', 'otter-blocks' ),
+									label: __( 'Close Button', 'otter-pro' ),
 									isShownByDefault: false
 								},
 								{
 									value: attributes.overlayColor,
 									onChange: overlayColor => setAttributes({ overlayColor }),
-									label: __( 'Overlay', 'otter-blocks' ),
+									label: __( 'Overlay', 'otter-pro' ),
 									isShownByDefault: false
 								},
 								{
 									value: attributes.borderColor,
 									onChange: borderColor => setAttributes({ borderColor }),
-									label: __( 'Border', 'otter-blocks' ),
+									label: __( 'Border', 'otter-pro' ),
 									isShownByDefault: false
 								}
 							] }
 						/>
 						<PanelBody
-							title={ __( 'Overlay', 'otter-blocks' ) }
+							title={ __( 'Overlay', 'otter-pro' ) }
 							initialOpen={ false }
 						>
 							<RangeControl
-								label={ __( 'Overlay Opacity', 'otter-blocks' ) }
+								label={ __( 'Overlay Opacity', 'otter-pro' ) }
 								value={ attributes.overlayOpacity }
 								initialPosition={ 100 }
 								onChange={ value => setAttributes({ overlayOpacity: value !== undefined ? Number( value ) : undefined }) }
@@ -277,23 +277,23 @@ const Inspector = ({
 						</PanelBody>
 
 						<PanelBody
-							title={ __( 'Close Button', 'otter-blocks' ) }
+							title={ __( 'Close Button', 'otter-pro' ) }
 							initialOpen={ false }
 						>
 							<ToggleControl
-								label={ __( 'Show Close Button', 'otter-blocks' ) }
+								label={ __( 'Show Close Button', 'otter-pro' ) }
 								checked={ attributes.showClose }
 								onChange={ () => setAttributes({ showClose: ! attributes.showClose }) }
 							/>
 							<SelectControl
-								label={ __( 'Position', 'otter-blocks' ) }
+								label={ __( 'Position', 'otter-pro' ) }
 								options={ [
 									{
-										label: __( 'Inside', 'otter-blocks' ),
+										label: __( 'Inside', 'otter-pro' ),
 										value: 'none'
 									},
 									{
-										label: __( 'Outside', 'otter-blocks' ),
+										label: __( 'Outside', 'otter-pro' ),
 										value: 'outside'
 									}
 								] }
@@ -303,11 +303,11 @@ const Inspector = ({
 						</PanelBody>
 
 						<PanelBody
-							title={ __( 'Border', 'otter-blocks' ) }
+							title={ __( 'Border', 'otter-pro' ) }
 							initialOpen={ false }
 						>
 							<BoxControl
-								label={ __( 'Width', 'otter-blocks' ) }
+								label={ __( 'Width', 'otter-pro' ) }
 								values={ attributes.borderWidth ?? { top: '0px', bottom: '0px', left: '0px', right: '0px' } }
 								onChange={ value => {
 									setAttributes({
@@ -318,7 +318,7 @@ const Inspector = ({
 
 							<BoxControl
 								id="o-border-raduis-box"
-								label={ __( 'Radius', 'otter-blocks' ) }
+								label={ __( 'Radius', 'otter-pro' ) }
 								values={ attributes.borderRadius ?? { top: '0px', bottom: '0px', left: '0px', right: '0px' } }
 								onChange={ value => {
 									setAttributes({

--- a/src/pro/blocks/review-comparison/block.json
+++ b/src/pro/blocks/review-comparison/block.json
@@ -6,7 +6,7 @@
 	"category": "themeisle-blocks",
 	"description": "A way to compare different product reviews made on the website. Powered by Otter.",
 	"keywords": [ "product", "review", "comparison" ],
-	"textdomain": "otter-blocks",
+	"textdomain": "otter-pro",
 	"attributes": {
 		"id": {
 			"type": "string"

--- a/src/pro/blocks/review-comparison/controls.js
+++ b/src/pro/blocks/review-comparison/controls.js
@@ -22,7 +22,7 @@ const Controls = ({
 		<BlockControls>
 			<ToolbarGroup>
 				<ToolbarButton
-					label={ __( 'Edit', 'otter-blocks' ) }
+					label={ __( 'Edit', 'otter-pro' ) }
 					icon={ edit }
 					onClick={ onEdit }
 				/>

--- a/src/pro/blocks/review-comparison/edit.js
+++ b/src/pro/blocks/review-comparison/edit.js
@@ -152,7 +152,7 @@ const Edit = ({
 			});
 
 			tableImages.push( <td>{ review.attrs.image && <img src={ review.attrs.image.url } alt={ review.attrs.image?.alt } /> }</td> );
-			tableName.push( <td>{ review.attrs.title || __( 'Untitled review', 'otter-blocks' ) }</td> );
+			tableName.push( <td>{ review.attrs.title || __( 'Untitled review', 'otter-pro' ) }</td> );
 			tablePrice.push( <td>{ review.attrs.discounted ? <Fragment><del>{ currency + review.attrs.price }</del> { currency + review.attrs.discounted }</Fragment> : ( review.attrs.price ? ( currency + review.attrs.price ) : '-' ) }</td> );
 			tableRating.push( <td><div className="o-review-comparison_ratings">{ getStars( overallRatings ) }</div></td> );
 			tableDescription.push( <td dangerouslySetInnerHTML={ { __html: review.attrs.description } }></td> );
@@ -234,32 +234,32 @@ const Edit = ({
 
 				<tbody>
 					<tr>
-						<th>{ __( 'Name', 'otter-blocks' ) }</th>
+						<th>{ __( 'Name', 'otter-pro' ) }</th>
 						{ tableName }
 					</tr>
 
 					<tr>
-						<th>{ __( 'Price', 'otter-blocks' ) }</th>
+						<th>{ __( 'Price', 'otter-pro' ) }</th>
 						{ tablePrice }
 					</tr>
 
 					<tr>
-						<th>{ __( 'Rating', 'otter-blocks' ) }</th>
+						<th>{ __( 'Rating', 'otter-pro' ) }</th>
 						{ tableRating }
 					</tr>
 
 					<tr>
-						<th>{ __( 'Description', 'otter-blocks' ) }</th>
+						<th>{ __( 'Description', 'otter-pro' ) }</th>
 						{ tableDescription }
 					</tr>
 
 					<tr>
-						<th>{ __( 'Statistics', 'otter-blocks' ) }</th>
+						<th>{ __( 'Statistics', 'otter-pro' ) }</th>
 						{ tableStatistics }
 					</tr>
 
 					<tr className={ cssNodeName }>
-						<th>{ __( 'Buy this product', 'otter-blocks' ) }</th>
+						<th>{ __( 'Buy this product', 'otter-pro' ) }</th>
 						{ tableLinks }
 					</tr>
 				</tbody>

--- a/src/pro/blocks/review-comparison/index.js
+++ b/src/pro/blocks/review-comparison/index.js
@@ -28,8 +28,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'Review Comparison Table', 'otter-blocks' ),
-	description: __( 'A way to compare different product reviews made on the website. Powered by Otter.', 'otter-blocks' ),
+	title: __( 'Review Comparison Table', 'otter-pro' ),
+	description: __( 'A way to compare different product reviews made on the website. Powered by Otter.', 'otter-pro' ),
 	icon,
 	keywords: [
 		'product',

--- a/src/pro/blocks/review-comparison/inspector.js
+++ b/src/pro/blocks/review-comparison/inspector.js
@@ -21,19 +21,19 @@ const Inspector = ({
 	return (
 		<InspectorControls>
 			<PanelColorSettings
-				title={ __( 'Color', 'otter-blocks' ) }
+				title={ __( 'Color', 'otter-pro' ) }
 				initialOpen={ false }
 				colorSettings={ [
 					{
 						value: attributes.buttonColor,
 						onChange: value => setAttributes({ buttonColor: value }),
-						label: __( 'Button', 'otter-blocks' ),
+						label: __( 'Button', 'otter-pro' ),
 						isShownByDefault: true
 					},
 					{
 						value: attributes.buttonText,
 						onChange: value => setAttributes({ buttonText: value }),
-						label: __( 'Button text', 'otter-blocks' ),
+						label: __( 'Button text', 'otter-pro' ),
 						isShownByDefault: true
 					}
 				] }

--- a/src/pro/blocks/review-comparison/placeholder.js
+++ b/src/pro/blocks/review-comparison/placeholder.js
@@ -55,7 +55,7 @@ const BlockPlaceholder = ({
 			<Button
 
 				/* translators: %s Label */
-				label={ sprintf( __( 'Remove %s', 'otter-blocks' ), label ) }
+				label={ sprintf( __( 'Remove %s', 'otter-pro' ), label ) }
 				icon="dismiss"
 				onClick={ () => toggleReview( value ) }
 			/>
@@ -68,7 +68,7 @@ const BlockPlaceholder = ({
 	}).map( value => {
 		const values = value.split( '-' );
 		const review = data.find( review => review.ID === Number( values[0]) && review.attrs.id.slice( review.attrs.id.length - 8 ) === values[1]);
-		const label = review.attrs.title || __( 'Untitled review', 'otter-blocks' );
+		const label = review.attrs.title || __( 'Untitled review', 'otter-pro' );
 
 		return {
 			label,
@@ -78,17 +78,17 @@ const BlockPlaceholder = ({
 
 	return (
 		<Placeholder
-			label={ __( 'Product Review Comparison', 'otter-blocks' ) }
-			instructions={ __( 'Display a selection of product reviews in a comparison table. You need to have some pre-existing reviews to use this block.', 'otter-blocks' ) }
+			label={ __( 'Product Review Comparison', 'otter-pro' ) }
+			instructions={ __( 'Display a selection of product reviews in a comparison table. You need to have some pre-existing reviews to use this block.', 'otter-pro' ) }
 			icon={ icon }
 			isColumnLayout={ true }
 			className="o-review-comparison__placeholder"
 		>
 			{ isLoading && <Spinner /> }
 
-			{ isError && __( 'There seems to have been an error.', 'otter-blocks' ) }
+			{ isError && __( 'There seems to have been an error.', 'otter-pro' ) }
 
-			{ ( isComplete && ! Boolean( data.length ) ) && __( 'No reviews found.', 'otter-blocks' ) }
+			{ ( isComplete && ! Boolean( data.length ) ) && __( 'No reviews found.', 'otter-pro' ) }
 
 			{ ( isComplete && Boolean( data.length ) ) && (
 				<div className="o-review-comparison__placeholder__container">
@@ -97,7 +97,7 @@ const BlockPlaceholder = ({
 							{
 
 								/* translators: %s Number of selected reviews. */
-								sprintf( __( '%s reviews selected', 'otter-blocks' ), attributes.reviews.length )
+								sprintf( __( '%s reviews selected', 'otter-pro' ), attributes.reviews.length )
 							}
 						</div>
 
@@ -111,19 +111,19 @@ const BlockPlaceholder = ({
 					</div>
 
 					<TextControl
-						label={ __( 'Search for review to display', 'otter-blocks' ) }
+						label={ __( 'Search for review to display', 'otter-pro' ) }
 						value={ query }
 						onChange={ setQuery }
 					/>
 
 					<MenuGroup>
-						{ data.filter( review => ( review.attrs.title || __( 'Untitled review', 'otter-blocks' ) ).toLowerCase().includes( query.toLowerCase() ) ).map( review => {
+						{ data.filter( review => ( review.attrs.title || __( 'Untitled review', 'otter-pro' ) ).toLowerCase().includes( query.toLowerCase() ) ).map( review => {
 							const ID = review.ID + '-' + review.attrs.id.slice( review.attrs.id.length - 8 );
 
 							return (
 								<CheckboxControl
 									key={ ID }
-									label={ review.attrs.title || __( 'Untitled review', 'otter-blocks' ) }
+									label={ review.attrs.title || __( 'Untitled review', 'otter-pro' ) }
 									checked={ attributes.reviews.includes( ID ) }
 									onChange={ () => toggleReview( ID ) }
 								/>
@@ -135,7 +135,7 @@ const BlockPlaceholder = ({
 						isPrimary
 						onClick={ onComplete }
 					>
-						{ __( 'Done', 'otter-blocks' ) }
+						{ __( 'Done', 'otter-pro' ) }
 					</Button>
 				</div>
 			) }

--- a/src/pro/blocks/review-comparison/placeholder.js
+++ b/src/pro/blocks/review-comparison/placeholder.js
@@ -54,8 +54,11 @@ const BlockPlaceholder = ({
 
 			<Button
 
-				/* translators: %s Label */
-				label={ sprintf( __( 'Remove %s', 'otter-pro' ), label ) }
+				label={ sprintf( 
+					// translators: %s label.
+					__( 'Remove %s', 'otter-pro' ),
+					label
+				) }
 				icon="dismiss"
 				onClick={ () => toggleReview( value ) }
 			/>

--- a/src/pro/blocks/woo-comparison/block.json
+++ b/src/pro/blocks/woo-comparison/block.json
@@ -6,7 +6,7 @@
 	"category": "themeisle-blocks",
 	"description": "A way to compare different WooCommerce products made on the website. Powered by Otter.",
 	"keywords": [ "woocommerce", "comparison", "table" ],
-	"textdomain": "otter-blocks",
+	"textdomain": "otter-pro",
 	"attributes": {
 		"id": {
 			"type": "string"

--- a/src/pro/blocks/woo-comparison/index.js
+++ b/src/pro/blocks/woo-comparison/index.js
@@ -53,15 +53,15 @@ const edit = ({
 
 	return (
 		<div { ...useBlockProps() }>
-			<Placeholder>{ __( 'You need to install the latest version of Neve with Sparks for WooCommerce to use WooCommerce Comparison Table.', 'otter-blocks' ) }</Placeholder>
+			<Placeholder>{ __( 'You need to install the latest version of Neve with Sparks for WooCommerce to use WooCommerce Comparison Table.', 'otter-pro' ) }</Placeholder>
 		</div>
 	);
 };
 
 registerBlockType( name, {
 	...metadata,
-	title: __( 'WooCommerce Comparison Table', 'otter-blocks' ),
-	description: __( 'A way to compare different WooCommerce products made on the website.', 'otter-blocks' ),
+	title: __( 'WooCommerce Comparison Table', 'otter-pro' ),
+	description: __( 'A way to compare different WooCommerce products made on the website.', 'otter-pro' ),
 	icon: 'editor-table',
 	keywords: [
 		'woocommerce',

--- a/src/pro/components/acf-image-select/index.js
+++ b/src/pro/components/acf-image-select/index.js
@@ -49,7 +49,7 @@ const ACFImageSelect = ({
 			value={ value }
 			options={ [
 				{
-					label: __( 'Select a field', 'otter-blocks' ),
+					label: __( 'Select a field', 'otter-pro' ),
 					value: 'none'
 				},
 				...fields

--- a/src/pro/components/autoresponder/index.js
+++ b/src/pro/components/autoresponder/index.js
@@ -11,14 +11,14 @@ const AutoresponderBodyModal = ({ value, onChange, area, addExtraMargin }) => {
 		<>
 			{ isOpen && (
 				<Modal
-					title={ __( 'Autoresponder Body' ) }
+					title={ __( 'Autoresponder Body', 'otter-pro'  ) }
 					onRequestClose={() => setOpen( false )}
 					shouldCloseOnClickOutside={ false }
 				>
 					<RichTextEditor
 						value={ value }
 						onChange={ onChange }
-						help={ __( 'Enter the body of the autoresponder email.', 'otter-blocks' ) }
+						help={ __( 'Enter the body of the autoresponder email.', 'otter-pro' ) }
 						allowRawHTML
 						area={ area }
 					/>
@@ -29,7 +29,7 @@ const AutoresponderBodyModal = ({ value, onChange, area, addExtraMargin }) => {
 				onClick={() => setOpen( true )}
 				className={ classNames({ 'o-autoresponder-margin': Boolean( addExtraMargin ) }) }
 			>
-				{ __( 'Add Autoresponder Body', 'otter-blocks' ) }
+				{ __( 'Add Autoresponder Body', 'otter-pro' ) }
 			</Button>
 		</>
 	);

--- a/src/pro/components/inactive/index.js
+++ b/src/pro/components/inactive/index.js
@@ -15,9 +15,9 @@ const Inactive = ({
 }) => {
 	const instructions = sprintf(
 		// translators: %1$s: block name, %2$s: action (renew or activate)
-		__( 'You need to %2$s your Otter Pro license in order to use %1$s block.', 'otter-blocks' ),
+		__( 'You need to %2$s your Otter Pro license in order to use %1$s block.', 'otter-pro' ),
 		label,
-		Boolean( window.otterPro.isExpired ) ? __( 'renew', 'otter-blocks' ) : __( 'activate', 'otter-blocks' )
+		Boolean( window.otterPro.isExpired ) ? __( 'renew', 'otter-pro' ) : __( 'activate', 'otter-pro' )
 	);
 
 	return (

--- a/src/pro/components/webhook-editor/index.tsx
+++ b/src/pro/components/webhook-editor/index.tsx
@@ -72,17 +72,17 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 
 	const checkWebhook = ( webhook: Webhook ) => {
 		if ( ! webhook.name ) {
-			return  __( 'Please enter a webhook name.', 'otter-blocks' );
+			return  __( 'Please enter a webhook name.', 'otter-pro' );
 		}
 
 		if ( ! webhook.url ) {
-			return __( 'Please enter a webhook URL.', 'otter-blocks' );
+			return __( 'Please enter a webhook URL.', 'otter-pro' );
 		}
 
 		if ( 0 < webhook.headers.length ) {
 			for ( const header of webhook.headers ) {
 				if ( ! header.key || ! header.value ) {
-					return __( 'Please enter a key and value for all headers.', 'otter-blocks' );
+					return __( 'Please enter a key and value for all headers.', 'otter-pro' );
 				}
 			}
 		}
@@ -96,7 +96,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 			if ( true !== check ) {
 				const msg = sprintf(
 					/* translators: %s: webhook name */
-					__( 'There was an error saving the webhook: %s', 'otter-blocks' ),
+					__( 'There was an error saving the webhook: %s', 'otter-pro' ),
 					webhook?.name
 				) + '\n';
 				setError( msg + check );
@@ -105,7 +105,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 		}
 
 		// Save to wp options
-		setOption?.( 'themeisle_webhooks_options', [ ...webhooksToSave ], __( 'Webhooks saved.', 'otter-blocks' ), 'webhook', ( response ) => {
+		setOption?.( 'themeisle_webhooks_options', [ ...webhooksToSave ], __( 'Webhooks saved.', 'otter-pro' ), 'webhook', ( response ) => {
 			setWebhooks( response?.['themeisle_webhooks_options'] ?? []);
 			window.oTrk?.add({ feature: 'webhook', featureComponent: 'saving' });
 		});
@@ -128,7 +128,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 		<Fragment>
 			{ isOpen && (
 				<Modal
-					title={ id ?  __( 'Webhook Editor' ) : __( 'Webhook List' ) }
+					title={ id ?  __( 'Webhook Editor', 'otter-pro'  ) : __( 'Webhook List', 'otter-pro'  ) }
 					onRequestClose={() => setOpen( false )}
 					shouldCloseOnClickOutside={ false }
 				>
@@ -136,21 +136,21 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 						id ? (
 							<Fragment>
 								<TextControl
-									label={ __( 'Webhook Name', 'otter-blocks' ) }
-									help={ __( 'Enter the URL to send the data to.', 'otter-blocks' )}
+									label={ __( 'Webhook Name', 'otter-pro' ) }
+									help={ __( 'Enter the URL to send the data to.', 'otter-pro' )}
 									value={name}
 									onChange={setName}
-									placeholder={ __( 'My Webhook', 'otter-blocks' )}
+									placeholder={ __( 'My Webhook', 'otter-pro' )}
 								/>
 								<TextControl
-									label={ __( 'URL', 'otter-blocks' ) }
-									help={ __( 'Enter the URL to send the data to.', 'otter-blocks' )}
+									label={ __( 'URL', 'otter-pro' ) }
+									help={ __( 'Enter the URL to send the data to.', 'otter-pro' )}
 									value={url}
 									onChange={setUrl}
-									placeholder={ __( 'https://example.com', 'otter-blocks' )}
+									placeholder={ __( 'https://example.com', 'otter-pro' )}
 								/>
 								<SelectControl
-									label={ __( 'Method', 'otter-blocks' ) }
+									label={ __( 'Method', 'otter-pro' ) }
 									value={method}
 									onChange={setMethod}
 									options={[
@@ -161,8 +161,8 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 								/>
 								<BaseControl
 									id="otter-blocks-webhook-headers"
-									label={ __( 'Headers', 'otter-blocks' ) }
-									help={ __( 'Enter the HTTP headers to send with the request.', 'otter-blocks' )}
+									label={ __( 'Headers', 'otter-pro' ) }
+									help={ __( 'Enter the HTTP headers to send with the request.', 'otter-pro' )}
 								>
 									<div className="o-webhook-headers">
 										{
@@ -171,7 +171,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 													<div className="o-webhook-header" key={index}>
 														<TextControl
 															value={header?.key ?? ''}
-															placeholder={ __( 'Content-Type', 'otter-blocks' )}
+															placeholder={ __( 'Content-Type', 'otter-pro' )}
 															onChange={( value ) => {
 																const newHeaders = [ ...headers ];
 																newHeaders[ index ] = {
@@ -183,7 +183,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 														/>
 														<TextControl
 															value={header?.value ?? ''}
-															placeholder={ __( 'application/json', 'otter-blocks' )}
+															placeholder={ __( 'application/json', 'otter-pro' )}
 															onChange={( value ) => {
 																const newHeaders = [ ...headers ];
 																newHeaders[ index ] = {
@@ -216,7 +216,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 												]);
 											}}
 										>
-											{ __( 'Add New Header', 'otter-blocks' ) }
+											{ __( 'Add New Header', 'otter-pro' ) }
 										</Button>
 									</div>
 								</BaseControl>
@@ -228,7 +228,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 												setId( '' );
 											}}
 										>
-											{ __( 'Back', 'otter-blocks' ) }
+											{ __( 'Back', 'otter-pro' ) }
 										</Button>
 										<Button
 											variant={ 'tertiary' }
@@ -238,7 +238,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 												setId( '' );
 											}}
 										>
-											{ __( 'Delete', 'otter-blocks' ) }
+											{ __( 'Delete', 'otter-pro' ) }
 										</Button>
 									</div>
 
@@ -274,7 +274,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 											saveWebhooks( newWebhooks );
 										}}
 									>
-										{ __( 'Save', 'otter-blocks' ) }
+										{ __( 'Save', 'otter-pro' ) }
 									</Button>
 								</div>
 							</Fragment>
@@ -318,7 +318,7 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 											setMethod( 'POST' );
 											setHeaders([]);
 										}}>
-										{ __( 'Add New Webhook', 'otter-blocks' ) }
+										{ __( 'Add New Webhook', 'otter-pro' ) }
 									</Button>
 								</div>
 							</div>
@@ -347,19 +347,19 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 						<br/>
 						<span>
 							<Spinner />
-							{ __( 'Loading Webhooks', 'otter-blocks' ) }
+							{ __( 'Loading Webhooks', 'otter-pro' ) }
 						</span>
 					</Fragment>
 				)
 			}
 
 			<SelectControl
-				label={ __( 'Webhook', 'otter-blocks' ) }
+				label={ __( 'Webhook', 'otter-pro' ) }
 				value={ props.webhookId }
 				options={
 					[
 						{
-							label: __( 'Select Webhook', 'otter-blocks' ),
+							label: __( 'Select Webhook', 'otter-pro' ),
 							value: ''
 						},
 						...(
@@ -381,11 +381,11 @@ const WebhookEditor = ( props: WebhookEditorProps ) => {
 				onClick={() => setOpen( true )}
 				className="wp-block-themeisle-blocks-tabs-inspector-add-tab"
 			>
-				{ __( 'Edit Webhooks', 'otter-blocks' ) }
+				{ __( 'Edit Webhooks', 'otter-pro' ) }
 			</Button>
 			< br />
 			<ExternalLink href="https://docs.themeisle.com/article/1550-otter-pro-documentation">
-				{ __( 'Learn more about webhooks.', 'otter-blocks' ) }
+				{ __( 'Learn more about webhooks.', 'otter-pro' ) }
 			</ExternalLink>
 		</Fragment>
 	);

--- a/src/pro/dashboard/index.js
+++ b/src/pro/dashboard/index.js
@@ -37,13 +37,13 @@ const Integrations = props => {
 	return (
 		<Fragment>
 			<PanelBody
-				title={ __( 'Fonts Module', 'otter-blocks' ) }
+				title={ __( 'Fonts Module', 'otter-pro' ) }
 				className="is-pro"
 			>
 				<PanelRow>
 					<ToggleControl
-						label={ __( 'Save Google Fonts Locally', 'otter-blocks' ) }
-						help={ __( 'Enable this option to save Google Fonts locally to make your website faster', 'otter-blocks' ) }
+						label={ __( 'Save Google Fonts Locally', 'otter-pro' ) }
+						help={ __( 'Enable this option to save Google Fonts locally to make your website faster', 'otter-pro' ) }
 						checked={ Boolean( getOption( 'otter_offload_fonts' ) ) }
 						disabled={ 'saving' === status }
 						onChange={ () => {
@@ -55,14 +55,14 @@ const Integrations = props => {
 			</PanelBody>
 
 			<PanelBody
-				title={ __( 'IPHub API Key', 'otter-blocks' ) }
+				title={ __( 'IPHub API Key', 'otter-pro' ) }
 				initialOpen={ false }
 				className="is-pro"
 			>
 				<PanelRow>
 					<BaseControl
-						label={ __( 'IPHub API Key', 'otter-blocks' ) }
-						help={ __( 'In order to use IP-based locations, you need to use IPHub API.', 'otter-blocks' ) }
+						label={ __( 'IPHub API Key', 'otter-pro' ) }
+						help={ __( 'In order to use IP-based locations, you need to use IPHub API.', 'otter-pro' ) }
 						id="otter-options-iphub-api"
 						className="otter-button-field"
 					>
@@ -70,7 +70,7 @@ const Integrations = props => {
 							type="password"
 							id="otter-options-iphub-api"
 							value={ IPHubAPI }
-							placeholder={ __( 'IPHub API Key', 'otter-blocks' ) }
+							placeholder={ __( 'IPHub API Key', 'otter-pro' ) }
 							disabled={ 'saving' === status }
 							onChange={ e => setIPHubAPI( e.target.value ) }
 						/>
@@ -85,13 +85,13 @@ const Integrations = props => {
 									updateOption( 'otter_iphub_api_key', IPHubAPI );
 								} }
 							>
-								{ __( 'Save', 'otter-blocks' ) }
+								{ __( 'Save', 'otter-pro' ) }
 							</Button>
 
 							<ExternalLink
 								href="https://iphub.info/api"
 							>
-								{ __( 'Get API Key', 'otter-blocks' ) }
+								{ __( 'Get API Key', 'otter-pro' ) }
 							</ExternalLink>
 						</div>
 					</BaseControl>

--- a/src/pro/plugins/conditions/edit.js
+++ b/src/pro/plugins/conditions/edit.js
@@ -35,31 +35,31 @@ import { decodeEntities } from '@wordpress/html-entities';
 const week = [
 	{
 		value: 'monday',
-		label: __( 'Monday', 'otter-blocks' )
+		label: __( 'Monday', 'otter-pro' )
 	},
 	{
 		value: 'tuesday',
-		label: __( 'Tuesday', 'otter-blocks' )
+		label: __( 'Tuesday', 'otter-pro' )
 	},
 	{
 		value: 'wednesday',
-		label: __( 'Wednesday', 'otter-blocks' )
+		label: __( 'Wednesday', 'otter-pro' )
 	},
 	{
 		value: 'thursday',
-		label: __( 'Thursday', 'otter-blocks' )
+		label: __( 'Thursday', 'otter-pro' )
 	},
 	{
 		value: 'friday',
-		label: __( 'Friday', 'otter-blocks' )
+		label: __( 'Friday', 'otter-pro' )
 	},
 	{
 		value: 'saturday',
-		label: __( 'Saturday', 'otter-blocks' )
+		label: __( 'Saturday', 'otter-pro' )
 	},
 	{
 		value: 'sunday',
-		label: __( 'Sunday', 'otter-blocks' )
+		label: __( 'Sunday', 'otter-pro' )
 	}
 ];
 
@@ -86,7 +86,7 @@ const DateRange = ({
 							isSecondary
 							aria-expanded={ isOpen }
 						>
-							{ value ? format( settings.formats.datetime, value ) : __( 'Select Date', 'otter-blocks' ) }
+							{ value ? format( settings.formats.datetime, value ) : __( 'Select Date', 'otter-pro' ) }
 						</Button>
 					</>
 				) }
@@ -297,7 +297,7 @@ const WooAttributes = ( props ) => {
 			options={ [
 				{
 					value: '',
-					label: __( 'Select an attribute', 'otter-blocks' )
+					label: __( 'Select an attribute', 'otter-pro' )
 				},
 				...attributes
 			] }
@@ -363,7 +363,7 @@ const CoursesSelect = ( props ) => {
 							options={ courses }
 						/>
 					) : (
-						<p>{ __( 'No courses available.', 'otter-blocks' ) }</p>
+						<p>{ __( 'No courses available.', 'otter-pro' ) }</p>
 					) }
 
 					{ props.children }
@@ -518,35 +518,35 @@ const Edit = ({
 			{ [ 'postMeta', 'loggedInUserMeta' ].includes( item.type ) && (
 				<Fragment>
 					<TextControl
-						label={ __( 'Meta Key', 'otter-blocks' ) }
-						help={ __( 'Key of the meta you want to compare.', 'otter-blocks' ) }
-						placeholder={ __( '_meta_key', 'otter-blocks' ) }
+						label={ __( 'Meta Key', 'otter-pro' ) }
+						help={ __( 'Key of the meta you want to compare.', 'otter-pro' ) }
+						placeholder={ __( '_meta_key', 'otter-pro' ) }
 						value={ item.meta_key }
 						onChange={ e => changeValue( e, groupIndex, itemIndex, 'meta_key' ) }
 					/>
 
 					<SelectControl
-						label={ __( 'Compare Operator', 'otter-blocks' ) }
+						label={ __( 'Compare Operator', 'otter-pro' ) }
 						options={ [
 							{
 								value: 'is_true',
-								label: __( 'Is True', 'otter-blocks' )
+								label: __( 'Is True', 'otter-pro' )
 							},
 							{
 								value: 'is_false',
-								label: __( 'Is False', 'otter-blocks' )
+								label: __( 'Is False', 'otter-pro' )
 							},
 							{
 								value: 'is_empty',
-								label: __( 'Is Empty', 'otter-blocks' )
+								label: __( 'Is Empty', 'otter-pro' )
 							},
 							{
 								value: 'if_equals',
-								label: __( 'If Equals', 'otter-blocks' )
+								label: __( 'If Equals', 'otter-pro' )
 							},
 							{
 								value: 'if_contains',
-								label: __( 'If Contains', 'otter-blocks' )
+								label: __( 'If Contains', 'otter-pro' )
 							}
 						] }
 						value={ item.meta_compare }
@@ -555,8 +555,8 @@ const Edit = ({
 
 					{ ( 'if_equals' === item.meta_compare || 'if_contains' === item.meta_compare ) && (
 						<TextControl
-							label={ __( 'Meta Value', 'otter-blocks' ) }
-							help={ __( 'Value of the meta to compare.', 'otter-blocks' ) }
+							label={ __( 'Meta Value', 'otter-pro' ) }
+							help={ __( 'Value of the meta to compare.', 'otter-pro' ) }
 							value={ item.meta_value }
 							onChange={ e => changeValue( e, groupIndex, itemIndex, 'meta_value' ) }
 						/>
@@ -567,23 +567,23 @@ const Edit = ({
 			{ 'queryString' === item.type && (
 				<Fragment>
 					<TextareaControl
-						label={ __( 'Query String', 'otter-blocks' ) }
-						help={ __( 'Write a key-value pair for each parameter, one per line.', 'otter-blocks' ) }
+						label={ __( 'Query String', 'otter-pro' ) }
+						help={ __( 'Write a key-value pair for each parameter, one per line.', 'otter-pro' ) }
 						placeholder="eg. utm_source=facebook"
 						value={ item.query_string }
 						onChange={ e => changeValue( e.replaceAll( '\itemIndex', '&' ), groupIndex, itemIndex, 'query_string' ) }
 					/>
 
 					<SelectControl
-						label={ __( 'Match if URL contains', 'otter-blocks' ) }
+						label={ __( 'Match if URL contains', 'otter-pro' ) }
 						options={ [
 							{
 								value: 'any',
-								label: __( 'Any of the parameters', 'otter-blocks' )
+								label: __( 'Any of the parameters', 'otter-pro' )
 							},
 							{
 								value: 'all',
-								label: __( 'All the parameters', 'otter-blocks' )
+								label: __( 'All the parameters', 'otter-pro' )
 							}
 						] }
 						value={ item.compare }
@@ -595,52 +595,52 @@ const Edit = ({
 			{ 'country' === item.type && (
 				<Fragment>
 					{ ! Boolean( window.otterPro.hasIPHubAPI ) && (
-						<ExternalLink href={ window.themeisleGutenberg.optionsPath }>{ __( 'Setup API to use this feature.', 'otter-blocks' ) }</ExternalLink>
+						<ExternalLink href={ window.themeisleGutenberg.optionsPath }>{ __( 'Setup API to use this feature.', 'otter-pro' ) }</ExternalLink>
 					) }
 
 					<TextControl
-						label={ __( 'Country Code(s)', 'otter-blocks' ) }
+						label={ __( 'Country Code(s)', 'otter-pro' ) }
 						placeholder="US, CA, GB"
-						help={ __( 'A comma separated list of country codes', 'otter-blocks' ) }
+						help={ __( 'A comma separated list of country codes', 'otter-pro' ) }
 						value={ item.value }
 						onChange={ e => changeValue( e, groupIndex, itemIndex, 'value' ) }
 					/>
 
-					<ExternalLink href="https://www.geoplugin.com/iso3166">{ __( 'A list of country codes.', 'otter-blocks' ) }</ExternalLink>
+					<ExternalLink href="https://www.geoplugin.com/iso3166">{ __( 'A list of country codes.', 'otter-pro' ) }</ExternalLink>
 				</Fragment>
 			) }
 
 			{ 'cookie' === item.type && (
 				<Fragment>
 					<TextControl
-						label={ __( 'Cookie', 'otter-blocks' ) }
-						help={ __( 'Key of the cookie you want to compare.', 'otter-blocks' ) }
+						label={ __( 'Cookie', 'otter-pro' ) }
+						help={ __( 'Key of the cookie you want to compare.', 'otter-pro' ) }
 						value={ item.cookie_key }
 						onChange={ e => changeValue( e, groupIndex, itemIndex, 'cookie_key' ) }
 					/>
 
 					<SelectControl
-						label={ __( 'Compare Operator', 'otter-blocks' ) }
+						label={ __( 'Compare Operator', 'otter-pro' ) }
 						options={ [
 							{
 								value: 'is_true',
-								label: __( 'Is True', 'otter-blocks' )
+								label: __( 'Is True', 'otter-pro' )
 							},
 							{
 								value: 'is_false',
-								label: __( 'Is False', 'otter-blocks' )
+								label: __( 'Is False', 'otter-pro' )
 							},
 							{
 								value: 'is_empty',
-								label: __( 'Is Empty', 'otter-blocks' )
+								label: __( 'Is Empty', 'otter-pro' )
 							},
 							{
 								value: 'if_equals',
-								label: __( 'If Equals', 'otter-blocks' )
+								label: __( 'If Equals', 'otter-pro' )
 							},
 							{
 								value: 'if_contains',
-								label: __( 'If Contains', 'otter-blocks' )
+								label: __( 'If Contains', 'otter-pro' )
 							}
 						] }
 						value={ item.cookie_compare }
@@ -649,8 +649,8 @@ const Edit = ({
 
 					{ ( 'if_equals' === item.cookie_compare || 'if_contains' === item.cookie_compare ) && (
 						<TextControl
-							label={ __( 'Cookie Value', 'otter-blocks' ) }
-							help={ __( 'Value of the cookie to compare.', 'otter-blocks' ) }
+							label={ __( 'Cookie Value', 'otter-pro' ) }
+							help={ __( 'Value of the cookie to compare.', 'otter-pro' ) }
 							value={ item.cookie_value }
 							onChange={ e => changeValue( e, groupIndex, itemIndex, 'cookie_value' ) }
 						/>
@@ -661,14 +661,14 @@ const Edit = ({
 			{ 'dateRange' === item.type && (
 				<Fragment>
 					<DateRange
-						label={ __( 'Start Date', 'otter-blocks' ) }
+						label={ __( 'Start Date', 'otter-pro' ) }
 						id={ `o-conditions-date-start${ groupIndex }-${ itemIndex }` }
 						value={ item.start_date }
 						onChange={ e => changeValue( e, groupIndex, itemIndex, 'start_date' ) }
 					/>
 
 					<DateRange
-						label={ __( 'End Date (Optional)', 'otter-blocks' ) }
+						label={ __( 'End Date (Optional)', 'otter-pro' ) }
 						id={ `o-conditions-date-end${ groupIndex }-${ itemIndex }` }
 						value={ item.end_date }
 						onChange={ e => changeValue( e, groupIndex, itemIndex, 'end_date' ) }
@@ -678,8 +678,8 @@ const Edit = ({
 
 			{ 'dateRecurring' === item.type && (
 				<BaseControl
-					label={ __( 'Recurring Days', 'otter-blocks' ) }
-					help={ __( 'You can use this in combination with other Date Time conditions to make more complex conditions.', 'otter-blocks' ) }
+					label={ __( 'Recurring Days', 'otter-pro' ) }
+					help={ __( 'You can use this in combination with other Date Time conditions to make more complex conditions.', 'otter-pro' ) }
 				>
 					{ week.map( ({ label, value }) => (
 						<CheckboxControl
@@ -695,11 +695,11 @@ const Edit = ({
 			{ 'timeRecurring' === item.type && (
 				<Fragment>
 					<BaseControl
-						label={ __( 'Start Time', 'otter-blocks' ) }
+						label={ __( 'Start Time', 'otter-pro' ) }
 					>
 						<div className="o-conditions">
 							<input
-								aria-label={ __( 'Hours', 'otter-blocks' ) }
+								aria-label={ __( 'Hours', 'otter-pro' ) }
 								className="components-datetime__time-field-hours-input"
 								type="number"
 								step="1"
@@ -724,7 +724,7 @@ const Edit = ({
 							{ ' : ' }
 
 							<input
-								aria-label={ __( 'Minutes', 'otter-blocks' ) }
+								aria-label={ __( 'Minutes', 'otter-pro' ) }
 								className="components-datetime__time-field-hours-input"
 								type="number"
 								step="1"
@@ -756,17 +756,17 @@ const Edit = ({
 									setAttributes({ otterConditions });
 								} }
 							>
-								{ __( 'Reset', 'otter-blocks' ) }
+								{ __( 'Reset', 'otter-pro' ) }
 							</Button>
 						</div>
 					</BaseControl>
 
 					<BaseControl
-						label={ __( 'End Time', 'otter-blocks' ) }
+						label={ __( 'End Time', 'otter-pro' ) }
 					>
 						<div className="o-conditions">
 							<input
-								aria-label={ __( 'Hours', 'otter-blocks' ) }
+								aria-label={ __( 'Hours', 'otter-pro' ) }
 								className="components-datetime__time-field-hours-input"
 								type="number"
 								step="1"
@@ -791,7 +791,7 @@ const Edit = ({
 							{ ' : ' }
 
 							<input
-								aria-label={ __( 'Minutes', 'otter-blocks' ) }
+								aria-label={ __( 'Minutes', 'otter-pro' ) }
 								className="components-datetime__time-field-hours-input"
 								type="number"
 								step="1"
@@ -823,7 +823,7 @@ const Edit = ({
 									setAttributes({ otterConditions });
 								} }
 							>
-								{ __( 'Reset', 'otter-blocks' ) }
+								{ __( 'Reset', 'otter-pro' ) }
 							</Button>
 						</div>
 					</BaseControl>
@@ -833,15 +833,15 @@ const Edit = ({
 			{ 'wooProductsInCart' === item.type && (
 				<Fragment>
 					<SelectControl
-						label={ __( 'Based on', 'otter-blocks' ) }
+						label={ __( 'Based on', 'otter-pro' ) }
 						options={ [
 							{
 								value: 'products',
-								label: __( 'Products', 'otter-blocks' )
+								label: __( 'Products', 'otter-pro' )
 							},
 							{
 								value: 'categories',
-								label: __( 'Categories', 'otter-blocks' )
+								label: __( 'Categories', 'otter-pro' )
 							}
 						] }
 						value={ item.on }
@@ -851,7 +851,7 @@ const Edit = ({
 					{ 'products' === item.on && (
 						<Fragment>
 							<ProductsMultiselect
-								label={ __( 'Products', 'otter-blocks' ) }
+								label={ __( 'Products', 'otter-pro' ) }
 								values={ item.products }
 								onChange={ values => changeProducts( values, groupIndex, itemIndex ) }
 							/>
@@ -861,7 +861,7 @@ const Edit = ({
 					{ 'categories' === item.on && (
 						<Fragment>
 							<CategoriesMultiselect
-								label={ __( 'Categories', 'otter-blocks' ) }
+								label={ __( 'Categories', 'otter-pro' ) }
 								values={ item.categories }
 								onChange={ values => changeCategories( values, groupIndex, itemIndex ) }
 							/>
@@ -872,11 +872,11 @@ const Edit = ({
 
 			{ 'wooTotalCartValue' === item.type && (
 				<TextControl
-					label={ __( 'Total Cart Value', 'otter-blocks' ) }
+					label={ __( 'Total Cart Value', 'otter-pro' ) }
 					help={ 
 						sprintf( 
 							/* translators: %s the currency. */
-							__( 'The currency will be based on your WooCommerce settings. Currently it is set to %s.', 'otter-blocks' ), 
+							__( 'The currency will be based on your WooCommerce settings. Currently it is set to %s.', 'otter-pro' ), 
 							window.wcSettings.currency.code 
 						) 
 					}
@@ -888,11 +888,11 @@ const Edit = ({
 
 			{ 'wooTotalSpent' === item.type && (
 				<TextControl
-					label={ __( 'Total Money Spent', 'otter-blocks' ) }
+					label={ __( 'Total Money Spent', 'otter-pro' ) }
 					help={ 
 						sprintf( 
 							/* translators: %s the currency. */
-							__( 'The currency will be based on your WooCommerce settings. Currently it is set to %s.', 'otter-blocks' ), 
+							__( 'The currency will be based on your WooCommerce settings. Currently it is set to %s.', 'otter-pro' ), 
 							window.wcSettings.currency.code 
 						) 
 					}
@@ -904,15 +904,15 @@ const Edit = ({
 
 			{ ( 'wooTotalCartValue' === item.type || 'wooTotalSpent' === item.type ) && (
 				<SelectControl
-					label={ __( 'Compare Operator', 'otter-blocks' ) }
+					label={ __( 'Compare Operator', 'otter-pro' ) }
 					options={ [
 						{
 							value: 'greater_than',
-							label: __( 'Greater Than (>)', 'otter-blocks' )
+							label: __( 'Greater Than (>)', 'otter-pro' )
 						},
 						{
 							value: 'less_than',
-							label: __( 'Less Than (<)', 'otter-blocks' )
+							label: __( 'Less Than (<)', 'otter-pro' )
 						}
 					] }
 					value={ item.compare }
@@ -923,7 +923,7 @@ const Edit = ({
 			{ 'wooPurchaseHistory' === item.type && (
 				<Fragment>
 					<ProductsMultiselect
-						label={ __( 'Products', 'otter-blocks' ) }
+						label={ __( 'Products', 'otter-pro' ) }
 						values={ item.products }
 						onChange={ values => changeProducts( values, groupIndex, itemIndex ) }
 					/>
@@ -932,14 +932,14 @@ const Edit = ({
 
 			{ 'wooCategory' === item.type && (
 				<CategoriesMultiselect
-					label={ __( 'Categories', 'otter-blocks' ) }
+					label={ __( 'Categories', 'otter-pro' ) }
 					values={ item.categories }
 					onChange={ values => changeCategories( values, groupIndex, itemIndex ) }
 				/>
 			) }
 			{ 'wooTag' === item.type && (
 				<TagsMultiselect
-					label={ __( 'Tags', 'otter-blocks' ) }
+					label={ __( 'Tags', 'otter-pro' ) }
 					values={ item.tags }
 					onChange={ values => changeTags( values, groupIndex, itemIndex ) }
 				/>
@@ -948,15 +948,15 @@ const Edit = ({
 			{ 'wooAttribute' === item.type && (
 				<Fragment>
 					<WooAttributes
-						label={ __( 'Attribute', 'otter-blocks' ) }
+						label={ __( 'Attribute', 'otter-pro' ) }
 						value={ item.attribute }
 						onChange={ values => changeAttribute( values, groupIndex, itemIndex ) }
 					/>
 
 					{ !! item.attribute && (
 						<FormTokenField
-							label={ __( 'Terms', 'otter-blocks' ) }
-							placeholder={ __( 'List the terms by their slug.', 'otter-blocks' ) }
+							label={ __( 'Terms', 'otter-pro' ) }
+							placeholder={ __( 'List the terms by their slug.', 'otter-pro' ) }
 							value={ item.terms }
 							onChange={ terms => changeArrayValue( terms, groupIndex, itemIndex, 'terms' ) }
 						/>
@@ -967,15 +967,15 @@ const Edit = ({
 			{ 'learnDashPurchaseHistory' === item.type && (
 				<Fragment>
 					<SelectControl
-						label={ __( 'Based on', 'otter-blocks' ) }
+						label={ __( 'Based on', 'otter-pro' ) }
 						options={ [
 							{
 								value: 'courses',
-								label: __( 'Courses', 'otter-blocks' )
+								label: __( 'Courses', 'otter-pro' )
 							},
 							{
 								value: 'groups',
-								label: __( 'Groups', 'otter-blocks' )
+								label: __( 'Groups', 'otter-pro' )
 							}
 						] }
 						value={ item.on }
@@ -985,7 +985,7 @@ const Edit = ({
 					{ 'courses' === item.on && (
 						<Fragment>
 							<CoursesMultiselect
-								label={ __( 'Courses', 'otter-blocks' ) }
+								label={ __( 'Courses', 'otter-pro' ) }
 								values={ item.courses }
 								onChange={ values => changeCourses( values, groupIndex, itemIndex ) }
 							/>
@@ -995,7 +995,7 @@ const Edit = ({
 					{ 'groups' === item.on && (
 						<Fragment>
 							<GroupsMultiselect
-								label={ __( 'Groups', 'otter-blocks' ) }
+								label={ __( 'Groups', 'otter-pro' ) }
 								values={ item.groups }
 								onChange={ values => changeGroups( values, groupIndex, itemIndex ) }
 							/>
@@ -1007,24 +1007,24 @@ const Edit = ({
 			{ 'learnDashCourseStatus' === item.type && (
 				<Fragment>
 					<CoursesSelect
-						label={ __( 'Course', 'otter-blocks' ) }
+						label={ __( 'Course', 'otter-pro' ) }
 						value={ item.course }
 						onChange={ e => changeValue( Number( e ), groupIndex, itemIndex, 'course' ) }
 					>
 						<SelectControl
-							label={ __( 'Status', 'otter-blocks' ) }
+							label={ __( 'Status', 'otter-pro' ) }
 							options={ [
 								{
 									value: 'not_started',
-									label: __( 'Not Started', 'otter-blocks' )
+									label: __( 'Not Started', 'otter-pro' )
 								},
 								{
 									value: 'in_progress',
-									label: __( 'In Progress', 'otter-blocks' )
+									label: __( 'In Progress', 'otter-pro' )
 								},
 								{
 									value: 'completed',
-									label: __( 'Completed', 'otter-blocks' )
+									label: __( 'Completed', 'otter-pro' )
 								}
 							] }
 							value={ item.status }

--- a/src/pro/plugins/conditions/index.js
+++ b/src/pro/plugins/conditions/index.js
@@ -20,141 +20,141 @@ const { Notice } = window.otterComponents;
 const applyProConditions = conditions => {
 	const proConditions = {
 		'users': {
-			label: __( 'Users', 'otter-blocks' ),
+			label: __( 'Users', 'otter-pro' ),
 			conditions: [
 				{
 					value: 'loggedInUserMeta',
-					label: __( 'Logged-in User Meta', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on meta of the logged-in user condition.' ),
+					label: __( 'Logged-in User Meta', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on meta of the logged-in user condition.', 'otter-pro' ),
 					toogleVisibility: true
 				}
 			]
 		},
 		'posts': {
-			label: __( 'Posts', 'otter-blocks' ),
+			label: __( 'Posts', 'otter-pro' ),
 			conditions: [
 				{
 					value: 'postMeta',
-					label: __( 'Post Meta', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on post meta condition.' ),
+					label: __( 'Post Meta', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on post meta condition.', 'otter-pro'  ),
 					toogleVisibility: true
 				}
 			]
 		},
 		'dateAndTime': {
-			label: __( 'Date & Time', 'otter-blocks' ),
+			label: __( 'Date & Time', 'otter-pro' ),
 			conditions: [
 				{
 					value: 'dateRange',
-					label: __( 'Date Range', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on the date range. Timezone is used based on your WordPress settings.' )
+					label: __( 'Date Range', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on the date range. Timezone is used based on your WordPress settings.', 'otter-pro'  )
 				},
 				{
 					value: 'dateRecurring',
-					label: __( 'Date Recurring', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on the selected days. Timezone is used based on your WordPress settings.' )
+					label: __( 'Date Recurring', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on the selected days. Timezone is used based on your WordPress settings.', 'otter-pro'  )
 				},
 				{
 					value: 'timeRecurring',
-					label: __( 'Time Recurring', 'otter-blocks' ),
-					help: __( 'The selected block will be visible during the selected time. Timezone is used based on your WordPress settings.' )
+					label: __( 'Time Recurring', 'otter-pro' ),
+					help: __( 'The selected block will be visible during the selected time. Timezone is used based on your WordPress settings.', 'otter-pro'  )
 				}
 			]
 		},
 		'advance': {
-			label: __( 'Advance', 'otter-blocks' ),
+			label: __( 'Advance', 'otter-pro' ),
 			conditions: [
 				{
 					value: 'queryString',
-					label: __( 'Query String', 'otter-blocks' ),
-					help: __( 'The condition will be met if the URL contains specified parameters.' ),
+					label: __( 'Query String', 'otter-pro' ),
+					help: __( 'The condition will be met if the URL contains specified parameters.', 'otter-pro'  ),
 					toogleVisibility: true
 				},
 				{
 					value: 'country',
-					label: __( 'Country', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on user\'s country based on the IP address.' ),
+					label: __( 'Country', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on user\'s country based on the IP address.', 'otter-pro'  ),
 					toogleVisibility: true
 				},
 				{
 					value: 'cookie',
-					label: __( 'Cookie', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on PHP cookies.' ),
+					label: __( 'Cookie', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on PHP cookies.', 'otter-pro'  ),
 					toogleVisibility: true
 				}
 			]
 		},
 		'woocommerce': {
-			label: __( 'WooCommerce', 'otter-blocks' ),
+			label: __( 'WooCommerce', 'otter-pro' ),
 			conditions: [
 				{
 					value: 'wooProductsInCart',
-					label: __( 'Products in Cart', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on the products added to WooCommerce cart.' ),
+					label: __( 'Products in Cart', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on the products added to WooCommerce cart.', 'otter-pro'  ),
 					toogleVisibility: true,
 					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
 				},
 				{
 					value: 'wooTotalCartValue',
-					label: __( 'Total Cart Value', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on the total value of WooCommerce cart.' ),
+					label: __( 'Total Cart Value', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on the total value of WooCommerce cart.', 'otter-pro'  ),
 					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
 				},
 				{
 					value: 'wooPurchaseHistory',
-					label: __( 'Purchase History', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on user\'s WooCommerce purchase history.' ),
+					label: __( 'Purchase History', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on user\'s WooCommerce purchase history.', 'otter-pro'  ),
 					toogleVisibility: true,
 					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
 				},
 				{
 					value: 'wooTotalSpent',
-					label: __( 'Total Spent', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on how much the user spent during lifetime.' ),
+					label: __( 'Total Spent', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on how much the user spent during lifetime.', 'otter-pro'  ),
 					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
 				}
 			]
 		},
 		'woocommerceProduct': {
-			label: __( 'WooCommerce Product', 'otter-blocks' ),
+			label: __( 'WooCommerce Product', 'otter-pro' ),
 			conditions: [
 				{
 					value: 'wooCategory',
-					label: __( 'Product Categories', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on the product categories.' ),
+					label: __( 'Product Categories', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on the product categories.', 'otter-pro'  ),
 					toogleVisibility: true,
 					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
 				},
 				{
 					value: 'wooTag',
-					label: __( 'Product Tags', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on the product tags.' ),
+					label: __( 'Product Tags', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on the product tags.', 'otter-pro'  ),
 					toogleVisibility: true,
 					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
 				},
 				{
 					value: 'wooAttribute',
-					label: __( 'Product Attributes', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on the product attribute.' ),
+					label: __( 'Product Attributes', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on the product attribute.', 'otter-pro'  ),
 					toogleVisibility: true,
 					isDisabled: ! Boolean( window.otterPro.hasWooCommerce )
 				}
 			]
 		},
 		'learndash': {
-			label: __( 'LearnDash', 'otter-blocks' ),
+			label: __( 'LearnDash', 'otter-pro' ),
 			conditions: [
 				{
 					value: 'learnDashPurchaseHistory',
-					label: __( 'Purchase History', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on user\'s LearnDash purchase history.' ),
+					label: __( 'Purchase History', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on user\'s LearnDash purchase history.', 'otter-pro'  ),
 					toogleVisibility: true,
 					isDisabled: ! Boolean( window.otterPro.hasLearnDash )
 				},
 				{
 					value: 'learnDashCourseStatus',
-					label: __( 'Course Status', 'otter-blocks' ),
-					help: __( 'The selected block will be visible based on user\'s LearnDash course status.' ),
+					label: __( 'Course Status', 'otter-pro' ),
+					help: __( 'The selected block will be visible based on user\'s LearnDash course status.', 'otter-pro'  ),
 					toogleVisibility: true,
 					isDisabled: ! Boolean( window.otterPro.hasLearnDash )
 				}
@@ -238,8 +238,8 @@ const Notices = el => {
 	if ( Boolean( window.otterPro.isExpired ) ) {
 		return (
 			<Notice
-				notice={ __( 'Otter Pro license has expired.', 'otter-blocks' ) }
-				instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Block Conditions.', 'otter-blocks' ) }
+				notice={ __( 'Otter Pro license has expired.', 'otter-pro' ) }
+				instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Block Conditions.', 'otter-pro' ) }
 			/>
 		);
 	}
@@ -247,8 +247,8 @@ const Notices = el => {
 	if ( ! Boolean( window.otterPro.isActive ) ) {
 		return (
 			<Notice
-				notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-				instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Block Conditions.', 'otter-blocks' ) }
+				notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+				instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Block Conditions.', 'otter-pro' ) }
 			/>
 		);
 	}

--- a/src/pro/plugins/countdown/index.tsx
+++ b/src/pro/plugins/countdown/index.tsx
@@ -33,24 +33,24 @@ const { Notice } = window.otterComponents;
 const countdownMoveHelpMsgCountdown = ( mode: any ) => {
 	switch ( mode ) {
 	case 'timer':
-		return __( 'A fixed amount of time for each browser session (Evergreen Countdown)', 'otter-blocks' );
+		return __( 'A fixed amount of time for each browser session (Evergreen Countdown)', 'otter-pro' );
 	case 'interval':
-		return __( 'The countdown will be active only between the Start Date and the End Date', 'otter-blocks' );
+		return __( 'The countdown will be active only between the Start Date and the End Date', 'otter-pro' );
 	default:
-		return __( 'An universal deadline for all visitors', 'otter-blocks' );
+		return __( 'An universal deadline for all visitors', 'otter-pro' );
 	}
 };
 
 const onExpireHelpMsgCountdown = ( behaviour: any ) => {
 	switch ( behaviour ) {
 	case 'redirectLink':
-		return __( 'Redirect the user to another URL, when the countdown reaches 0', 'otter-blocks' );
+		return __( 'Redirect the user to another URL, when the countdown reaches 0', 'otter-pro' );
 	case 'hide':
-		return __( 'Hide when the countdown reaches 0', 'otter-blocks' );
+		return __( 'Hide when the countdown reaches 0', 'otter-pro' );
 	case 'restart':
 		return 'The Countdown will restart when it reaches 0 and the page is refreshed';
 	default:
-		return __( 'The countdown remains visible when it reaches 0', 'otter-blocks' );
+		return __( 'The countdown remains visible when it reaches 0', 'otter-pro' );
 	}
 };
 
@@ -68,7 +68,7 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 	return (
 		<Fragment>
 			<SelectControl
-				label={ __( 'Countdown Type', 'otter-blocks' ) }
+				label={ __( 'Countdown Type', 'otter-pro' ) }
 				value={  attributes.mode }
 				onChange={ value => {
 					const attrs: any = {
@@ -98,15 +98,15 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 				}
 				options={[
 					{
-						label: __( 'Static', 'otter-blocks' ),
+						label: __( 'Static', 'otter-pro' ),
 						value: ''
 					},
 					{
-						label: __( 'Evergreen', 'otter-blocks' ),
+						label: __( 'Evergreen', 'otter-pro' ),
 						value: 'timer'
 					},
 					{
-						label: __( 'Interval', 'otter-blocks' ),
+						label: __( 'Interval', 'otter-pro' ),
 						value: 'interval'
 					}
 				]}
@@ -117,7 +117,7 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 				<Fragment>
 					<TextControl
 						type="number"
-						label={__( 'Days', 'otter-blocks' )}
+						label={__( 'Days', 'otter-pro' )}
 						value={ attributes?.timer?.days ?? '' }
 						onChange={ ( days ) => {
 							setAttributes({
@@ -127,7 +127,7 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 					/>
 					<TextControl
 						type="number"
-						label={__( 'Hours', 'otter-blocks' )}
+						label={__( 'Hours', 'otter-pro' )}
 						value={ attributes?.timer?.hours ?? '' }
 						onChange={ ( hours ) => {
 							setAttributes({
@@ -137,7 +137,7 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 					/>
 					<TextControl
 						type="number"
-						label={__( 'Minutes', 'otter-blocks' )}
+						label={__( 'Minutes', 'otter-pro' )}
 						value={ attributes?.timer?.minutes ?? '' }
 						onChange={ ( minutes ) => {
 							setAttributes({
@@ -147,7 +147,7 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 					/>
 					<TextControl
 						type="number"
-						label={__( 'Seconds', 'otter-blocks' )}
+						label={__( 'Seconds', 'otter-pro' )}
 						value={ attributes?.timer?.seconds ?? '' }
 						onChange={ ( seconds ) => {
 							setAttributes({
@@ -161,11 +161,11 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 			{ 'interval' === attributes.mode && (
 				<Fragment>
 					<BaseControl
-						label={ __( 'Start Date', 'otter-blocks' ) }
+						label={ __( 'Start Date', 'otter-pro' ) }
 					>
 						<Dropdown
 							position="bottom left"
-							headerTitle={ __( 'Select the date for the deadline', 'otter-blocks' ) }
+							headerTitle={ __( 'Select the date for the deadline', 'otter-pro' ) }
 							renderToggle={ ({ onToggle, isOpen }) => (
 								<>
 									<Button
@@ -174,7 +174,7 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 										aria-expanded={ isOpen }
 										className="o-extend-btn"
 									>
-										{ attributes.startInterval ? format( settings.formats.datetime, attributes.startInterval ) : __( 'Select Start Date', 'otter-blocks' ) }
+										{ attributes.startInterval ? format( settings.formats.datetime, attributes.startInterval ) : __( 'Select Start Date', 'otter-pro' ) }
 									</Button>
 								</>
 							) }
@@ -189,11 +189,11 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 					</BaseControl>
 
 					<BaseControl
-						label={ __( 'End Date', 'otter-blocks' ) }
+						label={ __( 'End Date', 'otter-pro' ) }
 					>
 						<Dropdown
 							position="bottom left"
-							headerTitle={ __( 'Select the date for the deadline', 'otter-blocks' ) }
+							headerTitle={ __( 'Select the date for the deadline', 'otter-pro' ) }
 							renderToggle={ ({ onToggle, isOpen }) => (
 								<>
 									<Button
@@ -202,7 +202,7 @@ const CountdownProFeaturesSettings = ( Template: React.FC<{}>, { attributes, set
 										aria-expanded={ isOpen }
 										className="o-extend-btn"
 									>
-										{ attributes.endInterval ? format( settings.formats.datetime, attributes.endInterval ) : __( 'Select End Date', 'otter-blocks' ) }
+										{ attributes.endInterval ? format( settings.formats.datetime, attributes.endInterval ) : __( 'Select End Date', 'otter-pro' ) }
 									</Button>
 								</>
 							) }
@@ -231,8 +231,8 @@ const CountdownProFeaturesEnd = ( Template: React.FC<{}>, {
 			<Fragment>
 				{ Template }
 				<Notice
-					notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-blocks' ) }
+					notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-pro' ) }
 				/>
 			</Fragment>
 		);
@@ -241,7 +241,7 @@ const CountdownProFeaturesEnd = ( Template: React.FC<{}>, {
 	return (
 		<Fragment>
 			<SelectControl
-				label={ __( 'On Expire', 'otter-blocks' ) }
+				label={ __( 'On Expire', 'otter-pro' ) }
 				value={ attributes.behaviour }
 				onChange={ behaviour => {
 					window.oTrk?.set( `${attributes.id}_beh`, { feature: 'countdown', featureComponent: 'countdown-behaviour', featureValue: behaviour, groupID: attributes.id });
@@ -253,19 +253,19 @@ const CountdownProFeaturesEnd = ( Template: React.FC<{}>, {
 				}}
 				options={[
 					{
-						label: __( 'No action', 'otter-blocks' ),
+						label: __( 'No action', 'otter-pro' ),
 						value: ''
 					},
 					{
-						label: __( 'Hide the Countdown', 'otter-blocks' ),
+						label: __( 'Hide the Countdown', 'otter-pro' ),
 						value: 'hide'
 					},
 					...( 'timer' === attributes.mode ? [{
-						label: __( 'Restart the Countdown', 'otter-blocks' ),
+						label: __( 'Restart the Countdown', 'otter-pro' ),
 						value: 'restart'
 					}] : []),
 					{
-						label: __( 'Redirect to link', 'otter-blocks' ),
+						label: __( 'Redirect to link', 'otter-pro' ),
 						value: 'redirectLink'
 					}
 				]}
@@ -274,15 +274,15 @@ const CountdownProFeaturesEnd = ( Template: React.FC<{}>, {
 
 			{ 'redirectLink' === attributes.behaviour && (
 				<TextControl
-					label={ __( 'Redirect Link', 'otter-blocks' ) }
+					label={ __( 'Redirect Link', 'otter-pro' ) }
 					value={ attributes.redirectLink ?? ''}
 					onChange={ redirectLink => setAttributes({ redirectLink })}
 				/>
 			) }
 
 			<ToggleControl
-				label={ __( 'Hide/Show Blocks When the Countdown Ends', 'otter-blocks' ) }
-				help={ __( 'Enable Hide/Show other blocks when the Countdown ends.', 'otter-blocks' ) }
+				label={ __( 'Hide/Show Blocks When the Countdown Ends', 'otter-pro' ) }
+				help={ __( 'Enable Hide/Show other blocks when the Countdown ends.', 'otter-pro' ) }
 				checked={ attributes.onEndAction !== undefined }
 				onChange={ value => {
 					window.oTrk?.set( `${attributes.id}_hide`, { feature: 'countdown', featureComponent: 'countdown-hide', featureValue: value ? 'all' : 'none', groupID: attributes.id });
@@ -297,13 +297,13 @@ const CountdownProFeaturesEnd = ( Template: React.FC<{}>, {
 			{ attributes?.onEndAction && (
 				<Fragment>
 					<p>
-						{ __( 'Paste the following code in the block that you want to show up or hide (in the same page) when the countdown end. Select the block, go to Inspector > Advanced, and paste into the field "Additional CSS class"', 'otter-blocks' ) }
+						{ __( 'Paste the following code in the block that you want to show up or hide (in the same page) when the countdown end. Select the block, go to Inspector > Advanced, and paste into the field "Additional CSS class"', 'otter-pro' ) }
 					</p>
-					<p style={{ marginTop: '10px', marginBottom: '5px' }}>{ __( 'Show trigger', 'otter-blocks' ) }</p>
+					<p style={{ marginTop: '10px', marginBottom: '5px' }}>{ __( 'Show trigger', 'otter-pro' ) }</p>
 					<code style={{ display: 'block', padding: '10px' }}>
 						{ `o-countdown-trigger-on-end-${ attributes.id?.split( '-' ).pop()} o-cntdn-bhv-show` }
 					</code>
-					<p style={{ marginTop: '10px', marginBottom: '5px' }}>{ __( 'Hide trigger', 'otter-blocks' ) }</p>
+					<p style={{ marginTop: '10px', marginBottom: '5px' }}>{ __( 'Hide trigger', 'otter-pro' ) }</p>
 					<code style={{ display: 'block', padding: '10px' }}>
 						{ `o-countdown-trigger-on-end-${ attributes.id?.split( '-' ).pop()} o-cntdn-bhv-hide` }
 					</code>

--- a/src/pro/plugins/dynamic-content/index.js
+++ b/src/pro/plugins/dynamic-content/index.js
@@ -18,8 +18,8 @@ const Notices = el => {
 	if ( Boolean( window.otterPro.isExpired ) ) {
 		return (
 			<Notice
-				notice={ __( 'Otter Pro license has expired.', 'otter-blocks' ) }
-				instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Dynamic Content.', 'otter-blocks' ) }
+				notice={ __( 'Otter Pro license has expired.', 'otter-pro' ) }
+				instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Dynamic Content.', 'otter-pro' ) }
 			/>
 		);
 	}
@@ -27,8 +27,8 @@ const Notices = el => {
 	if ( ! Boolean( window.otterPro.isActive ) ) {
 		return (
 			<Notice
-				notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-				instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Dynamic Content.', 'otter-blocks' ) }
+				notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+				instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Dynamic Content.', 'otter-pro' ) }
 			/>
 		);
 	}

--- a/src/pro/plugins/dynamic-content/link-edit.js
+++ b/src/pro/plugins/dynamic-content/link-edit.js
@@ -39,7 +39,7 @@ const Edit = ({
 		<Fragment>
 			{ ( 'acfURL' === attributes.type && Boolean( window.otterPro.hasACF ) ) && (
 				<BaseControl
-					label={ __( 'Meta Key', 'otter-blocks' ) }
+					label={ __( 'Meta Key', 'otter-pro' ) }
 				>
 					{ isLoaded ? (
 						<select
@@ -47,7 +47,7 @@ const Edit = ({
 							onChange={ event => changeAttributes({ metaKey: event.target.value  }) }
 							className="components-select-control__input"
 						>
-							<option value="none">{ __( 'Select a field', 'otter-blocks' ) }</option>
+							<option value="none">{ __( 'Select a field', 'otter-pro' ) }</option>
 
 							{ groups.map( group => {
 								return (
@@ -74,12 +74,12 @@ const Edit = ({
 			) }
 
 			{ ( 'acfURL' === attributes.type && ! Boolean( window.otterPro.hasACF ) ) && (
-				<p>{ __( 'You need to have Advanced Custom Fields plugin installed to use this feature.', 'otter-blocks' ) }</p>
+				<p>{ __( 'You need to have Advanced Custom Fields plugin installed to use this feature.', 'otter-pro' ) }</p>
 			) }
 
 			{ 'postMetaURL' === attributes.type && (
 				<TextControl
-					label={ __( 'Custom Meta Key', 'otter-blocks' ) }
+					label={ __( 'Custom Meta Key', 'otter-pro' ) }
 					value={ attributes.metaKey }
 					onChange={ metaKey => changeAttributes({ metaKey }) }
 				/>

--- a/src/pro/plugins/dynamic-content/link.js
+++ b/src/pro/plugins/dynamic-content/link.js
@@ -18,11 +18,11 @@ import Edit from './link-edit.js';
 const applyProContent = options => {
 	const proOptions = [
 		{
-			label: __( 'Post Custom Field', 'otter-blocks' ),
+			label: __( 'Post Custom Field', 'otter-pro' ),
 			value: 'postMetaURL'
 		},
 		{
-			label: __( 'Advanced Custom Fields', 'otter-blocks' ),
+			label: __( 'Advanced Custom Fields', 'otter-pro' ),
 			value: 'acfURL'
 		}
 	];

--- a/src/pro/plugins/dynamic-content/media.js
+++ b/src/pro/plugins/dynamic-content/media.js
@@ -25,18 +25,18 @@ const applyProContent = options => {
 	const proOptions = [
 		{
 			type: 'postMeta',
-			label: __( 'Post Meta', 'otter-blocks' ),
+			label: __( 'Post Meta', 'otter-pro' ),
 			icon: window.themeisleGutenberg.assetsPath + '/icons/meta.svg'
 		},
 		{
 			type: 'product',
-			label: __( 'Woo Product', 'otter-blocks' ),
+			label: __( 'Woo Product', 'otter-pro' ),
 			icon: window.themeisleGutenberg.assetsPath + '/icons/woo.svg',
 			isAvailable: Boolean( window.otterPro.hasWooCommerce )
 		},
 		{
 			type: 'acf',
-			label: __( 'ACF Image', 'otter-blocks' ),
+			label: __( 'ACF Image', 'otter-pro' ),
 			icon: window.themeisleGutenberg.assetsPath + '/icons/acf.svg',
 			isAvailable: Boolean( window.otterPro.hasACF )
 		}
@@ -58,7 +58,7 @@ const DynamicContent = (
 		<Fragment>
 			{ 'postMeta' === attributes?.type && (
 				<TextControl
-					label={ __( 'Meta Key', 'otter-blocks' ) }
+					label={ __( 'Meta Key', 'otter-pro' ) }
 					value={ attributes.meta || '' }
 					onChange={ meta => changeAttributes({ meta }) }
 				/>
@@ -66,7 +66,7 @@ const DynamicContent = (
 
 			{ 'product' === attributes?.type && (
 				<SelectProducts
-					label={ __( 'Select Product', 'otter-blocks' ) }
+					label={ __( 'Select Product', 'otter-pro' ) }
 					value={ attributes.id || '' }
 					onChange={ product => changeAttributes({ id: 0 === product ? undefined : product }) }
 				/>
@@ -74,7 +74,7 @@ const DynamicContent = (
 
 			{ 'acf' === attributes?.type && (
 				<ACFImageSelect
-					label={ __( 'Select Field', 'otter-blocks' ) }
+					label={ __( 'Select Field', 'otter-pro' ) }
 					value={ attributes.meta || '' }
 					onChange={ meta => changeAttributes({ meta }) }
 				/>

--- a/src/pro/plugins/dynamic-content/value-edit.js
+++ b/src/pro/plugins/dynamic-content/value-edit.js
@@ -96,15 +96,15 @@ const Edit = ({
 			{ [ 'postDate' ].includes( attributes.type ) && (
 				<Fragment>
 					<SelectControl
-						label={ __( 'Type', 'otter-blocks' ) }
+						label={ __( 'Type', 'otter-pro' ) }
 						value={ attributes.dateType || 'published' }
 						options={ [
 							{
-								label: __( 'Post Published', 'otter-blocks' ),
+								label: __( 'Post Published', 'otter-pro' ),
 								value: 'published'
 							},
 							{
-								label: __( 'Post Modified', 'otter-blocks' ),
+								label: __( 'Post Modified', 'otter-pro' ),
 								value: 'modified'
 							}
 						] }
@@ -112,11 +112,11 @@ const Edit = ({
 					/>
 
 					<SelectControl
-						label={ __( 'Format', 'otter-blocks' ) }
+						label={ __( 'Format', 'otter-pro' ) }
 						value={ attributes.dateFormat || 'default' }
 						options={ [
 							{
-								label: __( 'Default', 'otter-blocks' ),
+								label: __( 'Default', 'otter-pro' ),
 								value: 'default'
 							},
 							...Object.keys( dateFormats ).map( key => ({
@@ -124,7 +124,7 @@ const Edit = ({
 								value: key
 							}) ),
 							{
-								label: __( 'Custom', 'otter-blocks' ),
+								label: __( 'Custom', 'otter-pro' ),
 								value: 'custom'
 							}
 						] }
@@ -133,8 +133,8 @@ const Edit = ({
 
 					{ 'custom' === attributes.dateFormat && (
 						<TextControl
-							label={ __( 'Custom Format', 'otter-blocks' ) }
-							help={ <ExternalLink target="_blank" href="https://wordpress.org/support/article/formatting-date-and-time/">{ __( 'Formatting Date and Time in WordPress', 'otter-blocks' ) }</ExternalLink> }
+							label={ __( 'Custom Format', 'otter-pro' ) }
+							help={ <ExternalLink target="_blank" href="https://wordpress.org/support/article/formatting-date-and-time/">{ __( 'Formatting Date and Time in WordPress', 'otter-pro' ) }</ExternalLink> }
 							type="text"
 							value={ attributes.dateCustom || '' }
 							onChange={ dateCustom => changeAttributes({ dateCustom }) }
@@ -146,15 +146,15 @@ const Edit = ({
 			{ [ 'postTime' ].includes( attributes.type ) && (
 				<Fragment>
 					<SelectControl
-						label={ __( 'Type', 'otter-blocks' ) }
+						label={ __( 'Type', 'otter-pro' ) }
 						value={ attributes.timeType || 'published' }
 						options={ [
 							{
-								label: __( 'Post Published', 'otter-blocks' ),
+								label: __( 'Post Published', 'otter-pro' ),
 								value: 'published'
 							},
 							{
-								label: __( 'Post Modified', 'otter-blocks' ),
+								label: __( 'Post Modified', 'otter-pro' ),
 								value: 'modified'
 							}
 						] }
@@ -162,11 +162,11 @@ const Edit = ({
 					/>
 
 					<SelectControl
-						label={ __( 'Format', 'otter-blocks' ) }
+						label={ __( 'Format', 'otter-pro' ) }
 						value={ attributes.timeFormat || 'default' }
 						options={ [
 							{
-								label: __( 'Default', 'otter-blocks' ),
+								label: __( 'Default', 'otter-pro' ),
 								value: 'default'
 							},
 							...Object.keys( timeFormats ).map( key => ({
@@ -174,7 +174,7 @@ const Edit = ({
 								value: key
 							}) ),
 							{
-								label: __( 'Custom', 'otter-blocks' ),
+								label: __( 'Custom', 'otter-pro' ),
 								value: 'custom'
 							}
 						] }
@@ -183,8 +183,8 @@ const Edit = ({
 
 					{ 'custom' === attributes.timeFormat && (
 						<TextControl
-							label={ __( 'Custom Format', 'otter-blocks' ) }
-							help={ <ExternalLink target="_blank" href="https://wordpress.org/support/article/formatting-date-and-time/">{ __( 'Formatting Date and Time in WordPress', 'otter-blocks' ) }</ExternalLink> }
+							label={ __( 'Custom Format', 'otter-pro' ) }
+							help={ <ExternalLink target="_blank" href="https://wordpress.org/support/article/formatting-date-and-time/">{ __( 'Formatting Date and Time in WordPress', 'otter-pro' ) }</ExternalLink> }
 							type="text"
 							value={ attributes.timeCustom || '' }
 							onChange={ timeCustom => changeAttributes({ timeCustom }) }
@@ -196,19 +196,19 @@ const Edit = ({
 			{ 'postTerms' === attributes.type && (
 				<Fragment>
 					<SelectControl
-						label={ __( 'Type', 'otter-blocks' ) }
+						label={ __( 'Type', 'otter-pro' ) }
 						value={ attributes.termType || 'categories' }
 						options={ [
 							{
-								label: __( 'Categories', 'otter-blocks' ),
+								label: __( 'Categories', 'otter-pro' ),
 								value: 'categories'
 							},
 							{
-								label: __( 'Tags', 'otter-blocks' ),
+								label: __( 'Tags', 'otter-pro' ),
 								value: 'tags'
 							},
 							{
-								label: __( 'Custom', 'otter-blocks' ),
+								label: __( 'Custom', 'otter-pro' ),
 								value: 'custom'
 							}
 						] }
@@ -218,9 +218,9 @@ const Edit = ({
 					{
 						'custom' === attributes.termType && (
 							<TextControl
-								label={ __( 'Taxonomy', 'otter-blocks' ) }
+								label={ __( 'Taxonomy', 'otter-pro' ) }
 								type="text"
-								placeholder={ __( 'Enter taxonomy slug', 'otter-blocks' ) }
+								placeholder={ __( 'Enter taxonomy slug', 'otter-pro' ) }
 								value={ attributes.taxonomy }
 								onChange={ taxonomy => changeAttributes({ taxonomy }) }
 							/>
@@ -228,7 +228,7 @@ const Edit = ({
 					}
 
 					<TextControl
-						label={ __( 'Separator', 'otter-blocks' ) }
+						label={ __( 'Separator', 'otter-pro' ) }
 						type="text"
 						value={ attributes.termSeparator || ', ' }
 						onChange={ termSeparator => changeAttributes({ termSeparator }) }
@@ -239,7 +239,7 @@ const Edit = ({
 
 			{ ( 'acf' === attributes.type && Boolean( window.otterPro.hasACF ) ) && (
 				<BaseControl
-					label={ __( 'Meta Key', 'otter-blocks' ) }
+					label={ __( 'Meta Key', 'otter-pro' ) }
 				>
 					{ isLoaded ? (
 						<select
@@ -247,7 +247,7 @@ const Edit = ({
 							onChange={ event => changeAttributes({ metaKey: event.target.value  }) }
 							className="components-select-control__input"
 						>
-							<option value="none">{ __( 'Select a field', 'otter-blocks' ) }</option>
+							<option value="none">{ __( 'Select a field', 'otter-pro' ) }</option>
 
 							{ groups.map( group => {
 								return (
@@ -274,13 +274,13 @@ const Edit = ({
 			) }
 
 			{ ( 'acf' === attributes.type && ! Boolean( window.otterPro.hasACF ) ) && (
-				<p>{ __( 'You need to have Advanced Custom Fields plugin installed to use this feature.', 'otter-blocks' ) }</p>
+				<p>{ __( 'You need to have Advanced Custom Fields plugin installed to use this feature.', 'otter-pro' ) }</p>
 			) }
 
 			{ ([ 'postMeta', 'authorMeta', 'loggedInUserMeta' ].includes( attributes.type ) ) && (
 				<Fragment>
 					<FormTokenField
-						label={ __( 'Custom Meta Key', 'otter-blocks' ) }
+						label={ __( 'Custom Meta Key', 'otter-pro' ) }
 						value={ attributes.metaKey ? [ attributes.metaKey ] : [] }
 						maxLength={ 1 }
 						suggestions={ autocompleteData[ attributes.type ] }
@@ -289,38 +289,38 @@ const Edit = ({
 						__experimentalShowHowTo={ false }
 					/>
 
-					<p>{ __( 'Type your own or select a pre-defined value. Press Enter to confirm.', 'otter-blocks' ) }</p>
+					<p>{ __( 'Type your own or select a pre-defined value. Press Enter to confirm.', 'otter-pro' ) }</p>
 				</Fragment>
 			) }
 
 			{ ([ 'queryString' ].includes( attributes.type ) ) && (
 				<Fragment>
 					<TextControl
-						label={ __( 'Parameter', 'otter-blocks' ) }
-						placeholder={ __( 'A query string parameter from your URL, ie utm_source.', 'otter-blocks' ) }
+						label={ __( 'Parameter', 'otter-pro' ) }
+						placeholder={ __( 'A query string parameter from your URL, ie utm_source.', 'otter-pro' ) }
 						type="text"
 						value={ attributes.parameter }
 						onChange={ parameter => changeAttributes({ parameter }) }
 					/>
 
 					<SelectControl
-						label={ __( 'Format', 'otter-blocks' ) }
+						label={ __( 'Format', 'otter-pro' ) }
 						value={ attributes.format || 'default' }
 						options={ [
 							{
-								label: __( 'Default', 'otter-blocks' ),
+								label: __( 'Default', 'otter-pro' ),
 								value: 'default'
 							},
 							{
-								label: __( 'Capitalize', 'otter-blocks' ),
+								label: __( 'Capitalize', 'otter-pro' ),
 								value: 'capitalize'
 							},
 							{
-								label: __( 'Uppercase', 'otter-blocks' ),
+								label: __( 'Uppercase', 'otter-pro' ),
 								value: 'uppercase'
 							},
 							{
-								label: __( 'Lowercase', 'otter-blocks' ),
+								label: __( 'Lowercase', 'otter-pro' ),
 								value: 'lowercase'
 							}
 						] }
@@ -330,7 +330,7 @@ const Edit = ({
 			) }
 
 			{ ( 'country' === attributes.type && ! Boolean( window.otterPro.hasIPHubAPI ) ) && (
-				<ExternalLink href={ window.themeisleGutenberg.optionsPath }>{ __( 'Setup API to use this feature.', 'otter-blocks' ) }</ExternalLink>
+				<ExternalLink href={ window.themeisleGutenberg.optionsPath }>{ __( 'Setup API to use this feature.', 'otter-pro' ) }</ExternalLink>
 			) }
 		</Fragment>
 	);

--- a/src/pro/plugins/dynamic-content/value.js
+++ b/src/pro/plugins/dynamic-content/value.js
@@ -18,57 +18,57 @@ import Edit from './value-edit.js';
 const applyProContent = options => {
 	const proOptions = {
 		'posts': {
-			label: __( 'Posts', 'otter-blocks' ),
+			label: __( 'Posts', 'otter-pro' ),
 			options: [
 				{
-					label: __( 'Post Date', 'otter-blocks' ),
+					label: __( 'Post Date', 'otter-pro' ),
 					value: 'postDate'
 				},
 				{
-					label: __( 'Post Time', 'otter-blocks' ),
+					label: __( 'Post Time', 'otter-pro' ),
 					value: 'postTime'
 				},
 				{
-					label: __( 'Post Terms', 'otter-blocks' ),
+					label: __( 'Post Terms', 'otter-pro' ),
 					value: 'postTerms'
 				},
 				{
-					label: __( 'Post Custom Field', 'otter-blocks' ),
+					label: __( 'Post Custom Field', 'otter-pro' ),
 					value: 'postMeta'
 				},
 				{
-					label: __( 'Advanced Custom Field', 'otter-blocks' ),
+					label: __( 'Advanced Custom Field', 'otter-pro' ),
 					value: 'acf'
 				}
 			]
 		},
 		'author': {
-			label: __( 'Author', 'otter-blocks' ),
+			label: __( 'Author', 'otter-pro' ),
 			options: [
 				{
-					label: __( 'Author Meta', 'otter-blocks' ),
+					label: __( 'Author Meta', 'otter-pro' ),
 					value: 'authorMeta'
 				}
 			]
 		},
 		'loggedInUser': {
-			label: __( 'Logged-in User', 'otter-blocks' ),
+			label: __( 'Logged-in User', 'otter-pro' ),
 			options: [
 				{
-					label: __( 'Logged-in User Meta', 'otter-blocks' ),
+					label: __( 'Logged-in User Meta', 'otter-pro' ),
 					value: 'loggedInUserMeta'
 				}
 			]
 		},
 		'misc': {
-			label: __( 'Miscellaneous', 'otter-blocks' ),
+			label: __( 'Miscellaneous', 'otter-pro' ),
 			options: [
 				{
-					label: __( 'URL Parameter', 'otter-blocks' ),
+					label: __( 'URL Parameter', 'otter-pro' ),
 					value: 'queryString'
 				},
 				{
-					label: __( 'Country', 'otter-blocks' ),
+					label: __( 'Country', 'otter-pro' ),
 					value: 'country'
 				}
 			]

--- a/src/pro/plugins/form/index.js
+++ b/src/pro/plugins/form/index.js
@@ -34,9 +34,9 @@ const AutoresponderBody = ({ formOptions, setFormOption }) => {
 };
 
 const helpMessages = {
-	'database': __( 'Save form submissions to the database. You can see the submissions in Otter Blocks > Form Submissions on Dashboard Panel', 'otter-blocks' ),
-	'email': __( 'The submissions are send only via email. No data will be saved on the server, use this option to handle sensitive data.', 'otter-blocks' ),
-	'database-email': __( 'Save the submissions to the database and notify also via email.', 'otter-blocks' )
+	'database': __( 'Save form submissions to the database. You can see the submissions in Otter Blocks > Form Submissions on Dashboard Panel', 'otter-pro' ),
+	'email': __( 'The submissions are send only via email. No data will be saved on the server, use this option to handle sensitive data.', 'otter-pro' ),
+	'database-email': __( 'Save the submissions to the database and notify also via email.', 'otter-pro' )
 };
 
 /**
@@ -57,13 +57,13 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 
 			<ToolsPanelItem
 				hasValue={ () => undefined !== formOptions.submissionsSaveLocation }
-				label={ __( 'Submissions', 'otter-blocks' ) }
+				label={ __( 'Submissions', 'otter-pro' ) }
 				onDeselect={ () => setFormOption({ submissionsSaveLocation: undefined }) }
 				isShownByDefault={ true }
 			>
 				{Boolean( window.otterPro.isActive ) ? (
 					<SelectControl
-						label={ __( 'Save Location', 'otter-blocks' ) }
+						label={ __( 'Save Location', 'otter-pro' ) }
 						value={ formOptions.submissionsSaveLocation ?? 'database-email' }
 						onChange={ submissionsSaveLocation => {
 							window.oTrk?.set( `${attributes.id}_save`, { feature: 'form-storing', featureComponent: 'save-location', featureValue: submissionsSaveLocation, groupID: attributes.id });
@@ -71,9 +71,9 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 						} }
 						options={
 							[
-								{ label: __( 'Database', 'otter-blocks' ), value: 'database' },
-								{ label: __( 'Email Only', 'otter-blocks' ), value: 'email' },
-								{ label: __( 'Database and Email', 'otter-blocks' ), value: 'database-email' }
+								{ label: __( 'Database', 'otter-pro' ), value: 'database' },
+								{ label: __( 'Email Only', 'otter-pro' ), value: 'email' },
+								{ label: __( 'Database and Email', 'otter-pro' ), value: 'database-email' }
 							]
 						}
 						help={ helpMessages?.[formOptions?.submissionsSaveLocation] ?? helpMessages.database }
@@ -82,11 +82,11 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 						<OtterNotice
 							notice={__(
 								'You need to activate Otter Pro.',
-								'otter-blocks'
+								'otter-pro'
 							)}
 							instructions={__(
 								'You need to activate your Otter Pro license to use Pro features of Form Block.',
-								'otter-blocks'
+								'otter-pro'
 							)}
 						/>
 					</div>
@@ -98,16 +98,16 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 					undefined !== formOptions.autoresponder?.subject ||
 					undefined !== formOptions.autoresponder?.body
 				}
-				label={__( 'Autoresponder', 'otter-blocks' )}
+				label={__( 'Autoresponder', 'otter-pro' )}
 				onDeselect={() => setFormOption({ autoresponder: undefined })}
 			>
 				{Boolean( window.otterPro.isActive ) ? (
 					<>
 						<TextControl
-							label={__( 'Autoresponder Subject', 'otter-blocks' )}
+							label={__( 'Autoresponder Subject', 'otter-pro' )}
 							placeholder={__(
 								'Confirmation of your subscription',
-								'otter-blocks'
+								'otter-pro'
 							)}
 							value={formOptions.autoresponder?.subject}
 							onChange={( subject ) => {
@@ -121,7 +121,7 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 							}}
 							help={__(
 								'Enter the subject of the autoresponder email.',
-								'otter-blocks'
+								'otter-pro'
 							)}
 						/>
 
@@ -134,7 +134,7 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 							config?.showAutoResponderNotice && (
 								<Notice isDismissible={false} status={'info'}>
 									{
-										__( 'In order for Autoresponder to work, you need to have at least one Email field in Form.', 'otter-blocks' )
+										__( 'In order for Autoresponder to work, you need to have at least one Email field in Form.', 'otter-pro' )
 									}
 								</Notice>
 							)
@@ -146,11 +146,11 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 						<OtterNotice
 							notice={__(
 								'You need to activate Otter Pro.',
-								'otter-blocks'
+								'otter-pro'
 							)}
 							instructions={__(
 								'You need to activate your Otter Pro license to use Pro features of Form Block.',
-								'otter-blocks'
+								'otter-pro'
 							)}
 						/>
 					</div>
@@ -158,7 +158,7 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 			</ToolsPanelItem>
 			<ToolsPanelItem
 				hasValue={() => formOptions?.webhookId }
-				label={__( 'Webhook', 'otter-blocks' )}
+				label={__( 'Webhook', 'otter-pro' )}
 				onDeselect={() => setFormOption({ webhookId: undefined })}
 			>
 				{Boolean( window.otterPro.isActive ) ? (
@@ -178,11 +178,11 @@ const FormOptions = ( Options, formOptions, setFormOption, config, attributes ) 
 						<OtterNotice
 							notice={__(
 								'You need to activate Otter Pro.',
-								'otter-blocks'
+								'otter-pro'
 							)}
 							instructions={__(
 								'You need to activate your Otter Pro license to use Pro features of Form Block.',
-								'otter-blocks'
+								'otter-pro'
 							)}
 						/>
 					</div>
@@ -257,8 +257,8 @@ const FormFileInspector = ( Template, {
 			<Fragment>
 				{ Template }
 				<OtterNotice
-					notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-blocks' ) }
+					notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-pro' ) }
 				/>
 			</Fragment>
 		);
@@ -267,7 +267,7 @@ const FormFileInspector = ( Template, {
 	return (
 		<Fragment>
 			<TextControl
-				label={ __( 'Label', 'otter-blocks' ) }
+				label={ __( 'Label', 'otter-pro' ) }
 				value={ attributes.label }
 				onChange={ label => setAttributes({ label }) }
 			/>
@@ -277,7 +277,7 @@ const FormFileInspector = ( Template, {
 			<FieldInputWidth attributes={ attributes } setAttributes={ setAttributes } />
 
 			<TextControl
-				label={ __( 'Max File Size in MB', 'otter-blocks' ) }
+				label={ __( 'Max File Size in MB', 'otter-pro' ) }
 				type="number"
 				value={ ! isNaN( parseInt( attributes.maxFileSize ) ) ? attributes.maxFileSize : undefined }
 				onChange={ maxFileSize => {
@@ -285,44 +285,44 @@ const FormFileInspector = ( Template, {
 					setSavedState( attributes.id, true );
 					setAttributes({ maxFileSize: maxFileSize ? maxFileSize?.toString() : undefined });
 				} }
-				help={ __( 'You may need to contact your hosting provider to increase file sizes.', 'otter-blocks' ) }
+				help={ __( 'You may need to contact your hosting provider to increase file sizes.', 'otter-pro' ) }
 			/>
 
 			<FormTokenField
-				label={ __( 'Allowed File Types', 'otter-blocks' ) }
+				label={ __( 'Allowed File Types', 'otter-pro' ) }
 				value={ attributes.allowedFileTypes }
 				onChange={ allowedFileTypes => {
 					window.oTrk?.set( `${attributes.id}_type`, { feature: 'form-file', featureComponent: 'file-type', featureValue: allowedFileTypes, groupID: attributes.id });
 					setSavedState( attributes.id, true );
 					setAttributes({ allowedFileTypes: allowedFileTypes ? allowedFileTypes.map( replaceJPGWithJPEG ) : undefined });
 				} }
-				help={ __( 'Add the allowed files types that can be loaded. E.g.: .png, .mp4, .jpeg, .zip, .pdf. Attention: The host provider might not allow to saving of all type of files.', 'otter-blocks' ) }
+				help={ __( 'Add the allowed files types that can be loaded. E.g.: .png, .mp4, .jpeg, .zip, .pdf. Attention: The host provider might not allow to saving of all type of files.', 'otter-pro' ) }
 				suggestions={ fileTypeSuggestions }
 			/>
 
 			<TextControl
-				label={ __( 'Help Text', 'otter-blocks' ) }
+				label={ __( 'Help Text', 'otter-pro' ) }
 				value={ attributes.helpText }
 				onChange={ helpText => setAttributes({ helpText }) }
 			/>
 
 			<ToggleControl
-				label={ __( 'Required', 'otter-blocks' ) }
-				help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-blocks' ) }
+				label={ __( 'Required', 'otter-pro' ) }
+				help={ __( 'If enabled, the input field must be filled out before submitting the form.', 'otter-pro' ) }
 				checked={ attributes.isRequired }
 				onChange={ isRequired => setAttributes({ isRequired }) }
 			/>
 
 			<TextControl
-				label={ __( 'Mapped Name', 'otter-blocks' ) }
+				label={ __( 'Mapped Name', 'otter-pro' ) }
 				help={ mappedNameInfo }
 				value={ attributes.mappedName }
 				onChange={ mappedName => setAttributes({ mappedName }) }
-				placeholder={ __( 'photos', 'otter-blocks' ) }
+				placeholder={ __( 'photos', 'otter-pro' ) }
 			/>
 
 			<ToggleControl
-				label={ __( 'Allow multiple file uploads', 'otter-blocks' ) }
+				label={ __( 'Allow multiple file uploads', 'otter-pro' ) }
 				checked={ Boolean( attributes.multipleFiles ) }
 				onChange={ multipleFiles => {
 					window.oTrk?.add({ feature: 'form-file', featureComponent: 'enable-multiple-file', groupID: attributes.id });
@@ -334,7 +334,7 @@ const FormFileInspector = ( Template, {
 			{
 				attributes.multipleFiles && (
 					<TextControl
-						label={ __( 'Maximum number of files', 'otter-blocks' ) }
+						label={ __( 'Maximum number of files', 'otter-pro' ) }
 						type="number"
 						value={ ! isNaN( parseInt( attributes.maxFilesNumber ) ) ? ( attributes.maxFilesNumber ) : undefined }
 						onChange={ maxFilesNumber => {
@@ -342,14 +342,14 @@ const FormFileInspector = ( Template, {
 							setSavedState( attributes.id, true );
 							setAttributes({ maxFilesNumber: maxFilesNumber ? maxFilesNumber?.toString() : undefined });
 						} }
-						help={ __( 'By default, only 10 files are allowed to load.', 'otter-blocks' )}
+						help={ __( 'By default, only 10 files are allowed to load.', 'otter-pro' )}
 					/>
 				)
 			}
 
 			<ToggleControl
-				label={ __( 'Save to Media Library', 'otter-blocks' ) }
-				help={ __( 'If enabled, the files will be saved to Media Library instead of adding them as attachments to email.', 'otter-blocks' ) }
+				label={ __( 'Save to Media Library', 'otter-pro' ) }
+				help={ __( 'If enabled, the files will be saved to Media Library instead of adding them as attachments to email.', 'otter-pro' ) }
 				checked={ 'media-library' === attributes.saveFiles }
 				onChange={ value => {
 					window.oTrk?.add({ feature: 'form-file', featureComponent: 'enable-media-saving', groupID: attributes.id });

--- a/src/pro/plugins/live-search/edit.js
+++ b/src/pro/plugins/live-search/edit.js
@@ -47,8 +47,8 @@ const Edit = ({
 		if ( ! hasNecessaryPlan ) {
 			return (
 				<Notice
-					notice={ __( 'You need to upgrade your plan.', 'otter-blocks' ) }
-					instructions={ __( 'You need to upgrade your plan to Agency in order to use the Live Search feature.', 'otter-blocks' ) }
+					notice={ __( 'You need to upgrade your plan.', 'otter-pro' ) }
+					instructions={ __( 'You need to upgrade your plan to Agency in order to use the Live Search feature.', 'otter-pro' ) }
 				/>
 			);
 		}
@@ -56,8 +56,8 @@ const Edit = ({
 		if ( Boolean( window.otterPro.isExpired ) ) {
 			return (
 				<Notice
-					notice={ __( 'Otter Pro license has expired.', 'otter-blocks' ) }
-					instructions={ __( 'You need to renew your Otter Pro license in order to continue using the live search feature.', 'otter-blocks' ) }
+					notice={ __( 'Otter Pro license has expired.', 'otter-pro' ) }
+					instructions={ __( 'You need to renew your Otter Pro license in order to continue using the live search feature.', 'otter-pro' ) }
 				/>
 			);
 		}
@@ -65,8 +65,8 @@ const Edit = ({
 		if ( ! Boolean( window.otterPro.isActive ) ) {
 			return (
 				<Notice
-					notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-					instructions={ __( 'You need to activate your Otter Pro license to use the live search feature.', 'otter-blocks' ) }
+					notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+					instructions={ __( 'You need to activate your Otter Pro license to use the live search feature.', 'otter-pro' ) }
 				/>
 			);
 		}
@@ -78,14 +78,14 @@ const Edit = ({
 		<Fragment>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Live Search', 'otter-blocks' ) }
+					title={ __( 'Live Search', 'otter-pro' ) }
 					initialOpen={ false }
 				>
 					{ ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExpired ) ) && hasNecessaryPlan &&
 						(
 							<>
 								<ToggleControl
-									label={ __( 'Enable Live Search', 'otter-blocks' ) }
+									label={ __( 'Enable Live Search', 'otter-pro' ) }
 									checked={ props.attributes.otterIsLive }
 									onChange={ value => {
 
@@ -100,7 +100,7 @@ const Edit = ({
 								{ props.attributes.otterIsLive && (
 									<>
 										<FormTokenField
-											label={ __( 'Search in', 'otter-blocks' ) }
+											label={ __( 'Search in', 'otter-pro' ) }
 											value={ props.attributes.otterSearchQuery ? props.attributes.otterSearchQuery['post_type'] : [] }
 											suggestions={ postTypes.filter( type => ! excludeTypes.includes( type ) ) }
 											onChange={ types => onUpdateQuery( 'post_type', types ) }
@@ -109,13 +109,13 @@ const Edit = ({
 										/>
 
 										<Notice
-											notice={ __( 'Leave empty to search in all post types. Categories work only when searched exclusively in Posts.', 'otter-blocks' ) }
+											notice={ __( 'Leave empty to search in all post types. Categories work only when searched exclusively in Posts.', 'otter-pro' ) }
 											variant="help"
 										/>
 
 										{ props.attributes.otterSearchQuery && 1 === props.attributes.otterSearchQuery['post_type']?.length && props.attributes.otterSearchQuery['post_type'].includes( 'post' ) && (
 											<CategoriesFieldToken
-												label={ __( 'Post Category', 'otter-blocks' ) }
+												label={ __( 'Post Category', 'otter-pro' ) }
 												value={ props.attributes.otterSearchQuery?.cat ? props.attributes.otterSearchQuery?.cat?.split( ',' ) : [] }
 												onChange={ cat => onUpdateQuery( 'cat', cat.join( ',' ) ) }
 											/>

--- a/src/pro/plugins/live-search/index.js
+++ b/src/pro/plugins/live-search/index.js
@@ -50,13 +50,13 @@ if ( ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExpir
 
 	registerBlockVariation( 'core/search', {
 		name: 'themeisle-gutenberg/live-search',
-		title: __( 'Live Search', 'otter-blocks' ),
-		description: __( 'this is a temporary description.', 'otter-blocks' ),
+		title: __( 'Live Search', 'otter-pro' ),
+		description: __( 'this is a temporary description.', 'otter-pro' ),
 		icon,
 		category: 'themeisle-blocks',
 		attributes: {
-			buttonText: __( 'Search' ),
-			label: __( 'Search' ),
+			buttonText: __( 'Search', 'otter-pro'  ),
+			label: __( 'Search', 'otter-pro'  ),
 			otterIsLive: true
 		}
 	});

--- a/src/pro/plugins/popup/index.js
+++ b/src/pro/plugins/popup/index.js
@@ -18,21 +18,21 @@ const { Notice } = window.otterComponents;
 const applyTriggerOptions = () => {
 	return [
 		{
-			label: __( 'On Load', 'otter-blocks' ),
+			label: __( 'On Load', 'otter-pro' ),
 			value: 'onLoad'
 		},
 		{
-			label: __( 'On Anchor Click', 'otter-blocks' ),
+			label: __( 'On Anchor Click', 'otter-pro' ),
 			value: 'onClick',
 			disabled: ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExpired ) )
 		},
 		{
-			label: __( 'On Scroll', 'otter-blocks' ),
+			label: __( 'On Scroll', 'otter-pro' ),
 			value: 'onScroll',
 			disabled: ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExpired ) )
 		},
 		{
-			label: __( 'On Exit', 'otter-blocks' ),
+			label: __( 'On Exit', 'otter-pro' ),
 			value: 'onExit',
 			disabled: ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExpired ) )
 		}
@@ -50,8 +50,8 @@ const PopupControls = (
 				{ Controls }
 
 				<Notice
-					notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Popup Block.', 'otter-blocks' ) }
+					notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Popup Block.', 'otter-pro' ) }
 				/>
 			</Fragment>
 		);
@@ -61,8 +61,8 @@ const PopupControls = (
 		<Fragment>
 			{ 'onClick' === attributes.trigger && (
 				<TextControl
-					label={ __( 'Anchor', 'otter-blocks' ) }
-					help={ __( 'You can use this anchor as an anchor link anywhere on the page to open the popup.', 'otter-blocks' ) }
+					label={ __( 'Anchor', 'otter-pro' ) }
+					help={ __( 'You can use this anchor as an anchor link anywhere on the page to open the popup.', 'otter-pro' ) }
 					value={ attributes.anchor }
 					onChange={ anchor => setAttributes({ anchor }) }
 				/>
@@ -70,15 +70,15 @@ const PopupControls = (
 
 			{ Boolean( window.otterPro.isExpired ) && (
 				<Notice
-					notice={ __( 'Otter Pro license has expired.', 'otter-blocks' ) }
-					instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Popup Block.', 'otter-blocks' ) }
+					notice={ __( 'Otter Pro license has expired.', 'otter-pro' ) }
+					instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Popup Block.', 'otter-pro' ) }
 				/>
 			) }
 
 			{ 'onScroll' === attributes.trigger && (
 				<RangeControl
-					label={ __( 'Scroll Distance', 'otter-blocks' ) }
-					help={ __( 'Show the modal when this percentage of the page has been scrolled.', 'otter-blocks' ) }
+					label={ __( 'Scroll Distance', 'otter-pro' ) }
+					help={ __( 'Show the modal when this percentage of the page has been scrolled.', 'otter-pro' ) }
 					min={ 0 }
 					max={ 100 }
 					value={ attributes.scroll }
@@ -89,21 +89,21 @@ const PopupControls = (
 			) }
 
 			{ 'onExit' === attributes.trigger && (
-				<p>{ __( 'Shows the modal when the user moves the mouse outside of the top of the window.', 'otter-blocks' ) }</p>
+				<p>{ __( 'Shows the modal when the user moves the mouse outside of the top of the window.', 'otter-pro' ) }</p>
 			) }
 
 			{ Controls }
 
 			<ToggleControl
-				label={ __( 'Close On Anchor Click', 'otter-blocks' ) }
+				label={ __( 'Close On Anchor Click', 'otter-pro' ) }
 				checked={ attributes.anchorClose }
 				onChange={ () => setAttributes({ anchorClose: ! attributes.anchorClose }) }
 			/>
 
 			{ attributes.anchorClose && (
 				<TextControl
-					label={ __( 'Close Anchor', 'otter-blocks' ) }
-					help={ __( 'You can use this anchor as an anchor link anywhere on the page to close the popup.', 'otter-blocks' ) }
+					label={ __( 'Close Anchor', 'otter-pro' ) }
+					help={ __( 'You can use this anchor as an anchor link anywhere on the page to close the popup.', 'otter-pro' ) }
 					value={ attributes.closeAnchor }
 					onChange={ closeAnchor => setAttributes({ closeAnchor }) }
 				/>
@@ -111,7 +111,7 @@ const PopupControls = (
 
 			{ 'onClick' !== attributes.trigger && (
 				<ToggleControl
-					label={ __( 'Dismiss for Recurring Visitors', 'otter-blocks' ) }
+					label={ __( 'Dismiss for Recurring Visitors', 'otter-pro' ) }
 					checked={ attributes.recurringClose }
 					onChange={ () => setAttributes({ recurringClose: ! attributes.recurringClose }) }
 				/>
@@ -119,8 +119,8 @@ const PopupControls = (
 
 			{ ( attributes.recurringClose && 'onClick' !== attributes.trigger ) && (
 				<RangeControl
-					label={ __( 'Display Interval', 'otter-blocks' ) }
-					help={ __( 'Number of days until the popup is shown again. Leave it empty for one-time display', 'otter-blocks' ) }
+					label={ __( 'Display Interval', 'otter-pro' ) }
+					help={ __( 'Number of days until the popup is shown again. Leave it empty for one-time display', 'otter-pro' ) }
 					min={ 0 }
 					max={ 100 }
 					value={ attributes.recurringTime }

--- a/src/pro/plugins/posts/index.js
+++ b/src/pro/plugins/posts/index.js
@@ -70,7 +70,7 @@ const AddFields = (
 				href="https://wordpress.org/plugins/advanced-custom-fields/"
 				target="_blank"
 			>
-				{ __( 'Activate Advanced Custom Fields to add more fields.', 'otter-blocks' ) }
+				{ __( 'Activate Advanced Custom Fields to add more fields.', 'otter-pro' ) }
 			</ExternalLink>
 		);
 	}
@@ -120,20 +120,20 @@ const AddFields = (
 					});
 				} }
 			>
-				{ __( 'Add Custom Field', 'otter-blocks' ) }
+				{ __( 'Add Custom Field', 'otter-pro' ) }
 			</Button>
 
 			{ Boolean( window.otterPro.isExpired ) && (
 				<Notice
-					notice={ __( 'Otter Pro license has expired.', 'otter-blocks' ) }
-					instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Posts Block.', 'otter-blocks' ) }
+					notice={ __( 'Otter Pro license has expired.', 'otter-pro' ) }
+					instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Posts Block.', 'otter-pro' ) }
 				/>
 			) }
 
 			{ ! Boolean( window.otterPro.isActive ) && (
 				<Notice
-					notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Posts Block.', 'otter-blocks' ) }
+					notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Posts Block.', 'otter-pro' ) }
 				/>
 			) }
 		</Fragment>
@@ -206,7 +206,7 @@ const Controls = (
 	if ( ! Boolean( window.otterPro.isActive ) ) {
 		return (
 			<Notice
-				notice={ __( 'You need to activate Otter Pro to edit this field.', 'otter-blocks' ) }
+				notice={ __( 'You need to activate Otter Pro to edit this field.', 'otter-pro' ) }
 			/>
 		);
 	}
@@ -215,7 +215,7 @@ const Controls = (
 		<Fragment>
 			{ ! isEmpty( groups ) && (
 				<BaseControl
-					label={ __( 'Fields', 'otter-blocks' ) }
+					label={ __( 'Fields', 'otter-pro' ) }
 				>
 					<select
 						value={ fields[ customMeta.field ] ? customMeta.field : 'none' }
@@ -223,7 +223,7 @@ const Controls = (
 						className="components-select-control__input"
 						disabled={ Boolean( window.otterPro.isExpired ) }
 					>
-						<option value="none">{ __( 'Select a field', 'otter-blocks' ) }</option>
+						<option value="none">{ __( 'Select a field', 'otter-pro' ) }</option>
 
 						{ groups.map( group => {
 							return (
@@ -252,7 +252,7 @@ const Controls = (
 				<Fragment>
 					{ ( fields[ customMeta.field ][ 'default_value' ]) && (
 						<TextControl
-							label={ __( 'Default Value', 'otter-blocks' ) }
+							label={ __( 'Default Value', 'otter-pro' ) }
 							value={ fields[ customMeta.field ][ 'default_value' ]  }
 							disabled
 						/>
@@ -260,7 +260,7 @@ const Controls = (
 
 					{ ( fields[ customMeta.field ].prepend ) && (
 						<TextControl
-							label={ __( 'Before', 'otter-blocks' ) }
+							label={ __( 'Before', 'otter-pro' ) }
 							value={ fields[ customMeta.field ].prepend }
 							disabled
 						/>
@@ -268,7 +268,7 @@ const Controls = (
 
 					{ ( fields[ customMeta.field ].append ) && (
 						<TextControl
-							label={ __( 'After', 'otter-blocks' ) }
+							label={ __( 'After', 'otter-pro' ) }
 							value={ fields[ customMeta.field ].append }
 							disabled
 						/>
@@ -282,7 +282,7 @@ const Controls = (
 						href={ fields[ customMeta.field ]?.urlLocation }
 						target='_blank'
 					>
-						{ __( 'Edit in ACF', 'otter-blocks' ) }
+						{ __( 'Edit in ACF', 'otter-pro' ) }
 					</ExternalLink>
 					<br/>
 				</Fragment>
@@ -293,10 +293,10 @@ const Controls = (
 					href={ `${ window.otterPro.rootUrl || '' }/wp-admin/edit.php?post_type=acf-field-group` }
 					target='_blank'
 				>
-					{ __( 'There are no ACF fields. You can use this option after you add some.', 'otter-blocks' ) }
+					{ __( 'There are no ACF fields. You can use this option after you add some.', 'otter-pro' ) }
 				</ExternalLink>
 			) : ! fields[ customMeta.field ] &&  (
-				__( 'The selected field does not longer exists. Please select another field.', 'otter-blocks' )
+				__( 'The selected field does not longer exists. Please select another field.', 'otter-pro' )
 			) }
 
 			<Button
@@ -306,7 +306,7 @@ const Controls = (
 				isDestructive
 				className="o-conditions__add"
 			>
-				{ __( 'Delete', 'otter-blocks' ) }
+				{ __( 'Delete', 'otter-pro' ) }
 			</Button>
 		</Fragment>
 	);
@@ -324,7 +324,7 @@ const changeTabLabel = (
 		};
 	}, []);
 
-	return startCase( toLower( fields[ customMeta.field ]?.label || __( 'Custom Type', 'otter-blocks' ) ) );
+	return startCase( toLower( fields[ customMeta.field ]?.label || __( 'Custom Type', 'otter-pro' ) ) );
 };
 
 addFilter( 'blocks.registerBlockType', 'themeisle-gutenberg/posts-acf-extension-attributes', addAttribute );

--- a/src/pro/plugins/sticky/index.js
+++ b/src/pro/plugins/sticky/index.js
@@ -28,8 +28,8 @@ const StickyControls = (
 				{ Controls }
 
 				<Notice
-					notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-blocks' ) }
+					notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+					instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Sticky Extension.', 'otter-pro' ) }
 				/>
 			</Fragment>
 		);
@@ -53,22 +53,22 @@ const StickyControls = (
 		<Fragment>
 			{ Boolean( window.otterPro.isExpired ) && (
 				<Notice
-					notice={ __( 'Otter Pro license has expired.', 'otter-blocks' ) }
-					instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Sticky Extension.', 'otter-blocks' ) }
+					notice={ __( 'Otter Pro license has expired.', 'otter-pro' ) }
+					instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Sticky Extension.', 'otter-pro' ) }
 				/>
 			) }
 
 			<SelectControl
-				label={ __( 'Position', 'otter-blocks' ) }
-				help={ __( 'Position of the block in relation to the screen.', 'otter-blocks' ) }
+				label={ __( 'Position', 'otter-pro' ) }
+				help={ __( 'Position of the block in relation to the screen.', 'otter-pro' ) }
 				value={ position }
 				options={ [
 					{
-						label: __( 'Top', 'otter-blocks' ),
+						label: __( 'Top', 'otter-pro' ),
 						value: 'o-sticky-pos-top'
 					},
 					{
-						label: __( 'Bottom', 'otter-blocks' ),
+						label: __( 'Bottom', 'otter-pro' ),
 						value: 'o-sticky-pos-bottom'
 					}
 				] }
@@ -76,8 +76,8 @@ const StickyControls = (
 			/>
 
 			<RangeControl
-				label={ __( 'Offset', 'otter-blocks' ) }
-				help={ __( 'Distance from the block to the screen.', 'otter-blocks' ) }
+				label={ __( 'Offset', 'otter-pro' ) }
+				help={ __( 'Distance from the block to the screen.', 'otter-pro' ) }
 				value={ getOffsetValue() }
 				min={ 0 }
 				max={ 500 }
@@ -85,20 +85,20 @@ const StickyControls = (
 			/>
 
 			<SelectControl
-				label={ __( 'Behaviour', 'otter-blocks' ) }
-				help={ __( 'Behaviour when multiple sticky blocks with the same movement limit collide.', 'otter-blocks' ) }
+				label={ __( 'Behaviour', 'otter-pro' ) }
+				help={ __( 'Behaviour when multiple sticky blocks with the same movement limit collide.', 'otter-pro' ) }
 				value={ behaviour }
 				options={ [
 					{
-						label: __( 'Collapse', 'otter-blocks' ),
+						label: __( 'Collapse', 'otter-pro' ),
 						value: 'o-sticky-bhvr-keep'
 					},
 					{
-						label: __( 'Fade', 'otter-blocks' ),
+						label: __( 'Fade', 'otter-pro' ),
 						value: 'o-sticky-bhvr-hide'
 					},
 					{
-						label: __( 'Stack', 'otter-blocks' ),
+						label: __( 'Stack', 'otter-pro' ),
 						value: 'o-sticky-bhvr-stack'
 					}
 				] }
@@ -114,13 +114,13 @@ const StickyControls = (
 						textAlign: 'justify'
 					} }
 				>
-					{ __( 'The block will stack with other sticky elements with the same \'Stick To\' container, and Stack option in Behaviour. It works better with \'Stick to\' as Top Level Block or Screen.', 'otter-blocks' ) }
+					{ __( 'The block will stack with other sticky elements with the same \'Stick To\' container, and Stack option in Behavior. It works better with \'Stick to\' as Top Level Block or Screen.', 'otter-pro' ) }
 				</div>
 			) }
 
 			<ToggleControl
-				label={ __( 'Enable on Mobile', 'otter-blocks' ) }
-				help={ __( 'Make the sticky mode active for mobile users.' ) }
+				label={ __( 'Enable on Mobile', 'otter-pro' ) }
+				help={ __( 'Make the sticky mode active for mobile users.', 'otter-pro'  ) }
 				checked={ useOnMobile }
 				onChange={ ( value ) => addOption( value ? 'o-sticky-use-mobile' : undefined, FILTER_OPTIONS.usage ) }
 			/>
@@ -128,16 +128,16 @@ const StickyControls = (
 			{
 				isActive && (
 					<BaseControl
-						label={ __( 'Closing the Sticky', 'otter-blocks' ) }
+						label={ __( 'Closing the Sticky', 'otter-pro' ) }
 					>
 						<p>
-							{ __( 'You can make another block that is inside the sticky element to behave like a closing button by adding the following CSS class.' )}
+							{ __( 'You can make another block that is inside the sticky element to behave like a closing button by adding the following CSS class.', 'otter-pro'  )}
 						</p>
 						<code style={{ display: 'block', padding: '10px', marginBottom: '5px' }}>
 							{ 'o-sticky-close' }
 						</code>
 						<p>
-							{ __( 'You can transform a Button into a Close button by inserting the following anchor.', 'otter-blocks' )}
+							{ __( 'You can transform a Button into a Close button by inserting the following anchor.', 'otter-pro' )}
 						</p>
 						<code style={{ display: 'block', padding: '10px' }}>
 							{ '#o-sticky-close' }

--- a/src/pro/plugins/stripe-checkout/index.js
+++ b/src/pro/plugins/stripe-checkout/index.js
@@ -16,35 +16,35 @@ const Autoresponder = ( Template, attributes, setAttributes ) => {
 	return (
 		<Fragment>
 			<PanelBody
-				title={ __( 'Autoresponder', 'otter-blocks' ) }
+				title={ __( 'Autoresponder', 'otter-pro' ) }
 				initialOpen={ false }
 			>
 				<ToggleControl
-					label={ __( 'Enable Autoresponder', 'otter-blocks' ) }
+					label={ __( 'Enable Autoresponder', 'otter-pro' ) }
 					checked={ Boolean( attributes.autoresponder ) }
 					onChange={ ( value ) => setAttributes({ autoresponder: value ? { subject: undefined, body: undefined } : undefined })}
-					help={ __( 'Enable autoresponder email to be sent to the customer after a successful purchase.', 'otter-blocks' ) }
+					help={ __( 'Enable autoresponder email to be sent to the customer after a successful purchase.', 'otter-pro' ) }
 				/>
 
 				{
 					attributes.autoresponder && (
 						<Fragment>
 							<TextControl
-								label={__( 'Autoresponder Subject', 'otter-blocks' )}
+								label={__( 'Autoresponder Subject', 'otter-pro' )}
 								placeholder={__(
 									'Thank you for your purchase',
-									'otter-blocks'
+									'otter-pro'
 								)}
 								value={ attributes.autoresponder?.subject }
 								onChange={ ( subject ) => setAttributes({ autoresponder: { ...attributes.autoresponder, subject }})}
 								help={__(
 									'Enter the subject of the autoresponder email.',
-									'otter-blocks'
+									'otter-pro'
 								)}
 							/>
 
 							<AutoresponderBodyModal
-								value={ attributes.autoresponder?.body ?? __( 'Message example: We appreciate your recent purchase made on our website. You have received a promotional code, namely <strong>EXAMPLE</strong>, which can be applied during checkout on our <a href="https://themeisle.com/plugins/otter-blocks/">website</a>.', 'otter-blocks' ) }
+								value={ attributes.autoresponder?.body ?? __( 'Message example: We appreciate your recent purchase made on our website. You have received a promotional code, namely <strong>EXAMPLE</strong>, which can be applied during checkout on our <a href="https://themeisle.com/plugins/otter-blocks/">website</a>.', 'otter-pro' ) }
 								onChange={ ( body ) => setAttributes({ autoresponder: { ...attributes.autoresponder, body }}) }
 								area="stripe-autoresponder"
 							/>

--- a/src/pro/plugins/wc-integration/edit.js
+++ b/src/pro/plugins/wc-integration/edit.js
@@ -42,7 +42,7 @@ const Edit = ({
 					results: {},
 					status: {
 						isError: true,
-						message: error.message || __( 'Unknown error', 'otter-blocks' )
+						message: error.message || __( 'Unknown error', 'otter-pro' )
 					}
 				};
 			}
@@ -72,13 +72,13 @@ const Edit = ({
 
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Sync with WooCommerce', 'otter-blocks' ) }
+					title={ __( 'Sync with WooCommerce', 'otter-pro' ) }
 					initialOpen={ false }
 				>
-					<p>{ __( 'By selecting a product, the current review information will sync with the selected WooCommerce product.', 'otter-blocks' ) }</p>
+					<p>{ __( 'By selecting a product, the current review information will sync with the selected WooCommerce product.', 'otter-pro' ) }</p>
 
 					<SelectProducts
-						label={ __( 'Select Product', 'otter-blocks' ) }
+						label={ __( 'Select Product', 'otter-pro' ) }
 						value={ props.attributes.product }
 						disabled={ ! Boolean( window.otterPro.isActive ) || Boolean( window.otterPro.isExpired ) }
 						onChange={ product => props.setAttributes({ product: 0 === product ? undefined : product }) }
@@ -86,15 +86,15 @@ const Edit = ({
 
 					{ Boolean( window.otterPro.isExpired ) && (
 						<Notice
-							notice={ __( 'Otter Pro license has expired.', 'otter-blocks' ) }
-							instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Review Block.', 'otter-blocks' ) }
+							notice={ __( 'Otter Pro license has expired.', 'otter-pro' ) }
+							instructions={ __( 'You need to renew your Otter Pro license in order to continue using Pro features of Review Block.', 'otter-pro' ) }
 						/>
 					) }
 
 					{ ! Boolean( window.otterPro.isActive ) && (
 						<Notice
-							notice={ __( 'You need to activate Otter Pro.', 'otter-blocks' ) }
-							instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Review Block.', 'otter-blocks' ) }
+							notice={ __( 'You need to activate Otter Pro.', 'otter-pro' ) }
+							instructions={ __( 'You need to activate your Otter Pro license to use Pro features of Review Block.', 'otter-pro' ) }
 						/>
 					) }
 				</PanelBody>

--- a/src/pro/plugins/wc-integration/utility.js
+++ b/src/pro/plugins/wc-integration/utility.js
@@ -19,7 +19,7 @@ export const extractProductData = rawProduct => {
 		price: ( window.wc.priceFormat.formatPrice( Number( rawProduct?.prices?.regular_price ) ) ).replace( /[^0-9.-]+/g, '' ),
 		discounted: rawProduct?.prices?.regular_price !== rawProduct?.prices?.sale_price ? ( window.wc.priceFormat.formatPrice( Number( rawProduct?.prices?.sale_price ) ) ).replace( /[^0-9.-]+/g, '' ) : undefined,
 		currency: rawProduct?.prices?.currency_code,
-		links: [{ label: __( 'Buy Now', 'otter-blocks' ), href: rawProduct?.add_to_cart?.url, isSpoonsored: 'external' === rawProduct?.type }],
+		links: [{ label: __( 'Buy Now', 'otter-pro' ), href: rawProduct?.add_to_cart?.url, isSpoonsored: 'external' === rawProduct?.type }],
 		image: 0 < rawProduct?.images?.length ? extractImageData( rawProduct?.images[0]) : undefined
 	};
 };

--- a/src/pro/woocommerce/add-to-cart/block.json
+++ b/src/pro/woocommerce/add-to-cart/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display the add to cart section of your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "add to cart" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/add-to-cart/index.js
+++ b/src/pro/woocommerce/add-to-cart/index.js
@@ -29,8 +29,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Add to Cart', 'otter-blocks' ),
-		description: __( 'Display the add to cart section of your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Add to Cart', 'otter-pro' ),
+		description: __( 'Display the add to cart section of your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/images/index.js
+++ b/src/pro/woocommerce/images/index.js
@@ -29,8 +29,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Images', 'otter-blocks' ),
-		description: __( 'Display images of your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Images', 'otter-pro' ),
+		description: __( 'Display images of your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/meta/index.js
+++ b/src/pro/woocommerce/meta/index.js
@@ -29,8 +29,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Meta', 'otter-blocks' ),
-		description: __( 'Display the meta of your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Meta', 'otter-pro' ),
+		description: __( 'Display the meta of your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/price/block.json
+++ b/src/pro/woocommerce/price/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display the price of your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "price" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/price/index.js
+++ b/src/pro/woocommerce/price/index.js
@@ -29,8 +29,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Price', 'otter-blocks' ),
-		description: __( 'Display the price of your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Price', 'otter-pro' ),
+		description: __( 'Display the price of your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/rating/block.json
+++ b/src/pro/woocommerce/rating/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display the rating of your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "rating" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/rating/index.js
+++ b/src/pro/woocommerce/rating/index.js
@@ -29,8 +29,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Rating', 'otter-blocks' ),
-		description: __( 'Display the rating of your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Rating', 'otter-pro' ),
+		description: __( 'Display the rating of your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/related-products/block.json
+++ b/src/pro/woocommerce/related-products/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display related products for your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "related products" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/related-products/index.js
+++ b/src/pro/woocommerce/related-products/index.js
@@ -28,14 +28,14 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 		blockProps={ useBlockProps() }
 	/>;
 } else {
-	edit = () => <div { ...useBlockProps() }><Placeholder>{ __( 'Related products will be displayed here on the product page.', 'otter-blocks' ) }</Placeholder></div>;
+	edit = () => <div { ...useBlockProps() }><Placeholder>{ __( 'Related products will be displayed here on the product page.', 'otter-pro' ) }</Placeholder></div>;
 }
 
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Related Products', 'otter-blocks' ),
-		description: __( 'Display related products for your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Related Products', 'otter-pro' ),
+		description: __( 'Display related products for your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/short-description/block.json
+++ b/src/pro/woocommerce/short-description/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display the short description of your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "short description" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/short-description/index.js
+++ b/src/pro/woocommerce/short-description/index.js
@@ -29,8 +29,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Short Description', 'otter-blocks' ),
-		description: __( 'Display the short description of your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Short Description', 'otter-pro' ),
+		description: __( 'Display the short description of your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/stock/block.json
+++ b/src/pro/woocommerce/stock/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display the stock description of your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "stock" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/stock/index.js
+++ b/src/pro/woocommerce/stock/index.js
@@ -29,8 +29,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Stock', 'otter-blocks' ),
-		description: __( 'Display the stock of your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Stock', 'otter-pro' ),
+		description: __( 'Display the stock of your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/tabs/block.json
+++ b/src/pro/woocommerce/tabs/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display the tabs for your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "tabs" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/tabs/index.js
+++ b/src/pro/woocommerce/tabs/index.js
@@ -28,14 +28,14 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 		blockProps={ useBlockProps() }
 	/>;
 } else {
-	edit = () => <div { ...useBlockProps() }><Placeholder>{ __( 'Tabs will be displayed here on the product page.', 'otter-blocks' ) }</Placeholder></div>;
+	edit = () => <div { ...useBlockProps() }><Placeholder>{ __( 'Tabs will be displayed here on the product page.', 'otter-pro' ) }</Placeholder></div>;
 }
 
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Tabs', 'otter-blocks' ),
-		description: __( 'Display the tabs for your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Tabs', 'otter-pro' ),
+		description: __( 'Display the tabs for your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/title/block.json
+++ b/src/pro/woocommerce/title/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display the title of your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "title" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/title/index.js
+++ b/src/pro/woocommerce/title/index.js
@@ -29,8 +29,8 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Title', 'otter-blocks' ),
-		description: __( 'Display the title of your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Title', 'otter-pro' ),
+		description: __( 'Display the title of your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/src/pro/woocommerce/upsells/block.json
+++ b/src/pro/woocommerce/upsells/block.json
@@ -6,5 +6,5 @@
 	"category": "themeisle-woocommerce-blocks",
 	"description": "Display upsells for your WooCommerce product.",
 	"keywords": [ "woocommerce", "products", "upsells" ],
-	"textdomain": "otter-blocks"
+	"textdomain": "otter-pro"
 }

--- a/src/pro/woocommerce/upsells/index.js
+++ b/src/pro/woocommerce/upsells/index.js
@@ -28,14 +28,14 @@ if ( ! ( Boolean( window.otterPro.isActive ) && ! Boolean( window.otterPro.isExp
 		blockProps={ useBlockProps() }
 	/>;
 } else {
-	edit = () => <div { ...useBlockProps() }><Placeholder>{ __( 'Upsell products will be displayed here on the product page.', 'otter-blocks' ) }</Placeholder></div>;
+	edit = () => <div { ...useBlockProps() }><Placeholder>{ __( 'Upsell products will be displayed here on the product page.', 'otter-pro' ) }</Placeholder></div>;
 }
 
 if ( Boolean( window.otterPro.hasWooCommerce ) ) {
 	registerBlockType( name, {
 		...metadata,
-		title: __( 'Product Upsells', 'otter-blocks' ),
-		description: __( 'Display upsells for your WooCommerce product.', 'otter-blocks' ),
+		title: __( 'Product Upsells', 'otter-pro' ),
+		description: __( 'Display upsells for your WooCommerce product.', 'otter-pro' ),
 		icon,
 		keywords: [
 			'woocommerce',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,32 @@ const blockFiles = Object.keys( blocks ).filter( block => blocks[ block ].block 
 
 const blockFolders = Object.keys( blocks ).filter( block => true !== blocks[ block ]?.isPro ).map( block => `build/blocks/${ block }` );
 
+const changeTextDomain = textdomain => {
+	return {
+		test: /\.(j|t)sx?$/,
+		exclude: /node_modules/,
+		use: [
+			{
+				loader: require.resolve( 'babel-loader' ),
+				options: {
+					cacheDirectory:
+					process.env.BABEL_CACHE_DIRECTORY || true,
+					babelrc: false,
+					configFile: false,
+					presets: [
+						require.resolve(
+							'@wordpress/babel-preset-default'
+						)
+					],
+					plugins: [
+						[ '@automattic/babel-plugin-replace-textdomain', { textdomain }]
+					]
+				}
+			}
+		]
+	};
+};
+
 module.exports = [
 	{
 
@@ -74,6 +100,12 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/animation' )
 		},
+		module: {
+			rules: [
+				changeTextDomain('otter-blocks'),
+				...defaultConfig.module.rules
+			]
+		},
 		plugins: [
 			...defaultConfig.plugins,
 			new BundleAnalyzerPlugin({
@@ -94,6 +126,12 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/css' )
 		},
+		module: {
+			rules: [
+				changeTextDomain('otter-blocks'),
+				...defaultConfig.module.rules
+			]
+		},
 		plugins: [
 			...defaultConfig.plugins,
 			new BundleAnalyzerPlugin({
@@ -113,6 +151,12 @@ module.exports = [
 		},
 		output: {
 			path: path.resolve( __dirname, './build/export-import' )
+		},
+		module: {
+			rules: [
+				changeTextDomain('otter-blocks'),
+				...defaultConfig.module.rules
+			]
 		},
 		plugins: [
 			...defaultConfig.plugins,

--- a/webpack.config.plugins.js
+++ b/webpack.config.plugins.js
@@ -5,6 +5,32 @@ const path = require( 'path' );
 
 defaultConfig.plugins.splice( 1, 1 ); // We need to remove Core's Copy Files plugin.
 
+const changeTextDomain = textdomain => {
+	return {
+		test: /\.(j|t)sx?$/,
+		exclude: /node_modules/,
+		use: [
+			{
+				loader: require.resolve( 'babel-loader' ),
+				options: {
+					cacheDirectory:
+					process.env.BABEL_CACHE_DIRECTORY || true,
+					babelrc: false,
+					configFile: false,
+					presets: [
+						require.resolve(
+							'@wordpress/babel-preset-default'
+						)
+					],
+					plugins: [
+						[ '@automattic/babel-plugin-replace-textdomain', { textdomain }]
+					]
+				}
+			}
+		]
+	};
+};
+
 const plugins = {
 	plugins: [
 		...defaultConfig.plugins,
@@ -44,6 +70,12 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/animation' )
 		},
+		module: {
+			rules: [
+				changeTextDomain('blocks-animation'),
+				...defaultConfig.module.rules
+			]
+		},
 		...plugins
 	},
 	{
@@ -58,6 +90,12 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/css' )
 		},
+		module: {
+			rules: [
+				changeTextDomain('blocks-css'),
+				...defaultConfig.module.rules
+			]
+		},
 		...plugins
 	},
 	{
@@ -71,6 +109,12 @@ module.exports = [
 		},
 		output: {
 			path: path.resolve( __dirname, './build/export-import' )
+		},
+		module: {
+			rules: [
+				changeTextDomain('blocks-export-import'),
+				...defaultConfig.module.rules
+			]
 		},
 		...plugins
 	}

--- a/webpack.config.plugins.js
+++ b/webpack.config.plugins.js
@@ -5,37 +5,6 @@ const path = require( 'path' );
 
 defaultConfig.plugins.splice( 1, 1 ); // We need to remove Core's Copy Files plugin.
 
-const getConfig = textdomain => {
-	return {
-		rules: [
-			{
-				test: /\.(j|t)sx?$/,
-				exclude: /node_modules/,
-				use: [
-					{
-						loader: require.resolve( 'babel-loader' ),
-						options: {
-							cacheDirectory:
-                            process.env.BABEL_CACHE_DIRECTORY || true,
-							babelrc: false,
-							configFile: false,
-							presets: [
-								require.resolve(
-									'@wordpress/babel-preset-default'
-								)
-							],
-							plugins: [
-								[ '@automattic/babel-plugin-replace-textdomain', { 'textdomain': textdomain }]
-							]
-						}
-					}
-				]
-			},
-			...defaultConfig.module.rules
-		]
-	};
-};
-
 const plugins = {
 	plugins: [
 		...defaultConfig.plugins,
@@ -75,7 +44,6 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/animation' )
 		},
-		module: { ...getConfig( 'blocks-animation' ) },
 		...plugins
 	},
 	{
@@ -90,7 +58,6 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/css' )
 		},
-		module: { ...getConfig( 'blocks-css' ) },
 		...plugins
 	},
 	{
@@ -105,7 +72,6 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/export-import' )
 		},
-		module: { ...getConfig( 'blocks-export-import' ) },
 		...plugins
 	}
 ];

--- a/webpack.config.pro.js
+++ b/webpack.config.pro.js
@@ -18,6 +18,32 @@ const blockFilesPro = Object.keys( blocks ).filter( block => blocks[ block ].blo
 
 const blockFoldersPro = Object.keys( blocks ).filter( block => true === blocks[ block ]?.isPro ).map( block => `build/pro/${ block }` );
 
+const changeTextDomain = textdomain => {
+	return {
+		test: /\.(j|t)sx?$/,
+		exclude: /node_modules/,
+		use: [
+			{
+				loader: require.resolve( 'babel-loader' ),
+				options: {
+					cacheDirectory:
+					process.env.BABEL_CACHE_DIRECTORY || true,
+					babelrc: false,
+					configFile: false,
+					presets: [
+						require.resolve(
+							'@wordpress/babel-preset-default'
+						)
+					],
+					plugins: [
+						[ '@automattic/babel-plugin-replace-textdomain', { textdomain }]
+					]
+				}
+			}
+		]
+	};
+};
+
 module.exports = [
 	{
 
@@ -38,6 +64,12 @@ module.exports = [
 			path: path.resolve( __dirname, './build/pro' ),
 			filename: '[name].js',
 			chunkFilename: 'chunk-[name].js'
+		},
+		module: {
+			rules: [
+				changeTextDomain('otter-pro'),
+				...defaultConfig.module.rules
+			]
 		},
 		plugins: [
 			...defaultConfig.plugins,


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Separated the translation domain for each sub-plugin and Otter Pro
- When the sub-plugin is bundled with Otter, their domains are changed to `otter-blocks` for JS and PHP files. (Their JS files have a check to load the translation based on their location -- in Otter or as an individual plugin).
- Set stable tags for plugins.

> [!IMPORTANT]
> Unlike the PHP files, the JS have their translation tied up with their `index.js` path. You have to set the domain based on the USED script location.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the text-domain in each build folder to be separated.
- Check stable tags.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

