### PR TITLE
dev: update WordPress sniff packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,17 @@
     ],
 	"require-dev": {
 		"squizlabs/php_codesniffer": "^3.3",
-		"wp-coding-standards/wpcs": "^1",
+		"wp-coding-standards/wpcs": "^3.2",
 		"phpcompatibility/php-compatibility": "^9",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
-		"automattic/vipwpcs": "^1.0.0",
 		"phpunit/phpunit": "9.6.5",
 		"yoast/phpunit-polyfills": "^4.0",
 		"phpstan/phpstan": "^2.1",
 		"php-stubs/woocommerce-stubs": "^9.1",
 		"php-stubs/acf-pro-stubs": "^6.0",
 		"wpackagist-plugin/woocommerce": "*",
-		"szepeviktor/phpstan-wordpress": "^2.0"
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"automattic/vipwpcs": "^3.0"
 	},
 	"license": "GPL-2.0+",
 	"authors": [
@@ -39,7 +39,7 @@
 		"phpunit": "phpunit",
 		"phpstan": "phpstan analyse --memory-limit 2G",
 		"phpstan:generate:baseline": "phpstan analyse --memory-limit 2G --generate-baseline",
-		"format-dist": "phpcbf --standard=phpcs.export.xml"
+		"format-dist": "phpcbf --standard=phpcs.xml.dist"
 	},
 	"prefer-stable": true,
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "341c7931ffba722141772961613cf262",
+    "content-hash": "b823d780538a4de103f62cac887db88d",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
@@ -94,16 +94,16 @@
         },
         {
             "name": "masterminds/html5",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Masterminds/html5-php.git",
-                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6"
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
-                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
                 "shasum": ""
             },
             "require": {
@@ -155,22 +155,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Masterminds/html5-php/issues",
-                "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
             },
-            "time": "2024-03-31T07:05:07+00:00"
+            "time": "2025-07-25T09:04:22+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
-            "version": "v8.8.0",
+            "version": "v8.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
-                "reference": "3de493bdddfd1f051249af725c7e0d2c38fed740"
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/3de493bdddfd1f051249af725c7e0d2c38fed740",
-                "reference": "3de493bdddfd1f051249af725c7e0d2c38fed740",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9",
                 "shasum": ""
             },
             "require": {
@@ -178,7 +178,8 @@
                 "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41"
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41",
+                "rawr/cross-data-providers": "^2.0.0"
             },
             "suggest": {
                 "ext-mbstring": "for parsing UTF-8 CSS"
@@ -220,22 +221,22 @@
             ],
             "support": {
                 "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
-                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.8.0"
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
             },
-            "time": "2025-03-23T17:59:05+00:00"
+            "time": "2025-07-11T13:20:48+00:00"
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v15.7.0",
+            "version": "v15.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "3e8161c1d7d1e9fb79751a693cd6123550f6ce21"
+                "reference": "3df1a19a33477af9ead8984dbd84e8f637c36199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/3e8161c1d7d1e9fb79751a693cd6123550f6ce21",
-                "reference": "3e8161c1d7d1e9fb79751a693cd6123550f6ce21",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/3df1a19a33477af9ead8984dbd84e8f637c36199",
+                "reference": "3df1a19a33477af9ead8984dbd84e8f637c36199",
                 "shasum": ""
             },
             "require": {
@@ -279,9 +280,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v15.7.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v15.10.0"
             },
-            "time": "2024-08-15T21:17:26+00:00"
+            "time": "2024-09-18T18:38:30+00:00"
         },
         {
             "name": "tubalmartin/cssmin",
@@ -389,30 +390,32 @@
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "1.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "8544a94c32f990b6669f2c7f034d4ba75ccbb558"
+                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/8544a94c32f990b6669f2c7f034d4ba75ccbb558",
-                "reference": "8544a94c32f990b6669f2c7f034d4ba75ccbb558",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "squizlabs/php_codesniffer": "^3.2.3",
-                "wp-coding-standards/wpcs": "1.*"
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.2.1",
+                "phpcsstandards/phpcsutils": "^1.0.11",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.18",
+                "squizlabs/php_codesniffer": "^3.9.2",
+                "wp-coding-standards/wpcs": "^3.1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpunit/phpunit": "^5 || ^6 || ^7"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -429,6 +432,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -436,7 +440,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2019-04-24T21:34:09+00:00"
+            "time": "2024-05-10T20:31:09+00:00"
         },
         {
             "name": "composer/installers",
@@ -726,16 +730,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.1",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -774,7 +778,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -782,20 +786,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T12:36:36+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.5.0",
+            "version": "v5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
-                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
                 "shasum": ""
             },
             "require": {
@@ -814,7 +818,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -838,9 +842,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
             },
-            "time": "2025-05-31T08:24:38+00:00"
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -962,16 +966,16 @@
         },
         {
             "name": "php-stubs/acf-pro-stubs",
-            "version": "v6.3.10",
+            "version": "v6.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/acf-pro-stubs.git",
-                "reference": "49a1766f214c8a8484b0b3c2de2a8188ce4fc354"
+                "reference": "e93769018c3292aff74ee28cf1213f8e864cafe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/acf-pro-stubs/zipball/49a1766f214c8a8484b0b3c2de2a8188ce4fc354",
-                "reference": "49a1766f214c8a8484b0b3c2de2a8188ce4fc354",
+                "url": "https://api.github.com/repos/php-stubs/acf-pro-stubs/zipball/e93769018c3292aff74ee28cf1213f8e864cafe8",
+                "reference": "e93769018c3292aff74ee28cf1213f8e864cafe8",
                 "shasum": ""
             },
             "require": {
@@ -1008,22 +1012,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/acf-pro-stubs/issues",
-                "source": "https://github.com/php-stubs/acf-pro-stubs/tree/v6.3.10"
+                "source": "https://github.com/php-stubs/acf-pro-stubs/tree/v6.4.2"
             },
-            "time": "2024-11-06T12:26:27+00:00"
+            "time": "2025-05-24T07:46:54+00:00"
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v9.8.2",
+            "version": "v9.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "3e8464d5471332cd56d595fde61ce8821236674f"
+                "reference": "3f4d4e14afe6150569bd96cf14e8a17a84812447"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/3e8464d5471332cd56d595fde61ce8821236674f",
-                "reference": "3e8464d5471332cd56d595fde61ce8821236674f",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/3f4d4e14afe6150569bd96cf14e8a17a84812447",
+                "reference": "3f4d4e14afe6150569bd96cf14e8a17a84812447",
                 "shasum": ""
             },
             "require": {
@@ -1052,22 +1056,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v9.8.2"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v9.9.5"
             },
-            "time": "2025-04-23T03:16:52+00:00"
+            "time": "2025-07-14T17:12:48+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.8.1",
+            "version": "v6.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "92e444847d94f7c30f88c60004648f507688acd5"
+                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/92e444847d94f7c30f88c60004648f507688acd5",
-                "reference": "92e444847d94f7c30f88c60004648f507688acd5",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
+                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
                 "shasum": ""
             },
             "conflict": {
@@ -1075,7 +1079,7 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "nikic/php-parser": "^5.4",
+                "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.4.1",
@@ -1103,9 +1107,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.2"
             },
-            "time": "2025-05-02T12:33:34+00:00"
+            "time": "2025-07-16T06:41:00+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1168,6 +1172,181 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
             "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-06-14T07:40:39+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-08-10T01:04:45+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -1817,16 +1996,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
                 "shasum": ""
             },
             "require": {
@@ -1879,15 +2058,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2025-08-10T06:51:50+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -2154,16 +2345,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -2206,15 +2397,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2387,16 +2590,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -2438,15 +2641,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -2612,17 +2827,74 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.13.0",
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "65ff2489553b83b4597e89c3b8b721487011d186"
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "4debf5383d9ade705e0a25121f16c3fecaf433a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/65ff2489553b83b4597e89c3b8b721487011d186",
-                "reference": "65ff2489553b83b4597e89c3b8b721487011d186",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/4debf5383d9ade705e0a25121f16c3fecaf433a7",
+                "reference": "4debf5383d9ade705e0a25121f16c3fecaf433a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2025-03-17T16:17:38+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
                 "shasum": ""
             },
             "require": {
@@ -2693,7 +2965,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-05-11T03:36:00+00:00"
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
@@ -2809,27 +3081,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "1.2.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
-                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
-                "phpcompatibility/php-compatibility": "^9.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2839,33 +3122,40 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
-                "issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
-                "source": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards",
-                "wiki": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki"
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2018-12-18T09:43:51+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-07-24T20:08:31+00:00"
         },
         {
             "name": "wpackagist-plugin/woocommerce",
-            "version": "9.8.5",
+            "version": "10.1.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/woocommerce/",
-                "reference": "tags/9.8.5"
+                "reference": "tags/10.1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/woocommerce.9.8.5.zip"
+                "url": "https://downloads.wordpress.org/plugin/woocommerce.10.1.2.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/inc/class-base-css.php
+++ b/inc/class-base-css.php
@@ -107,31 +107,31 @@ class Base_CSS {
 	/**
 	 * Check if string is empty without accepting zero
 	 *
-	 * @param string $var Var to check.
+	 * @param string $value Var to check.
 	 *
 	 * @return bool
 	 * @since   1.3.1
 	 * @access  public
 	 */
-	public function is_empty( $var ) {
-		return empty( $var ) && 0 !== $var;
+	public function is_empty( $value ) {
+		return empty( $value ) && 0 !== $value;
 	}
 
 	/**
 	 * Get block attribute value with default
 	 *
 	 * @param mixed $attr Attributes.
-	 * @param mixed $default Default value.
+	 * @param mixed $default_value Default value.
 	 *
 	 * @return mixed
 	 * @since   1.3.0
 	 * @access  public
 	 */
-	public function get_attr_value( $attr, $default = 'unset' ) {
+	public function get_attr_value( $attr, $default_value = 'unset' ) {
 		if ( ! $this->is_empty( $attr ) ) {
 			return $attr;
 		} else {
-			return $default;
+			return $default_value;
 		}
 	}
 
@@ -150,10 +150,8 @@ class Base_CSS {
 					'fontfamily'  => $attr['fontFamily'],
 					'fontvariant' => ( isset( $attr['fontVariant'] ) && ! empty( $attr['fontVariant'] ) ? array( $attr['fontVariant'] ) : array() ),
 				);
-			} else {
-				if ( ! in_array( $attr['fontVariant'], self::$google_fonts[ $attr['fontFamily'] ]['fontvariant'], true ) ) {
+			} elseif ( ! in_array( $attr['fontVariant'], self::$google_fonts[ $attr['fontFamily'] ]['fontvariant'], true ) ) {
 					array_push( self::$google_fonts[ $attr['fontFamily'] ]['fontvariant'], ( isset( $attr['fontStyle'] ) && 'italic' === $attr['fontStyle'] ) ? $attr['fontVariant'] . ':i' : $attr['fontVariant'] );
-				}
 			}
 		}
 	}
@@ -644,7 +642,7 @@ class Base_CSS {
 	 * @access  protected
 	 */
 	protected function get_dir() {
-		return dirname( __FILE__ );
+		return __DIR__;
 	}
 
 	/**

--- a/inc/class-pro.php
+++ b/inc/class-pro.php
@@ -384,7 +384,7 @@ class Pro {
 	 */
 	public function schedule_cron_events() {
 		if ( ! wp_next_scheduled( 'otter_montly_scheduled_events' ) ) {
-			wp_schedule_event( current_time( 'timestamp', true ), 'monthly', 'otter_montly_scheduled_events' );
+			wp_schedule_event( time(), 'monthly', 'otter_montly_scheduled_events' );
 		}
 	}
 

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -347,13 +347,11 @@ class Registration {
 
 		if ( is_singular() ) {
 			$this->enqueue_dependencies();
-		} else {
-			if ( ! is_null( $wp_query->posts ) && 0 < count( $wp_query->posts ) ) {
+		} elseif ( ! is_null( $wp_query->posts ) && 0 < count( $wp_query->posts ) ) {
 				$posts = wp_list_pluck( $wp_query->posts, 'ID' );
 
-				foreach ( $posts as $post ) {
-					$this->enqueue_dependencies( $post );
-				}
+			foreach ( $posts as $post ) {
+				$this->enqueue_dependencies( $post );
 			}
 		}
 
@@ -437,7 +435,7 @@ class Registration {
 			$blocks = parse_blocks( $content );
 			$blocks = array_filter(
 				$blocks,
-				function( $block ) {
+				function ( $block ) {
 					return 'core/block' === $block['blockName'] && isset( $block['attrs']['ref'] );
 				}
 			);
@@ -490,7 +488,7 @@ class Registration {
 
 			add_action(
 				'wp_head',
-				function() {
+				function () {
 					echo '
 						<style type="text/css" data-source="otter-blocks">
 							[class*="o-countdown-trigger-on-end-"] {

--- a/inc/css/blocks/class-accordion-css.php
+++ b/inc/css/blocks/class-accordion-css.php
@@ -64,10 +64,10 @@ class Accordion_CSS extends Base_CSS {
 					array(
 						'property'  => '--border-width',
 						'value'     => 'borderWidth',
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return $value;
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderWidth'] );
 						},
 					),
@@ -79,7 +79,7 @@ class Accordion_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 0,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['horizontal'];
 								},
 							),
@@ -87,7 +87,7 @@ class Accordion_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 0,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['vertical'];
 								},
 							),
@@ -95,7 +95,7 @@ class Accordion_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 5,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['blur'];
 								},
 							),
@@ -103,35 +103,35 @@ class Accordion_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 1,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['spread'];
 								},
 							),
 							'color'      => array(
 								'value'   => 'boxShadow',
 								'default' => '#000',
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									$opacity = $value['colorOpacity'];
 									$color   = isset( $value['color'] ) ? $value['color'] : '#000000';
 									return ( strpos( $color, '#' ) !== false && $opacity < 100 ) ? Base_CSS::hex2rgba( $color, $opacity / 100 ) : $color;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow']['active'];
 						},
 					),
 					array(
 						'property' => '--gap',
 						'value'    => 'gap',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return $value . 'px';
 						},
 					),
 					array(
 						'property' => '--padding',
 						'value'    => 'padding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -146,7 +146,7 @@ class Accordion_CSS extends Base_CSS {
 					array(
 						'property' => '--padding-tablet',
 						'value'    => 'paddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -161,7 +161,7 @@ class Accordion_CSS extends Base_CSS {
 					array(
 						'property' => '--padding-mobile',
 						'value'    => 'paddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -263,30 +263,30 @@ class Accordion_CSS extends Base_CSS {
 					array(
 						'property'  => 'content',
 						'value'     => 'icon',
-						'format'    => function( $value ) use ( $fa_icons ) {
+						'format'    => function ( $value ) use ( $fa_icons ) {
 							return '"\\\\' . $fa_icons[ $value['name'] ]['unicode'] . '"';
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['icon'] );
 						},
 					),
 					array(
 						'property'  => 'font-weight',
 						'value'     => 'icon',
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return 'fas' !== $value['prefix'] ? 400 : 900;
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['icon'] );
 						},
 					),
 					array(
 						'property'  => 'font-family',
 						'value'     => 'icon',
-						'format'    => function( $value ) use ( $prefix_to_family ) {
+						'format'    => function ( $value ) use ( $prefix_to_family ) {
 							return '"' . $prefix_to_family[ $value['prefix'] ] . '"';
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['icon'] );
 						},
 					),
@@ -301,30 +301,30 @@ class Accordion_CSS extends Base_CSS {
 					array(
 						'property'  => 'content',
 						'value'     => 'openItemIcon',
-						'format'    => function( $value ) use ( $fa_icons ) {
+						'format'    => function ( $value ) use ( $fa_icons ) {
 							return '"\\\\' . $fa_icons[ $value['name'] ]['unicode'] . '"';
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['openItemIcon'] );
 						},
 					),
 					array(
 						'property'  => 'font-weight',
 						'value'     => 'openItemIcon',
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return 'fas' !== $value['prefix'] ? 400 : 900;
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['openItemIcon'] );
 						},
 					),
 					array(
 						'property'  => 'font-family',
 						'value'     => 'openItemIcon',
-						'format'    => function( $value ) use ( $prefix_to_family ) {
+						'format'    => function ( $value ) use ( $prefix_to_family ) {
 							return '"' . $prefix_to_family[ $value['prefix'] ] . '"';
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['openItemIcon'] );
 						},
 					),

--- a/inc/css/blocks/class-advanced-column-css.php
+++ b/inc/css/blocks/class-advanced-column-css.php
@@ -81,7 +81,7 @@ class Advanced_Column_CSS extends Base_CSS {
 
 		$uses_old_sizing = $this->array_any(
 			$old_attributes,
-			function( $value ) use ( $block ) {
+			function ( $value ) use ( $block ) {
 				return isset( $block['attrs'][ $value ] ) && is_numeric( $block['attrs'][ $value ] );
 			}
 		);
@@ -100,10 +100,10 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property'  => 'padding-top',
 							'value'     => 'padding',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['top'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['padding'] ) && isset( $attrs['padding']['top'] );
 							},
 							'hasSync'   => 'column-padding-top',
@@ -111,10 +111,10 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property'  => 'padding-bottom',
 							'value'     => 'padding',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['bottom'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['padding'] ) && isset( $attrs['padding']['bottom'] );
 							},
 							'hasSync'   => 'column-padding-bottom',
@@ -122,10 +122,10 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property'  => 'padding-left',
 							'value'     => 'padding',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['left'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['padding'] ) && isset( $attrs['padding']['left'] );
 							},
 							'hasSync'   => 'column-padding-left',
@@ -133,10 +133,10 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property'  => 'padding-right',
 							'value'     => 'padding',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['right'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['padding'] ) && isset( $attrs['padding']['right'] );
 							},
 							'hasSync'   => 'column-padding-right',
@@ -144,10 +144,10 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property'  => 'margin-top',
 							'value'     => 'margin',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['top'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['margin'] ) && isset( $attrs['margin']['top'] );
 							},
 							'hasSync'   => 'column-margin-top',
@@ -155,10 +155,10 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property'  => 'margin-bottom',
 							'value'     => 'margin',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['bottom'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['margin'] ) && isset( $attrs['margin']['bottom'] );
 							},
 							'hasSync'   => 'column-margin-bottom',
@@ -166,10 +166,10 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property'  => 'margin-left',
 							'value'     => 'margin',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['left'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['margin'] ) && isset( $attrs['margin']['left'] );
 							},
 							'hasSync'   => 'column-margin-left',
@@ -177,10 +177,10 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property'  => 'margin-right',
 							'value'     => 'margin',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['right'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['margin'] ) && isset( $attrs['margin']['right'] );
 							},
 							'hasSync'   => 'column-margin-right',
@@ -192,7 +192,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						array(
 							'property' => 'align-self',
 							'value'    => 'verticalAlign',
-							'format'   => function( $value, $attrs ) {
+							'format'   => function ( $value, $attrs ) {
 								$values = array(
 									'top'    => 'flex-start',
 									'center' => 'center',
@@ -215,7 +215,7 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'color',
 						'default'   => 'var( --content-color-hover )',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['colorHover'] );
 						},
 					),
@@ -230,7 +230,7 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'color',
 						'default'   => 'var( --link-color )',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['linkColor'] );
 						},
 					),
@@ -253,7 +253,7 @@ class Advanced_Column_CSS extends Base_CSS {
 						'property' => 'flex-basis',
 						'value'    => 'columnWidth',
 						'unit'     => '%',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return floatval( $value );
 						},
 					),
@@ -268,10 +268,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-top',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['top'] );
 						},
 						'hasSync'   => 'column-padding-top-tablet',
