### PR TITLE
Added title to close button

### DIFF
--- a/src/blocks/blocks/popup/save.js
+++ b/src/blocks/blocks/popup/save.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
+
 import {
 	InnerBlocks,
 	useBlockProps
@@ -36,7 +38,7 @@ const Save = ({
 				<div className="otter-popup__modal_content">
 					{ attributes.showClose && (
 						<div className="otter-popup__modal_header">
-							<button type="button" className="components-button has-icon"><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg></button>
+							<button title={ __( 'Close Button', 'otter-blocks' ) } type="button" className="components-button has-icon"><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg></button>
 						</div>
 					) }
 


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2716

### Summary
Added the missing title to the close button in pop-up.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()