### PR TITLE
fix: show validation errors on submit

### DIFF
--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -387,7 +387,7 @@ const collectAndSendInputFormData = async( form, btn, displayMsg ) => {
 	const spinner = makeSpinner( btn );
 	const isValidationSuccessful = validateInputs( form );
 
-	if ( formIsEmpty ) {
+	if ( formIsEmpty || ! isValidationSuccessful) {
 		btn.disabled = false;
 		spinner.hide();
 		return;


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2735

### Summary
Validate the form input fields to show the validation.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional scripts in the frontend only if they are required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()