### PR TITLE
Fixed tabs broken on mobile

### DIFF
--- a/src/blocks/frontend/tabs/index.js
+++ b/src/blocks/frontend/tabs/index.js
@@ -52,7 +52,6 @@ domReady( () => {
 				tabContent.classList.toggle( 'hidden', tabIndex !== index );
 
 				tabHeaderMobile.classList.toggle( 'active', tabIndex === index );
-				tabHeaderMobile.classList.toggle( 'hidden', tabIndex !== index );
 				tabHeaderMobile.setAttribute( 'aria-selected', tabIndex === index );
 
 				const headerItems = Array.from( header.childNodes );


### PR DESCRIPTION
Closes https://github.com/Codeinwp/hestia-pro/issues/2912

### Summary
Remove the `hidden` class from the mobile tab header to fix the broken tab layout in mobile view.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()