@@ -279,10 +279,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-bottom',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['bottom'] );
 						},
 						'hasSync'   => 'column-padding-bottom-tablet',
@@ -290,10 +290,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-left',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['left'] );
 						},
 						'hasSync'   => 'column-padding-left-tablet',
@@ -301,10 +301,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-right',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['right'] );
 						},
 						'hasSync'   => 'column-padding-right-tablet',
@@ -312,10 +312,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-top',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['top'] );
 						},
 						'hasSync'   => 'column-margin-top-tablet',
@@ -323,10 +323,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-bottom',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['bottom'] );
 						},
 						'hasSync'   => 'column-margin-bottom-tablet',
@@ -334,10 +334,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-left',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['left'] );
 						},
 						'hasSync'   => 'column-margin-left-tablet',
@@ -345,10 +345,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-right',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['right'] );
 						},
 						'hasSync'   => 'column-margin-right-tablet',
@@ -364,10 +364,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-top',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['top'] );
 						},
 						'hasSync'   => 'column-padding-top-mobile',
@@ -375,10 +375,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-bottom',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['bottom'] );
 						},
 						'hasSync'   => 'column-padding-bottom-mobile',
@@ -386,10 +386,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-left',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['left'] );
 						},
 						'hasSync'   => 'column-padding-left-mobile',
@@ -397,10 +397,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-right',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['right'] );
 						},
 						'hasSync'   => 'column-padding-right-mobile',
@@ -408,10 +408,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-top',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['top'] );
 						},
 						'hasSync'   => 'column-margin-top-mobile',
@@ -419,10 +419,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-bottom',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['bottom'] );
 						},
 						'hasSync'   => 'column-margin-bottom-mobile',
@@ -430,10 +430,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-left',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['left'] );
 						},
 						'hasSync'   => 'column-margin-left-mobile',
@@ -441,10 +441,10 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-right',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['right'] );
 						},
 						'hasSync'   => 'column-margin-right-mobile',
@@ -549,20 +549,16 @@ class Advanced_Column_CSS extends Base_CSS {
 			$margin['bottom'] = isset( $attrs['marginBottom'] ) ? $attrs['marginBottom'] . 'px' : ( is_numeric( $attrs['margin'] ) ? $attrs['margin'] . 'px' : '20px' );
 			$margin['left']   = isset( $attrs['marginLeft'] ) ? $attrs['marginLeft'] . 'px' : ( is_numeric( $attrs['margin'] ) ? $attrs['margin'] . 'px' : '20px' );
 			$margin['right']  = isset( $attrs['marginRight'] ) ? $attrs['marginRight'] . 'px' : ( is_numeric( $attrs['margin'] ) ? $attrs['margin'] . 'px' : '20px' );
-		} else {
-			if ( isset( $attrs['marginType'] ) && 'linked' === $attrs['marginType'] ) {
+		} elseif ( isset( $attrs['marginType'] ) && 'linked' === $attrs['marginType'] ) {
 				$margin['top']    = isset( $attrs['margin'] ) ? $attrs['margin'] . 'px' : ( isset( $attrs['marginTop'] ) ? $attrs['marginTop'] . 'px' : '0px' );
 				$margin['bottom'] = isset( $attrs['margin'] ) ? $attrs['margin'] . 'px' : ( isset( $attrs['marginBottom'] ) ? $attrs['marginBottom'] . 'px' : '0px' );
 				$margin['left']   = isset( $attrs['margin'] ) ? $attrs['margin'] . 'px' : ( isset( $attrs['marginLeft'] ) ? $attrs['marginLeft'] . 'px' : '0px' );
 				$margin['right']  = isset( $attrs['margin'] ) ? $attrs['margin'] . 'px' : ( isset( $attrs['marginRight'] ) ? $attrs['marginRight'] . 'px' : '0px' );
-			} else {
-				if ( ! isset( $attrs['marginType'] ) && ! isset( $attrs['margin'] ) ) {
-					$margin['top']    = isset( $attrs['marginTop'] ) ? $attrs['marginTop'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '20px' );
-					$margin['bottom'] = isset( $attrs['marginBottom'] ) ? $attrs['marginBottom'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '20px' );
-					$margin['left']   = isset( $attrs['marginLeft'] ) ? $attrs['marginLeft'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '0px' );
-					$margin['right']  = isset( $attrs['marginRight'] ) ? $attrs['marginRight'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '0px' );
-				}
-			}
+		} elseif ( ! isset( $attrs['marginType'] ) && ! isset( $attrs['margin'] ) ) {
+				$margin['top']    = isset( $attrs['marginTop'] ) ? $attrs['marginTop'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '20px' );
+				$margin['bottom'] = isset( $attrs['marginBottom'] ) ? $attrs['marginBottom'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '20px' );
+				$margin['left']   = isset( $attrs['marginLeft'] ) ? $attrs['marginLeft'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '0px' );
+				$margin['right']  = isset( $attrs['marginRight'] ) ? $attrs['marginRight'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '0px' );
 		}
 
 		if ( isset( $attrs['marginTypeTablet'] ) && 'linked' === $attrs['marginTypeTablet'] ) {
@@ -711,240 +707,240 @@ class Advanced_Column_CSS extends Base_CSS {
 					array(
 						'property'  => '--column-padding-top',
 						'value'     => 'padding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['top'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-bottom',
 						'value'     => 'padding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-left',
 						'value'     => 'padding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['left'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-right',
 						'value'     => 'padding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['right'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-top',
 						'value'     => 'margin',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['top'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-bottom',
 						'value'     => 'margin',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-left',
 						'value'     => 'margin',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['left'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-right',
 						'value'     => 'margin',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['right'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-top-tablet',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['top'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-bottom-tablet',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-left-tablet',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['left'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-right-tablet',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['right'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-top-tablet',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['top'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-bottom-tablet',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-left-tablet',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['left'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-right-tablet',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['right'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-top-mobile',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['top'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-bottom-mobile',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-left-mobile',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['left'] );
 						},
 					),
 					array(
 						'property'  => '--column-padding-right-mobile',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['right'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-top-mobile',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marMobilegMobilein'] ) && isset( $attrs['marginMobile']['top'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-bottom-mobile',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-left-mobile',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['left'] );
 						},
 					),
 					array(
 						'property'  => '--column-margin-right-mobile',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['right'] );
 						},
 					),
@@ -960,15 +956,15 @@ class Advanced_Column_CSS extends Base_CSS {
 	/**
 	 * A port of array.some for PHP.
 	 *
-	 * @param array    $array Haystack.
-	 * @param callable $fn Callback function.
+	 * @param array    $items Haystack.
+	 * @param callable $callback Callback function.
 	 * @return boolean
 	 * @since   2.0.0
 	 * @access  public
 	 */
-	public function array_any( $array, $fn ) {
-		foreach ( $array as $value ) {
-			if ( $fn( $value ) ) {
+	public function array_any( $items, $callback ) {
+		foreach ( $items as $value ) {
+			if ( $callback( $value ) ) {
 				return true;
 			}
 		}

--- a/inc/css/blocks/class-advanced-columns-css.php
+++ b/inc/css/blocks/class-advanced-columns-css.php
@@ -75,7 +75,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 
 		$uses_old_sizing = $this->array_any(
 			$old_attributes,
-			function( $value ) use ( $block ) {
+			function ( $value ) use ( $block ) {
 				return isset( $block['attrs'][ $value ] ) && is_numeric( $block['attrs'][ $value ] );
 			}
 		);
@@ -99,10 +99,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 						array(
 							'property'  => 'padding-top',
 							'value'     => 'padding',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['top'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['padding'] ) && isset( $attrs['padding']['top'] );
 							},
 							'hasSync'   => 'section-padding-top',
@@ -110,10 +110,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 						array(
 							'property'  => 'padding-bottom',
 							'value'     => 'padding',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['bottom'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['padding'] ) && isset( $attrs['padding']['bottom'] );
 							},
 							'hasSync'   => 'section-padding-bottom',
@@ -121,10 +121,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 						array(
 							'property'  => 'padding-left',
 							'value'     => 'padding',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['left'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['padding'] ) && isset( $attrs['padding']['left'] );
 							},
 							'hasSync'   => 'section-padding-left',
@@ -132,10 +132,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 						array(
 							'property'  => 'padding-right',
 							'value'     => 'padding',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['right'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['padding'] ) && isset( $attrs['padding']['right'] );
 							},
 							'hasSync'   => 'section-padding-right',
@@ -143,10 +143,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 						array(
 							'property'  => 'margin-top',
 							'value'     => 'margin',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['top'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['margin'] ) && isset( $attrs['margin']['top'] );
 							},
 							'hasSync'   => 'section-margin-top',
@@ -154,10 +154,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 						array(
 							'property'  => 'margin-bottom',
 							'value'     => 'margin',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['bottom'];
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['margin'] ) && isset( $attrs['margin']['bottom'] );
 							},
 							'hasSync'   => 'section-margin-bottom',
@@ -165,7 +165,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 						array(
 							'property' => '--columns-width',
 							'value'    => 'columnsWidth',
-							'format'   => function( $value, $attrs ) {
+							'format'   => function ( $value, $attrs ) {
 								return is_numeric( $value ) ? $value . 'px' : $value;
 							},
 							'hasSync'  => 'section-columns-width',
@@ -191,17 +191,17 @@ class Advanced_Columns_CSS extends Base_CSS {
 							'property'  => 'min-height',
 							'value'     => 'columnsHeight',
 							'default'   => 'auto',
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return ! isset( $attrs['columnsHeight'] ) || 'custom' !== $attrs['columnsHeight'];
 							},
 						),
 						array(
 							'property'  => 'min-height',
 							'value'     => 'columnsHeightCustom',
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return is_numeric( $value ) ? $value . 'px' : $value;
 							},
-							'condition' => function( $attrs ) {
+							'condition' => function ( $attrs ) {
 								return isset( $attrs['columnsHeight'] ) && 'custom' === $attrs['columnsHeight'];
 							},
 						),
@@ -218,7 +218,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'color',
 						'default'   => 'var( --content-color-hover )',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['colorHover'] );
 						},
 					),
@@ -233,7 +233,7 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'color',
 						'default'   => 'var( --link-color )',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['linkColor'] );
 						},
 					),
@@ -263,12 +263,12 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'pattern_values' => array(
 							'width' => array(
 								'value'  => 'dividerTopWidth',
-								'format' => function( $value, $attrs ) {
+								'format' => function ( $value, $attrs ) {
 									return $value / 100;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['dividerTopWidth'] );
 						},
 					),
@@ -291,12 +291,12 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'pattern_values' => array(
 							'width' => array(
 								'value'  => 'dividerBottomWidth',
-								'format' => function( $value, $attrs ) {
+								'format' => function ( $value, $attrs ) {
 									return $value / 100;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['dividerBottomWidth'] );
 						},
 					),
@@ -311,10 +311,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-top',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['top'] );
 						},
 						'hasSync'   => 'section-padding-top-tablet',
@@ -322,10 +322,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-bottom',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['bottom'] );
 						},
 						'hasSync'   => 'section-padding-bottom-tablet',
@@ -333,10 +333,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-left',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['left'] );
 						},
 						'hasSync'   => 'section-padding-left-tablet',
@@ -344,10 +344,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-right',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['right'] );
 						},
 						'hasSync'   => 'section-padding-right-tablet',
@@ -355,10 +355,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-top',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['top'] );
 						},
 						'hasSync'   => 'section-margin-top-tablet',
@@ -366,10 +366,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-bottom',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['bottom'] );
 						},
 						'hasSync'   => 'section-margin-bottom-tablet',
@@ -377,10 +377,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'min-height',
 						'value'     => 'columnsHeightCustomTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['columnsHeight'] ) && 'custom' === $attrs['columnsHeight'];
 						},
 					),
@@ -404,12 +404,12 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'pattern_values' => array(
 							'width' => array(
 								'value'  => 'dividerTopWidthTablet',
-								'format' => function( $value, $attrs ) {
+								'format' => function ( $value, $attrs ) {
 									return $value / 100;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['dividerTopWidthTablet'] );
 						},
 					),
@@ -433,12 +433,12 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'pattern_values' => array(
 							'width' => array(
 								'value'  => 'dividerBottomWidthTablet',
-								'format' => function( $value, $attrs ) {
+								'format' => function ( $value, $attrs ) {
 									return $value / 100;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['dividerBottomWidthTablet'] );
 						},
 					),
@@ -453,10 +453,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-top',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['top'] );
 						},
 						'hasSync'   => 'section-padding-top-mobile',
@@ -464,10 +464,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-bottom',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['bottom'] );
 						},
 						'hasSync'   => 'section-padding-bottom-mobile',
@@ -475,10 +475,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-left',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['left'] );
 						},
 						'hasSync'   => 'section-padding-left-mobile',
@@ -486,10 +486,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'padding-right',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['right'] );
 						},
 						'hasSync'   => 'section-padding-right-mobile',
@@ -497,10 +497,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-top',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['top'] );
 						},
 						'hasSync'   => 'section-margin-top-mobile',
@@ -508,10 +508,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'margin-bottom',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['bottom'] );
 						},
 						'hasSync'   => 'section-margin-bottom-mobile',
@@ -519,10 +519,10 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => 'min-height',
 						'value'     => 'columnsHeightCustomMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['columnsHeight'] ) && 'custom' === $attrs['columnsHeight'];
 						},
 					),
@@ -546,12 +546,12 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'pattern_values' => array(
 							'width' => array(
 								'value'  => 'dividerTopWidthMobile',
-								'format' => function( $value, $attrs ) {
+								'format' => function ( $value, $attrs ) {
 									return $value / 100;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['dividerTopWidthMobile'] );
 						},
 					),
@@ -575,12 +575,12 @@ class Advanced_Columns_CSS extends Base_CSS {
 						'pattern_values' => array(
 							'width' => array(
 								'value'  => 'dividerBottomWidthMobile',
-								'format' => function( $value, $attrs ) {
+								'format' => function ( $value, $attrs ) {
 									return $value / 100;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['dividerBottomWidthMobile'] );
 						},
 					),
@@ -687,14 +687,12 @@ class Advanced_Columns_CSS extends Base_CSS {
 		} elseif ( isset( $attrs['margin'] ) && ! is_array( $attrs['margin'] ) && ! isset( $attrs['marginType'] ) ) {
 			$margin['top']    = isset( $attrs['marginTop'] ) ? $attrs['marginTop'] . 'px' : ( is_numeric( $attrs['margin'] ) ? $attrs['margin'] . 'px' : '20px' );
 			$margin['bottom'] = isset( $attrs['marginBottom'] ) ? $attrs['marginBottom'] . 'px' : ( is_numeric( $attrs['margin'] ) ? $attrs['margin'] . 'px' : '20px' );
-		} else {
-			if ( isset( $attrs['marginType'] ) && 'linked' === $attrs['marginType'] ) {
+		} elseif ( isset( $attrs['marginType'] ) && 'linked' === $attrs['marginType'] ) {
 				$margin['top']    = isset( $attrs['margin'] ) ? $attrs['margin'] . 'px' : ( isset( $attrs['marginTop'] ) ? $attrs['marginTop'] . 'px' : '20px' );
 				$margin['bottom'] = isset( $attrs['margin'] ) ? $attrs['margin'] . 'px' : ( isset( $attrs['marginBottom'] ) ? $attrs['marginBottom'] . 'px' : '20px' );
-			} else {
-				$margin['top']    = isset( $attrs['marginTop'] ) ? $attrs['marginTop'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '20px' );
-				$margin['bottom'] = isset( $attrs['marginBottom'] ) ? $attrs['marginBottom'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '20px' );
-			}
+		} else {
+			$margin['top']    = isset( $attrs['marginTop'] ) ? $attrs['marginTop'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '20px' );
+			$margin['bottom'] = isset( $attrs['marginBottom'] ) ? $attrs['marginBottom'] . 'px' : ( ( isset( $attrs['margin'] ) && is_numeric( $attrs['margin'] ) ) ? $attrs['margin'] . 'px' : '20px' );
 		}
 
 		if ( isset( $attrs['marginTypeTablet'] ) && 'linked' === $attrs['marginTypeTablet'] ) {
@@ -823,187 +821,187 @@ class Advanced_Columns_CSS extends Base_CSS {
 					array(
 						'property'  => '--section-padding-top',
 						'value'     => 'padding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['top'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-bottom',
 						'value'     => 'padding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-left',
 						'value'     => 'padding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['left'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-right',
 						'value'     => 'padding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && isset( $attrs['padding']['right'] );
 						},
 					),
 					array(
 						'property'  => '--section-margin-top',
 						'value'     => 'margin',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['top'] );
 						},
 					),
 					array(
 						'property'  => '--section-margin-bottom',
 						'value'     => 'margin',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['margin'] ) && isset( $attrs['margin']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-top-tablet',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['top'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-bottom-tablet',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-left-tablet',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['left'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-right-tablet',
 						'value'     => 'paddingTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && isset( $attrs['paddingTablet']['right'] );
 						},
 					),
 					array(
 						'property'  => '--section-margin-top-tablet',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['top'] );
 						},
 					),
 					array(
 						'property'  => '--section-margin-bottom-tablet',
 						'value'     => 'marginTablet',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && isset( $attrs['marginTablet']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-top-mobile',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['top'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-bottom-mobile',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['bottom'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-left-mobile',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['left'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['left'] );
 						},
 					),
 					array(
 						'property'  => '--section-padding-right-mobile',
 						'value'     => 'paddingMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['right'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && isset( $attrs['paddingMobile']['right'] );
 						},
 					),
 					array(
 						'property'  => '--section-margin-top-mobile',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['top'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marMobilegMobilein'] ) && isset( $attrs['marginMobile']['top'] );
 						},
 					),
 					array(
 						'property'  => '--section-margin-bottom-mobile',
 						'value'     => 'marginMobile',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['bottom'];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && isset( $attrs['marginMobile']['bottom'] );
 						},
 					),
 					array(
 						'property' => '--section-columns-width',
 						'value'    => 'columnsWidth',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
@@ -1033,15 +1031,15 @@ class Advanced_Columns_CSS extends Base_CSS {
 	/**
 	 * A port of array.some for PHP.
 	 *
-	 * @param array    $array Haystack.
-	 * @param callable $fn Callback function.
+	 * @param array    $items Haystack.
+	 * @param callable $callback Callback function.
 	 * @return boolean
 	 * @since   2.0.0
 	 * @access  public
 	 */
-	public function array_any( $array, $fn ) {
-		foreach ( $array as $value ) {
-			if ( $fn( $value ) ) {
+	public function array_any( $items, $callback ) {
+		foreach ( $items as $value ) {
+			if ( $callback( $value ) ) {
 				return true;
 			}
 		}

--- a/inc/css/blocks/class-advanced-heading-css.php
+++ b/inc/css/blocks/class-advanced-heading-css.php
@@ -56,7 +56,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 					array(
 						'property' => 'font-weight',
 						'value'    => 'fontVariant',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return 'regular' === $value ? 'normal' : $value;
 						},
 					),
@@ -71,10 +71,10 @@ class Advanced_Heading_CSS extends Base_CSS {
 					array(
 						'property'  => 'line-height',
 						'value'     => 'lineHeight',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['lineHeight'] ) && is_numeric( $attrs['lineHeight'] );
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							if ( is_numeric( $value ) && ! is_string( $value ) ) {
 								return 3 < $value ? $value . 'px' : $value;
 							}
@@ -85,7 +85,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 					array(
 						'property'  => 'line-height',
 						'value'     => 'lineHeight',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['lineHeight'] ) && is_string( $attrs['lineHeight'] );
 						},
 					),
@@ -93,14 +93,14 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'letter-spacing',
 						'value'     => 'letterSpacing',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['letterSpacing'] ) && is_numeric( $attrs['letterSpacing'] );
 						},
 					),
 					array(
 						'property'  => 'letter-spacing',
 						'value'     => 'letterSpacing',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['letterSpacing'] ) && is_string( $attrs['letterSpacing'] );
 						},
 					),
