### PR TITLE
fix: menu icon fonts and date time field in ACF

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -942,7 +942,7 @@ class Registration {
 				self::$is_fa_loaded = true;
 
 				// See the src/blocks/plugins/menu-icons/inline.css file for where this comes from.
-				$styles = '.fab.wp-block-navigation-item,.far.wp-block-navigation-item,.fas.wp-block-navigation-item{-moz-osx-font-smoothing:inherit;-webkit-font-smoothing:inherit;font-weight:inherit}.fab.wp-block-navigation-item:before,.far.wp-block-navigation-item:before,.fas.wp-block-navigation-item:before{font-family:Font Awesome\ 5 Free;margin-right:5px}.fab.wp-block-navigation-item:before,.far.wp-block-navigation-item:before{font-weight:400;padding-right:5px}.fas.wp-block-navigation-item:before{font-weight:900;padding-right:5px}.fab.wp-block-navigation-item:before{font-family:Font Awesome\ 5 Brands}';
+				$styles = '.fab.wp-block-navigation-item,.far.wp-block-navigation-item,.fas.wp-block-navigation-item{-moz-osx-font-smoothing:inherit;-webkit-font-smoothing:inherit;font-weight:inherit;font-family: inherit}.fab.wp-block-navigation-item:before,.far.wp-block-navigation-item:before,.fas.wp-block-navigation-item:before{font-family:Font Awesome\ 5 Free;margin-right:5px}.fab.wp-block-navigation-item:before,.far.wp-block-navigation-item:before{font-weight:400;padding-right:5px}.fas.wp-block-navigation-item:before{font-weight:900;padding-right:5px}.fab.wp-block-navigation-item:before{font-family:Font Awesome\ 5 Brands}';
 
 				wp_add_inline_style( 'font-awesome-5', $styles );
 				return $block_content;

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -28,7 +28,8 @@ class Dashboard {
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'register_menu_page' ) );
 		add_action( 'admin_init', array( $this, 'maybe_redirect' ) );
-		add_action( 'admin_head', array( $this, 'form_submission_elements' ) );
+		add_action( 'admin_head', array( $this, 'survey_elements' ) );
+		add_action( 'admin_notices', array( $this, 'form_submission_elements' ), 30 );
 		add_action( 'admin_head', array( $this, 'add_inline_css' ) );
 
 		$form_options = get_option( 'themeisle_blocks_form_emails' );
@@ -318,18 +319,28 @@ class Dashboard {
 	}
 
 	/**
+	 * Add elements for the survey.
+	 *
+	 * @return void
+	 */
+	public function survey_elements() {
+		$screen = get_current_screen();
+
+		if ( 'edit-otter_form_record' === $screen->id ) {
+			do_action( 'themeisle_internal_page', OTTER_PRODUCT_SLUG, 'form-submissions' );
+		}
+	}
+
+	/**
 	 * Add elements for Form Block submission page.
 	 *
 	 * @return void
 	 */
 	public function form_submission_elements() {
 		$screen = get_current_screen();
+
 		if ( 'edit-otter_form_record' === $screen->id || 'otter-blocks_page_form-submissions-free' === $screen->id ) {
 			$this->the_otter_banner();
-		}
-		
-		if ( 'edit-otter_form_record' === $screen->id ) {
-			do_action( 'themeisle_internal_page', OTTER_PRODUCT_SLUG, 'form-submissions' );
 		}
 	}
 

--- a/src/blocks/plugins/menu-icons/inline.scss
+++ b/src/blocks/plugins/menu-icons/inline.scss
@@ -7,6 +7,7 @@
 .far {
 	&.wp-block-navigation-item {
 		font-weight: inherit;
+		font-family: inherit;
 		-moz-osx-font-smoothing: inherit;
 		-webkit-font-smoothing: inherit;
 

--- a/src/pro/plugins/posts/index.js
+++ b/src/pro/plugins/posts/index.js
@@ -41,7 +41,10 @@ const ALLOWED_ACF_TYPES = [
 	'number',
 	'url',
 	'email',
-	'password'
+	'password',
+	'date_picker',
+	'date_time_picker',
+	'time_picker',
 ];
 
 const addAttribute = ( props ) => {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2011, https://github.com/Codeinwp/otter-blocks/issues/2357.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Fixes issue with FSE menu's font changing with Menu Icons
- Adds Date/Time/DateTime field from ACF to Posts Block

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

