### PR TITLE
feat: show cloud library only if the user has/had used it

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -9,6 +9,7 @@ namespace ThemeIsle\GutenbergBlocks;
 
 use ThemeIsle\GutenbergBlocks\Main, ThemeIsle\GutenbergBlocks\Pro, ThemeIsle\GutenbergBlocks\Plugins\Stripe_API;
 use ThemeIsle\GutenbergBlocks\Plugins\LimitedOffers;
+use ThemeIsle\GutenbergBlocks\Plugins\Template_Cloud;
 
 /**
  * Class Registration.
@@ -292,6 +293,7 @@ class Registration {
 				'isRTL'                   => is_rtl(),
 				'highlightDynamicText'    => get_option( 'themeisle_blocks_settings_highlight_dynamic', true ),
 				'hasOpenAiKey'            => ! empty( get_option( 'themeisle_open_ai_api_key' ) ),
+				'hasPatternSources'       => Template_Cloud::has_used_pattern_sources(),
 			)
 		);
 

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -9,6 +9,7 @@ namespace ThemeIsle\GutenbergBlocks\Plugins;
 
 use ThemeIsle\GutenbergBlocks\Pro;
 use ThemeIsle\GutenbergBlocks\Plugins\FSE_Onboarding;
+use ThemeIsle\GutenbergBlocks\Plugins\Template_Cloud;
 
 /**
  * Class Dashboard
@@ -278,6 +279,7 @@ class Dashboard {
 				)
 			),
 			'neveInstalled'          => defined( 'NEVE_VERSION' ),
+			'hasPatternSources'      => Template_Cloud::has_used_pattern_sources(),
 		);
 
 		$global_data = apply_filters( 'otter_dashboard_data', $global_data );

--- a/inc/plugins/class-template-cloud.php
+++ b/inc/plugins/class-template-cloud.php
@@ -181,7 +181,6 @@ class Template_Cloud {
 	 */
 	public static function has_used_pattern_sources() {
 		$sources = get_option( self::SOURCES_SETTING_KEY, null );
-		// @phpstan-ignore-next-line
 		return is_array( $sources );
 	}
 

--- a/inc/plugins/class-template-cloud.php
+++ b/inc/plugins/class-template-cloud.php
@@ -182,7 +182,7 @@ class Template_Cloud {
 	public static function has_used_pattern_sources() {
 		$sources = get_option( self::SOURCES_SETTING_KEY, null );
 		// @phpstan-ignore-next-line
-		return ( is_array( $sources ) && ( ! empty( $sources ) || [] === $sources ) );
+		return is_array( $sources );
 	}
 
 	/**

--- a/inc/plugins/class-template-cloud.php
+++ b/inc/plugins/class-template-cloud.php
@@ -175,6 +175,16 @@ class Template_Cloud {
 	}
 
 	/**
+	 * Check if sources exist, even if user has used the feature in past.
+	 * 
+	 * @return bool
+	 */
+	public static function has_used_pattern_sources() {
+		$sources = get_option( self::SOURCES_SETTING_KEY, null );
+		return is_array( $sources ) && ( ! empty( $sources ) || $sources === [] );
+	}
+
+	/**
 	 * Save the pattern sources.
 	 *
 	 * @param array $new_sources The new sources.

--- a/inc/plugins/class-template-cloud.php
+++ b/inc/plugins/class-template-cloud.php
@@ -181,7 +181,8 @@ class Template_Cloud {
 	 */
 	public static function has_used_pattern_sources() {
 		$sources = get_option( self::SOURCES_SETTING_KEY, null );
-		return is_array( $sources ) && ( ! empty( $sources ) || $sources === [] );
+		// @phpstan-ignore-next-line
+		return ( is_array( $sources ) && ( ! empty( $sources ) || [] === $sources ) );
 	}
 
 	/**

--- a/src/blocks/plugins/options/index.js
+++ b/src/blocks/plugins/options/index.js
@@ -442,6 +442,8 @@ const Sidebar = () => {
 };
 
 const Options = () => {
+	const [ canUser, setCanUser ] = useState( false );
+
 	useEffect( () => {
 		let isMounted = true;
 
@@ -452,7 +454,6 @@ const Options = () => {
 				setCanUser( true );
 			} else {
 				setCanUser( false );
-				setAPILoaded( true );
 			}
 		};
 
@@ -462,8 +463,6 @@ const Options = () => {
 			isMounted = false;
 		};
 	}, []);
-
-	const [ canUser, setCanUser ] = useState( false );
 
 	return (
 		<Fragment>

--- a/src/blocks/plugins/patterns-library/library.js
+++ b/src/blocks/plugins/patterns-library/library.js
@@ -213,7 +213,7 @@ const Library = ({
 							{ __( 'My Favorites', 'otter-blocks' ) }
 						</Button>
 
-						{tcCategories.length < 1 && (
+						{( tcCategories.length < 1 && Boolean( window?.themeisleGutenberg?.hasPatternSources ) ) && (
 							<Button
 								icon="open-folder"
 								isPressed={ 'cloud-empty' === selectedCategory }
@@ -275,7 +275,7 @@ const Library = ({
 					</div>
 
 					<div className="o-library__modal__content">
-						{selectedCategory === CLOUD_EMPTY_CATEGORY && <CloudLibraryPlaceholder />}
+						{( selectedCategory === CLOUD_EMPTY_CATEGORY && Boolean( window?.themeisleGutenberg?.hasPatternSources ) ) && <CloudLibraryPlaceholder />}
 						{selectedCategory !== CLOUD_EMPTY_CATEGORY && (
 							<>
 								<div className="o-library__modal__content__actions">

--- a/src/dashboard/components/pages/Integrations.js
+++ b/src/dashboard/components/pages/Integrations.js
@@ -397,7 +397,7 @@ const Integrations = () => {
 				}
 			</PanelBody>
 
-			<TCPanel/>
+			{ Boolean( window?.otterObj?.hasPatternSources ) && <TCPanel/> }
 		</Fragment>
 	);
 };


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/251.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

If you're a new user of Otter or an existing users who have never used the Cloud Library issue, the feature will not appear.

If you're an existing user who is using the feature or has used it in the past, it should continue to work the same way.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the Cloud Patterns options appear in Settings and Patterns Modal based on if the user is new or existing.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

