### PR TITLE
Hide SDK random promo notice

### DIFF
--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -59,7 +59,7 @@ add_filter(
 );
 
 add_filter( 'otter_pro_hide_license_field', '__return_true' );
-add_filter( 'themeisle_sdk_ran_promos', '__return_false' );
+add_filter( 'themeisle_sdk_ran_promos', '__return_true' );
 
 if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
 	add_action(


### PR DESCRIPTION
Issue https://github.com/Codeinwp/themeisle/issues/1676

### Summary
Added the following filter to hide the SDK promo notice.
`add_filter( 'themeisle_sdk_ran_promos', '__return_true' );` 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()
