### PR TITLE
feat: trigget formbricks in the editor, add welcome notice and fix pagination

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -8,7 +8,7 @@
 namespace ThemeIsle\GutenbergBlocks;
 
 use ThemeIsle\GutenbergBlocks\Main, ThemeIsle\GutenbergBlocks\Pro, ThemeIsle\GutenbergBlocks\Plugins\Stripe_API;
-use ThemeIsle\GutenbergBlocks\Plugins\LimitedOffers;
+use ThemeIsle\GutenbergBlocks\Plugins\LimitedOffers, ThemeIsle\GutenbergBlocks\Plugins\Dashboard;
 
 /**
  * Class Registration.
@@ -296,6 +296,9 @@ class Registration {
 		);
 
 		wp_enqueue_style( 'otter-editor', OTTER_BLOCKS_URL . 'build/blocks/editor.css', array( 'wp-edit-blocks', 'font-awesome-5', 'font-awesome-4-shims' ), $asset_file['version'] );
+
+		add_filter( 'themeisle-sdk/survey/' . OTTER_PRODUCT_SLUG, array( Dashboard::class, 'get_survey_metadata' ), 10, 2 );
+		do_action( 'themeisle_internal_page', OTTER_PRODUCT_SLUG, 'editor' );
 	}
 
 	/**

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -241,11 +241,13 @@ class Dashboard {
 			'assetsPath'             => OTTER_BLOCKS_URL . 'assets/',
 			'stylesExist'            => is_dir( $basedir ) || boolval( get_transient( 'otter_animations_parsed' ) ),
 			'hasPro'                 => Pro::is_pro_installed(),
+			'otterPage'              => tsdk_translate_link( tsdk_utmify( 'https://themeisle.com/plugins/otter-blocks/', 'welcome', 'admin' ) ),
 			'upgradeLink'            => tsdk_translate_link( tsdk_utmify( Pro::get_url(), 'options', Pro::get_reference() ) ),
 			'upgradeLinkFromTc'      => tsdk_utmify( Pro::get_url(), 'templatecloud' ),
 			'tcUpgradeLink'          => tsdk_utmify( 'https://themeisle.com/plugins/templates-cloud/', 'templatecloud', 'otter-blocks' ),
 			'tcDocs'                 => 'https://docs.themeisle.com/article/2191-templates-cloud-collections',
 			'docsLink'               => Pro::get_docs_url(),
+			'newPageUrl'             => esc_url( admin_url( 'post-new.php?post_type=page' ) ),
 			'showFeedbackNotice'     => $this->should_show_feedback_notice(),
 			'deal'                   => ! Pro::is_pro_installed() ? $offer->get_localized_data() : array(),
 			'hasOnboarding'          => false !== get_theme_support( FSE_Onboarding::SUPPORT_KEY ),
@@ -313,7 +315,7 @@ class Dashboard {
 		}
 
 		update_option( 'themeisle_blocks_settings_redirect', false );
-		wp_safe_redirect( admin_url( 'admin.php?page=otter' ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=otter&welcome=true' ) );
 		exit;
 	}
 

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -36,7 +36,7 @@ class Dashboard {
 			add_action( 'wp_dashboard_setup', array( $this, 'form_submissions_widget' ) );
 		}
 
-		add_filter( 'themeisle-sdk/survey/' . OTTER_PRODUCT_SLUG, array( $this, 'get_survey_metadata' ), 10, 2 );
+		add_filter( 'themeisle-sdk/survey/' . OTTER_PRODUCT_SLUG, array( __CLASS__, 'get_survey_metadata' ), 10, 2 );
 	}
 
 	/**
@@ -761,17 +761,16 @@ class Dashboard {
 	 * 
 	 * @return array The data in Frombricks format.
 	 */