@@ -126,13 +126,13 @@ class Advanced_Heading_CSS extends Base_CSS {
 							'color'      => array(
 								'value'   => 'textShadowColor',
 								'default' => '#000',
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									$opacity = ( isset( $attrs['textShadowColorOpacity'] ) ? $attrs['textShadowColorOpacity'] : 50 ) / 100;
 									return Base_CSS::hex2rgba( $value, $opacity );
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['textShadow'] );
 						},
 					),
@@ -141,7 +141,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'padding',
 						'unit'      => 'px',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['padding'] ) && ! is_array( $attrs['padding'] ) ) && ! ( isset( $attrs['paddingType'] ) && is_numeric( $attrs['padding'] ) && 'unlinked' === $attrs['paddingType'] );
 						},
 					),
@@ -150,7 +150,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'paddingTop',
 						'unit'      => 'px',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['padding'] ) && ! is_array( $attrs['padding'] ) ) && isset( $attrs['paddingType'] ) && 'unlinked' === $attrs['paddingType'];
 						},
 					),
@@ -159,7 +159,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'paddingRight',
 						'unit'      => 'px',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['padding'] ) && ! is_array( $attrs['padding'] ) ) && isset( $attrs['paddingType'] ) && 'unlinked' === $attrs['paddingType'];
 						},
 					),
@@ -168,7 +168,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'paddingBottom',
 						'unit'      => 'px',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['padding'] ) && ! is_array( $attrs['padding'] ) ) && isset( $attrs['paddingType'] ) && 'unlinked' === $attrs['paddingType'];
 						},
 					),
@@ -177,7 +177,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'paddingLeft',
 						'unit'      => 'px',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['padding'] ) && ! is_array( $attrs['padding'] ) ) && isset( $attrs['paddingType'] ) && 'unlinked' === $attrs['paddingType'];
 						},
 					),
@@ -186,7 +186,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'margin',
 						'unit'      => 'px',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['margin'] ) && ! is_array( $attrs['margin'] ) ) && isset( $attrs['marginType'] ) && 'linked' === $attrs['marginType'];
 						},
 					),
@@ -195,7 +195,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'margin',
 						'unit'      => 'px',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['margin'] ) && ! is_array( $attrs['margin'] ) ) && isset( $attrs['marginType'] ) && 'linked' === $attrs['marginType'];
 						},
 					),
@@ -204,7 +204,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'marginTop',
 						'unit'      => 'px',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['margin'] ) && ! is_array( $attrs['margin'] ) ) && ! ( isset( $attrs['marginType'] ) && 'linked' === $attrs['marginType'] );
 						},
 					),
@@ -213,7 +213,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'value'     => 'marginBottom',
 						'unit'      => 'px',
 						'default'   => 20,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['margin'] ) && ! is_array( $attrs['margin'] ) ) && ! ( isset( $attrs['marginType'] ) && 'linked' === $attrs['marginType'] );
 						},
 					),
@@ -254,7 +254,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding',
 						'value'     => 'paddingTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingTablet'] ) && ! is_array( $attrs['paddingTablet'] ) ) && ! ( isset( $attrs['paddingTypeTablet'] ) && is_numeric( $attrs['paddingTablet'] ) && 'unlinked' === $attrs['paddingTypeTablet'] );
 						},
 					),
@@ -262,7 +262,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding-top',
 						'value'     => 'paddingTopTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingTablet'] ) && ! is_array( $attrs['paddingTablet'] ) ) && isset( $attrs['paddingTypeTablet'] ) && 'unlinked' === $attrs['paddingTypeTablet'];
 						},
 					),
@@ -270,7 +270,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding-right',
 						'value'     => 'paddingRightTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingTablet'] ) && ! is_array( $attrs['paddingTablet'] ) ) && isset( $attrs['paddingTypeTablet'] ) && 'unlinked' === $attrs['paddingTypeTablet'];
 						},
 					),
@@ -278,7 +278,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding-bottom',
 						'value'     => 'paddingBottomTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingTablet'] ) && ! is_array( $attrs['paddingTablet'] ) ) && isset( $attrs['paddingTypeTablet'] ) && 'unlinked' === $attrs['paddingTypeTablet'];
 						},
 					),
@@ -286,7 +286,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding-left',
 						'value'     => 'paddingLeftTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingTablet'] ) && ! is_array( $attrs['paddingTablet'] ) ) && isset( $attrs['paddingTypeTablet'] ) && 'unlinked' === $attrs['paddingTypeTablet'];
 						},
 					),
@@ -294,7 +294,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'margin-top',
 						'value'     => 'marginTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['marginTablet'] ) && ! is_array( $attrs['marginTablet'] ) ) && isset( $attrs['marginTypeTablet'] ) && 'linked' === $attrs['marginTypeTablet'];
 						},
 					),
@@ -302,7 +302,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'margin-bottom',
 						'value'     => 'marginTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['marginTablet'] ) && ! is_array( $attrs['marginTablet'] ) ) && isset( $attrs['marginTypeTablet'] ) && 'linked' === $attrs['marginTypeTablet'];
 						},
 					),
@@ -310,7 +310,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'margin-top',
 						'value'     => 'marginTopTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['marginTablet'] ) && ! is_array( $attrs['marginTablet'] ) ) && ! ( isset( $attrs['marginTypeTablet'] ) && 'linked' === $attrs['marginTypeTablet'] );
 						},
 					),
@@ -318,7 +318,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'margin-bottom',
 						'value'     => 'marginBottomTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['marginTablet'] ) && ! is_array( $attrs['marginTablet'] ) ) && ! ( isset( $attrs['marginTypeTablet'] ) && 'linked' === $attrs['marginTypeTablet'] );
 						},
 					),
@@ -326,14 +326,14 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'font-size',
 						'value'     => 'fontSizeTablet',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['fontSizeTablet'] ) && is_numeric( $attrs['fontSizeTablet'] );
 						},
 					),
 					array(
 						'property'  => 'font-size',
 						'value'     => 'fontSizeTablet',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['fontSizeTablet'] ) && is_string( $attrs['fontSizeTablet'] );
 						},
 					),
@@ -349,7 +349,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding',
 						'value'     => 'paddingMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingMobile'] ) && ! is_array( $attrs['paddingMobile'] ) ) && ! ( isset( $attrs['paddingTypeMobile'] ) && is_numeric( $attrs['paddingMobile'] ) && 'unlinked' === $attrs['paddingTypeMobile'] );
 						},
 					),
@@ -357,7 +357,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding-top',
 						'value'     => 'paddingTopMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingMobile'] ) && ! is_array( $attrs['paddingMobile'] ) ) && isset( $attrs['paddingTypeMobile'] ) && 'unlinked' === $attrs['paddingTypeMobile'];
 						},
 					),
@@ -365,7 +365,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding-right',
 						'value'     => 'paddingRightMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingMobile'] ) && ! is_array( $attrs['paddingMobile'] ) ) && isset( $attrs['paddingTypeMobile'] ) && 'unlinked' === $attrs['paddingTypeMobile'];
 						},
 					),
@@ -373,7 +373,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding-bottom',
 						'value'     => 'paddingBottomMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingMobile'] ) && ! is_array( $attrs['paddingMobile'] ) ) && isset( $attrs['paddingTypeMobile'] ) && 'unlinked' === $attrs['paddingTypeMobile'];
 						},
 					),
@@ -381,7 +381,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'padding-left',
 						'value'     => 'paddingLeftMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['paddingMobile'] ) && ! is_array( $attrs['paddingMobile'] ) ) && isset( $attrs['paddingTypeMobile'] ) && 'unlinked' === $attrs['paddingTypeMobile'];
 						},
 					),
@@ -389,7 +389,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'margin-top',
 						'value'     => 'marginMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['marginMobile'] ) && ! is_array( $attrs['marginMobile'] ) ) && isset( $attrs['marginTypeMobile'] ) && 'linked' === $attrs['marginTypeMobile'];
 						},
 					),
@@ -397,7 +397,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'margin-bottom',
 						'value'     => 'marginMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['marginMobile'] ) && ! is_array( $attrs['marginMobile'] ) ) && isset( $attrs['marginTypeMobile'] ) && 'linked' === $attrs['marginTypeMobile'];
 						},
 					),
@@ -405,7 +405,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'margin-top',
 						'value'     => 'marginTopMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['marginMobile'] ) && ! is_array( $attrs['marginMobile'] ) ) && ! ( isset( $attrs['marginTypeMobile'] ) && 'linked' === $attrs['marginTypeMobile'] );
 						},
 					),
@@ -413,7 +413,7 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'margin-bottom',
 						'value'     => 'marginBottomMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( isset( $attrs['marginMobile'] ) && ! is_array( $attrs['marginMobile'] ) ) && ! ( isset( $attrs['marginTypeMobile'] ) && 'linked' === $attrs['marginTypeMobile'] );
 						},
 					),
@@ -421,14 +421,14 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'font-size',
 						'value'     => 'fontSizeMobile',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['fontSizeMobile'] ) && is_numeric( $attrs['fontSizeMobile'] );
 						},
 					),
 					array(
 						'property'  => 'font-size',
 						'value'     => 'fontSizeMobile',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['fontSizeMobile'] ) && is_string( $attrs['fontSizeMobile'] );
 						},
 					),
@@ -443,14 +443,14 @@ class Advanced_Heading_CSS extends Base_CSS {
 						'property'  => 'font-size',
 						'value'     => 'fontSize',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['fontSize'] ) && is_numeric( $attrs['fontSize'] );
 						},
 					),
 					array(
 						'property'  => 'font-size',
 						'value'     => 'fontSize',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['fontSize'] ) && is_string( $attrs['fontSize'] );
 						},
 					),
@@ -469,60 +469,60 @@ class Advanced_Heading_CSS extends Base_CSS {
 					array(
 						'property'  => '--padding',
 						'value'     => 'padding',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && is_array( $attrs['padding'] );
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return CSS_Utility::render_box( $value );
 						},
 					),
 					array(
 						'property'  => '--padding-tablet',
 						'value'     => 'paddingTablet',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingTablet'] ) && is_array( $attrs['paddingTablet'] );
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return CSS_Utility::render_box( $value );
 						},
 					),
 					array(
 						'property'  => '--padding-mobile',
 						'value'     => 'paddingMobile',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['paddingMobile'] ) && is_array( $attrs['paddingMobile'] );
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return CSS_Utility::render_box( $value );
 						},
 					),
 					array(
 						'property'  => '--margin',
 						'value'     => 'margin',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['margin'] ) && is_array( $attrs['margin'] );
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property'  => '--margin-tablet',
 						'value'     => 'marginTablet',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginTablet'] ) && is_array( $attrs['marginTablet'] );
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property'  => '--margin-mobile',
 						'value'     => 'marginMobile',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['marginMobile'] ) && is_array( $attrs['marginMobile'] );
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),

--- a/inc/css/blocks/class-button-css.php
+++ b/inc/css/blocks/class-button-css.php
@@ -41,21 +41,21 @@ class Button_CSS extends Base_CSS {
 					array(
 						'property'  => 'display',
 						'default'   => 'inline-flex',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['library'] ) && 'themeisle-icons' === $attrs['library'];
 						},
 					),
 					array(
 						'property'  => 'align-items',
 						'default'   => 'center',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['library'] ) && 'themeisle-icons' === $attrs['library'];
 						},
 					),
 					array(
 						'property'  => 'justify-content',
 						'default'   => 'center',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['library'] ) && 'themeisle-icons' === $attrs['library'];
 						},
 					),
@@ -63,7 +63,7 @@ class Button_CSS extends Base_CSS {
 						'property'  => 'border-width',
 						'value'     => 'borderSize',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderSize'] ) && is_numeric( $attrs['borderSize'] );
 						},
 						'hasSync'   => 'gr-btn-border-width',
@@ -71,7 +71,7 @@ class Button_CSS extends Base_CSS {
 					array(
 						'property'  => 'border-width',
 						'value'     => 'borderSize',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -82,7 +82,7 @@ class Button_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderSize'] ) && is_array( $attrs['borderSize'] );
 						},
 						'hasSync'   => 'gr-btn-border-size',
@@ -91,7 +91,7 @@ class Button_CSS extends Base_CSS {
 						'property'  => 'border-style',
 						'default'   => 'solid',
 						'hasSync'   => 'gr-btn-border-style',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['border'] ) && ! empty( $attrs['border'] );
 						},
 					),
@@ -99,7 +99,7 @@ class Button_CSS extends Base_CSS {
 						'property'  => 'border-radius',
 						'value'     => 'borderRadius',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderRadius'] ) && is_numeric( $attrs['borderRadius'] );
 						},
 						'hasSync'   => 'gr-btn-border-radius',
@@ -107,7 +107,7 @@ class Button_CSS extends Base_CSS {
 					array(
 						'property'  => 'border-radius',
 						'value'     => 'borderRadius',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -118,7 +118,7 @@ class Button_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderRadius'] ) && is_array( $attrs['borderRadius'] );
 						},
 						'hasSync'   => 'gr-btn-border-radius',
@@ -178,13 +178,13 @@ class Button_CSS extends Base_CSS {
 							'color'      => array(
 								'value'   => 'boxShadowColor',
 								'default' => '#000',
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									$opacity = ( isset( $attrs['boxShadowColorOpacity'] ) ? $attrs['boxShadowColorOpacity'] : 50 ) / 100;
 									return Base_CSS::hex2rgba( $value, $opacity );
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow'];
 						},
 						'hasSync'        => 'gr-btn-shadow',
@@ -244,13 +244,13 @@ class Button_CSS extends Base_CSS {
 							'color'      => array(
 								'value'   => 'hoverBoxShadowColor',
 								'default' => '#000',
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									$opacity = ( isset( $attrs['hoverBoxShadowColorOpacity'] ) ? $attrs['hoverBoxShadowColorOpacity'] : 50 ) / 100;
 									return Base_CSS::hex2rgba( $value, $opacity );
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow'];
 						},
 						'hasSync'        => 'gr-btn-shadow-hover',
@@ -311,14 +311,14 @@ class Button_CSS extends Base_CSS {
 						'property'  => '--gr-btn-border-size',
 						'value'     => 'borderSize',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderSize'] ) && is_numeric( $attrs['borderSize'] );
 						},
 					),
 					array(
 						'property'  => '--gr-btn-border-size',
 						'value'     => 'borderSize',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -329,21 +329,21 @@ class Button_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderSize'] ) && is_array( $attrs['borderSize'] );
 						},
 					),
 					array(
 						'property'  => '--gr-btn-border-color',
 						'value'     => 'border',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['border'] ) && ! empty( $attrs['border'] );
 						},
 					),
 					array(
 						'property'  => '--gr-btn-border-style',
 						'default'   => 'solid',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['border'] ) && ! empty( $attrs['border'] );
 						},
 					),
@@ -351,14 +351,14 @@ class Button_CSS extends Base_CSS {
 						'property'  => '--gr-btn-border-radius',
 						'value'     => 'borderRadius',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderRadius'] ) && is_numeric( $attrs['borderRadius'] );
 						},
 					),
 					array(
 						'property'  => '--gr-btn-border-radius',
 						'value'     => 'borderRadius',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -369,7 +369,7 @@ class Button_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderRadius'] ) && is_array( $attrs['borderRadius'] );
 						},
 					),
@@ -400,13 +400,13 @@ class Button_CSS extends Base_CSS {
 							'color'      => array(
 								'value'   => 'boxShadowColor',
 								'default' => '#000',
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									$opacity = ( isset( $attrs['boxShadowColorOpacity'] ) ? $attrs['boxShadowColorOpacity'] : 50 ) / 100;
 									return Base_CSS::hex2rgba( $value, $opacity );
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow'];
 						},
 					),
@@ -461,13 +461,13 @@ class Button_CSS extends Base_CSS {
 							'color'      => array(
 								'value'   => 'hoverBoxShadowColor',
 								'default' => '#000',
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									$opacity = ( isset( $attrs['hoverBoxShadowColorOpacity'] ) ? $attrs['hoverBoxShadowColorOpacity'] : 50 ) / 100;
 									return Base_CSS::hex2rgba( $value, $opacity );
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow'];
 						},
 					),

--- a/inc/css/blocks/class-button-group-css.php
+++ b/inc/css/blocks/class-button-group-css.php
@@ -44,7 +44,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--spacing',
 						'value'    => 'spacing',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'gr-btn-spacing',
@@ -52,7 +52,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--font-size',
 						'value'    => 'fontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'gr-btn-font-size',
@@ -60,7 +60,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--padding-tablet',
 						'value'    => 'paddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -76,7 +76,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--padding-mobile',
 						'value'    => 'paddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -100,7 +100,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => 'padding-top',
 						'value'    => 'paddingTopBottom',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'gr-btn-padding-vertical',
@@ -108,7 +108,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => 'padding-bottom',
 						'value'    => 'paddingTopBottom',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'gr-btn-padding-vertical',
@@ -116,7 +116,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => 'padding-left',
 						'value'    => 'paddingLeftRight',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'gr-btn-padding-horizontal',
@@ -124,7 +124,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => 'padding-right',
 						'value'    => 'paddingLeftRight',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'gr-btn-padding-horizontal',
@@ -137,7 +137,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => 'font-weight',
 						'value'    => 'fontVariant',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return 'regular' === $value ? 'normal' : $value;
 						},
 						'hasSync'  => 'gr-btn-font-variant',
@@ -156,7 +156,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => 'line-height',
 						'value'    => 'lineHeight',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return ! is_string( $value ) && is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'gr-btn-font-height',
@@ -172,7 +172,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => 'width',
 						'value'    => 'fontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'gr-btn-font-size',
@@ -220,21 +220,21 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--gr-btn-spacing',
 						'value'    => 'spacing',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--gr-btn-font-size',
 						'value'    => 'fontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--gr-btn-padding-tablet',
 						'value'    => 'paddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -249,7 +249,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--gr-btn-padding-mobile',
 						'value'    => 'paddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -272,14 +272,14 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--gr-btn-padding-vertical',
 						'value'    => 'paddingTopBottom',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--gr-btn-padding-horizontal',
 						'value'    => 'paddingLeftRight',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
@@ -290,7 +290,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--gr-btn-font-variant',
 						'value'    => 'fontVariant',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return 'regular' === $value ? 'normal' : $value;
 						},
 					),
