### PR TITLE
Fixed is_amp_endpoint() deprecated warning

### DIFF
--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -129,7 +129,7 @@ class Blocks_Animation {
 	 * @access  public
 	 */
 	public function enqueue_block_frontend_assets() {
-		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( did_action( 'parse_request' ) && function_exists( 'amp_is_request' ) && amp_is_request() ) {
 			self::$can_load_frontend = false;
 		}
 

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -441,7 +441,7 @@ class Registration {
 			}
 		}
 
-		if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) || is_admin() ) {
+		if ( ( did_action( 'parse_request' ) && function_exists( 'amp_is_request' ) && amp_is_request() ) || is_admin() ) {
 			return;
 		}
 
@@ -976,7 +976,7 @@ class Registration {
 	 * @since 2.0.5
 	 */
 	public function load_sticky( $block_content, $block ) {
-		if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) || self::$scripts_loaded['sticky'] ) {
+		if ( ( did_action( 'parse_request' ) && function_exists( 'amp_is_request' ) && amp_is_request() ) || self::$scripts_loaded['sticky'] ) {
 			return $block_content;
 		}
 

--- a/inc/render/amp/class-circle-counter-block.php
+++ b/inc/render/amp/class-circle-counter-block.php
@@ -33,7 +33,7 @@ class Circle_Counter_Block {
 	 * @return mixed|string
 	 */
 	public function render_blocks( $block_content, $block ) {
-		if ( 'themeisle-blocks/circle-counter' === $block['blockName'] && function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( 'themeisle-blocks/circle-counter' === $block['blockName'] && did_action( 'parse_request' ) && function_exists( 'amp_is_request' ) && amp_is_request() ) {
 			$id            = $block['attrs']['id'];
 			$block_content = '<div id="' . $id . '" class="wp-block-themeisle-blocks-circle-counter">';
 

--- a/inc/render/amp/class-lottie.block.php
+++ b/inc/render/amp/class-lottie.block.php
@@ -33,7 +33,7 @@ class Lottie_Block {
 	 * @return mixed|string
 	 */
 	public function render_blocks( $block_content, $block ) {
-		if ( 'themeisle-blocks/lottie' === $block['blockName'] && function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( 'themeisle-blocks/lottie' === $block['blockName'] && did_action( 'parse_request' ) && function_exists( 'amp_is_request' ) && amp_is_request() ) {
 			if ( ! isset( $block['attrs']['file'] ) ) {
 				return $block_content;
 			}

--- a/inc/render/amp/class-slider-block.php
+++ b/inc/render/amp/class-slider-block.php
@@ -35,7 +35,7 @@ class Slider_Block {
 	 * @return mixed|string
 	 */
 	public function render_blocks( $block_content, $block ) {
-		if ( 'themeisle-blocks/slider' === $block['blockName'] && function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( 'themeisle-blocks/slider' === $block['blockName'] && did_action( 'parse_request' ) && function_exists( 'amp_is_request' ) && amp_is_request() ) {
 			$html5         = new HTML5();
 			$dom           = $html5->loadHTML( $block['innerHTML'] );
 			$id            = $block['attrs']['id'];

--- a/inc/render/class-google-map-block.php
+++ b/inc/render/class-google-map-block.php
@@ -23,7 +23,7 @@ class Google_Map_Block {
 	 * @return mixed|string
 	 */
 	public function render( $attributes ) {
-		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( did_action( 'parse_request' ) && function_exists( 'amp_is_request' ) && amp_is_request() ) {
 			$apikey = get_option( 'themeisle_google_map_block_api_key' );
 
 			// Don't output anything if there is no API key.

--- a/inc/render/class-leaflet-map-block.php
+++ b/inc/render/class-leaflet-map-block.php
@@ -22,7 +22,7 @@ class Leaflet_Map_Block {
 	 * @return mixed|string
 	 */
 	public function render( $attributes ) {
-		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( did_action( 'parse_request' ) && function_exists( 'amp_is_request' ) && amp_is_request() ) {
 			$link = 'https://www.openstreetmap.org/export/embed.html?bbox=' . stripslashes( esc_attr( $attributes['bbox'] ) ) . '&amp;layer=mapnik';
 
 			$output  = '<amp-iframe width="400" height="' . intval( $attributes['height'] ) . '" sandbox="allow-scripts allow-same-origin" layout="responsive" src="' . stripslashes( $link ) . '" style="border: 1px solid black">';


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2601

### Summary
Fixed the `is_amp_endpoint()` deprecated warning.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()
