### PR TITLE
fix: columns layout settings for the section block is not working for mobile & tablet in the editor

### DIFF
--- a/src/blocks/blocks/section/column/edit.js
+++ b/src/blocks/blocks/section/column/edit.js
@@ -150,16 +150,15 @@ const Edit = ({
 		isTablet = isPreviewTablet;
 		isMobile = isPreviewMobile;
 	}
+	const { layout, layoutTablet, layoutMobile } = parentBlock.attributes;
+	const index = parentBlock.innerBlocks.findIndex( i => i.clientId === clientId );
+	let { columns } = parentBlock.attributes;
+
+	if ( 6 < columns ) {
+		columns = 6;
+	}
 
 	if ( attributes.columnWidth === undefined ) {
-		const index = parentBlock.innerBlocks.findIndex( i => i.clientId === clientId );
-		let { columns } = parentBlock.attributes;
-		const { layout } = parentBlock.attributes;
-
-		if ( 6 < columns ) {
-			columns = 6;
-		}
-
 		updateBlockAttributes( clientId, {
 			columnWidth: layouts[columns][layout][index]
 		});
@@ -180,9 +179,18 @@ const Edit = ({
 		marginLeft: getValue( 'margin' )?.left
 	};
 
+	if ( isDesktop ) {
+		const desktopStyle = pickBy({
+			flexBasis: `${ attributes.columnWidth }%`,
+		}, ( value ) => value );
+		stylesheet = merge( stylesheet, desktopStyle );
+	}
 
 	if ( isTablet || isMobile ) {
+		const flexBasis = layouts[columns][layoutTablet][index];
+
 		const tabletStyle = pickBy({
+			flexBasis: `${ flexBasis }%`,
 			paddingTop: getValue( 'paddingTablet' )?.top,
 			paddingRight: getValue( 'paddingTablet' )?.right,
 			paddingBottom: getValue( 'paddingTablet' )?.bottom,
@@ -196,7 +204,10 @@ const Edit = ({
 	}
 
 	if ( isMobile ) {
+		const flexBasis = layouts[columns][layoutMobile][index];
+
 		const mobileStyle = pickBy({
+			flexBasis: `${ flexBasis }%`,
 			paddingTop: getValue( 'paddingMobile' )?.top,
 			paddingRight: getValue( 'paddingMobile' )?.right,
 			paddingBottom: getValue( 'paddingMobile' )?.bottom,
@@ -265,7 +276,6 @@ const Edit = ({
 	};
 
 	const style = {
-		flexBasis: `${ attributes.columnWidth }%`,
 		...stylesheet,
 		...background,
 		...borderStyle,


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2335.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

This fixes the issue with mobile/tablet settings not previewing the column size change in the editor. Here's a video from Ionut on how to reproduce the issue: https://www.loom.com/share/48fa2cadde5846bfaf539e360b52442f?from_recorder=1&focus_title=1

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

Make sure the preview shows the correct size for their respective screen choice.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