@@ -306,7 +306,7 @@ class Button_Group_CSS extends Base_CSS {
 					array(
 						'property' => '--gr-btn-font-height',
 						'value'    => 'lineHeight',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),

--- a/inc/css/blocks/class-circle-counter-css.php
+++ b/inc/css/blocks/class-circle-counter-css.php
@@ -63,7 +63,7 @@ class Circle_Counter_CSS extends Base_CSS {
 					array(
 						'property' => '--background-color',
 						'value'    => 'backgroundColor',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							$percentage = isset( $attrs['percentage'] ) ? $attrs['percentage'] : 50;
 
 							if ( 50 > $percentage ) {
@@ -76,7 +76,7 @@ class Circle_Counter_CSS extends Base_CSS {
 					array(
 						'property' => '--progress-color',
 						'value'    => 'progressColor',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							$percentage = isset( $attrs['percentage'] ) ? $attrs['percentage'] : 50;
 
 							if ( 50 > $percentage ) {
@@ -101,7 +101,7 @@ class Circle_Counter_CSS extends Base_CSS {
 						'property' => '--percentage-start',
 						'value'    => 'percentage',
 						'default'  => 50,
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							if ( 50 > $value ) {
 								return 'rotate( ' . ( $this->degree( $value ) + 180 ) . 'deg )';
 							}
@@ -113,7 +113,7 @@ class Circle_Counter_CSS extends Base_CSS {
 						'property' => '--percentage-end',
 						'value'    => 'percentage',
 						'default'  => 50,
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							if ( 50 > $value ) {
 								return 'rotate( 360deg )';
 							}

--- a/inc/css/blocks/class-core-image-plugin-css.php
+++ b/inc/css/blocks/class-core-image-plugin-css.php
@@ -80,13 +80,13 @@ class Core_Image_Plugin_CSS extends Base_CSS {
 							'color'      => array(
 								'value'   => 'boxShadowColor',
 								'default' => '#000',
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									$opacity = ( isset( $attrs['boxShadowColorOpacity'] ) ? $attrs['boxShadowColorOpacity'] : 50 );
 									return ( strpos( $value, '#' ) !== false && $opacity < 100 ) ? Base_CSS::hex2rgba( $value, $opacity / 100 ) : $value;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] );
 						},
 					),

--- a/inc/css/blocks/class-countdown-css.php
+++ b/inc/css/blocks/class-countdown-css.php
@@ -42,7 +42,7 @@ class Countdown_CSS extends Base_CSS {
 						'value'     => 'borderRadius',
 						'unit'      => '%',
 						'default'   => 0,
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ( ! isset( $attrs['borderRadiusBox'] ) ) && ! ( isset( $attrs['borderRadiusType'] ) && 'unlinked' === $attrs['borderRadiusType'] ) && isset( $attrs['borderRadius'] ) && is_numeric( $attrs['borderRadius'] );
 						},
 					),
@@ -71,7 +71,7 @@ class Countdown_CSS extends Base_CSS {
 								'default' => 0,
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return ( ! isset( $attrs['borderRadiusBox'] ) ) && isset( $attrs['borderRadiusType'] ) && 'unlinked' === $attrs['borderRadiusType'] && isset( $attrs['borderRadius'] ) && is_numeric( $attrs['borderRadius'] );
 						},
 					),
@@ -90,7 +90,7 @@ class Countdown_CSS extends Base_CSS {
 					array(
 						'property' => '--border-radius',
 						'value'    => 'borderRadiusBox',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -166,42 +166,42 @@ class Countdown_CSS extends Base_CSS {
 					array(
 						'property' => '--value-font-size',
 						'value'    => 'valueFontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--value-font-size-tablet',
 						'value'    => 'valueFontSizeTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--value-font-size-mobile',
 						'value'    => 'valueFontSizeMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--label-font-size',
 						'value'    => 'labelFontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--label-font-size-tablet',
 						'value'    => 'labelFontSizeTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--label-font-size-mobile',
 						'value'    => 'labelFontSizeMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
@@ -216,7 +216,7 @@ class Countdown_CSS extends Base_CSS {
 					array(
 						'property' => '--padding',
 						'value'    => 'padding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -231,7 +231,7 @@ class Countdown_CSS extends Base_CSS {
 					array(
 						'property' => '--padding-tablet',
 						'value'    => 'paddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -246,7 +246,7 @@ class Countdown_CSS extends Base_CSS {
 					array(
 						'property' => '--padding-mobile',
 						'value'    => 'paddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -261,10 +261,10 @@ class Countdown_CSS extends Base_CSS {
 					array(
 						'property'  => 'display',
 						'value'     => 'exclude',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return 'none';
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['exclude'] ) && is_array( $attrs['exclude'] ) && 4 === count( $attrs['exclude'] );
 						}, 
 					),
@@ -315,7 +315,7 @@ class Countdown_CSS extends Base_CSS {
 					array(
 						'property'  => 'display',
 						'default'   => 'none',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['separatorAlignment'] ) && 'center' === $attrs['separatorAlignment'];
 						},
 					),

--- a/inc/css/blocks/class-flip-css.php
+++ b/inc/css/blocks/class-flip-css.php
@@ -47,14 +47,14 @@ class Flip_CSS extends Base_CSS {
 						'property'  => '--width',
 						'value'     => 'width',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['width'] ) && is_numeric( $attrs['width'] );
 						},
 					),
 					array(
 						'property'  => '--width',
 						'value'     => 'width',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['width'] ) && is_string( $attrs['width'] );
 						},
 					),
@@ -72,14 +72,14 @@ class Flip_CSS extends Base_CSS {
 						'property'  => '--height',
 						'value'     => 'height',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['height'] ) && is_numeric( $attrs['height'] );
 						},
 					),
 					array(
 						'property'  => '--height',
 						'value'     => 'height',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['height'] ) && is_string( $attrs['height'] );
 						},
 					),
@@ -101,17 +101,17 @@ class Flip_CSS extends Base_CSS {
 						'property'  => '--border-width',
 						'value'     => 'borderWidth',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderWidth'] ) && is_numeric( $attrs['borderWidth'] );
 						},
 					),
 					array(
 						'property'  => '--border-width',
 						'value'     => 'borderWidth',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderWidth'] ) && is_array( $attrs['borderWidth'] );
 						},
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values( $value, CSS_Utility::make_box( '3px' ) );
 						},
 					),
@@ -119,31 +119,31 @@ class Flip_CSS extends Base_CSS {
 						'property'  => '--border-radius',
 						'value'     => 'borderRadius',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderRadius'] ) && is_numeric( $attrs['borderRadius'] );
 						},
 					),
 					array(
 						'property'  => '--border-radius',
 						'value'     => 'borderRadius',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderRadius'] ) && is_array( $attrs['borderRadius'] );
 						},
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values( $value, CSS_Utility::make_box( '10px' ) );
 						},
 					),
 					array(
 						'property'  => '--front-background',
 						'value'     => 'frontBackgroundColor',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ! isset( $attrs['frontBackgroundType'] );
 						},
 					),
 					array(
 						'property'  => '--front-background',
 						'value'     => 'frontBackgroundGradient',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['frontBackgroundType'] ) && 'gradient' === $attrs['frontBackgroundType'];
 						},
 					),
@@ -153,7 +153,7 @@ class Flip_CSS extends Base_CSS {
 						'pattern_values' => array(
 							'imageURL'   => array(
 								'value'  => 'frontBackgroundImage',
-								'format' => function( $value, $attrs ) {
+								'format' => function ( $value, $attrs ) {
 									return apply_filters( 'otter_apply_dynamic_image', $value['url'] );
 								},
 							),
@@ -171,7 +171,7 @@ class Flip_CSS extends Base_CSS {
 									'x' => 0.5,
 									'y' => 0.5,
 								),
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									if ( isset( $value['x'] ) && isset( $value['y'] ) ) {
 										return ( $value['x'] * 100 ) . '% ' . ( $value['y'] * 100 ) . '%';
 									}
@@ -183,7 +183,7 @@ class Flip_CSS extends Base_CSS {
 								'default' => 'auto',
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['frontBackgroundType'] ) && 'image' === $attrs['frontBackgroundType'] && isset( $attrs['frontBackgroundImage'] ) && isset( $attrs['frontBackgroundImage']['url'] );
 						},
 					),
@@ -198,14 +198,14 @@ class Flip_CSS extends Base_CSS {
 					array(
 						'property'  => '--back-background',
 						'value'     => 'backBackgroundColor',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ! isset( $attrs['backBackgroundType'] );
 						},
 					),
 					array(
 						'property'  => '--back-background',
 						'value'     => 'backBackgroundGradient',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['backBackgroundType'] ) && 'gradient' === $attrs['backBackgroundType'];
 						},
 					),
@@ -215,7 +215,7 @@ class Flip_CSS extends Base_CSS {
 						'pattern_values' => array(
 							'imageURL'   => array(
 								'value'  => 'backBackgroundImage',
-								'format' => function( $value, $attrs ) {
+								'format' => function ( $value, $attrs ) {
 									return apply_filters( 'otter_apply_dynamic_image', $value['url'] );
 								},
 							),
@@ -233,7 +233,7 @@ class Flip_CSS extends Base_CSS {
 									'x' => 0.5,
 									'y' => 0.5,
 								),
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									if ( isset( $value['x'] ) && isset( $value['y'] ) ) {
 										return ( $value['x'] * 100 ) . '% ' . ( $value['y'] * 100 ) . '%';
 									}
@@ -245,7 +245,7 @@ class Flip_CSS extends Base_CSS {
 								'default' => 'auto',
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['backBackgroundType'] ) && 'image' === $attrs['backBackgroundType'] && isset( $attrs['backBackgroundImage'] ) && isset( $attrs['backBackgroundImage']['url'] );
 						},
 					),
@@ -257,24 +257,24 @@ class Flip_CSS extends Base_CSS {
 						'property'  => '--padding',
 						'value'     => 'padding',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && is_numeric( $attrs['padding'] );
 						},
 					),
 					array(
 						'property'  => '--padding',
 						'value'     => 'padding',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['padding'] ) && is_array( $attrs['padding'] );
 						},
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values( $value, CSS_Utility::make_box( '20px' ) );
 						},
 					),
 					array(
 						'property' => '--padding',
 						'value'    => 'paddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::render_box(
 								CSS_Utility::merge_views(
 									CSS_Utility::make_box( '20px' ),
@@ -288,7 +288,7 @@ class Flip_CSS extends Base_CSS {
 					array(
 						'property' => '--padding',
 						'value'    => 'paddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::render_box(
 								CSS_Utility::merge_views(
 									CSS_Utility::make_box( '20px' ),
@@ -322,13 +322,13 @@ class Flip_CSS extends Base_CSS {
 							'color'      => array(
 								'value'   => 'boxShadowColor',
 								'default' => '#000',
-								'format'  => function( $value, $attrs ) {
+								'format'  => function ( $value, $attrs ) {
 									$opacity = ( isset( $attrs['boxShadowColorOpacity'] ) ? $attrs['boxShadowColorOpacity'] : 50 );
 									return ( strpos( $value, '#' ) !== false && $opacity < 100 ) ? Base_CSS::hex2rgba( $value, $opacity / 100 ) : $value;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] );
 						},
 					),
@@ -336,7 +336,7 @@ class Flip_CSS extends Base_CSS {
 						'property'  => '--front-media-width',
 						'value'     => 'frontMediaWidth',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['--front-media-width'] ) && is_numeric( $attrs['--front-media-width'] );
 						},
 					),
@@ -344,21 +344,21 @@ class Flip_CSS extends Base_CSS {
 						'property'  => '--front-media-height',
 						'value'     => 'frontMediaHeight',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['--front-media-height'] ) && is_numeric( $attrs['--front-media-height'] );
 						},
 					),
 					array(
 						'property'  => '--front-media-width',
 						'value'     => 'frontMediaWidth',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['frontMediaWidth'] ) && is_string( $attrs['frontMediaWidth'] );
 						},
 					),
 					array(
 						'property'  => '--front-media-height',
 						'value'     => 'frontMediaHeight',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['frontMediaHeight'] ) && is_string( $attrs['frontMediaHeight'] );
 						},
 					),
@@ -377,7 +377,7 @@ class Flip_CSS extends Base_CSS {
 					array(
 						'property' => 'font-size',
 						'value'    => 'titleFontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
@@ -396,7 +396,7 @@ class Flip_CSS extends Base_CSS {
 					array(
 						'property' => 'font-size',
 						'value'    => 'descriptionFontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),

--- a/inc/css/blocks/class-font-awesome-icons-css.php
+++ b/inc/css/blocks/class-font-awesome-icons-css.php
@@ -46,40 +46,40 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property'  => '--align',
 						'value'     => 'align',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['align'] ) && is_string( $attrs['align'] );
 						},
-						'format'    => function( $value, $attrs ) use ( $align_map ) {
+						'format'    => function ( $value, $attrs ) use ( $align_map ) {
 							return $align_map[ $value ];
 						},
 					),
 					array(
 						'property'  => '--align',
 						'value'     => 'align',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['align'] ) && isset( $attrs['align']['desktop'] );
 						},
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['desktop'];
 						},
 					),
 					array(
 						'property'  => '--align-tablet',
 						'value'     => 'align',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['align'] ) && isset( $attrs['align']['tablet'] );
 						},
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['tablet'];
 						},
 					),
 					array(
 						'property'  => '--align-mobile',
 						'value'     => 'align',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['align'] ) && isset( $attrs['align']['mobile'] );
 						},
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return $value['mobile'];
 						},
 					),
@@ -100,7 +100,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property' => '--margin',
 						'value'    => 'margin',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							if ( is_numeric( $value ) ) {
 								return $value . 'px';
 							}
@@ -120,7 +120,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property' => '--padding',
 						'value'    => 'padding',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							if ( is_numeric( $value ) ) {
 								return $value . 'px';
 							}
@@ -140,7 +140,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property' => '--font-size',
 						'value'    => 'fontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 						'hasSync'  => 'icon-font-size',
@@ -174,7 +174,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property'  => 'color',
 						'value'     => 'textColorHover',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ! ( isset( $attrs['library'] ) && 'themeisle-icons' === $this->get_attr_value( $attrs['library'], 'fontawesome' ) );
 						},
 						'hasSync'   => 'icon-text-color-hover',
@@ -200,7 +200,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property'  => 'color',
 						'value'     => 'textColor',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ! ( isset( $attrs['library'] ) && 'themeisle-icons' === $this->get_attr_value( $attrs['library'], 'fontawesome' ) );
 						},
 						'hasSync'   => 'icon-text-color',
@@ -216,7 +216,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property'  => 'fill',
 						'value'     => 'textColor',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['library'] ) && 'themeisle-icons' === $this->get_attr_value( $attrs['library'], 'fontawesome' );
 						},
 						'hasSync'   => 'icon-text-color',
@@ -232,7 +232,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property'  => 'fill',
 						'value'     => 'textColorHover',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['library'] ) && 'themeisle-icons' === $this->get_attr_value( $attrs['library'], 'fontawesome' );
 						},
 						'hasSync'   => 'icon-text-color-hover',
@@ -280,7 +280,7 @@ class Font_Awesome_Icons_CSS extends Base_CSS {
 					array(
 						'property' => '--icon-font-size',
 						'value'    => 'fontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),

--- a/inc/css/blocks/class-form-css.php
+++ b/inc/css/blocks/class-form-css.php
@@ -44,7 +44,7 @@ class Form_CSS extends Base_CSS {
 						'property'  => '--border-radius',
 						'value'     => 'inputBorderRadius',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputBorderRadius'] ) && is_numeric( $attrs['inputBorderRadius'] );
 						},
 						'hasSync'   => 'form-border-radius',
@@ -52,7 +52,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property'  => '--border-radius',
 						'value'     => 'inputBorderRadius',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -63,7 +63,7 @@ class Form_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputBorderRadius'] ) && is_array( $attrs['inputBorderRadius'] );
 						},
 						'hasSync'   => 'form-border-radius',
@@ -77,7 +77,7 @@ class Form_CSS extends Base_CSS {
 						'property'  => '--border-width',
 						'value'     => 'inputBorderWidth',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputBorderWidth'] ) && is_numeric( $attrs['inputBorderWidth'] );
 						},
 						'hasSync'   => 'form-border-width',
@@ -85,7 +85,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property'  => '--border-width',
 						'value'     => 'inputBorderWidth',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -96,7 +96,7 @@ class Form_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputBorderWidth'] ) && is_array( $attrs['inputBorderWidth'] );
 						},
 						'hasSync'   => 'form-border-width',
@@ -105,7 +105,7 @@ class Form_CSS extends Base_CSS {
 						'property'  => '--padding',
 						'value'     => 'inputPadding',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputPadding'] ) && is_numeric( $attrs['inputPadding'] );
 						},
 						'hasSync'   => 'form-padding',
@@ -113,7 +113,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property'  => '--padding',
 						'value'     => 'inputPadding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -124,7 +124,7 @@ class Form_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputPadding'] ) && is_array( $attrs['inputPadding'] );
 						},
 						'hasSync'   => 'form-padding',
@@ -205,7 +205,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--padding-tablet',
 						'value'    => 'inputPaddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -221,7 +221,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--padding-mobile',
 						'value'    => 'inputPaddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -237,7 +237,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--btn-pad',
 						'value'    => 'buttonPadding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -253,7 +253,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--btn-pad-tablet',
 						'value'    => 'buttonPaddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -269,7 +269,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--btn-pad-mobile',
 						'value'    => 'buttonPaddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -362,14 +362,14 @@ class Form_CSS extends Base_CSS {
 						'property'  => '--form-border-radius',
 						'value'     => 'inputBorderRadius',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputBorderRadius'] ) && is_numeric( $attrs['inputBorderRadius'] );
 						},
 					),
 					array(
 						'property'  => '--form-border-radius',
 						'value'     => 'inputBorderRadius',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -380,7 +380,7 @@ class Form_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputBorderRadius'] ) && is_array( $attrs['inputBorderRadius'] );
 						},
 					),
@@ -392,14 +392,14 @@ class Form_CSS extends Base_CSS {
 						'property'  => '--form-border-width',
 						'value'     => 'inputBorderWidth',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputBorderWidth'] ) && is_numeric( $attrs['inputBorderWidth'] );
 						},
 					),
 					array(
 						'property'  => '--form-border-width',
 						'value'     => 'inputBorderWidth',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -410,7 +410,7 @@ class Form_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputBorderWidth'] ) && is_array( $attrs['inputBorderWidth'] );
 						},
 					),
@@ -418,14 +418,14 @@ class Form_CSS extends Base_CSS {
 						'property'  => '--form-padding',
 						'value'     => 'inputPadding',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputPadding'] ) && is_numeric( $attrs['inputPadding'] );
 						},
 					),
 					array(
 						'property'  => '--form-padding',
 						'value'     => 'inputPadding',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -436,7 +436,7 @@ class Form_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['inputPadding'] ) && is_array( $attrs['inputPadding'] );
 						},
 					),
@@ -502,7 +502,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--form-padding-tablet',
 						'value'    => 'paddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -517,7 +517,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--form-padding-mobile',
 						'value'    => 'paddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -532,7 +532,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--form-btn-pad',
 						'value'    => 'buttonPadding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -547,7 +547,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--form-btn-pad-tablet',
 						'value'    => 'buttonPaddingTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -562,7 +562,7 @@ class Form_CSS extends Base_CSS {
 					array(
 						'property' => '--form-btn-pad-mobile',
 						'value'    => 'buttonPaddingMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(

--- a/inc/css/blocks/class-form-input-css.php
+++ b/inc/css/blocks/class-form-input-css.php
@@ -53,5 +53,4 @@ class Form_Input_CSS extends Base_CSS {
 
 		return $style;
 	}
-
 }

--- a/inc/css/blocks/class-form-multiple-choice-css.php
+++ b/inc/css/blocks/class-form-multiple-choice-css.php
@@ -48,5 +48,4 @@ class Form_Multiple_Choice_CSS extends Base_CSS {
 
 		return $style;
 	}
-
 }

--- a/inc/css/blocks/class-form-textarea-css.php
+++ b/inc/css/blocks/class-form-textarea-css.php
@@ -52,5 +52,4 @@ class Form_Textarea_CSS extends Base_CSS {
 
 		return $style;
 	}
-
 }

--- a/inc/css/blocks/class-google-map-css.php
+++ b/inc/css/blocks/class-google-map-css.php
@@ -39,7 +39,7 @@ class Google_Map_CSS extends Base_CSS {
 					array(
 						'property' => '--height',
 						'value'    => 'height',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),

--- a/inc/css/blocks/class-icon-list-css.php
+++ b/inc/css/blocks/class-icon-list-css.php
@@ -53,14 +53,14 @@ class Icon_List_CSS extends Base_CSS {
 						'property'  => '--gap',
 						'value'     => 'gap',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['gap'] ) && is_numeric( $attrs['gap'] );
 						},
 					),
 					array(
 						'property'  => '--gap',
 						'value'     => 'gap',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['gap'] ) && is_string( $attrs['gap'] );
 						},
 					),
