### PR TITLE
feat: load Formbricks survey via internal pages hooks

### DIFF
--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -757,24 +757,12 @@ class Dashboard {
 	 */
 	public function get_survey_metadata( $data, $page_slug ) {
 		$dash_data = $this->get_dashboard_data();
-
-		$install_category    = 0;
-		$install_days_number = $dash_data['days_since_install'];
 		
-		if ( 1 < $install_days_number && 8 > $install_days_number ) {
-			$install_category = 7;
-		} elseif ( 8 <= $install_days_number && 31 > $install_days_number ) {
-			$install_category = 30;
-		} elseif ( 30 < $install_days_number && 90 > $install_days_number ) {
-			$install_category = 90;
-		} elseif ( 90 <= $install_days_number ) {
-			$install_category = 91;
-		}
+		$install_days_number = $dash_data['days_since_install'];
 
 		$data = array(
 			'environmentId' => 'clp9hqm8c1osfdl2ixwd0k0iz',
 			'attributes'    => array(
-				'days_since_install'  => $install_category,
 				'install_days_number' => $install_days_number,
 				'plan'                => isset( $dash_data['license'], $dash_data['license']['type'] ) ? $dash_data['license']['type'] : 'free',
 				'freeVersion'         => $dash_data['version'],

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -28,13 +28,15 @@ class Dashboard {
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'register_menu_page' ) );
 		add_action( 'admin_init', array( $this, 'maybe_redirect' ) );
-		add_action( 'admin_notices', array( $this, 'maybe_add_otter_banner' ), 30 );
+		add_action( 'admin_notices', array( $this, 'form_submission_elements' ), 30 );
 		add_action( 'admin_head', array( $this, 'add_inline_css' ) );
 
 		$form_options = get_option( 'themeisle_blocks_form_emails' );
 		if ( ! empty( $form_options ) ) {
 			add_action( 'wp_dashboard_setup', array( $this, 'form_submissions_widget' ) );
 		}
+
+		add_filter( 'themeisle-sdk/survey/' . OTTER_PRODUCT_SLUG, array( $this, 'get_survey_metadata' ), 10, 2 );
 	}
 
 	/**
@@ -217,7 +219,7 @@ class Dashboard {
 			$this->get_dashboard_data()
 		);
 
-		$this->load_survey();
+		do_action( 'themeisle_internal_page', OTTER_PRODUCT_SLUG, 'dashboard' );
 	}
 
 	/**
@@ -243,7 +245,7 @@ class Dashboard {
 			'showFeedbackNotice'     => $this->should_show_feedback_notice(),
 			'deal'                   => ! Pro::is_pro_installed() ? $offer->get_localized_data() : array(),
 			'hasOnboarding'          => false !== get_theme_support( FSE_Onboarding::SUPPORT_KEY ),
-			'days_since_install'     => (int) round( ( time() - get_option( 'otter_blocks_install', time() ) ) / DAY_IN_SECONDS ),
+			'days_since_install'     => intval( ( time() - get_option( 'otter_blocks_install', time() ) ) / DAY_IN_SECONDS ),
 			'rootUrl'                => get_site_url(),
 			'neveThemePreviewUrl'    => esc_url(
 				add_query_arg(
@@ -273,6 +275,14 @@ class Dashboard {
 			),
 			'neveInstalled'          => defined( 'NEVE_VERSION' ),
 		);
+		
+		if (
+			isset( $global_data['license'], $global_data['license']['key'] )
+			&& 'free' !== $global_data['license']['key']
+			&& 6 >= strlen( $global_data['license']['key'] )
+		) {
+			$global_data['license']['key'] = str_repeat( '*', 26 ) . substr( $global_data['license']['key'], -6 );
+		}
 
 		return apply_filters( 'otter_dashboard_data', $global_data );
 	}
@@ -302,14 +312,18 @@ class Dashboard {
 	}
 
 	/**
-	 * Add the Otter banner on the 'edit-otter_form_record' page.
+	 * Add elements for Form Block submission page.
 	 *
 	 * @return void
 	 */
-	public function maybe_add_otter_banner() {
+	public function form_submission_elements() {
 		$screen = get_current_screen();
 		if ( 'edit-otter_form_record' === $screen->id || 'otter-blocks_page_form-submissions-free' === $screen->id ) {
 			$this->the_otter_banner();
+		}
+		
+		if ( 'edit-otter_form_record' === $screen->id ) {
+			do_action( 'themeisle_internal_page', OTTER_PRODUCT_SLUG, 'form-submissions' );
 		}
 	}
 
@@ -734,15 +748,48 @@ class Dashboard {
 	}
 
 	/**
-	 * Load the Formbricks deps from SDK to initiate the survey.
+	 * Register survey.
+	 * 
+	 * @param array  $data The data in Formbricks format.
+	 * @param string $page_slug The page slug.
+	 * 
+	 * @return array The data in Frombricks format.
 	 */
-	private function load_survey() {
-		$survey_handler = apply_filters( 'themeisle_sdk_dependency_script_handler', 'survey' );
-		if ( empty( $survey_handler ) ) {
-			return;
+	public function get_survey_metadata( $data, $page_slug ) {
+		$dash_data = $this->get_dashboard_data();
+
+		$install_category    = 0;
+		$install_days_number = $dash_data['days_since_install'];
+		
+		if ( 1 < $install_days_number && 8 > $install_days_number ) {
+			$install_category = 7;
+		} elseif ( 8 <= $install_days_number && 31 > $install_days_number ) {
+			$install_category = 30;
+		} elseif ( 30 < $install_days_number && 90 > $install_days_number ) {
+			$install_category = 90;
+		} elseif ( 90 <= $install_days_number ) {
+			$install_category = 91;
 		}
 
-		do_action( 'themeisle_sdk_dependency_enqueue_script', 'survey' );
+		$data = array(
+			'environmentId' => 'clp9hqm8c1osfdl2ixwd0k0iz',
+			'attributes'    => array(
+				'days_since_install'  => $install_category,
+				'install_days_number' => $install_days_number,
+				'plan'                => isset( $dash_data['license'], $dash_data['license']['type'] ) ? $dash_data['license']['type'] : 'free',
+				'freeVersion'         => $dash_data['version'],
+			),
+		);
+
+		if ( isset( $dash_data['license'], $dash_data['license']['key'] ) ) {
+			$data['attributes']['license_key'] = apply_filters( 'themeisle_sdk_secret_masking', apply_filters( 'product_otter_license_key', '' ) );
+		}
+
+		if ( isset( $dash_data['proVersion'] ) ) {
+			$data['attributes']['proVersion'] = $dash_data['proVersion'];
+		}
+
+		return $data;
 	}
 
 	/**

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -275,16 +275,18 @@ class Dashboard {
 			),
 			'neveInstalled'          => defined( 'NEVE_VERSION' ),
 		);
+
+		$global_data = apply_filters( 'otter_dashboard_data', $global_data );
 		
 		if (
 			isset( $global_data['license'], $global_data['license']['key'] )
 			&& 'free' !== $global_data['license']['key']
-			&& 6 >= strlen( $global_data['license']['key'] )
+			&& 6 <= strlen( $global_data['license']['key'] )
 		) {
 			$global_data['license']['key'] = str_repeat( '*', 26 ) . substr( $global_data['license']['key'], -6 );
 		}
 
-		return apply_filters( 'otter_dashboard_data', $global_data );
+		return $global_data;
 	}
 
 	/**

--- a/otter-blocks.php
+++ b/otter-blocks.php
@@ -29,6 +29,7 @@ define( 'OTTER_BLOCKS_PATH', dirname( __FILE__ ) );
 define( 'OTTER_BLOCKS_VERSION', '3.0.10' );
 define( 'OTTER_BLOCKS_PRO_SUPPORT', true );
 define( 'OTTER_BLOCKS_SHOW_NOTICES', false );
+define( 'OTTER_PRODUCT_SLUG', basename( OTTER_BLOCKS_PATH ) );
 
 $vendor_file = OTTER_BLOCKS_PATH . '/vendor/autoload.php';
 

--- a/plugins/otter-pro/inc/server/class-dashboard-server.php
+++ b/plugins/otter-pro/inc/server/class-dashboard-server.php
@@ -65,6 +65,7 @@ class Dashboard_Server {
 				'hasNevePro'         => defined( 'NEVE_PRO_VERSION' ),
 				'storeURL'           => 'https://store.themeisle.com/',
 				'purchaseHistoryURL' => 'https://store.themeisle.com/purchase-history',
+				'proVersion'         => OTTER_PRO_VERSION,
 			)
 		);
 	}

--- a/plugins/otter-pro/inc/server/class-dashboard-server.php
+++ b/plugins/otter-pro/inc/server/class-dashboard-server.php
@@ -86,6 +86,7 @@ class Dashboard_Server {
 					'args'                => array(
 						'key'    => array(
 							'type'              => 'string',
+							'required'          => false,
 							'sanitize_callback' => function ( $key ) {
 								return (string) esc_attr( $key );
 							},
@@ -123,13 +124,20 @@ class Dashboard_Server {
 	public function toggle_license( $request ) {
 		$fields = $request->get_json_params();
 
-		if ( ! isset( $fields['key'] ) || ! isset( $fields['action'] ) ) {
+		if (
+			! isset( $fields['action'] )
+			|| ( 'activate' === $fields['action'] && ! isset( $fields['key'] ) )
+		) {
 			return new \WP_REST_Response(
 				array(
 					'message' => __( 'Invalid Action. Please refresh the page and try again.', 'otter-pro' ),
 					'success' => false,
 				)
 			);
+		}
+	
+		if ( 'deactivate' === $fields['action'] ) {
+			$fields['key'] = apply_filters( 'product_otter_license_key', 'free' );
 		}
 
 		$response = apply_filters( 'themeisle_sdk_license_process_otter', $fields['key'], $fields['action'] );

--- a/src/dashboard/components/LicenseField.js
+++ b/src/dashboard/components/LicenseField.js
@@ -100,10 +100,12 @@ const LicenseField = () => {
 					isSecondary={ isValid }
 					isBusy={ isLoading }
 					disabled={ isLoading }
-					onClick={ () => onSaveLicense({
-						action: isValid ? 'deactivate' : 'activate',
-						key: licenseKey
-					}) }
+					onClick={ () => {
+						onSaveLicense({
+							action: isValid ? 'deactivate' : 'activate',
+							key: isValid ? undefined : licenseKey
+						});
+					} }
 				>
 					{ isValid ? __( 'Deactivate', 'otter-blocks' ) : __( 'Activate', 'otter-blocks' ) }
 				</Button>

--- a/src/dashboard/components/LicenseField.js
+++ b/src/dashboard/components/LicenseField.js
@@ -87,7 +87,7 @@ const LicenseField = () => {
 
 			<input
 				type="text"
-				value={ isValid ? '******************************' + licenseKey.slice( -5 ) : licenseKey }
+				value={ licenseKey }
 				placeholder={ __( 'Enter license key', 'otter-blocks' ) }
 				disabled={ isLoading || isValid }
 				onChange={ e => setLicenseKey( e.target.value ) }

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -75,20 +75,3 @@ const App = () => {
 const root = createRoot( document.getElementById( 'otter' ) );
 
 root.render( <App /> );
-
-/**
- * Initialize the formbricks survey.
- *
- * @see https://github.com/formbricks/setup-examples/tree/main/html
- */
-window.addEventListener('themeisle:survey:loaded', function () {
-	window?.tsdk_formbricks?.init?.({
-		environmentId: 'clp9hqm8c1osfdl2ixwd0k0iz',
-		apiHost: 'https://app.formbricks.com',
-		userId: 'otter_' + ( undefined !== window.otterObj?.license?.key ? window.otterObj.license.key : window.otterObj.rootUrl.replace( /[^\w\d]*/g, '' ) ),
-		attributes: {
-			plan: undefined !== window.otterObj?.license?.type ? window.otterObj.license.type : 'free',
-			days_since_install: convertToCategory( window.otterObj.days_since_install )
-		}
-	});
-});   

--- a/tests/php/static-analysis-stubs/otter.php
+++ b/tests/php/static-analysis-stubs/otter.php
@@ -9,6 +9,7 @@ define( 'OTTER_BLOCKS_BASEFILE', __FILE__ );
 define( 'OTTER_BLOCKS_URL', plugins_url( '/', __FILE__ ) );
 define( 'OTTER_BLOCKS_PATH', dirname( __FILE__ ) );
 define( 'OTTER_BLOCKS_VERSION', '2.2.7' );
+define( 'OTTER_PRODUCT_SLUG', basename( OTTER_BLOCKS_PATH ) );
 
 define( 'OTTER_PRO_VERSION', OTTER_BLOCKS_VERSION );
 define( 'OTTER_PRO_URL', OTTER_BLOCKS_URL . 'plugins/otter-pro/' );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1687
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Add internal pages.
- Load survey via internal pages.
- Always use a masked license key on the dashboard.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Use https://github.com/Codeinwp/themeisle-sdk-main/pull/287 then go to Otter dashboard with this URL `/wp-admin/admin.php?page=otter&formbricksDebug=true` then check the Console

![CleanShot 2025-02-13 at 13 45 11@2x](https://github.com/user-attachments/assets/8497f8e7-6c96-43cd-ba8a-91faf1d3b119)

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

