### PR TITLE
fix: prevent unauthenticated request

### DIFF
--- a/inc/server/class-dynamic-content-server.php
+++ b/inc/server/class-dynamic-content-server.php
@@ -124,8 +124,8 @@ class Dynamic_Content_Server {
 							},
 						),
 					),
-					'permission_callback' => function () {
-						return $this->check_permission( $_GET['context'] );
+					'permission_callback' => function ( $request ) {
+						return $this->check_permission( $request->get_param( 'context' ) );
 					},
 				),
 			)
@@ -140,8 +140,8 @@ class Dynamic_Content_Server {
 					'callback'            => function( $request ) {
 						return Dynamic_Content::instance()->apply_data( $request->get_params() );
 					},
-					'permission_callback' => function () {
-						return $this->check_permission( $_GET['context'] );
+					'permission_callback' => function ( $request ) {
+						return $this->check_permission( $request->get_param( 'context' ) );
 					},
 				),
 			)

--- a/inc/server/class-dynamic-content-server.php
+++ b/inc/server/class-dynamic-content-server.php
@@ -125,7 +125,7 @@ class Dynamic_Content_Server {
 						),
 					),
 					'permission_callback' => function () {
-						return true;
+						return $this->check_permission( $_GET['context'] );
 					},
 				),
 			)
@@ -141,11 +141,36 @@ class Dynamic_Content_Server {
 						return Dynamic_Content::instance()->apply_data( $request->get_params() );
 					},
 					'permission_callback' => function () {
-						return true;
+						return $this->check_permission( $_GET['context'] );
 					},
 				),
 			)
 		);
+	}
+
+	/**
+	 * Check permission to perform the request.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return bool
+	 */
+	public function check_permission( $post_id = 0 ) {
+		if ( empty( $post_id ) ) {
+			return false;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return false;
+		}
+
+		// Allow only if the post is published or the user has permission to view it.
+		if ( 'publish' === $post->post_status || current_user_can( 'edit_post', $post_id ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-internals/issues/259

### Summary
Prevent unauthenticated users from requesting the API.
 
### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