@@ -80,14 +80,14 @@ class Icon_List_CSS extends Base_CSS {
 						'property'  => '--font-size',
 						'value'     => 'defaultSize',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['defaultSize'] ) && is_numeric( $attrs['defaultSize'] );
 						},
 					),
 					array(
 						'property'  => '--font-size',
 						'value'     => 'defaultSize',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['defaultSize'] ) && is_string( $attrs['defaultSize'] );
 						},
 					),
@@ -98,7 +98,7 @@ class Icon_List_CSS extends Base_CSS {
 					array(
 						'property' => '--label-visibility',
 						'value'    => 'hideLabels',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return $value ? 'none' : '';
 						},
 					),
@@ -117,51 +117,51 @@ class Icon_List_CSS extends Base_CSS {
 					array(
 						'property' => '--divider-margin-left',
 						'value'    => 'horizontalAlign',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return 'auto';
 						},
 					),
 					array(
 						'property' => '--divider-margin-left-tablet',
 						'value'    => 'alignmentTablet',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return 'auto';
 						},
 					),
 					array(
 						'property' => '--divider-margin-left-mobile',
 						'value'    => 'alignmentMobile',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return 'auto';
 						},
 					),
 					array(
 						'property'  => '--divider-margin-right',
 						'value'     => 'horizontalAlign',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['horizontalAlign'] ) && 'flex-end' === $attrs['horizontalAlign'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '0';
 						},
 					),
 					array(
 						'property'  => '--divider-margin-right-tablet',
 						'value'     => 'alignmentTablet',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['alignmentTablet'] ) && 'flex-end' === $attrs['alignmentTablet'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '0';
 						},
 					),
 					array(
 						'property'  => '--divider-margin-right-mobile',
 						'value'     => 'alignmentMobile',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['alignmentMobile'] ) && 'flex-end' === $attrs['alignmentMobile'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '0';
 						},
 					),

--- a/inc/css/blocks/class-leaflet-map-css.php
+++ b/inc/css/blocks/class-leaflet-map-css.php
@@ -39,7 +39,7 @@ class Leaflet_Map_CSS extends Base_CSS {
 					array(
 						'property' => '--height',
 						'value'    => 'height',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 
 							// Check if the value is a number.
 							if ( is_numeric( $value ) ) {

--- a/inc/css/blocks/class-popup-css.php
+++ b/inc/css/blocks/class-popup-css.php
@@ -68,21 +68,21 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property' => '--overlay-opacity',
 						'value'    => 'overlayOpacity',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return $value / 100;
 						},
 					),
 					array(
 						'property' => '--brd-width',
 						'value'    => 'borderWidth',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property' => '--brd-radius',
 						'value'    => 'borderRadius',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
@@ -130,21 +130,21 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property' => '--padding',
 						'value'    => 'padding',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property' => '--padding-tablet',
 						'value'    => 'paddingTablet',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property' => '--padding-mobile',
 						'value'    => 'paddingMobile',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
@@ -159,50 +159,50 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property'  => 'top',
 						'value'     => 'verticalPosition',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['verticalPosition'] ) && 'top' === $attrs['verticalPosition'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '30px';
 						},
 					),
 					array(
 						'property'  => 'bottom',
 						'value'     => 'verticalPosition',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['verticalPosition'] ) && 'bottom' === $attrs['verticalPosition'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '30px';
 						},
 					),
 					array(
 						'property'  => 'right',
 						'value'     => 'horizontalPosition',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['horizontalPosition'] ) && 'right' === $attrs['horizontalPosition'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '30px';
 						},
 					),
 					array(
 						'property'  => 'left',
 						'value'     => 'horizontalPosition',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['horizontalPosition'] ) && 'left' === $attrs['horizontalPosition'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '30px';
 						},
 					),
 					array(
 						'property'  => 'top',
 						'value'     => 'verticalPositionTablet',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['verticalPositionTablet'] ) && 'top' === $attrs['verticalPositionTablet'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '15px';
 						},
 						'media'     => 'tablet',
@@ -210,10 +210,10 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property'  => 'bottom',
 						'value'     => 'verticalPositionTablet',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['verticalPositionTablet'] ) && 'bottom' === $attrs['verticalPositionTablet'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '15px';
 						},
 						'media'     => 'tablet',
@@ -221,10 +221,10 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property'  => 'right',
 						'value'     => 'horizontalPositionTablet',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['horizontalPositionTablet'] ) && 'right' === $attrs['horizontalPositionTablet'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '15px';
 						},
 						'media'     => 'tablet',
@@ -232,10 +232,10 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property'  => 'left',
 						'value'     => 'horizontalPositionTablet',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['horizontalPositionTablet'] ) && 'left' === $attrs['horizontalPositionTablet'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '15px';
 						},
 						'media'     => 'tablet',
@@ -243,10 +243,10 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property'  => 'top',
 						'value'     => 'verticalPositionMobile',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['verticalPositionMobile'] ) && 'top' === $attrs['verticalPositionMobile'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '10px';
 						},
 						'media'     => 'mobile',
@@ -254,10 +254,10 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property'  => 'bottom',
 						'value'     => 'verticalPositionMobile',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['verticalPositionMobile'] ) && 'bottom' === $attrs['verticalPositionMobile'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '10px';
 						},
 						'media'     => 'mobile',
@@ -265,10 +265,10 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property'  => 'right',
 						'value'     => 'horizontalPositionMobile',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['horizontalPositionMobile'] ) && 'right' === $attrs['horizontalPositionMobile'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '10px';
 						},
 						'media'     => 'mobile',
@@ -276,10 +276,10 @@ class Popup_CSS extends Base_CSS {
 					array(
 						'property'  => 'left',
 						'value'     => 'horizontalPositionMobile',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['horizontalPositionMobile'] ) && 'left' === $attrs['horizontalPositionMobile'];
 						},
-						'format'    => function( $value ) {
+						'format'    => function ( $value ) {
 							return '10px';
 						},
 						'media'     => 'mobile',
@@ -292,7 +292,7 @@ class Popup_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 0,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['horizontal'];
 								},
 							),
@@ -300,7 +300,7 @@ class Popup_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 0,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['vertical'];
 								},
 							),
@@ -308,7 +308,7 @@ class Popup_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 5,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['blur'];
 								},
 							),
@@ -316,21 +316,21 @@ class Popup_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 1,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['spread'];
 								},
 							),
 							'color'      => array(
 								'value'   => 'boxShadow',
 								'default' => '#000',
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									$opacity = $value['colorOpacity'];
 									$color   = isset( $value['color'] ) ? $value['color'] : '#000000';
 									return ( strpos( $color, '#' ) !== false && $opacity < 100 ) ? Base_CSS::hex2rgba( $color, $opacity / 100 ) : $color;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow']['active'];
 						},
 					),

--- a/inc/css/blocks/class-posts-css.php
+++ b/inc/css/blocks/class-posts-css.php
@@ -50,7 +50,7 @@ class Posts_CSS extends Base_CSS {
 					array(
 						'property' => '--vert-align',
 						'value'    => 'verticalAlign',
-						'format'   => function( $value, $attrs ) use ( $vertical_value_mapping ) {
+						'format'   => function ( $value, $attrs ) use ( $vertical_value_mapping ) {
 							return $vertical_value_mapping[ $value ];
 						},
 					),
@@ -73,42 +73,42 @@ class Posts_CSS extends Base_CSS {
 					array(
 						'property' => '--title-text-size',
 						'value'    => 'customTitleFontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--title-text-size-tablet',
 						'value'    => 'customTitleFontSizeTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--title-text-size-mobile',
 						'value'    => 'customTitleFontSizeMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--description-text-size',
 						'value'    => 'customDescriptionFontSize',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--description-text-size-tablet',
 						'value'    => 'customDescriptionFontSizeTablet',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
 					array(
 						'property' => '--description-text-size-mobile',
 						'value'    => 'customDescriptionFontSizeMobile',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
@@ -127,7 +127,7 @@ class Posts_CSS extends Base_CSS {
 					array(
 						'property' => '--img-width',
 						'value'    => 'imageWidth',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),
@@ -142,7 +142,7 @@ class Posts_CSS extends Base_CSS {
 					array(
 						'property' => '--img-border-radius',
 						'value'    => 'borderRadius',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							if ( is_numeric( $value ) ) {
 								return $value . 'px';
 							}
@@ -166,7 +166,7 @@ class Posts_CSS extends Base_CSS {
 								'value'   => 'imageBoxShadow',
 								'unit'    => 'px',
 								'default' => 0,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['horizontal'];
 								},
 							),
@@ -174,7 +174,7 @@ class Posts_CSS extends Base_CSS {
 								'value'   => 'imageBoxShadow',
 								'unit'    => 'px',
 								'default' => 0,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['vertical'];
 								},
 							),
@@ -182,7 +182,7 @@ class Posts_CSS extends Base_CSS {
 								'value'   => 'imageBoxShadow',
 								'unit'    => 'px',
 								'default' => 5,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['blur'];
 								},
 							),
@@ -190,21 +190,21 @@ class Posts_CSS extends Base_CSS {
 								'value'   => 'imageBoxShadow',
 								'unit'    => 'px',
 								'default' => 1,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['spread'];
 								},
 							),
 							'color'      => array(
 								'value'   => 'imageBoxShadow',
 								'default' => '#000',
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									$opacity = $value['colorOpacity'];
 									$color   = isset( $value['color'] ) ? $value['color'] : '#000000';
 									return ( strpos( $color, '#' ) !== false && $opacity < 100 ) ? Base_CSS::hex2rgba( $color, $opacity / 100 ) : $color;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['imageBoxShadow'] ) && true === $attrs['imageBoxShadow']['active'];
 						},
 					),
@@ -219,7 +219,7 @@ class Posts_CSS extends Base_CSS {
 					array(
 						'property' => '--border-radius',
 						'value'    => 'cardBorderRadius',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -239,7 +239,7 @@ class Posts_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 0,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['horizontal'];
 								},
 							),
@@ -247,7 +247,7 @@ class Posts_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 0,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['vertical'];
 								},
 							),
@@ -255,7 +255,7 @@ class Posts_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 5,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['blur'];
 								},
 							),
@@ -263,21 +263,21 @@ class Posts_CSS extends Base_CSS {
 								'value'   => 'boxShadow',
 								'unit'    => 'px',
 								'default' => 1,
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									return $value['spread'];
 								},
 							),
 							'color'      => array(
 								'value'   => 'boxShadow',
 								'default' => '#000',
-								'format'  => function( $value ) {
+								'format'  => function ( $value ) {
 									$opacity = $value['colorOpacity'];
 									$color   = isset( $value['color'] ) ? $value['color'] : '#000000';
 									return ( strpos( $color, '#' ) !== false && $opacity < 100 ) ? Base_CSS::hex2rgba( $color, $opacity / 100 ) : $color;
 								},
 							),
 						),
-						'condition'      => function( $attrs ) {
+						'condition'      => function ( $attrs ) {
 							return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow']['active'];
 						},
 					),
@@ -368,28 +368,28 @@ class Posts_CSS extends Base_CSS {
 					array(
 						'property' => '--pag-border-radius',
 						'value'    => 'pagBorderRadius',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property' => '--pag-border-width',
 						'value'    => 'pagBorderWidth',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property' => '--pag-padding',
 						'value'    => 'pagPadding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values( $value );
 						},
 					),
 					array(
 						'property' => '--pag-cont-margin',
 						'value'    => 'pagContMargin',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -412,14 +412,14 @@ class Posts_CSS extends Base_CSS {
 			);
 		
 			$properties = array_map(
-				function( $position, $css_variable ) {
+				function ( $position, $css_variable ) {
 					return array(
 						'property'  => $css_variable,
 						'value'     => 'cardBorderRadius',
-						'format'    => function( $value, $attrs ) use ( $position ) {
+						'format'    => function ( $value, $attrs ) use ( $position ) {
 							return $value[ $position ];
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							// @phpstan-ignore-next-line
 							return isset( $attrs['className'] ) && strpos( $attrs['className'], 'is-style-tiled' ) !== false;
 						},

--- a/inc/css/blocks/class-progress-bar-css.php
+++ b/inc/css/blocks/class-progress-bar-css.php
@@ -51,28 +51,28 @@ class Progress_Bar_CSS extends Base_CSS {
 					array(
 						'property'  => '--percentage-color',
 						'value'     => 'percentageColor',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return ! isset( $attrs['percentagePosition'] );
 						},
 					),
 					array(
 						'property'  => '--percentage-color-outer',
 						'value'     => 'percentageColor',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['percentagePosition'] ) && 'outer' === $attrs['percentagePosition'];
 						},
 					),
 					array(
 						'property'  => '--percentage-color-tooltip',
 						'value'     => 'percentageColor',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['percentagePosition'] ) && 'tooltip' === $attrs['percentagePosition'];
 						},
 					),
 					array(
 						'property'  => '--percentage-color-append',
 						'value'     => 'percentageColor',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['percentagePosition'] ) && 'append' === $attrs['percentagePosition'];
 						},
 					),

--- a/inc/css/blocks/class-review-css.php
+++ b/inc/css/blocks/class-review-css.php
@@ -61,10 +61,10 @@ class Review_CSS extends Base_CSS {
 					array(
 						'property'  => $item['prefix'] . $side,
 						'value'     => $key,
-						'format'    => function( $value, $attrs ) use ( $side ) {
+						'format'    => function ( $value, $attrs ) use ( $side ) {
 							return $value[ $side ];
 						},
-						'condition' => function( $attrs ) use ( $key, $side ) {
+						'condition' => function ( $attrs ) use ( $key, $side ) {
 							return isset( $attrs[ $key ] ) && isset( $attrs[ $key ][ $side ] );
 						},
 					)
@@ -138,7 +138,7 @@ class Review_CSS extends Base_CSS {
 									'value'   => 'boxShadow',
 									'unit'    => 'px',
 									'default' => 0,
-									'format'  => function( $value ) {
+									'format'  => function ( $value ) {
 										return $value['horizontal'];
 									},
 								),
@@ -146,7 +146,7 @@ class Review_CSS extends Base_CSS {
 									'value'   => 'boxShadow',
 									'unit'    => 'px',
 									'default' => 0,
-									'format'  => function( $value ) {
+									'format'  => function ( $value ) {
 										return $value['vertical'];
 									},
 								),
@@ -154,7 +154,7 @@ class Review_CSS extends Base_CSS {
 									'value'   => 'boxShadow',
 									'unit'    => 'px',
 									'default' => 5,
-									'format'  => function( $value ) {
+									'format'  => function ( $value ) {
 										return $value['blur'];
 									},
 								),
@@ -162,21 +162,21 @@ class Review_CSS extends Base_CSS {
 									'value'   => 'boxShadow',
 									'unit'    => 'px',
 									'default' => 1,
-									'format'  => function( $value ) {
+									'format'  => function ( $value ) {
 										return $value['spread'];
 									},
 								),
 								'color'      => array(
 									'value'   => 'boxShadow',
 									'default' => '#000',
-									'format'  => function( $value ) {
+									'format'  => function ( $value ) {
 										$opacity = $value['colorOpacity'];
 										$color   = isset( $value['color'] ) ? $value['color'] : '#000000';
 										return ( strpos( $color, '#' ) !== false && $opacity < 100 ) ? Base_CSS::hex2rgba( $color, $opacity / 100 ) : $color;
 									},
 								),
 							),
-							'condition'      => function( $attrs ) {
+							'condition'      => function ( $attrs ) {
 								return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow']['active'];
 							},
 						),

--- a/inc/css/blocks/class-shared-css.php
+++ b/inc/css/blocks/class-shared-css.php
@@ -34,7 +34,7 @@ class Shared_CSS {
 			array(
 				'property'  => '--background',
 				'value'     => 'backgroundColor',
-				'condition' => function( $attrs ) {
+				'condition' => function ( $attrs ) {
 					return ! ( isset( $attrs['backgroundType'] ) && 'color' !== $attrs['backgroundType'] );
 				},
 			),
@@ -45,7 +45,7 @@ class Shared_CSS {
 					'imageURL'   => array(
 						'value'   => 'backgroundImage',
 						'default' => 'none',
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							if ( isset( $attrs['backgroundImageURL'] ) ) {
 								return apply_filters( 'otter_apply_dynamic_image', $attrs['backgroundImageURL'] );
 							}
@@ -64,7 +64,7 @@ class Shared_CSS {
 					'position'   => array(
 						'value'   => 'backgroundPosition',
 						'default' => '50% 50%',
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							if ( is_array( $value ) && isset( $value['x'] ) ) {
 								return ( $value['x'] * 100 ) . '% ' . ( $value['y'] * 100 ) . '%';
 							}
@@ -77,7 +77,7 @@ class Shared_CSS {
 						'default' => 'auto',
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['backgroundType'] ) && 'image' === $attrs['backgroundType'] && ( isset( $attrs['backgroundImageURL'] ) && Base_CSS::is_image_url( $attrs['backgroundImageURL'] ) || isset( $attrs['backgroundImage'] ) && Base_CSS::is_image_url( $attrs['backgroundImage']['url'] ) );
 				},
 			),
@@ -85,7 +85,7 @@ class Shared_CSS {
 				'property'  => '--background',
 				'value'     => 'backgroundGradient',
 				'default'   => 'linear-gradient(90deg,rgba(54,209,220,1) 0%,rgba(91,134,229,1) 100%)',
-				'condition' => function( $attrs ) {
+				'condition' => function ( $attrs ) {
 					return isset( $attrs['backgroundType'] ) && 'gradient' === $attrs['backgroundType'] && isset( $attrs['backgroundGradient'] );
 				},
 			),
@@ -117,7 +117,7 @@ class Shared_CSS {
 						'default' => 100,
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['backgroundType'] ) && 'gradient' === $attrs['backgroundType'] && ! isset( $attrs['backgroundGradient'] );
 				},
 			),
@@ -148,14 +148,14 @@ class Shared_CSS {
 						'default' => 100,
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['backgroundType'] ) && 'gradient' === $attrs['backgroundType'] && isset( $attrs['backgroundGradientType'] ) && 'radial' === $attrs['backgroundGradientType'];
 				},
 			),
 			array(
 				'property'  => 'color',
 				'default'   => 'var( --text-color )',
-				'condition' => function( $attrs ) {
+				'condition' => function ( $attrs ) {
 					return isset( $attrs['color'] );
 				},
 			),
@@ -166,47 +166,47 @@ class Shared_CSS {
 					'top'    => array(
 						'value'   => 'border',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['top'] ) ? $value['top'] : 0;
 						},
 					),
 					'right'  => array(
 						'value'   => 'border',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['right'] ) ? $value['right'] : 0;
 						},
 					),
 					'bottom' => array(
 						'value'   => 'border',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['bottom'] ) ? $value['bottom'] : 0;
 						},
 					),
 					'left'   => array(
 						'value'   => 'border',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['left'] ) ? $value['left'] : 0;
 						},
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['border'] ) && is_array( $attrs['border'] );
 				},
 			),
 			array(
 				'property'  => 'border-style',
 				'default'   => 'solid',
-				'condition' => function( $attrs ) {
+				'condition' => function ( $attrs ) {
 					return isset( $attrs['border'] ) && is_array( $attrs['border'] );
 				},
 			),
 			array(
 				'property'  => 'border-color',
 				'value'     => 'borderColor',
-				'condition' => function( $attrs ) {
+				'condition' => function ( $attrs ) {
 					return isset( $attrs['border'] ) && is_array( $attrs['border'] );
 				},
 			),
@@ -217,33 +217,33 @@ class Shared_CSS {
 					'top-left'     => array(
 						'value'   => 'borderRadius',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['top'] ) ? $value['top'] : 0;
 						},
 					),
 					'top-right'    => array(
 						'value'   => 'borderRadius',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['right'] ) ? $value['right'] : 0;
 						},
 					),
 					'bottom-right' => array(
 						'value'   => 'borderRadius',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['bottom'] ) ? $value['bottom'] : 0;
 						},
 					),
 					'bottom-left'  => array(
 						'value'   => 'borderRadius',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['left'] ) ? $value['left'] : 0;
 						},
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['borderRadius'] ) && is_array( $attrs['borderRadius'] );
 				},
 			),
