### PR TITLE
feat: auto-open block conditions, random sort in posts and more

### DIFF
--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -51,6 +51,7 @@ class Main {
 		add_filter( 'themeisle_sdk_blackfriday_data', array( $this, 'add_black_friday_data' ) );
 
 		add_action( 'parse_query', array( $this, 'pagination_support' ) );
+		add_filter( 'rest_post_collection_params', array( $this, 'add_random_orderby_param' ) );
 	}
 
 	/**
@@ -628,6 +629,21 @@ class Main {
 		$configs[ OTTER_PRODUCT_SLUG ] = $config;
 
 		return $configs;
+	}
+
+	/**
+	 * Add random orderby parameter to REST API.
+	 *
+	 * @param array $params REST API parameters.
+	 *
+	 * @return array Modified parameters.
+	 */
+	public function add_random_orderby_param( $params ) {
+		if ( isset( $params['orderby'] ) ) {
+			$params['orderby']['enum'][] = 'rand';
+		}
+
+		return $params;
 	}
 
 	/**

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -360,7 +360,7 @@ class Posts_Grid_Block {
 			'post_type'        => $attributes['postTypes'],
 			'posts_per_page'   => $attributes['postsToShow'],
 			'post_status'      => 'publish',
-			'order'            => $attributes['order'],
+			'order'            => $attributes['order'] || 'DESC',
 			'orderby'          => $attributes['orderBy'],
 			'offset'           => $offset,
 			'cat'              => $categories,

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -360,7 +360,7 @@ class Posts_Grid_Block {
 			'post_type'        => $attributes['postTypes'],
 			'posts_per_page'   => $attributes['postsToShow'],
 			'post_status'      => 'publish',
-			'order'            => $attributes['order'] || 'DESC',
+			'order'            => $attributes['order'] ?? 'DESC',
 			'orderby'          => $attributes['orderBy'],
 			'offset'           => $offset,
 			'cat'              => $categories,

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -360,7 +360,7 @@ class Posts_Grid_Block {
 			'post_type'        => $attributes['postTypes'],
 			'posts_per_page'   => $attributes['postsToShow'],
 			'post_status'      => 'publish',
-			'order'            => $attributes['order'] ?? 'DESC',
+			'order'            => isset( $attributes['order'] ) ? $attributes['order'] : 'DESC',
 			'orderby'          => $attributes['orderBy'],
 			'offset'           => $offset,
 			'cat'              => $categories,

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -91,7 +91,7 @@ const Edit = ({
 
 		const latestPostsQuery = pickBy({
 			categories: catIds,
-			order: attributes.order,
+			order: attributes.order || 'desc',
 			orderby: attributes.orderBy,
 			per_page: attributes.postsToShow, // eslint-disable-line camelcase
 			offset: attributes.offset,

--- a/src/blocks/blocks/posts/inspector.js
+++ b/src/blocks/blocks/posts/inspector.js
@@ -272,6 +272,28 @@ const Inspector = ({
 						<QueryControls
 							order={ attributes.order }
 							orderBy={ attributes.orderBy }
+							orderByOptions={ [
+								{
+									label: __( 'Newest to oldest', 'otter-blocks' ),
+									value: 'date/desc',
+								},
+								{
+									label: __( 'Oldest to newest', 'otter-blocks' ),
+									value: 'date/asc',
+								},
+								{
+									label: __( 'A → Z', 'otter-blocks' ),
+									value: 'title/asc',
+								},
+								{
+									label: __( 'Z → A', 'otter-blocks' ),
+									value: 'title/desc',
+								},
+								{
+									label: __( 'Random', 'otter-blocks' ),
+									value: 'rand',
+								}
+							] }
 							onOrderChange={ value => setAttributes({ order: value }) }
 							onOrderByChange={ value => setAttributes({ orderBy: value }) }
 							numberOfItems={ attributes.postsToShow }

--- a/src/blocks/components/panel-tab/index.js
+++ b/src/blocks/components/panel-tab/index.js
@@ -15,9 +15,10 @@ import './editor.scss';
 const PanelTab = ({
 	label,
 	onDelete,
-	children
+	children,
+	initialOpen = false
 }) => {
-	const [ isOpen, setOpen ] = useState( false );
+	const [ isOpen, setOpen ] = useState( initialOpen );
 
 	return (
 		<div className="o-panel-tab">

--- a/src/blocks/components/typography-selector-control/editor.scss
+++ b/src/blocks/components/typography-selector-control/editor.scss
@@ -8,28 +8,6 @@
 		}
 	}
 
-	.o-two-column-components {
-		gap: 10px;
-		justify-content: space-between;
-		align-items: baseline;
-		display: grid;
-		justify-items: stretch;
-		grid-template-columns: 1fr 1fr;
-		max-height: 55px;
-
-		&> div:first-child:last-child {
-			grid-column: 1 / 3;
-		}
-
-		&> div > .components-base-control {
-			margin: 8px 0px;
-		}
-
-		&~ .o-two-column-components {
-			margin-top: 10px;
-		}
-	}
-
 	.components-font-size-picker__controls .components-base-control {
 		margin: 0 0 8px 0;
 	}
@@ -39,10 +17,6 @@
 	.o-typo-header {
 		padding-top: 0;
 	}
-}
-
-.o-options-global-defaults-modal .o-typo-component .o-two-column-components {
-	margin-bottom: 25px;
 }
 
 .block-editor-block-inspector, .o-options-global-defaults-modal {

--- a/src/blocks/components/typography-selector-control/index.tsx
+++ b/src/blocks/components/typography-selector-control/index.tsx
@@ -17,6 +17,7 @@ import {
 	TextControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
 	DropdownMenu,
 	Disabled,
 	Spinner
@@ -28,12 +29,6 @@ import './editor.scss';
 import { useInstanceId } from '@wordpress/compose';
 import googleFontsLoader from '../../helpers/google-fonts';
 import classNames from 'classnames';
-
-const TwoItemOnRow = ({ children }) => {
-	return <div className='o-two-column-components'>
-		{ children }
-	</div>;
-};
 
 interface IsEnabled {
 	fontSize: boolean
@@ -326,22 +321,22 @@ const TypographySelectorControl = ( props: TypographySelectorControlProps ) => {
 				</DropdownMenu>
 			</HStack>
 
-
 			<Disabled
 
 				// @ts-ignore
 				isDisabled={ Boolean( showAsDisable?.fontSize ) }
 			>
-				<FontSizePicker
+				<Spacer>
+					<FontSizePicker
 
-					/*@ts-ignore */
-					value={ componentsValue?.fontSize ?? componentsDefaultValue?.fontSize }
+						/*@ts-ignore */
+						value={ componentsValue?.fontSize ?? componentsDefaultValue?.fontSize }
 