-	public function get_survey_metadata( $data, $page_slug ) {
-		$dash_data = $this->get_dashboard_data();
-		
-		$install_days_number = $dash_data['days_since_install'];
+	public static function get_survey_metadata( $data, $page_slug ) {
+		$dash_data           = apply_filters( 'otter_dashboard_data', array() );
+		$install_days_number = intval( ( time() - get_option( 'otter_blocks_install', time() ) ) / DAY_IN_SECONDS );
 
 		$data = array(
 			'environmentId' => 'clp9hqm8c1osfdl2ixwd0k0iz',
 			'attributes'    => array(
 				'install_days_number' => $install_days_number,
 				'plan'                => isset( $dash_data['license'], $dash_data['license']['type'] ) ? $dash_data['license']['type'] : 'free',
-				'freeVersion'         => $dash_data['version'],
+				'freeVersion'         => OTTER_BLOCKS_VERSION,
 			),
 		);
 

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -417,8 +417,7 @@ class Posts_Grid_Block {
 	 * @return string
 	 */
 	protected function render_pagination( $page_number, $total_pages ) {
-		$big  = 9999999;
-
+		$big     = 9999999;
 		$output  = '<div class="o-posts-grid-pag">';
 		$output .= paginate_links(
 			array(

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -418,13 +418,11 @@ class Posts_Grid_Block {
 	 */
 	protected function render_pagination( $page_number, $total_pages ) {
 		$big  = 9999999;
-		$base = str_replace( strval( $big ), '%#%', esc_url( get_pagenum_link( $big ) ) );
 
 		$output  = '<div class="o-posts-grid-pag">';
 		$output .= paginate_links(
 			array(
-				'base'      => $base,
-				'format'    => '?paged=%#%',
+				'format'    => is_front_page() ? '?page=%#%' : '?paged=%#%',
 				'current'   => $page_number,
 				'total'     => $total_pages,
 				'prev_text' => __( 'Prev', 'otter-blocks' ),

--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -421,7 +421,7 @@ class Posts_Grid_Block {
 		$output  = '<div class="o-posts-grid-pag">';
 		$output .= paginate_links(
 			array(
-				'format'    => is_front_page() ? '?page=%#%' : '?paged=%#%',
+				'format'    => ( is_front_page() && ! is_singular() ) ? '?page=%#%' : '?paged=%#%',
 				'current'   => $page_number,
 				'total'     => $total_pages,
 				'prev_text' => __( 'Prev', 'otter-blocks' ),

--- a/src/dashboard/components/Main.js
+++ b/src/dashboard/components/Main.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies.
  */
-import {
-	__,
-	sprintf
-} from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 import {
 	Placeholder,
@@ -26,15 +23,13 @@ import NoticeCard from './NoticeCard';
 import { applyFilters } from '@wordpress/hooks';
 import Blocks from './pages/Blocks';
 import Deal from './Deal';
+import WelcomeNotice from './WelcomeNotice.js';
 
-let daysLeft = sprintf( 
-	// Translators: %s is the number of days left.
-	__( '%s Days', 'otter-blocks' ), 
-	Number( window.otterObj.daysLeft ) 
-);
+let isWelcomePage = false;
 
-if ( 1 === Number( window.otterObj.daysLeft ) ) {
-	daysLeft = __( 'Less than 24 hours', 'otter-blocks' );
+if ( typeof window !== 'undefined' && window.location ) {
+	const urlParams = new URLSearchParams( window.location.search );
+	isWelcomePage = urlParams.get('welcome') === 'true';
 }
 
 const Main = ({
@@ -98,8 +93,12 @@ const Main = ({
 				)
 			}
 			<div id="tsdk_banner" className="otter-banner"></div>
-			<div className={ `otter-main is-${ currentTab }`}>
 
+			{ isWelcomePage && (
+				<WelcomeNotice />
+			) }
+
+			<div className={ `otter-main is-${ currentTab }`}>
 				{ 'dashboard' === currentTab && window.otterObj.showFeedbackNotice && (
 					<NoticeCard
 						slug="feedback"

--- a/src/dashboard/components/WelcomeNotice.js
+++ b/src/dashboard/components/WelcomeNotice.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+
+import { Button } from '@wordpress/components';
+
+const WelcomeNotice = () => {
+	return (
+		<div className="otter-nv-sidebar-upsell o-welcome">
+			<div className="otter-nv-sidebar-left">
+				<div className="otter-nv-sidebar-heading">
+					{/* eslint-disable-next-line jsx-a11y/alt-text */}
+					<h2>{ __( 'Welcome to Otter!', 'otter-blocks' ) }</h2>
+				</div>
+				<div className="otter-nv-sidebar-text">
+					<p>
+						{ __( 'We\'re excited to help you build beautiful, fast, and flexible WordPress sites. Explore our powerful blocks and customization tools — your site-building journey just got a whole lot easier.', 'otter-blocks' ) }
+					</p>
+				</div>
+				<div className="otter-nv-sidebar-action">
+					<Button variant="primary" href={ window.otterObj?.newPageUrl }>{ __( 'Create New Page', 'otter-blocks' ) }</Button>
+					<Button icon="external" iconPosition="right" variant="secondary" href={ window.otterObj?.otterPage } target="_blank">{ __( 'Learn More', 'otter-blocks' ) }</Button>
+				</div>
+			</div>
+			<div className="otter-nv-sidebar-right">
+				{/* eslint-disable-next-line jsx-a11y/alt-text */}
+				<iframe src="https://www.youtube.com/embed/WcS2Vi4IOYw" title="Otter - Page Builder Blocks &amp; Extensions for Gutenberg" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+			</div>
+		</div>
+	);
+};
+
+export default WelcomeNotice;

--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -845,6 +845,30 @@
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
+
+	&.o-welcome {
+		.otter-nv-sidebar-heading {
+			h2 {
+				font-size: 20px;
+				font-weight: 600;
+				color: #000;
+			}
+		}
+
+		.otter-nv-sidebar-right {
+			iframe {
+				width: calc( 100% - 32px );
+				height: 200px;
+
+				@media(max-width: 991px) {
+					width: 100%;
+					height: 360px;
+					padding: 32px;
+				}
+			}
+		}
+	}
+
 	.otter-nv-sidebar-left{
 		width: calc(100% - 360px);
 		padding: 32px;
@@ -879,6 +903,7 @@
 			margin: 0;
 			color: #3B5DE6;
 			font-size: 16px;
+
 		}
 	}
 	.otter-nv-sidebar-text{


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/249, https://github.com/Codeinwp/otter-internals/issues/248, https://github.com/Codeinwp/otter-blocks/issues/2489.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Trigger Formbricks in the Block Editor after a block from Otter collection has been added. You can see the script being triggered in the console.
- Adds a welcome notice to Dashboard once you activate Otter and automatically redirected to Dashboard.
- Fixes the pagination issue in Homepage.

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- For pagination, make sure it works in Homepage and also works in Page/Posts with and without pretty permalinks.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

