### PR TITLE
Fixed count animation delay and speed

### DIFF
--- a/src/animation/frontend/count/index.js
+++ b/src/animation/frontend/count/index.js
@@ -23,7 +23,9 @@ const speedConfig = {
  */
 const getConfiguration = ( elem ) => {
 	let parent = elem.parentElement;
-	if (parent && (['STRONG', 'B'].includes(parent.tagName))) {
+	const formattingTags = ['STRONG', 'B', 'EM', 'I', 'U', 'SPAN', 'CODE', 'MARK', 'SMALL', 'S', 'DEL', 'INS', 'SUP', 'SUB'];
+
+	while (parent && (formattingTags.includes(parent.tagName))) {
 		parent = parent.parentElement;
 	}
 	for ( let i = 0; i < MAX_PARENT_SEARCH; ++i ) {

--- a/src/animation/frontend/count/index.js
+++ b/src/animation/frontend/count/index.js
@@ -13,7 +13,7 @@ const speedConfig = {
 	'o-count-slower': 3,
 	'o-count-slow': 2,
 	'o-count-fast': 1.5,
-	'o-count-fastest': 1
+	'o-count-faster': 1
 };
 
 /**
@@ -36,7 +36,7 @@ const getConfiguration = ( elem ) => {
 
 			return {
 				speed: speedConfig[speed],
-				delay: number * ( isMS ? 0 : 1000 )
+				delay: number * ( isMS ? 1 : 1000 )
 			};
 		}
 	}

--- a/src/animation/frontend/count/index.js
+++ b/src/animation/frontend/count/index.js
@@ -22,7 +22,10 @@ const speedConfig = {
  * @return Configuration options.
  */
 const getConfiguration = ( elem ) => {
-	const parent = elem.parentElement;
+	let parent = elem.parentElement;
+	if (parent && (['STRONG', 'B'].includes(parent.tagName))) {
+		parent = parent.parentElement;
+	}
 	for ( let i = 0; i < MAX_PARENT_SEARCH; ++i ) {
 		if ( Array.from( parent.classList ).some( o => o.includes( 'o-count-' ) ) ) {
 			const arr = Array.from( parent.classList );


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2559

### Summary
I've fixed the delay and speed settings in the count animation.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

