### PR TITLE
fix: Review block generating schema twice, and other smaller fixes

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -615,6 +615,8 @@ class Registration {
 				'themeisleGutenbergSlider',
 				array(
 					'isRTL' => is_rtl(),
+					'next'  => __( 'Next Slide', 'otter-blocks' ),
+					'prev'  => __( 'Previous Slide', 'otter-blocks' ),
 				)
 			);
 		}

--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -44,7 +44,7 @@ class Review_Block {
 			add_action(
 				'wp_footer',
 				function() use ( $attributes, $post_id ) {
-					$added_schemas = &self::$added_schemas; // Reference the static property.
+					$added_schemas = &Review_Block::$added_schemas; // Reference the static property explicitly.
 
 					if ( ! isset( $added_schemas[ $post_id ] ) ) {
 						echo '<script type="application/ld+json">' . wp_json_encode( $this->get_json_ld( $attributes, $post_id ) ) . '</script>';

--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -15,6 +15,15 @@ use ThemeIsle\GutenbergBlocks\Pro;
 class Review_Block {
 
 	/**
+	 * Static variable to track if the schema has already been added.
+	 *
+	 * This is used to prevent adding the same schema multiple times on the same page.
+	 *
+	 * @var array
+	 */
+	private static $added_schemas = array();
+
+	/**
 	 * Block render function for server-side.
 	 *
 	 * This method will pe passed to the render_callback parameter and it will output
@@ -28,13 +37,17 @@ class Review_Block {
 			$attributes = apply_filters( 'otter_blocks_review_block_woocommerce', $attributes );
 		}
 
+		// Add a static variable to track if the schema has already been added.
 		if ( isset( $attributes['title'] ) && ! empty( $attributes['title'] ) && isset( $attributes['features'] ) && count( $attributes['features'] ) > 0 && get_option( 'themeisle_blocks_settings_disable_review_schema', true ) ) {
 			$post_id = get_the_ID();
 
 			add_action(
 				'wp_footer',
 				function() use ( $attributes, $post_id ) {
-					echo '<script type="application/ld+json">' . wp_json_encode( $this->get_json_ld( $attributes, $post_id ) ) . '</script>';
+					if ( ! isset( self::$added_schemas[ $post_id ] ) ) {
+						echo '<script type="application/ld+json">' . wp_json_encode( $this->get_json_ld( $attributes, $post_id ) ) . '</script>';
+						self::$added_schemas[ $post_id ] = true;
+					}
 				}
 			);
 		}

--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -44,9 +44,11 @@ class Review_Block {
 			add_action(
 				'wp_footer',
 				function() use ( $attributes, $post_id ) {
-					if ( ! isset( self::$added_schemas[ $post_id ] ) ) {
+					$added_schemas = &self::$added_schemas; // Reference the static property.
+
+					if ( ! isset( $added_schemas[ $post_id ] ) ) {
 						echo '<script type="application/ld+json">' . wp_json_encode( $this->get_json_ld( $attributes, $post_id ) ) . '</script>';
-						self::$added_schemas[ $post_id ] = true;
+						$added_schemas[ $post_id ] = true; // Mark schema as added for this post ID.
 					}
 				}
 			);

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -65,23 +65,46 @@ if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
 	add_action(
 		'admin_notices',
 		function() {
-			$message = __( 'You need to install Otter – Page Builder Blocks & Extensions for Gutenberg plugin to use Otter Pro.', 'otter-pro' );
-			$link    = wp_nonce_url(
-				add_query_arg(
-					array(
-						'action' => 'install-plugin',
-						'plugin' => 'otter-blocks',
+			$plugin_file = ABSPATH . 'wp-content/plugins/otter-blocks/otter-blocks.php';
+			$message     = __( 'You need Otter – Page Builder Blocks & Extensions for Gutenberg plugin to use Otter Pro.', 'otter-pro' );
+			$button_text = esc_html__( 'Install', 'otter-pro' );
+			$link        = '';
+
+			if ( file_exists( $plugin_file ) ) {
+				// Otter is installed but not active.
+				$link = wp_nonce_url(
+					add_query_arg(
+						array(
+							'action' => 'activate',
+							'plugin' => 'otter-blocks/otter-blocks.php',
+						),
+						admin_url( 'plugins.php' )
 					),
-					admin_url( 'update.php' )
-				),
-				'install-plugin_otter-blocks'
-			);
+					'activate-plugin_otter-blocks/otter-blocks.php'
+				);
+
+				$button_text = esc_html__( 'Activate', 'otter-pro' );
+			} else {
+				// Otter is not installed.
+				$link = wp_nonce_url(
+					add_query_arg(
+						array(
+							'action' => 'install-plugin',
+							'plugin' => 'otter-blocks',
+						),
+						admin_url( 'update.php' )
+					),
+					'install-plugin_otter-blocks'
+				);
+
+				$button_text = esc_html__( 'Install', 'otter-pro' );
+			}
 
 			printf(
 				'<div class="error"><p>%1$s <a href="%2$s">%3$s</a></p></div>',
 				esc_html( $message ),
 				esc_url( $link ),
-				esc_html__( 'Install', 'otter-pro' )
+				$button_text
 			);
 		}
 	);

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -104,7 +104,7 @@ if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
 				'<div class="error"><p>%1$s <a href="%2$s">%3$s</a></p></div>',
 				esc_html( $message ),
 				esc_url( $link ),
-				$button_text
+				esc_html( $button_text )
 			);
 		}
 	);

--- a/src/animation/editor.js
+++ b/src/animation/editor.js
@@ -253,7 +253,7 @@ function AnimationControls({
 				customDelay = customDelay.replace( 'o-anim-value-delay-', '' );
 
 				// The string must start with a number and end with s or ms.
-				if ( ! customDelay.match( /^[0-9]+(ms|s)$/ ) ) {
+				if ( ! customDelay.match( /^[0-9]*\.?[0-9]+(ms|s)$/ ) ) {
 					customDelay = undefined;
 				}
 			}
@@ -263,7 +263,7 @@ function AnimationControls({
 				customSpeed = customSpeed.replace( 'o-anim-value-speed-', '' );
 
 				// The string must start with a number and end with s or ms.
-				if ( ! customSpeed.match( /^[0-9]+(ms|s)$/ ) ) {
+				if ( ! customSpeed.match( /^[0-9]*\.?[0-9]+(ms|s)$/ ) ) {
 					customSpeed = undefined;
 				}
 			}

--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -336,23 +336,28 @@ const createCustomAnimationNode = ( elements ) => {
 	if ( 0 < customDelays.length || 0 < customSpeeds.length ) {
 		const customValuesNode = document.createElement( 'style' );
 		customValuesNode.id = 'o-anim-custom-values';
+		// Helper to escape CSS class names (e.g., 2.3 -> 2\.3)
+		const escapeCssClass = className => className.replace(/([!"#$%&'()*+,.\/:;<=>?@[\\\]^`{|}~])/g, '\\$1');
+
 		customValuesNode.innerHTML = customDelays.reduce(
 			( accumulator, cssClass ) => {
 				const delayValue = cssClass.replace( 'o-anim-value-delay-', '' );
+				const escapedClass = escapeCssClass( cssClass );
 
 				return (
 					accumulator +
-					`.animated.${ cssClass } { animation-delay: ${ delayValue }; -webkit-animation-delay: ${ delayValue }; }`
+					`.animated.${escapedClass} { animation-delay: ${delayValue}; -webkit-animation-delay: ${delayValue}; }`
 				);
 			},
 			''
 		) + '\n' + customSpeeds.reduce(
 			( accumulator, cssClass ) => {
 				const speedValue = cssClass.replace( 'o-anim-value-speed-', '' );
+				const escapedClass = escapeCssClass( cssClass );
 
 				return (
 					accumulator +
-					`.animated.${ cssClass } { animation-duration: ${ speedValue }; -webkit-animation-duration: ${ speedValue }; }`
+					`.animated.${escapedClass} { animation-duration: ${speedValue}; -webkit-animation-duration: ${speedValue}; }`
 				);
 			},
 			''

--- a/src/blocks/blocks/popup/style.scss
+++ b/src/blocks/blocks/popup/style.scss
@@ -112,12 +112,6 @@ $base-index: 99999 !default;
 		&::-webkit-scrollbar {
 			display: none;
 		}
-
-
-	}
-
-	.otter-popup__modal_header + .otter-popup__modal_body {
-		margin-top: -40px;
 	}
 
 	.otter-popup__modal_body > * {
@@ -125,9 +119,8 @@ $base-index: 99999 !default;
 	}
 
 	.otter-popup__modal_header {
-		display: flex;
-		justify-content: flex-end;
-		padding-bottom: 20px;
+		position: absolute;
+		right: var( --padding );
 
 		@media (max-width: 600px) {
 			padding-bottom: 0px;
@@ -162,6 +155,7 @@ $base-index: 99999 !default;
 
 	&.with-outside-button {
 		.otter-popup__modal_header {
+			position: initial;
 			padding-bottom: 0px;
 
 			button {

--- a/src/blocks/blocks/slider/style.scss
+++ b/src/blocks/blocks/slider/style.scss
@@ -22,16 +22,6 @@
 
 	.glide__slides {
 		height: var( --height );
-		animation: load 4s 3;
-
-		@keyframes load {
-			0%, 100% {
-				background-color: inherit;
-			}
-			50% {
-				background-color: #d8d8d8;
-			}
-		}
 
 		@media ( min-width: 600px ) and ( max-width: 960px ) {
 			height: var( --height-tablet ) !important;

--- a/src/blocks/frontend/slider/index.js
+++ b/src/blocks/frontend/slider/index.js
@@ -3,7 +3,10 @@
  */
 import { domReady } from '../../helpers/frontend-helper-functions.js';
 
-const SliderArrows = '<div class="glide__arrows" data-glide-el="controls"><button class="glide__arrow glide__arrow--left" data-glide-dir="<"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewbox="0 0 100 100" role="img" aria-hidden="true"><path d="M 10,50 L 60,100 L 70,90 L 30,50  L 70,10 L 60,0 Z"></path></svg></button><button class="glide__arrow glide__arrow--right" data-glide-dir="&gt;"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewbox="0 0 100 100" role="img" aria-hidden="true"><path d="M 10,50 L 60,100 L 70,90 L 30,50  L 70,10 L 60,0 Z"></path></svg></button></div>';
+const leftLabel = window.themeisleGutenbergSlider.isRTL ? window.themeisleGutenbergSlider.next : window.themeisleGutenbergSlider.prev;
+const rightLabel = window.themeisleGutenbergSlider.isRTL ? window.themeisleGutenbergSlider.prev : window.themeisleGutenbergSlider.next;
+
+const SliderArrows = '<div class="glide__arrows" data-glide-el="controls"><button class="glide__arrow glide__arrow--left" data-glide-dir="<" aria-label="' + leftLabel + '"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewbox="0 0 100 100" role="img" aria-hidden="true"><path d="M 10,50 L 60,100 L 70,90 L 30,50  L 70,10 L 60,0 Z"></path></svg></button><button class="glide__arrow glide__arrow--right" data-glide-dir="&gt;" aria-label="' + rightLabel + '"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewbox="0 0 100 100" role="img" aria-hidden="true"><path d="M 10,50 L 60,100 L 70,90 L 30,50  L 70,10 L 60,0 Z"></path></svg></button></div>';
 
 const init = () => {
 	const sliders = document.querySelectorAll( '.wp-block-themeisle-blocks-slider' );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2230, https://github.com/Codeinwp/otter-blocks/issues/2030, https://github.com/Codeinwp/otter-blocks/issues/2090, https://github.com/Codeinwp/otter-blocks/issues/2280, https://github.com/Codeinwp/otter-blocks/issues/2403, https://github.com/Codeinwp/otter-blocks/issues/2430.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Fixes issue with Review Block generating schema twice in some cases. Fix tested on https://themeisle.com/blog/wp-engine-review-for-wordpress/ already.
- Fixes issue with Otter Pro trying to install Otter Blocks again if it was inactive
- Fixes Popup not showing top-padding
- Fixes issue with Slider Block arrows not having aria-label.
- Fixes SVG background appearing to be flickering
- Fixes decimal second values not working for Animation delay/speed

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure all described changes are there and work as intended.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

