### PR TITLE
feat: add from field to Form Block

### DIFF
--- a/inc/integrations/class-form-settings-data.php
+++ b/inc/integrations/class-form-settings-data.php
@@ -94,6 +94,13 @@ class Form_Settings_Data {
 	private $from_name;
 
 	/**
+	 * The email of the sender.
+	 *
+	 * @var string|null
+	 */
+	private $from_email;
+
+	/**
 	 * The CC recipients.
 	 *
 	 * @var string
@@ -232,6 +239,9 @@ class Form_Settings_Data {
 				}
 				if ( isset( $form['fromName'] ) ) {
 					$integration->set_from_name( $form['fromName'] );
+				}
+				if ( isset( $form['fromEmail'] ) ) {
+					$integration->set_from_email( $form['fromEmail'] );
 				}
 				if ( isset( $form['cc'] ) ) {
 					$integration->set_cc( $form['cc'] );
@@ -417,6 +427,16 @@ class Form_Settings_Data {
 	 */
 	public function has_from_name() {
 		return isset( $this->from_name ) && '' !== $this->from_name;
+	}
+
+	/**
+	 * Check if it has the from_email set.
+	 *
+	 * @return bool
+	 * @since 2.0.3
+	 */
+	public function has_from_email() {
+		return isset( $this->from_email ) && '' !== $this->from_email && filter_var( $this->from_email, FILTER_VALIDATE_EMAIL ) !== false;
 	}
 
 	/**
@@ -612,6 +632,30 @@ class Form_Settings_Data {
 	public function set_from_name( $from_name ) {
 		$this->from_name = $from_name;
 
+		return $this;
+	}
+
+	/**
+	 * Get the email of the sender.
+	 *
+	 * @return string
+	 */
+	public function get_from_email() {
+		return $this->from_email;
+	}
+
+	/**
+	 * Set the email of the sender.
+	 *
+	 * @param string $from_email The email of the sender.
+	 * @return Form_Settings_Data
+	 */
+	public function set_from_email( $from_email ) {
+		if ( filter_var( $from_email, FILTER_VALIDATE_EMAIL ) !== false ) {
+			$this->from_email = $from_email;
+		} else {
+			$this->from_email = '';
+		}
 		return $this;
 	}
 

--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -324,6 +324,9 @@ class Options_Settings {
 							if ( isset( $item['fromName'] ) ) {
 								$item['fromName'] = sanitize_text_field( $item['fromName'] );
 							}
+							if ( isset( $item['fromEmail'] ) ) {
+								$item['fromEmail'] = sanitize_email( $item['fromEmail'] );
+							}
 							if ( isset( $item['cc'] ) ) {
 								$item['cc'] = sanitize_text_field( $item['cc'] );
 							}
@@ -387,6 +390,9 @@ class Options_Settings {
 									'type' => 'string',
 								),
 								'fromName'                => array(
+									'type' => 'string',
+								),
+								'fromEmail'               => array(
 									'type' => 'string',
 								),
 								'redirectLink'            => array(

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -428,7 +428,8 @@ class Form_Server {
 			$email_body    = apply_filters( 'otter_form_email_build_body', $email_message );
 
 			// Sent the form date to the admin site as a default behavior.
-			$to = sanitize_email( get_site_option( 'admin_email' ) );
+			$to         = sanitize_email( get_site_option( 'admin_email' ) );
+			$from_email = $to;
 
 			// Check if we need to send it to another user email.
 			if ( $form_data->payload_has( 'formOption' ) ) {
@@ -444,8 +445,6 @@ class Form_Server {
 				if ( empty( $to ) ) {
 					$to = sanitize_email( get_site_option( 'admin_email' ) );
 				}
-
-				$from_email = $to;
 
 				if ( $form_options->has_from_email() && '' !== $form_options->get_from_email() ) {
 					$from_email = sanitize_email( $form_options->get_from_email() );

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -444,9 +444,15 @@ class Form_Server {
 				if ( empty( $to ) ) {
 					$to = sanitize_email( get_site_option( 'admin_email' ) );
 				}
+
+				$from_email = $to;
+
+				if ( $form_options->has_from_email() && '' !== $form_options->get_from_email() ) {
+					$from_email = sanitize_email( $form_options->get_from_email() );
+				}
 			}
 
-			$headers = array( 'Content-Type: text/html', 'From: ' . ( $form_options->has_from_name() ? sanitize_text_field( $form_options->get_from_name() ) : get_bloginfo( 'name', 'display' ) ) . ' <' . $to . '>' );
+			$headers = array( 'Content-Type: text/html', 'From: ' . ( $form_options->has_from_name() ? sanitize_text_field( $form_options->get_from_name() ) : get_bloginfo( 'name', 'display' ) ) . ' <' . $from_email . '>' );
 
 			if ( ! empty( $form_options->get_cc() ) ) {
 				$arr = explode( ',', $form_options->get_cc() );

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -332,8 +332,14 @@ class Form_Pro_Features {
 		}
 
 		try {
+			$from_email = sanitize_email( get_site_option( 'admin_email' ) );
+
+			if ( $form_data->get_wp_options()->has_from_email() && '' !== $form_data->get_wp_options()->get_from_email() ) {
+				$from_email = sanitize_email( $form_data->get_wp_options()->get_from_email() );
+			}
+
 			$headers[] = 'Content-Type: text/html';
-			$headers[] = 'From: ' . ( $form_data->get_wp_options()->has_from_name() ? sanitize_text_field( $form_data->get_wp_options()->get_from_name() ) : get_bloginfo( 'name', 'display' ) );
+			$headers[] = 'From: ' . ( $form_data->get_wp_options()->has_from_name() ? sanitize_text_field( $form_data->get_wp_options()->get_from_name() ) : get_bloginfo( 'name', 'display' ) ) . ' <' . $from_email . '>';
 
 			$autoresponder = $form_data->get_wp_options()->get_autoresponder();
 			$body          = $this->replace_magic_tags( $autoresponder['body'], $form_data->get_fields() );

--- a/src/blocks/blocks/form/edit.js
+++ b/src/blocks/blocks/form/edit.js
@@ -77,6 +77,7 @@ const formOptionsMap = {
 	submitMessage: 'submitMessage',
 	errorMessage: 'errorMessage',
 	fromName: 'fromName',
+	fromEmail: 'fromEmail',
 	cc: 'cc',
 	bcc: 'bcc',
 	autoresponder: 'autoresponder',
@@ -133,6 +134,7 @@ const Edit = ({
 		provider: undefined,
 		redirectLink: undefined,
 		fromName: undefined,
+		fromEmail: undefined,
 		emailTo: undefined,
 		subject: undefined,
 		email: undefined,
@@ -358,6 +360,7 @@ const Edit = ({
 		setFormOptions({
 			emailTo: wpOptions?.email,
 			fromName: wpOptions?.fromName,
+			fromEmail: wpOptions?.fromEmail,
 			redirectLink: wpOptions?.redirectLink,
 			subject: wpOptions?.emailSubject,
 			cc: wpOptions?.cc,

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -184,6 +184,21 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 			</ToolsPanelItem>
 
 			<ToolsPanelItem
+				hasValue={ () => Boolean( formOptions.fromEmail ) }
+				label={ __( 'From Email', 'otter-blocks' ) }
+				onDeselect={ () => setFormOption({ fromEmail: '' }) }
+				isShownByDefault={ false }
+			>
+				<TextControl
+					label={ __( 'From Email', 'otter-blocks' ) }
+					type="email"
+					onChange={ fromEmail => setFormOption({ fromEmail }) }
+					value={ formOptions.fromEmail }
+					help={ __( 'Set the email of the sender. Some SMTP plugins might override this value.', 'otter-blocks' ) }
+				/>
+			</ToolsPanelItem>
+
+			<ToolsPanelItem
 				hasValue={ () => Boolean( formOptions.redirectLink ) }
 				label={ __( 'Redirect on Submit', 'otter-blocks' ) }
 				onDeselect={ () => setFormOption({ redirectLink: '' }) }

--- a/src/blocks/blocks/form/inspector.js
+++ b/src/blocks/blocks/form/inspector.js
@@ -191,6 +191,7 @@ const FormOptions = ({ formOptions, setFormOption, attributes, setAttributes }) 
 			>
 				<TextControl
 					label={ __( 'From Email', 'otter-blocks' ) }
+					placeholder={ __( 'e.g. noreply@example.com', 'otter-blocks' ) }
 					type="email"
 					onChange={ fromEmail => setFormOption({ fromEmail }) }
 					value={ formOptions.fromEmail }

--- a/src/blocks/blocks/form/type.d.ts
+++ b/src/blocks/blocks/form/type.d.ts
@@ -53,6 +53,7 @@ export type FormOptions = {
 	hasCaptcha?: boolean
 	email?: string
 	fromName?: string
+	fromEmail?: string
 	redirectLink?: string
 	emailSubject?: string
 	submitMessage?: string


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/255.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
This adds a From Field option to Form Block. This allows user to replace the default Admin Email when the emails are sent, to the admin or from the Autoresponder.

Keep in mind that this option might always work if the user is using an SMTP plugin that tend to override it.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the From Email is reflected properly on sent emails.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