@@ -274,7 +274,7 @@ class Shared_CSS {
 					'color'      => array(
 						'value'   => 'boxShadowColor',
 						'default' => '#000',
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							if ( ! isset( $attrs['boxShadowColorOpacity'] ) ) {
 								return $value;
 							}
@@ -288,7 +288,7 @@ class Shared_CSS {
 						},
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['boxShadow'] ) && true === $attrs['boxShadow'];
 				},
 			),
@@ -305,7 +305,7 @@ class Shared_CSS {
 			array(
 				'property'  => 'background',
 				'value'     => 'backgroundOverlayColor',
-				'condition' => function( $attrs ) {
+				'condition' => function ( $attrs ) {
 					return ! ( isset( $attrs['backgroundOverlayType'] ) && 'color' !== $attrs['backgroundOverlayType'] );
 				},
 			),
@@ -313,7 +313,7 @@ class Shared_CSS {
 				'property' => 'opacity',
 				'value'    => 'backgroundOverlayOpacity',
 				'default'  => 50,
-				'format'   => function( $value, $attrs ) {
+				'format'   => function ( $value, $attrs ) {
 					return $value / 100;
 				},
 			),
@@ -324,7 +324,7 @@ class Shared_CSS {
 					'imageURL'   => array(
 						'value'   => 'backgroundOverlayImage',
 						'default' => 'none',
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							if ( isset( $attrs['backgroundOverlayImageURL'] ) ) {
 								return apply_filters( 'otter_apply_dynamic_image', $attrs['backgroundOverlayImageURL'] );
 							}
@@ -343,7 +343,7 @@ class Shared_CSS {
 					'position'   => array(
 						'value'   => 'backgroundOverlayPosition',
 						'default' => '50% 50%',
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							if ( is_array( $value ) && isset( $value['x'] ) ) {
 								return ( $value['x'] * 100 ) . '% ' . ( $value['y'] * 100 ) . '%';
 							}
@@ -356,7 +356,7 @@ class Shared_CSS {
 						'default' => 'auto',
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['backgroundOverlayType'] ) && 'image' === $attrs['backgroundOverlayType'] && ( isset( $attrs['backgroundOverlayImageURL'] ) && Base_CSS::is_image_url( $attrs['backgroundOverlayImageURL'] ) || isset( $attrs['backgroundOverlayImage'] ) && Base_CSS::is_image_url( $attrs['backgroundOverlayImage']['url'] ) );
 				},
 			),
@@ -364,7 +364,7 @@ class Shared_CSS {
 				'property'  => 'background',
 				'value'     => 'backgroundOverlayGradient',
 				'default'   => 'linear-gradient(90deg,rgba(54,209,220,1) 0%,rgba(91,134,229,1) 100%)',
-				'condition' => function( $attrs ) {
+				'condition' => function ( $attrs ) {
 					return isset( $attrs['backgroundOverlayType'] ) && 'gradient' === $attrs['backgroundOverlayType'] && isset( $attrs['backgroundOverlayGradient'] );
 				},
 			),
@@ -396,7 +396,7 @@ class Shared_CSS {
 						'default' => 100,
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['backgroundOverlayType'] ) && 'gradient' === $attrs['backgroundOverlayType'] && ! isset( $attrs['backgroundOverlayGradient'] );
 				},
 			),
@@ -427,7 +427,7 @@ class Shared_CSS {
 						'default' => 100,
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['backgroundOverlayType'] ) && 'gradient' === $attrs['backgroundOverlayType'] && isset( $attrs['backgroundOverlayGradientType'] ) && 'radial' === $attrs['backgroundOverlayGradientType'];
 				},
 			),
@@ -439,28 +439,28 @@ class Shared_CSS {
 						'value'   => 'backgroundOverlayFilterBlur',
 						'unit'    => 'px',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return $value / 10;
 						},
 					),
 					'filterBrightness' => array(
 						'value'   => 'backgroundOverlayFilterBrightness',
 						'default' => 10,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return $value / 10;
 						},
 					),
 					'filterContrast'   => array(
 						'value'   => 'backgroundOverlayFilterContrast',
 						'default' => 10,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return $value / 10;
 						},
 					),
 					'filterGrayscale'  => array(
 						'value'   => 'backgroundOverlayFilterGrayscale',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return $value / 100;
 						},
 					),
@@ -472,12 +472,12 @@ class Shared_CSS {
 					'filterSaturate'   => array(
 						'value'   => 'backgroundOverlayFilterSaturate',
 						'default' => 10,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return $value / 10;
 						},
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['backgroundOverlayFilterBlur'] );
 				},
 			),
@@ -493,33 +493,33 @@ class Shared_CSS {
 					'top-left'     => array(
 						'value'   => 'borderRadius',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['top'] ) ? $value['top'] : 0;
 						},
 					),
 					'top-right'    => array(
 						'value'   => 'borderRadius',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['right'] ) ? $value['right'] : 0;
 						},
 					),
 					'bottom-right' => array(
 						'value'   => 'borderRadius',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['bottom'] ) ? $value['bottom'] : 0;
 						},
 					),
 					'bottom-left'  => array(
 						'value'   => 'borderRadius',
 						'default' => 0,
-						'format'  => function( $value, $attrs ) {
+						'format'  => function ( $value, $attrs ) {
 							return isset( $value['left'] ) ? $value['left'] : 0;
 						},
 					),
 				),
-				'condition'      => function( $attrs ) {
+				'condition'      => function ( $attrs ) {
 					return isset( $attrs['borderRadius'] ) && is_array( $attrs['borderRadius'] );
 				},
 			),

