### PR TITLE
Fixed media upload height

### DIFF
--- a/src/pro/blocks/modal/edit.js
+++ b/src/pro/blocks/modal/edit.js
@@ -241,7 +241,7 @@ const Edit = ({
 												}
 											},
 											[
-												[ 'core/image', { height: '150px' }],
+												[ 'core/image'],
 												[ 'core/heading', { placeholder: __( 'Modal Title', 'otter-pro'  ) }],
 												[ 'core/paragraph', { placeholder: __( 'Modal Content', 'otter-pro'  ) }]
 											]


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2616

### Summary
I have fixed the media upload height for the modal block.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()