-					/*@ts-ignore */
-					fontSizes={ props.fontSizes ?? defaultStates.fontSizes }
-					onChange={ fontSize => onChangeValue( 'fontSize', fontSize?.toString() ) }
-					__nextHasNoMarginBottom={ true }
-				/>
+						/*@ts-ignore */
+						fontSizes={ props.fontSizes ?? defaultStates.fontSizes }
+						onChange={ fontSize => onChangeValue( 'fontSize', fontSize?.toString() ) }
+					/>
+				</Spacer>
 			</Disabled>
 
 
@@ -496,7 +491,7 @@ const TypographySelectorControl = ( props: TypographySelectorControlProps ) => {
 
 			{
 				( ( allowVariants && showComponent?.variant ) || showComponent?.lineHeight ) && (
-					<TwoItemOnRow>
+					<Fragment>
 						{
 							allowVariants && showComponent?.variant && (
 								<Disabled
@@ -520,43 +515,45 @@ const TypographySelectorControl = ( props: TypographySelectorControlProps ) => {
 									// @ts-ignore
 									isDisabled={ Boolean( showAsDisable?.lineHeight ) }
 								>
-									<UnitControl
-										label={ __( 'Line Height', 'otter-blocks' ) }
+									<Spacer>
+										<UnitControl
+											label={ __( 'Line Height', 'otter-blocks' ) }
 
-										/*@ts-ignore */
-										value={ componentsValue?.lineHeight ?? componentsDefaultValue?.lineHeight }
-										onChange={ ( lineHeight: string ) => onChangeValue( 'lineHeight', lineHeight ) }
-										units={[
-											{
-												a11yLabel: 'Unitless (-)',
-												label: '-',
-												step: 0.1,
-												value: ''
-											},
-											{
-												a11yLabel: 'Pixels (px)',
-												label: 'px',
-												step: 0.1,
-												value: 'px'
-											},
-											{
-												a11yLabel: 'Percentage (%)',
-												label: '%',
-												step: 1,
-												value: '%'
-											}
-										]}
-									/>
+											/*@ts-ignore */
+											value={ componentsValue?.lineHeight ?? componentsDefaultValue?.lineHeight }
+											onChange={ ( lineHeight: string ) => onChangeValue( 'lineHeight', lineHeight ) }
+											units={[
+												{
+													a11yLabel: 'Unitless (-)',
+													label: '-',
+													step: 0.1,
+													value: ''
+												},
+												{
+													a11yLabel: 'Pixels (px)',
+													label: 'px',
+													step: 0.1,
+													value: 'px'
+												},
+												{
+													a11yLabel: 'Percentage (%)',
+													label: '%',
+													step: 1,
+													value: '%'
+												}
+											]}
+										/>
+									</Spacer>
 								</Disabled>
 							)
 						}
-					</TwoItemOnRow>
+					</Fragment>
 				)
 			}
 
 			{
 				( showComponent?.appearance || showComponent?.spacing ) && (
-					<TwoItemOnRow>
+					<Fragment>
 						{
 							showComponent?.appearance && (
 								<Disabled
@@ -598,7 +595,7 @@ const TypographySelectorControl = ( props: TypographySelectorControlProps ) => {
 								</Disabled>
 							)
 						}
-					</TwoItemOnRow>
+					</Fragment>
 				)
 			}
 

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -328,6 +328,7 @@ const Edit = ({
 	const [ conditions, setConditions ] = useState({});
 	const [ flatConditions, setFlatConditions ] = useState([]);
 	const [ toggleVisibility, setToggleVisibility ] = useState([]);
+	const [ openTabs, setOpenTabs ] = useState(new Set()); // State to track open tabs
 
 	const setAttributes = ( attrs ) => {
 
@@ -351,7 +352,7 @@ const Edit = ({
 	 * Use an intermediary buffer to add the real attributes to the block.
 	 */
 	useEffect( () => {
-		if ( buffer &&  window.wp.hasOwnProperty( 'customize' ) && window.wp.customize ) {
+		if ( buffer && window.wp.hasOwnProperty( 'customize' ) && window.wp.customize ) {
 			_setAttributes( buffer );
 		}
 	}, [ buffer ]);
@@ -389,8 +390,10 @@ const Edit = ({
 
 	const addGroup = () => {
 		const otterConditions = [ ...( attributes.otterConditions || []) ];
+		const newGroupIndex = otterConditions.length; // Use the index of the new group
 		otterConditions.push([{}]);
 		setAttributes({ otterConditions });
+		setOpenTabs(prev => new Set(prev).add(newGroupIndex));
 	};
 
 	const removeGroup = n => {
@@ -511,6 +514,7 @@ const Edit = ({
 						<PanelTab
 							label={ __( 'Rule Group', 'otter-blocks' ) }
 							onDelete={ () => removeGroup( index ) }
+							initialOpen={ openTabs.has(index) }
 						>
 							{ group && group.map( ( condObj, condIdx ) => (
 								<Fragment key={ `${ index }_${ condIdx }` }>

--- a/src/dashboard/components/pages/Dashboard.js
+++ b/src/dashboard/components/pages/Dashboard.js
@@ -280,7 +280,7 @@ const Dashboard = () => {
 				<PanelRow>
 					<ToggleControl
 						label={ __( 'Enable Patterns Library', 'otter-blocks' ) }
-						help={ __( 'Toggle the visibility of the Patterns Library in the Block Editor.', 'otter-blocks' ) }
+						help={ __( 'Toggle the visibility of the Patterns Library in the Block Editor. Patterns will still be visible in the Block Editor.', 'otter-blocks' ) }
 						checked={ state.values.enablePatternsLibrary }
 						disabled={ 'saving' === state.status.enablePatternsLibrary }
 						onChange={ ( value ) => applyAction({ type: 'update', name: 'enablePatternsLibrary', value }) }


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/258, https://github.com/Codeinwp/otter-blocks/issues/2575, https://github.com/Codeinwp/otter-blocks/issues/2112, https://github.com/Codeinwp/otter-blocks/issues/2557.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

This PR addresses various small fixes, which are:

- Auto-open newly added rule tab in Block Conditions
- Add “Random” Sort Option to Otter Posts Block
- Letter Case overlapping in the Sidebar
- Disabling Patterns Library doesn't hide patterns

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure each issue is fixed. For Pattern Library, we only changed the description.
<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