--- a/inc/css/blocks/class-shared-css.php
+++ b/inc/css/blocks/class-shared-css.php
@@ -78,7 +78,10 @@ class Shared_CSS {
 					),
 				),
 				'condition'      => function ( $attrs ) {
-					return isset( $attrs['backgroundType'] ) && 'image' === $attrs['backgroundType'] && ( isset( $attrs['backgroundImageURL'] ) && Base_CSS::is_image_url( $attrs['backgroundImageURL'] ) || isset( $attrs['backgroundImage'] ) && Base_CSS::is_image_url( $attrs['backgroundImage']['url'] ) );
+					return isset( $attrs['backgroundType'] ) && 'image' === $attrs['backgroundType'] && (
+						( isset( $attrs['backgroundImageURL'] ) && Base_CSS::is_image_url( $attrs['backgroundImageURL'] ) ) ||
+						( isset( $attrs['backgroundImage'] ) && Base_CSS::is_image_url( $attrs['backgroundImage']['url'] ) )
+					);
 				},
 			),
 			array(
@@ -357,7 +360,10 @@ class Shared_CSS {
 					),
 				),
 				'condition'      => function ( $attrs ) {
-					return isset( $attrs['backgroundOverlayType'] ) && 'image' === $attrs['backgroundOverlayType'] && ( isset( $attrs['backgroundOverlayImageURL'] ) && Base_CSS::is_image_url( $attrs['backgroundOverlayImageURL'] ) || isset( $attrs['backgroundOverlayImage'] ) && Base_CSS::is_image_url( $attrs['backgroundOverlayImage']['url'] ) );
+					return isset( $attrs['backgroundOverlayType'] ) && 'image' === $attrs['backgroundOverlayType'] && (
+						( isset( $attrs['backgroundOverlayImageURL'] ) && Base_CSS::is_image_url( $attrs['backgroundOverlayImageURL'] ) ) ||
+						( isset( $attrs['backgroundOverlayImage'] ) && Base_CSS::is_image_url( $attrs['backgroundOverlayImage']['url'] ) )
+					);
 				},
 			),
 			array(

--- a/inc/css/blocks/class-sharing-icons-css.php
+++ b/inc/css/blocks/class-sharing-icons-css.php
@@ -42,20 +42,20 @@ class Sharing_Icons_CSS extends Base_CSS {
 						array(
 							'property'  => '--icon-bg-color',
 							'value'     => $icon,
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['backgroundColor'];
 							},
-							'condition' => function( $attrs ) use ( $icon ) {
+							'condition' => function ( $attrs ) use ( $icon ) {
 								return isset( $attrs[ $icon ]['backgroundColor'] );
 							},
 						),
 						array(
 							'property'  => '--text-color',
 							'value'     => $icon,
-							'format'    => function( $value, $attrs ) {
+							'format'    => function ( $value, $attrs ) {
 								return $value['textColor'];
 							},
-							'condition' => function( $attrs ) use ( $icon ) {
+							'condition' => function ( $attrs ) use ( $icon ) {
 								return isset( $attrs[ $icon ]['textColor'] );
 							},
 						),

--- a/inc/css/blocks/class-slider-css.php
+++ b/inc/css/blocks/class-slider-css.php
@@ -40,7 +40,7 @@ class Slider_CSS extends Base_CSS {
 					array(
 						'property' => '--height',
 						'value'    => 'height',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return is_numeric( $value ) ? $value . 'px' : $value;
 						},
 					),

--- a/inc/css/blocks/class-tabs-css.php
+++ b/inc/css/blocks/class-tabs-css.php
@@ -41,7 +41,7 @@ class Tabs_CSS extends Base_CSS {
 						'property'  => '--border-width',
 						'value'     => 'borderWidth',
 						'unit'      => 'px',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderWidth'] ) && is_numeric( $attrs['borderWidth'] );
 						},
 					),
@@ -92,7 +92,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--title-border-width',
 						'value'    => 'titleBorderWidth',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -108,7 +108,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property'  => '--border-width',
 						'value'     => 'borderWidth',
-						'format'    => function( $value, $attrs ) {
+						'format'    => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -119,7 +119,7 @@ class Tabs_CSS extends Base_CSS {
 								)
 							);
 						},
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderWidth'] ) && is_array( $attrs['borderWidth'] );
 						},
 						'hasSync'   => 'tabs-border-width',
@@ -127,7 +127,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--title-padding',
 						'value'    => 'titlePadding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -143,7 +143,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--content-padding',
 						'value'    => 'contentPadding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -159,7 +159,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--border-side-width',
 						'value'    => 'borderWidth',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 
 							if ( isset( $attrs['tabsPosition'] ) ) {
 								if ( 'left' === $attrs['tabsPosition'] ) {
@@ -261,7 +261,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--tabs-title-border-width',
 						'value'    => 'titleBorderWidth',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -276,7 +276,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--tabs-border-width',
 						'value'    => 'borderWidth',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -291,7 +291,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--tabs-title-padding',
 						'value'    => 'titlePadding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -306,7 +306,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--tabs-content-padding',
 						'value'    => 'contentPadding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -321,7 +321,7 @@ class Tabs_CSS extends Base_CSS {
 					array(
 						'property' => '--tabs-border-side-width',
 						'value'    => 'borderWidth',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 
 							if ( isset( $attrs['tabsPosition'] ) ) {
 								if ( 'left' === $attrs['tabsPosition'] ) {

--- a/inc/css/blocks/class-timeline-css.php
+++ b/inc/css/blocks/class-timeline-css.php
@@ -64,7 +64,7 @@ class Timeline_CSS extends Base_CSS {
 					array(
 						'property' => '--o-timeline-cnt-br-w',
 						'value'    => 'containerBorder',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -79,7 +79,7 @@ class Timeline_CSS extends Base_CSS {
 					array(
 						'property' => '--o-timeline-cnt-br-r',
 						'value'    => 'containerRadius',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -94,7 +94,7 @@ class Timeline_CSS extends Base_CSS {
 					array(
 						'property' => '--o-timeline-cnt-pd',
 						'value'    => 'containerPadding',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(

--- a/inc/css/blocks/class-timeline-item-css.php
+++ b/inc/css/blocks/class-timeline-item-css.php
@@ -52,7 +52,7 @@ class Timeline_Item_CSS extends Base_CSS {
 					array(
 						'property' => '--o-timeline-cnt-br-w',
 						'value'    => 'containerBorder',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(
@@ -67,7 +67,7 @@ class Timeline_Item_CSS extends Base_CSS {
 					array(
 						'property' => '--o-timeline-cnt-br-r',
 						'value'    => 'containerRadius',
-						'format'   => function( $value, $attrs ) {
+						'format'   => function ( $value, $attrs ) {
 							return CSS_Utility::box_values(
 								$value,
 								array(

--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -353,10 +353,8 @@ class CSS_Handler extends Base_CSS {
 
 		if ( count( self::$google_fonts ) > 0 ) {
 			update_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', self::$google_fonts );
-		} else {
-			if ( get_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', true ) ) {
+		} elseif ( get_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', true ) ) {
 				delete_post_meta( $post_id, '_themeisle_gutenberg_block_fonts' );
-			}
 		}
 
 		if ( self::is_writable() ) {
@@ -447,10 +445,8 @@ class CSS_Handler extends Base_CSS {
 
 		if ( count( self::$google_fonts ) > 0 ) {
 			update_option( 'themeisle_blocks_widgets_fonts', self::$google_fonts );
-		} else {
-			if ( get_option( 'themeisle_blocks_widgets_fonts' ) ) {
+		} elseif ( get_option( 'themeisle_blocks_widgets_fonts' ) ) {
 				delete_option( 'themeisle_blocks_widgets_fonts' );
-			}
 		}
 
 		$file_name     = 'widgets-' . time();

--- a/inc/css/class-css-utility.php
+++ b/inc/css/class-css-utility.php
@@ -180,7 +180,7 @@ class CSS_Utility {
 	public function filter_out_media_queries( $selector, $properties ) {
 		$query_items = array_filter(
 			$properties,
-			function( $ar ) {
+			function ( $ar ) {
 				return isset( $ar['media'] );
 			}
 		);
@@ -376,7 +376,7 @@ class CSS_Utility {
 
 		$valid = array_filter(
 			$views,
-			function( $view ) {
+			function ( $view ) {
 				return isset( $view ) && is_array( $view );
 			}
 		);

--- a/inc/integrations/api/form-request-data.php
+++ b/inc/integrations/api/form-request-data.php
@@ -290,14 +290,14 @@ class Form_Data_Request {
 	/**
 	 * Sanitize the given array.
 	 *
-	 * @param array|string $array The array with the values.
+	 * @param array|string $value The array with the values.
 	 * @return array|string
 	 * @since 2.0.3
 	 */
-	public static function sanitize_array_map_deep( $array ) {
+	public static function sanitize_array_map_deep( $value ) {
 		$new = array();
-		if ( is_array( $array ) ) {
-			foreach ( $array as $key => $val ) {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $val ) {
 				if ( is_array( $val ) ) {
 					$new[ $key ] = self::sanitize_array_map_deep( $val );
 				} else {
@@ -305,7 +305,7 @@ class Form_Data_Request {
 				}
 			}
 		} else {
-			$new = sanitize_text_field( $array );
+			$new = sanitize_text_field( $value );
 		}
 		return $new;
 	}

--- a/inc/integrations/class-form-providers.php
+++ b/inc/integrations/class-form-providers.php
@@ -77,7 +77,7 @@ class Form_Providers {
 	public function register_providers( $new_providers ) {
 		foreach ( $new_providers as $name => $handlers ) {
 			if ( array_key_exists( $name, $this->providers ) ) {
-				throw new Exception( 'Provider ' . $name . ' is already registered.' ); // phpcs:ignore Squiz.Commenting.FunctionComment.EmptyThrows
+				throw new Exception( 'Provider ' . esc_html( $name ) . ' is already registered.' ); // phpcs:ignore Squiz.Commenting.FunctionComment.EmptyThrows
 			}
 		}
 

--- a/inc/integrations/providers/class-mailchimp.php
+++ b/inc/integrations/providers/class-mailchimp.php
@@ -47,7 +47,6 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 	 * The default constructor.
 	 */
 	public function __construct() {
-
 	}
 
 	/**
@@ -99,7 +98,7 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 		} else {
 			$return['success'] = true;
 			$return['list_id'] = array_map(
-				function( $item ) {
+				function ( $item ) {
 					return array(
 						'id'   => $item['id'],
 						'name' => $item['name'],
@@ -165,12 +164,10 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 
 			if ( ! empty( $body['detail'] ) && strpos( $body['detail'], 'fake' ) !== false ) {
 				$form_data->set_error( Form_Data_Response::ERROR_PROVIDER_INVALID_EMAIL );
-			} else {
-				if ( $this->is_credential_error( $body['status'] ) ) {
+			} elseif ( $this->is_credential_error( $body['status'] ) ) {
 					$form_data->set_error( Form_Data_Response::ERROR_PROVIDER_CREDENTIAL_ERROR );
-				} else {
-					$form_data->set_error( Form_Data_Response::ERROR_PROVIDER_SUBSCRIBE_ERROR, $body['detail'] );
-				}
+			} else {
+				$form_data->set_error( Form_Data_Response::ERROR_PROVIDER_SUBSCRIBE_ERROR, $body['detail'] );
 			}
 		}
 
@@ -338,7 +335,7 @@ class Mailchimp_Integration implements FormSubscribeServiceInterface {
 
 		return array_filter(
 			$body['merge_fields'],
-			function( $item ) {
+			function ( $item ) {
 				return ! empty( $item['tag'] );
 			}
 		);

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -94,7 +94,7 @@ class Dashboard {
 			__( 'Blocks', 'otter-blocks' ),
 			'manage_options',
 			'otter-blocks-toggle',
-			function() {
+			function () {
 				echo '<p>Redirecting...</p>
 				<script>document.location.href = "/wp-admin/admin.php?page=otter#blocks";</script>';
 			}
@@ -130,7 +130,6 @@ class Dashboard {
 			}
 		</style>
 		<?php
-
 	}
 
 	/**
@@ -313,7 +312,7 @@ class Dashboard {
 			return;
 		}
 
-		if ( is_network_admin() || isset( $_GET['activate-multi'] ) ) { // phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected,WordPress.Security.NonceVerification.NoNonceVerification
+		if ( is_network_admin() || isset( $_GET['activate-multi'] ) ) { // phpcs:ignore WordPress.VIP.SuperGlobalInputUsage.AccessDetected,WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -549,7 +549,7 @@ class Dynamic_Content {
 			$format = esc_html( $data['dateCustom'] );
 		}
 
-		$date = date( $format );
+		$date = gmdate( $format );
 
 		return $date;
 	}
@@ -572,7 +572,7 @@ class Dynamic_Content {
 			$format = esc_html( $data['timeCustom'] );
 		}
 
-		$time = date( $format );
+		$time = gmdate( $format );
 
 		return $time;
 	}

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -213,7 +213,7 @@ class Dynamic_Content {
 
 		global $post;
 
-		$id = ( defined( 'REST_REQUEST' ) && REST_REQUEST || ( isset( $data['context'] ) && 'query' === $data['context'] ) ) ? $post->ID : get_queried_object_id();
+		$id = ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || ( isset( $data['context'] ) && 'query' === $data['context'] ) ) ? $post->ID : get_queried_object_id();
 
 		if ( isset( $data['context'] ) && ( 0 === $data['context'] || 'query' === $data['context'] || ( is_singular() && $data['context'] !== $id ) ) ) {
 			$data['context'] = $id;

--- a/inc/plugins/class-fse-onboarding.php
+++ b/inc/plugins/class-fse-onboarding.php
@@ -52,7 +52,7 @@ class FSE_Onboarding {
 			esc_html__( 'Theme Setup', 'otter-blocks' ),
 			'manage_options',
 			'otter-onboarding',
-			function() {
+			function () {
 				$redirect = add_query_arg(
 					array(
 						'onboarding' => 'true',

--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -306,7 +306,7 @@ class Options_Settings {
 			array(
 				'type'              => 'array',
 				'description'       => __( 'Email used in the Form block.', 'otter-blocks' ),
-				'sanitize_callback' => function ( $array ) {
+				'sanitize_callback' => function ( $email_settings ) {
 					return array_map(
 						function ( $item ) {
 							if ( isset( $item['form'] ) ) {
@@ -371,7 +371,7 @@ class Options_Settings {
 
 							return $item;
 						},
-						$array
+						$email_settings
 					);
 				},
 				'show_in_rest'      => array(
@@ -467,7 +467,7 @@ class Options_Settings {
 			array(
 				'type'              => 'array',
 				'description'       => __( 'Form Fields used in the Form block.', 'otter-blocks' ),
-				'sanitize_callback' => function ( $array ) {
+				'sanitize_callback' => function ( $fields ) {
 					return array_map(
 						function ( $item ) {
 							if ( isset( $item['fieldOptionName'] ) ) {
@@ -506,7 +506,7 @@ class Options_Settings {
 
 							return $item;
 						},
-						$array
+						$fields
 					);
 				},
 				'show_in_rest'      => array(
@@ -572,7 +572,7 @@ class Options_Settings {
 			array(
 				'type'              => 'object',
 				'description'       => __( 'Notifications Logs.', 'otter-blocks' ),
-				'sanitize_callback' => function ( $array ) {
+				'sanitize_callback' => function ( $notifications ) {
 					return array_map(
 						function ( $item ) {
 							if ( isset( $item['editor_upsell'] ) ) {
@@ -580,7 +580,7 @@ class Options_Settings {
 							}
 							return $item;
 						},
-						$array
+						$notifications
 					);
 				},
 				'show_in_rest'      => array(
@@ -605,7 +605,7 @@ class Options_Settings {
 			array(
 				'type'              => 'array',
 				'description'       => __( 'Otter Registered Webhooks.', 'otter-blocks' ),
-				'sanitize_callback' => function ( $array ) {
+				'sanitize_callback' => function ( $webhooks ) {
 					return array_map(
 						function ( $item ) {
 							if ( isset( $item['id'] ) ) {
@@ -630,7 +630,7 @@ class Options_Settings {
 							}
 							return $item;
 						},
-						$array
+						$webhooks
 					);
 				},
 				'show_in_rest'      => array(
@@ -740,8 +740,8 @@ class Options_Settings {
 			array(
 				'type'              => 'array',
 				'description'       => __( 'The disabled blocks that will no longer be shown in Inserter.', 'otter-blocks' ),
-				'sanitize_callback' => function( $array ) {
-					return array_map( 'sanitize_text_field', $array );
+				'sanitize_callback' => function ( $disabled_blocks ) {
+					return array_map( 'sanitize_text_field', $disabled_blocks );
 				},
 				'default'           => array(),
 				'show_in_rest'      => array(
@@ -772,9 +772,9 @@ class Options_Settings {
 			array(
 				'type'              => 'array',
 				'description'       => __( 'The prompt actions list of toolbar.', 'otter-blocks' ),
-				'sanitize_callback' => function( $array ) {
+				'sanitize_callback' => function ( $prompts ) {
 					return array_map(
-						function( $item ) {
+						function ( $item ) {
 							if ( isset( $item['title'] ) ) {
 								$item['title'] = sanitize_text_field( $item['title'] );
 							}
@@ -783,7 +783,7 @@ class Options_Settings {
 							}
 							return $item;
 						},
-						$array
+						$prompts
 					);
 				},
 				'default'           => array(
@@ -870,7 +870,7 @@ class Options_Settings {
 				'show_in_rest'  => true,
 				'single'        => true,
 				'type'          => 'boolean',
-				'auth_callback' => function() {
+				'auth_callback' => function () {
 					return current_user_can( 'edit_posts' );
 				},
 			)

--- a/inc/plugins/class-stripe-api.php
+++ b/inc/plugins/class-stripe-api.php
@@ -73,8 +73,8 @@ class Stripe_API {
 	 * @access public
 	 */
 	public function init() {
-		if ( isset( $_GET['stripe_session_id'] ) ) {// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-			$session_id = esc_attr( $_GET['stripe_session_id'] );// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( isset( $_GET['stripe_session_id'] ) ) {// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$session_id = esc_attr( $_GET['stripe_session_id'] );// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$session    = $this->create_request( 'get_session', $session_id );
 
 			if ( isset( $session['status'] ) && 'complete' === $session['status'] ) {
@@ -291,7 +291,7 @@ class Stripe_API {
 
 		$possible_values = array_filter(
 			$data,
-			function( $item ) use ( $product ) {
+			function ( $item ) use ( $product ) {
 				return $product === $item['product_id'];
 			}
 		);

--- a/inc/render/class-plugin-card-block.php
+++ b/inc/render/class-plugin-card-block.php
@@ -91,7 +91,6 @@ class Plugin_Card_Block {
 
 			return $markup;
 		}
-
 	}
 
 	/**

--- a/inc/render/class-review-block.php
+++ b/inc/render/class-review-block.php
@@ -43,7 +43,7 @@ class Review_Block {
 
 			add_action(
 				'wp_footer',
-				function() use ( $attributes, $post_id ) {
+				function () use ( $attributes, $post_id ) {
 					$added_schemas = &Review_Block::$added_schemas; // Reference the static property explicitly.
 
 					if ( ! isset( $added_schemas[ $post_id ] ) ) {
@@ -240,7 +240,7 @@ class Review_Block {
 
 		$rating = array_reduce(
 			$features,
-			function( $carry, $feature ) {
+			function ( $carry, $feature ) {
 				$carry += $feature['rating'];
 				return $carry;
 			},
@@ -323,7 +323,7 @@ class Review_Block {
 					'name'     => esc_html( $pro ),
 				);
 
-				$count++;
+				++$count;
 
 				array_push( $items, $item );
 			}
@@ -345,7 +345,7 @@ class Review_Block {
 					'name'     => esc_html( $con ),
 				);
 
-				$count++;
+				++$count;
 
 				array_push( $items, $item );
 			}

--- a/inc/render/class-stripe-checkout-block.php
+++ b/inc/render/class-stripe-checkout-block.php
@@ -50,14 +50,14 @@ class Stripe_Checkout_Block {
 	 * Watch for the checkout.
 	 */
 	public function watch_checkout() {
-		if ( ! isset( $_GET['action'] ) || 'buy_stripe' !== $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		if ( ! isset( $_GET['action'] ) || 'buy_stripe' !== $_GET['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 
-		$product_id = isset( $_GET['product_id'] ) ? sanitize_text_field( wp_unslash( $_GET['product_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-		$price_id   = isset( $_GET['price_id'] ) ? sanitize_text_field( wp_unslash( $_GET['price_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-		$url        = isset( $_GET['url'] ) ? sanitize_text_field( wp_unslash( $_GET['url'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-		$mode       = isset( $_GET['mode'] ) ? sanitize_text_field( wp_unslash( $_GET['mode'] ) ) : 'payment'; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		$product_id = isset( $_GET['product_id'] ) ? sanitize_text_field( wp_unslash( $_GET['product_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$price_id   = isset( $_GET['price_id'] ) ? sanitize_text_field( wp_unslash( $_GET['price_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$url        = isset( $_GET['url'] ) ? sanitize_text_field( wp_unslash( $_GET['url'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$mode       = isset( $_GET['mode'] ) ? sanitize_text_field( wp_unslash( $_GET['mode'] ) ) : 'payment'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( empty( $product_id ) || empty( $price_id ) || empty( $url ) ) {
 			return sprintf(
@@ -114,9 +114,9 @@ class Stripe_Checkout_Block {
 			return '';
 		}
 
-		if ( isset( $_GET['stripe_session_id'] ) ) {// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-			$session_id = esc_attr( $_GET['stripe_session_id'] );// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$status     = $this->stripe_api->get_status_for_price_id( $session_id, esc_attr( $attributes['price'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		if ( isset( $_GET['stripe_session_id'] ) ) {// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$session_id = esc_attr( $_GET['stripe_session_id'] );// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$status     = $this->stripe_api->get_status_for_price_id( $session_id, esc_attr( $attributes['price'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			if ( false !== $status ) {
 				if ( 'success' === $status ) {

--- a/inc/server/class-dynamic-content-server.php
+++ b/inc/server/class-dynamic-content-server.php
@@ -137,7 +137,7 @@ class Dynamic_Content_Server {
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => function( $request ) {
+					'callback'            => function ( $request ) {
 						return Dynamic_Content::instance()->apply_data( $request->get_params() );
 					},
 					'permission_callback' => function ( $request ) {

--- a/inc/server/class-form-server.php
+++ b/inc/server/class-form-server.php
@@ -202,12 +202,12 @@ class Form_Server {
 					},
 					'args'                => array(
 						'record_id' => array(
-							'validate_callback' => function( $param, $request, $key ) {
+							'validate_callback' => function ( $param, $request, $key ) {
 								return is_numeric( $param );
 							},
 						),
 						'session'   => array(
-							'validate_callback' => function( $param, $request, $key ) {
+							'validate_callback' => function ( $param, $request, $key ) {
 								return is_string( $param );
 							},
 						),

--- a/inc/server/class-prompt-server.php
+++ b/inc/server/class-prompt-server.php
@@ -396,7 +396,7 @@ class Prompt_Server {
 
 		foreach ( $usage['usage_count'] as &$u ) {
 			if ( isset( $u['key'] ) && $u['key'] === $action ) {
-				$u['value']++;
+				++$u['value'];
 				$is_missing = false;
 			}
 		}

--- a/otter-blocks.php
+++ b/otter-blocks.php
@@ -25,7 +25,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 define( 'OTTER_BLOCKS_BASEFILE', __FILE__ );
 define( 'OTTER_BLOCKS_URL', plugins_url( '/', __FILE__ ) );
-define( 'OTTER_BLOCKS_PATH', dirname( __FILE__ ) );
+define( 'OTTER_BLOCKS_PATH', __DIR__ );
 define( 'OTTER_BLOCKS_VERSION', '3.1.1' );
 define( 'OTTER_BLOCKS_PRO_SUPPORT', true );
 define( 'OTTER_BLOCKS_SHOW_NOTICES', false );
@@ -52,7 +52,7 @@ add_filter(
 
 add_filter(
 	'otter_blocks_welcome_metadata',
-	function() {
+	function () {
 		return [
 			'is_enabled' => ! defined( 'OTTER_PRO_VERSION' ),
 			'pro_name'   => __( 'Otter Blocks Pro', 'otter-blocks' ),
@@ -76,7 +76,7 @@ add_filter(
 
 add_action(
 	'plugin_action_links_' . plugin_basename( __FILE__ ),
-	function( $links ) {
+	function ( $links ) {
 		array_unshift(
 			$links,
 			sprintf( '<a href="%s">%s</a>', admin_url( 'admin.php?page=otter' ), __( 'Settings', 'otter-blocks' ) )
@@ -89,7 +89,7 @@ add_filter( 'themeisle_sdk_enable_telemetry', '__return_true' );
 
 add_filter(
 	'themeisle_sdk_telemetry_products',
-	function( $products ) {
+	function ( $products ) {
 		$already_registered = false;
 
 		$license    = apply_filters( 'product_otter_license_key', 'free' );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0"?>
 <ruleset name="">
     <description>ThemeIsle ruleset</description>
-    <rule ref="WordPress-VIP-Go" />
 
-    <rule ref="WordPress-Core" />
+    <rule ref="WordPress-Core">
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+        <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.Found" />
+        <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed" />
+    </rule>
 
     <rule ref="WordPress-Docs" />
 
@@ -12,6 +15,16 @@
         <exclude name="WordPress.Files.FileName" />
     </rule>
 
+    <rule ref="WordPress-VIP-Go">
+        <!-- Exclude deprecated JS sniffs -->
+        <exclude name="WordPressVIPMinimum.JS.Window" />
+        <exclude name="WordPressVIPMinimum.JS.DangerouslySetInnerHTML" />
+        <exclude name="WordPressVIPMinimum.JS.InnerHTML" />
+        <exclude name="WordPressVIPMinimum.JS.StrippingTags" />
+        <exclude name="WordPressVIPMinimum.JS.StringConcat" />
+        <exclude name="WordPressVIPMinimum.JS.HTMLExecutingFunctions" />
+        <exclude name="WordPressVIPMinimum.Security.Mustache.OutputNotation" />
+    </rule>
 
     <config name="testVersion" value="5.6-" />
 
@@ -27,7 +40,6 @@
             </property>
         </properties>
     </rule>
-
 
     <arg name="extensions" value="php" />
     <arg value="s" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,21 +2,7 @@
 <ruleset name="">
     <description>ThemeIsle ruleset</description>
 
-    <rule ref="WordPress-VIP-Go" />
-
-    <rule ref="WordPress-Core" />
-
-    <rule ref="WordPress-Docs" />
-
-    <rule ref="WordPress-Extra">
-        <!-- Forget about file names -->
-        <exclude name="WordPress.Files.FileName" />
-    </rule>
-
-
-    <config name="testVersion" value="5.6-" />
-
-    <rule ref="PHPCompatibility" />
+    <rule ref="WordPress" />
 
     <rule ref="WordPress.WP.I18n">
         <properties>
@@ -28,12 +14,17 @@
 
     <rule ref="WordPress.Utils.I18nTextDomainFixer">
         <properties>
-            <property name="old_text_domain"
-                value="blocks-animation,blocks-import-export,otter-pro,blocks-css" />
+            <property name="old_text_domain" type="array">
+                <element value="blocks-animation" />
+                <element value="blocks-import-export" />
+                <element value="otter-pro" />
+                <element value="blocks-css" />
+            </property>
             <property name="new_text_domain" value="otter-blocks" />
         </properties>
     </rule>
 
     <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>assets/*</exclude-pattern>
     <exclude-pattern>build/*</exclude-pattern>
 </ruleset>

--- a/plugins/blocks-animation/blocks-animation.php
+++ b/plugins/blocks-animation/blocks-animation.php
@@ -31,7 +31,7 @@ if ( defined( 'OTTER_BLOCKS_PATH' ) ) {
 }
 
 define( 'BLOCKS_ANIMATION_URL', plugins_url( '/', __FILE__ ) );
-define( 'BLOCKS_ANIMATION_PATH', dirname( __FILE__ ) );
+define( 'BLOCKS_ANIMATION_PATH', __DIR__ );
 define( 'BLOCKS_ANIMATION_PRODUCT_SLUG', basename( BLOCKS_ANIMATION_PATH ) );
 
 $vendor_file = BLOCKS_ANIMATION_PATH . '/vendor/autoload.php';
@@ -54,7 +54,7 @@ add_action(
 	function () {
 		// call this only if Gutenberg is active.
 		if ( function_exists( 'register_block_type' ) ) {
-			require_once dirname( __FILE__ ) . '/class-blocks-animation.php';
+			require_once __DIR__ . '/class-blocks-animation.php';
 
 			if ( class_exists( '\ThemeIsle\GutenbergBlocks\Blocks_Animation' ) ) {
 				\ThemeIsle\GutenbergBlocks\Blocks_Animation::instance();

--- a/plugins/blocks-css/blocks-css.php
+++ b/plugins/blocks-css/blocks-css.php
@@ -27,7 +27,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 define( 'BLOCKS_CSS_URL', plugins_url( '/', __FILE__ ) );
-define( 'BLOCKS_CSS_PATH', dirname( __FILE__ ) );
+define( 'BLOCKS_CSS_PATH', __DIR__ );
 define( 'BLOCKS_CSS_PRODUCT_SLUG', basename( BLOCKS_CSS_PATH ) );
 
 add_action(
@@ -35,7 +35,7 @@ add_action(
 	function () {
 		// call this only if Gutenberg is active.
 		if ( function_exists( 'register_block_type' ) ) {
-			require_once dirname( __FILE__ ) . '/class-blocks-css.php';
+			require_once __DIR__ . '/class-blocks-css.php';
 
 			if ( class_exists( '\ThemeIsle\GutenbergBlocks\Blocks_CSS' ) ) {
 				\ThemeIsle\GutenbergBlocks\Blocks_CSS::instance();

--- a/plugins/blocks-export-import/blocks-export-import.php
+++ b/plugins/blocks-export-import/blocks-export-import.php
@@ -27,14 +27,14 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 define( 'BLOCKS_EXPORT_IMPORT_URL', plugins_url( '/', __FILE__ ) );
-define( 'BLOCKS_EXPORT_IMPORT_PATH', dirname( __FILE__ ) );
+define( 'BLOCKS_EXPORT_IMPORT_PATH', __DIR__ );
 
 add_action(
 	'plugins_loaded',
 	function () {
 		// call this only if Gutenberg is active.
 		if ( function_exists( 'register_block_type' ) ) {
-			require_once dirname( __FILE__ ) . '/class-blocks-export-import.php';
+			require_once __DIR__ . '/class-blocks-export-import.php';
 
 			if ( class_exists( '\ThemeIsle\GutenbergBlocks\Blocks_Export_Import' ) ) {
 				\ThemeIsle\GutenbergBlocks\Blocks_Export_Import::instance();

--- a/plugins/otter-pro/autoloader.php
+++ b/plugins/otter-pro/autoloader.php
@@ -64,23 +64,23 @@ class Autoloader {
 	/**
 	 * Loads the class file for a given class name.
 	 *
-	 * @param string $class The fully-qualified class name.
+	 * @param string $class_name The fully-qualified class name.
 	 * @return mixed The mapped file name on success, or boolean false on
 	 * failure.
 	 */
-	public function load_class( $class ) {
+	public function load_class( $class_name ) {
 		// the current namespace prefix.
-		$prefix = $class;
+		$prefix = $class_name;
 
 		// work backwards through the namespace names of the fully-qualified.
 		// class name to find a mapped file name.
 		while ( false !== $pos = strrpos( $prefix, '\\' ) ) { // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 			// retain the trailing namespace separator in the prefix.
-			$prefix = substr( $class, 0, $pos + 1 );
+			$prefix = substr( $class_name, 0, $pos + 1 );
 
 			// the rest is the relative class name.
-			$relative_class = substr( $class, $pos + 1 );
+			$relative_class = substr( $class_name, $pos + 1 );
 
 			// try to load a mapped file for the prefix and relative class.
 			$mapped_file = $this->load_mapped_file( $prefix, $relative_class );

--- a/plugins/otter-pro/inc/class-main.php
+++ b/plugins/otter-pro/inc/class-main.php
@@ -211,7 +211,7 @@ class Main {
 
 		global $pagenow;
 
-		if ( class_exists( 'WooCommerce' ) && ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) && ( ( isset( $_GET['post'] ) && 'product' === get_post_type( intval( $_GET['post'] ) ) ) || ( isset( $_GET['post_type'] ) && 'product' === sanitize_text_field( $_GET['post_type'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		if ( class_exists( 'WooCommerce' ) && ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) && ( ( isset( $_GET['post'] ) && 'product' === get_post_type( intval( $_GET['post'] ) ) ) || ( isset( $_GET['post_type'] ) && 'product' === sanitize_text_field( $_GET['post_type'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$asset_file = include OTTER_PRO_BUILD_PATH . 'woocommerce.asset.php';
 
 			wp_enqueue_script(

--- a/plugins/otter-pro/inc/css/blocks/class-business-hours-css.php
+++ b/plugins/otter-pro/inc/css/blocks/class-business-hours-css.php
@@ -58,7 +58,7 @@ class Business_Hours_CSS extends Base_CSS {
 					array(
 						'property'  => 'border-style',
 						'default'   => 'solid',
-						'condition' => function( $attrs ) {
+						'condition' => function ( $attrs ) {
 							return isset( $attrs['borderWidth'] ) && ! empty( $attrs['borderWidth'] );
 						},
 					),

--- a/plugins/otter-pro/inc/css/blocks/class-form-file-css.php
+++ b/plugins/otter-pro/inc/css/blocks/class-form-file-css.php
@@ -48,5 +48,4 @@ class Form_File_CSS extends Base_CSS {
 
 		return $style;
 	}
-
 }

--- a/plugins/otter-pro/inc/css/blocks/class-form-stripe-field-css.php
+++ b/plugins/otter-pro/inc/css/blocks/class-form-stripe-field-css.php
@@ -47,14 +47,14 @@ class Form_Stripe_Field_CSS extends Base_CSS {
 					array(
 						'property' => '--stripe-border-radius',
 						'value'    => 'borderRadius',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return CSS_Utility::render_box( $value );
 						},
 					),
 					array(
 						'property' => '--stripe-border-width',
 						'value'    => 'borderWidth',
-						'format'   => function( $value ) {
+						'format'   => function ( $value ) {
 							return CSS_Utility::render_box( $value );
 						},
 					),
@@ -66,5 +66,4 @@ class Form_Stripe_Field_CSS extends Base_CSS {
 
 		return $style;
 	}
-
 }

--- a/plugins/otter-pro/inc/plugins/class-block-conditions.php
+++ b/plugins/otter-pro/inc/plugins/class-block-conditions.php
@@ -33,14 +33,14 @@ class Block_Conditions {
 	/**
 	 * Evaluate single condition
 	 *
-	 * @param bool  $bool a default true value.
+	 * @param bool  $default_value a default true value.
 	 * @param array $condition condition.
 	 * @param bool  $visibility visibility.
 	 *
 	 * @since 2.0.1
 	 * @return bool
 	 */
-	public function evaluate_condition( $bool, $condition, $visibility ) {
+	public function evaluate_condition( $default_value, $condition, $visibility ) {
 		if ( ! isset( $condition['type'] ) ) {
 			return true;
 		}
@@ -113,7 +113,7 @@ class Block_Conditions {
 			return $visibility ? $this->has_course_status( $condition ) : ! $this->has_course_status( $condition );
 		}
 
-		return $bool;
+		return $default_value;
 	}
 
 	/**
@@ -215,10 +215,8 @@ class Block_Conditions {
 						if ( $key === $cond_param['key'] && ( ! isset( $cond_param['value'] ) || in_array( $cond_param['value'], $value ) ) ) {
 							return true;
 						}
-					} else {
-						if ( $key === $cond_param['key'] && ( ! isset( $cond_param['value'] ) || $value === $cond_param['value'] ) ) {
+					} elseif ( $key === $cond_param['key'] && ( ! isset( $cond_param['value'] ) || $value === $cond_param['value'] ) ) {
 							return true;
-						}
 					}
 				}
 			}
@@ -235,10 +233,8 @@ class Block_Conditions {
 				}
 			} elseif ( ! isset( $cond_param['value'] ) ) {
 				return false;
-			} else {
-				if ( $params[ $cond_param['key'] ] !== $cond_param['value'] ) {
+			} elseif ( $params[ $cond_param['key'] ] !== $cond_param['value'] ) {
 					return false;
-				}
 			}
 		}
 
@@ -494,7 +490,7 @@ class Block_Conditions {
 		foreach ( $products as $product ) {
 			if ( wc_customer_bought_product( $current_user->user_email, $current_user->ID, $product ) ) {
 				return true;
-			};
+			}
 		}
 
 		return false;
@@ -631,7 +627,7 @@ class Block_Conditions {
 			foreach ( $condition['courses'] as $course ) {
 				if ( ld_course_check_user_access( $course, $current_user->ID ) ) {
 					return true;
-				};
+				}
 			}
 		}
 

--- a/plugins/otter-pro/inc/plugins/class-dynamic-content.php
+++ b/plugins/otter-pro/inc/plugins/class-dynamic-content.php
@@ -296,26 +296,26 @@ class Dynamic_Content {
 	/**
 	 * Format String.
 	 *
-	 * @param string $string String.
+	 * @param string $value String.
 	 * @param string $format String Format Type.
 	 *
 	 * @return string
 	 */
-	public function format_string( $string, $format = 'default' ) {
-		$value = $string;
+	public function format_string( $value, $format = 'default' ) {
+		$value = $value;
 
 		switch ( $format ) {
 			case 'capitalize':
-				$value = ucfirst( $string );
+				$value = ucfirst( $value );
 				break;
 			case 'uppercase':
-				$value = strtoupper( $string );
+				$value = strtoupper( $value );
 				break;
 			case 'lowercase':
-				$value = strtolower( $string );
+				$value = strtolower( $value );
 				break;
 			default:
-				$value = $string;
+				$value = $value;
 		}
 
 		return $value;

--- a/plugins/otter-pro/inc/plugins/class-form-emails-storing.php
+++ b/plugins/otter-pro/inc/plugins/class-form-emails-storing.php
@@ -353,7 +353,7 @@ class Form_Emails_Storing {
 	 * @return array
 	 */
 	public function form_record_bulk_actions() {
-		$status       = isset( $_GET['post_status'] ) ? sanitize_text_field( wp_unslash( $_GET['post_status'] ) ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		$status       = isset( $_GET['post_status'] ) ? sanitize_text_field( wp_unslash( $_GET['post_status'] ) ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$bulk_actions = array();
 
 		if ( 'trash' !== $status ) {
@@ -684,7 +684,7 @@ class Form_Emails_Storing {
 			return;
 		}
 
-		if ( empty( $_POST['action'] ) || 'editpost' !== $_POST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		if ( empty( $_POST['action'] ) || 'editpost' !== $_POST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 
@@ -794,7 +794,7 @@ class Form_Emails_Storing {
 					id="<?php echo intval( $id ); ?>"
 					type="text"
 					class="otter_form_record_meta__value"
-					value="<?php echo esc_html( $field['value'] ); ?>"
+					value="<?php echo esc_attr( $field['value'] ); ?>"
 				/>
 				<?php
 				break;
@@ -832,7 +832,7 @@ class Form_Emails_Storing {
 					id="<?php echo intval( $id ); ?>"
 					type="text"
 					class="otter_form_record_meta__value"
-					value="<?php echo esc_html( $field['value'] ); ?>"
+					value="<?php echo esc_attr( $field['value'] ); ?>"
 				/>
 				<?php
 				break;
@@ -844,7 +844,7 @@ class Form_Emails_Storing {
 					id="<?php echo intval( $id ); ?>"
 					type="<?php echo isset( $field['type'] ) ? esc_attr( $field['type'] ) : ''; ?>"
 					class="otter_form_record_meta__value"
-					value="<?php echo esc_html( $field['value'] ); ?>"
+					value="<?php echo esc_attr( $field['value'] ); ?>"
 				/>
 				<?php
 		}
@@ -880,7 +880,7 @@ class Form_Emails_Storing {
 			<div id="major-publishing-actions">
 				<div id="delete-action">
 					<?php
-					echo sprintf(
+					printf(
 						'<a href="?action=%s&post=%s&_wpnonce=%s" class="submitdelete">%s</a>',
 						'trash',
 						intval( $post->ID ),
@@ -892,7 +892,7 @@ class Form_Emails_Storing {
 
 				<div id="updating-action" style="text-align: right">
 					<?php
-					echo sprintf(
+					printf(
 						'<input type="submit" class="button button-primary button-large" value="%s"/>',
 						esc_html__( 'Update', 'otter-pro' )
 					);
@@ -924,11 +924,11 @@ class Form_Emails_Storing {
 	 * @return void
 	 */
 	public function mark_read_on_edit() {
-		if ( ! isset( $_REQUEST['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		if ( ! isset( $_REQUEST['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 
-		$post = intval( wp_unslash( $_REQUEST['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		$post = intval( wp_unslash( $_REQUEST['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! get_post( $post ) || self::FORM_RECORD_TYPE !== get_post_type( $post ) ) {
 			return;
 		}
@@ -952,7 +952,7 @@ class Form_Emails_Storing {
 	 * @return string The post ID.
 	 */
 	public function check_posts( $action ) {
-		$id   = ! empty( $_REQUEST[ self::FORM_RECORD_TYPE ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ self::FORM_RECORD_TYPE ] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		$id   = ! empty( $_REQUEST[ self::FORM_RECORD_TYPE ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ self::FORM_RECORD_TYPE ] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$post = get_post( $id );
 
 		if ( empty( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) ), $action . '-' . self::FORM_RECORD_TYPE . '_' . $id ) ) {
@@ -1073,7 +1073,7 @@ class Form_Emails_Storing {
 			return;
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$form = isset( $_GET['form'] ) ? sanitize_text_field( wp_unslash( $_GET['form'] ) ) : '';
 
 		?>
@@ -1099,7 +1099,7 @@ class Form_Emails_Storing {
 			return;
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$post = isset( $_GET['post'] ) ? sanitize_text_field( wp_unslash( $_GET['post'] ) ) : '';
 
 		?>
@@ -1257,7 +1257,7 @@ class Form_Emails_Storing {
 		$now = current_time( 'mysql' );
 
 		// Calculate the time 15 minutes ago.
-		$time_15_minutes_ago = date( 'Y-m-d H:i:s', strtotime( '-15 minutes', strtotime( $now ) ) );
+		$time_15_minutes_ago = gmdate( 'Y-m-d H:i:s', strtotime( '-15 minutes', strtotime( $now ) ) );
 
 		$args = array(
 			'post_type'      => self::FORM_RECORD_TYPE,
@@ -1331,7 +1331,7 @@ class Form_Emails_Storing {
 	 * Export submissions with ajax.
 	 */
 	public function export_submissions() {
-		$nonce = isset( $_POST['_nonce'] ) ? sanitize_text_field( $_POST['_nonce'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		$nonce = isset( $_POST['_nonce'] ) ? sanitize_text_field( $_POST['_nonce'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! wp_verify_nonce( $nonce, 'otter_form_export_submissions' ) ) {
 			wp_die( esc_html( __( 'Invalid nonce.', 'otter-pro' ) ) );
 		}

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -77,7 +77,7 @@ class Form_Pro_Features {
 					if ( ! isset( $counts_files[ $name ] ) ) {
 						$counts_files[ $name ] = 1;
 					} else {
-						$counts_files[ $name ]++;
+						++$counts_files[ $name ];
 
 						if (
 							$form_data->get_field_option( $name )->has_option( 'maxFilesNumber' ) &&

--- a/plugins/otter-pro/inc/plugins/class-woocommerce-builder.php
+++ b/plugins/otter-pro/inc/plugins/class-woocommerce-builder.php
@@ -102,9 +102,9 @@ class WooCommerce_Builder {
 	 * @access  public
 	 */
 	public function enable_block_editor( $can_edit, $post_type ) {
-		if ( isset( $_GET['otter-woo-builder'] ) && 'product' === $post_type ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-			if ( ! boolval( $_GET['otter-woo-builder'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-				$_GET['toggle-woobuilder'] = 0; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		if ( isset( $_GET['otter-woo-builder'] ) && 'product' === $post_type ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( ! boolval( $_GET['otter-woo-builder'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$_GET['toggle-woobuilder'] = 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$post_id                   = get_the_ID();
 
 				if ( has_blocks( $post_id ) ) {
@@ -118,10 +118,10 @@ class WooCommerce_Builder {
 
 				delete_post_meta( $post_id, '_themeisle_gutenberg_woo_builder' );
 			} else {
-				update_post_meta( get_the_ID(), '_themeisle_gutenberg_woo_builder', rest_sanitize_boolean( $_GET['otter-woo-builder'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				update_post_meta( get_the_ID(), '_themeisle_gutenberg_woo_builder', rest_sanitize_boolean( $_GET['otter-woo-builder'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			}
 
-			return rest_sanitize_boolean( $_GET['otter-woo-builder'] ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			return rest_sanitize_boolean( $_GET['otter-woo-builder'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
 		$woo_builder_enabled = get_post_meta( get_the_ID(), '_themeisle_gutenberg_woo_builder', true );

--- a/plugins/otter-pro/inc/render/class-review-comparison-block.php
+++ b/plugins/otter-pro/inc/render/class-review-comparison-block.php
@@ -243,7 +243,7 @@ class Review_Comparison_Block {
 
 		$rating = array_reduce(
 			$features,
-			function( $carry, $feature ) {
+			function ( $carry, $feature ) {
 				$carry += $feature['rating'];
 				return $carry;
 			},

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-add-to-cart-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-add-to-cart-block.php
@@ -32,7 +32,7 @@ class Product_Add_To_Cart_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		woocommerce_template_single_add_to_cart();
 		$output = ob_get_clean();
 		return $output;

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-images-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-images-block.php
@@ -32,7 +32,7 @@ class Product_Images_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 
 		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 			remove_action( 'woocommerce_product_thumbnails', 'woocommerce_show_product_thumbnails', 20 );

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-meta-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-meta-block.php
@@ -32,7 +32,7 @@ class Product_Meta_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		woocommerce_template_single_meta();
 		$output = ob_get_clean();
 		return $output;

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-price-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-price-block.php
@@ -32,7 +32,7 @@ class Product_Price_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		woocommerce_template_single_price();
 		$output = ob_get_clean();
 		return $output;

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-rating-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-rating-block.php
@@ -32,7 +32,7 @@ class Product_Rating_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		woocommerce_template_single_rating();
 		$output = ob_get_clean();
 

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-related-products-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-related-products-block.php
@@ -32,7 +32,7 @@ class Product_Related_Products_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		woocommerce_output_related_products();
 		$output = ob_get_clean();
 		return $output;

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-short-description-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-short-description-block.php
@@ -32,7 +32,7 @@ class Product_Short_Description_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		woocommerce_template_single_excerpt();
 		$output = ob_get_clean();
 		return $output;

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-stock-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-stock-block.php
@@ -30,7 +30,7 @@ class Product_Stock_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		$output = wc_get_stock_html( $product );
 
 		if ( empty( $output ) ) {

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-tabs-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-tabs-block.php
@@ -32,11 +32,11 @@ class Product_Tabs_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 
 		add_filter(
 			'woocommerce_product_tabs',
-			function( $tabs ) {
+			function ( $tabs ) {
 				unset( $tabs['description'] );
 				return $tabs;
 			} 

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-title-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-title-block.php
@@ -32,7 +32,7 @@ class Product_Title_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		woocommerce_template_single_title();
 		$output = ob_get_clean();
 		return $output;

--- a/plugins/otter-pro/inc/render/woocommerce/class-product-upsells-block.php
+++ b/plugins/otter-pro/inc/render/woocommerce/class-product-upsells-block.php
@@ -32,7 +32,7 @@ class Product_Upsells_Block {
 
 		if ( ! $product ) {
 			return;
-		};
+		}
 		woocommerce_upsell_display();
 		$output = ob_get_clean();
 		return $output;

--- a/plugins/otter-pro/inc/render/woocommerce/tpl/content-single-product.php
+++ b/plugins/otter-pro/inc/render/woocommerce/tpl/content-single-product.php
@@ -12,6 +12,7 @@ global $product;
 do_action( 'woocommerce_before_single_product' );
 
 if ( post_password_required() ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo get_the_password_form(); // WPCS: XSS ok.
 	return;
 }

--- a/plugins/otter-pro/inc/server/class-live-search-server.php
+++ b/plugins/otter-pro/inc/server/class-live-search-server.php
@@ -145,7 +145,7 @@ class Live_Search_Server {
 			array(
 				'success' => true,
 				'results' => array_map(
-					function( $post ) {
+					function ( $post ) {
 						$data = array(
 							'id'             => $post->ID,
 							'link'           => get_permalink( $post->ID ),
@@ -202,7 +202,7 @@ class Live_Search_Server {
 			$post_types = array_values(
 				array_filter(
 					$searchable_post_types,
-					function( $post_type ) use ( $needed_post_types ) {
+					function ( $post_type ) use ( $needed_post_types ) {
 						return in_array( $post_type, $needed_post_types, true );
 					}
 				) 

--- a/plugins/otter-pro/otter-pro.php
+++ b/plugins/otter-pro/otter-pro.php
@@ -25,14 +25,14 @@ if ( ! defined( 'WPINC' ) ) {
 
 define( 'OTTER_PRO_BASEFILE', __FILE__ );
 define( 'OTTER_PRO_URL', plugins_url( '/', __FILE__ ) );
-define( 'OTTER_PRO_PATH', dirname( __FILE__ ) );
+define( 'OTTER_PRO_PATH', __DIR__ );
 define( 'OTTER_PRO_BUILD_URL', plugins_url( '/', __FILE__ ) . 'build/pro/' );
-define( 'OTTER_PRO_BUILD_PATH', dirname( __FILE__ ) . '/build/pro/' );
+define( 'OTTER_PRO_BUILD_PATH', __DIR__ . '/build/pro/' );
 define( 'OTTER_PRO_VERSION', '3.1.1' );
 
-require_once dirname( __FILE__ ) . '/autoloader.php';
+require_once __DIR__ . '/autoloader.php';
 $autoloader = new \ThemeIsle\OtterPro\Autoloader();
-$autoloader->add_namespace( '\ThemeIsle\OtterPro', dirname( __FILE__ ) . '/inc/' );
+$autoloader->add_namespace( '\ThemeIsle\OtterPro', __DIR__ . '/inc/' );
 $autoloader->register();
 
 add_filter(
@@ -64,7 +64,7 @@ add_filter( 'themeisle_sdk_ran_promos', '__return_true' );
 if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
 	add_action(
 		'admin_notices',
-		function() {
+		function () {
 			$plugin_file = ABSPATH . 'wp-content/plugins/otter-blocks/otter-blocks.php';
 			$message     = __( 'You need Otter – Page Builder Blocks & Extensions for Gutenberg plugin to use Otter Pro.', 'otter-pro' );
 			$button_text = esc_html__( 'Install', 'otter-pro' );
@@ -113,7 +113,7 @@ if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
 if ( defined( 'OTTER_BLOCKS_VERSION' ) && ! defined( 'OTTER_BLOCKS_PRO_SUPPORT' ) ) {
 	add_action(
 		'admin_notices',
-		function() {
+		function () {
 			$message = __( 'You need to update Otter – Page Builder Blocks & Extensions for Gutenberg to the latest version to use Otter Pro.', 'otter-pro' );
 
 			printf(
@@ -129,7 +129,7 @@ add_action(
 	function () {
 		// call this only if Gutenberg is active.
 		if ( function_exists( 'register_block_type' ) && defined( 'OTTER_BLOCKS_VERSION' ) && defined( 'OTTER_BLOCKS_PRO_SUPPORT' ) ) {
-			require_once dirname( __FILE__ ) . '/inc/class-main.php';
+			require_once __DIR__ . '/inc/class-main.php';
 
 			if ( class_exists( '\ThemeIsle\OtterPro\Main' ) ) {
 				\ThemeIsle\OtterPro\Main::instance();


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2657
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Update the WordPress sniff packages to make the domain replacer to work.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Download the build from this PR
- Check the `class-blocks-animation.php`
- The translation domain should set to `otter-blocks` like `__( 'Activate %s', 'otter-blocks' )`

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

