### PR TITLE
refactor: update black friday labels

### DIFF
--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -606,21 +606,30 @@ class Main {
 		$license = apply_filters( 'product_otter_license_key', false );
 		$status  = apply_filters( 'product_otter_license_status', false );
 
-		$is_pro     = 'valid' === $status;
-		$is_expired = 'expired' === $status || 'active-expired' === $status;
+		$is_pro           = 'valid' === $status;
+		$is_expired       = 'expired' === $status || 'active-expired' === $status;
+		$pro_product_slug = defined( 'OTTER_PRO_BASEFILE' ) ? basename( dirname( OTTER_PRO_BASEFILE ) ) : '';
 
 		if ( $is_pro ) {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'otter-blocks' ), '30%' );
 			// translators: %1$s - discount, %2$s - discount.
 			$message   = sprintf( __( 'Upgrade your Otter Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'otter-blocks' ), '30%', '20%' );
 			$cta_label = __( 'See your options', 'otter-blocks' );
 		} elseif ( $is_expired ) {
-			$message   = __( 'Your Otter Pro features are still here, just locked. Renew at a reduced rate this week.', 'otter-blocks' );
-			$cta_label = __( 'Reactivate now', 'otter-blocks' );
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'otter-blocks' ), '50%' );
+			// translators: %s is the discount percentage.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'otter-blocks' ), '50%' );
+			$message                     = __( 'Your Otter Pro features are still here, just locked. Renew at a reduced rate this week.', 'otter-blocks' );
+			$cta_label                   = __( 'Reactivate now', 'otter-blocks' );
 		} else {
-			// translators: %s - discount.
-			$config['title'] = sprintf( __( 'Otter Pro: %s off this week', 'otter-blocks' ), '60%' );
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'otter-blocks' ), '60%' );
 			// translators: %s is the discount percentage.
 			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'otter-blocks' ), '60%' );
+			// translators: %s - discount.
+			$config['title'] = sprintf( __( 'Otter Pro: %s off this week', 'otter-blocks' ), '60%' );
 		}
 
 		$url_params = array(
@@ -629,12 +638,8 @@ class Main {
 			'expired'  => $is_expired ? '1' : false,
 		);
 
-		if ( $is_pro || $is_expired ) {
-			// translators: %s is the discount percentage.
-			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'otter-blocks' ), '30%' );
-		} else {
-			// translators: %s is the discount percentage.
-			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'otter-blocks' ), '60%' );
+		if ( ( $is_pro || $is_expired ) && ! empty( $pro_product_slug ) ) {
+			$config['plugin_meta_targets'] = array( $pro_product_slug );
 		}
 
 		$config['cta_label'] = $cta_label;

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -627,6 +627,14 @@ class Main {
 			'expired'  => $is_expired ? '1' : false,
 		);
 
+		if ( $is_pro || $is_expired ) {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'otter-blocks' ), '30%' );
+		} else {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'otter-blocks' ), '60%' );
+		}
+
 		$config['cta_label'] = $cta_label;
 		$config['message']   = $message;
 		$config['sale_url']  = add_query_arg(

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -599,30 +599,37 @@ class Main {
 	public function add_black_friday_data( $configs ) {
 		$config = $configs['default'];
 
-		// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-		$message_template = __( 'Our biggest sale of the year: %1$sup to %2$s OFF%3$s on %4$s. Don\'t miss this limited-time offer.', 'otter-blocks' );
-		$product_label    = 'Otter Blocks';
-		$discount         = '70%';
+		$message   = __( 'Advanced blocks, custom CSS, WooCommerce integration. Everything you need to build better pages, without code. Exclusively for existing Otter users.', 'otter-blocks' );
+		$cta_label = __( 'Get Otter Pro', 'otter-blocks' );
 
 		$plan    = apply_filters( 'product_otter_license_plan', 0 );
 		$license = apply_filters( 'product_otter_license_key', false );
-		$is_pro  = 0 < $plan;
+		$status  = apply_filters( 'product_otter_license_status', false );
+
+		$is_pro     = 'valid' === $status;
+		$is_expired = 'expired' === $status || 'active-expired' === $status;
 
 		if ( $is_pro ) {
-			// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-			$message_template = __( 'Get %1$sup to %2$s off%3$s when you upgrade your %4$s plan or renew early.', 'otter-blocks' );
-			$product_label    = 'Otter Pro';
-			$discount         = '30%';
+			// translators: %1$s - discount, %2$s - discount.
+			$message   = sprintf( __( 'Upgrade your Otter Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'otter-blocks' ), '30%', '20%' );
+			$cta_label = __( 'See your options', 'otter-blocks' );
+		} elseif ( $is_expired ) {
+			$message   = __( 'Your Otter Pro features are still here, just locked. Renew at a reduced rate this week.', 'otter-blocks' );
+			$cta_label = __( 'Reactivate now', 'otter-blocks' );
+		} else {
+			// translators: %s - discount.
+			$config['title'] = sprintf( __( 'Otter Pro: %s off this week', 'otter-blocks' ), '60%' );
 		}
-		
-		$product_label = sprintf( '<strong>%s</strong>', $product_label );
-		$url_params    = array(
+
+		$url_params = array(
 			'utm_term' => $is_pro ? 'plan-' . $plan : 'free',
 			'lkey'     => ! empty( $license ) ? $license : false,
+			'expired'  => $is_expired ? '1' : false,
 		);
-		
-		$config['message']  = sprintf( $message_template, '<strong>', $discount, '</strong>', $product_label );
-		$config['sale_url'] = add_query_arg(
+
+		$config['cta_label'] = $cta_label;
+		$config['message']   = $message;
+		$config['sale_url']  = add_query_arg(
 			$url_params,
 			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/otter-bf', 'bfcm', 'otter' ) )
 		);

--- a/inc/class-main.php
+++ b/inc/class-main.php
@@ -619,6 +619,8 @@ class Main {
 		} else {
 			// translators: %s - discount.
 			$config['title'] = sprintf( __( 'Otter Pro: %s off this week', 'otter-blocks' ), '60%' );
+			// translators: %s is the discount percentage.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'otter-blocks' ), '60%' );
 		}
 
 		$url_params = array(

--- a/plugins/blocks-animation/blocks-animation.php
+++ b/plugins/blocks-animation/blocks-animation.php
@@ -72,17 +72,18 @@ add_filter(
 
 		$config = $configs['default'];
 
-		$config['message']             = __( 'You use Blocks Animation. Sites like yours get more from Otter Pro: advanced blocks, custom CSS, animations and more. Built by the same team.', 'blocks-animation' );
+		// translators: 1. Number of free licenses, 2. The price of the product.
+		$config['message']             = sprintf( __( 'You’re using Blocks Animation, and the team behind it is celebrating Black Friday by giving away %1$s licences of Otter Pro. A powerful block collection worth %2$s, with advanced blocks, custom CSS, animations, and WooCommerce integration. Claim yours before they run out.', 'blocks-animation' ), 100, '$69' );
 		$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Otter Pro free', 'blocks-animation' );
 		$config['sale_url']            = add_query_arg(
 			array(
 				'utm_term' => 'free',
 			),
-			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/otter-bf', 'bfcm', 'blocks-animation' ) )
+			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/otter-claim-bf', 'bfcm', 'blocks-animation' ) )
 		);
 
 		$configs[ BLOCKS_ANIMATION_PRODUCT_SLUG ] = $config;
 
 		return $configs;
-	} 
+	}
 );

--- a/plugins/blocks-animation/blocks-animation.php
+++ b/plugins/blocks-animation/blocks-animation.php
@@ -72,10 +72,7 @@ add_filter(
 
 		$config = $configs['default'];
 
-		// translators: %1$s - plugin name, %2$s - plugin name, %3$s - discount.
-		$message_template = __( 'Extend %1$s with %2$s – up to %3$s OFF in our biggest sale of the year. Limited time only.', 'blocks-animation' );
-	
-		$config['message']  = sprintf( $message_template, 'Block Animation', 'Otter Pro Blocks', '70%' );
+		$config['message']  = __( 'You use Blocks Animation. Sites like yours get more from Otter Pro: advanced blocks, custom CSS, animations and more. Built by the same team.', 'blocks-animation' );
 		$config['sale_url'] = add_query_arg(
 			array(
 				'utm_term' => 'free',

--- a/plugins/blocks-animation/blocks-animation.php
+++ b/plugins/blocks-animation/blocks-animation.php
@@ -73,6 +73,7 @@ add_filter(
 		$config = $configs['default'];
 
 		$config['message']  = __( 'You use Blocks Animation. Sites like yours get more from Otter Pro: advanced blocks, custom CSS, animations and more. Built by the same team.', 'blocks-animation' );
+		$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Otter Pro free', 'blocks-animation' );
 		$config['sale_url'] = add_query_arg(
 			array(
 				'utm_term' => 'free',

--- a/plugins/blocks-animation/blocks-animation.php
+++ b/plugins/blocks-animation/blocks-animation.php
@@ -72,9 +72,9 @@ add_filter(
 
 		$config = $configs['default'];
 
-		$config['message']  = __( 'You use Blocks Animation. Sites like yours get more from Otter Pro: advanced blocks, custom CSS, animations and more. Built by the same team.', 'blocks-animation' );
+		$config['message']             = __( 'You use Blocks Animation. Sites like yours get more from Otter Pro: advanced blocks, custom CSS, animations and more. Built by the same team.', 'blocks-animation' );
 		$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Otter Pro free', 'blocks-animation' );
-		$config['sale_url'] = add_query_arg(
+		$config['sale_url']            = add_query_arg(
 			array(
 				'utm_term' => 'free',
 			),

--- a/plugins/blocks-css/blocks-css.php
+++ b/plugins/blocks-css/blocks-css.php
@@ -68,9 +68,9 @@ add_filter(
 
 		$config = $configs['default'];
 	
-		$config['message']  = __( 'You use Blocks CSS. Otter Pro includes custom CSS per block, plus advanced blocks and WooCommerce integration. Built by the same team.', 'blocks-css' );
+		$config['message']             = __( 'You use Blocks CSS. Otter Pro includes custom CSS per block, plus advanced blocks and WooCommerce integration. Built by the same team.', 'blocks-css' );
 		$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Otter Pro free', 'blocks-css' );
-		$config['sale_url'] = add_query_arg(
+		$config['sale_url']            = add_query_arg(
 			array(
 				'utm_term' => 'free',
 			),

--- a/plugins/blocks-css/blocks-css.php
+++ b/plugins/blocks-css/blocks-css.php
@@ -67,11 +67,8 @@ add_filter(
 		}
 
 		$config = $configs['default'];
-
-		// translators: %1$s - plugin name, %2$s - plugin name, %3$s - discount.
-		$message_template = __( 'Extend %1$s with %2$s – up to %3$s OFF in our biggest sale of the year. Limited time only.', 'blocks-css' );
 	
-		$config['message']  = sprintf( $message_template, 'Blocks CSS', 'Otter Pro Blocks', '70%' );
+		$config['message']  = __( 'You use Blocks CSS. Otter Pro includes custom CSS per block, plus advanced blocks and WooCommerce integration. Built by the same team.', 'blocks-css' );
 		$config['sale_url'] = add_query_arg(
 			array(
 				'utm_term' => 'free',

--- a/plugins/blocks-css/blocks-css.php
+++ b/plugins/blocks-css/blocks-css.php
@@ -67,18 +67,19 @@ add_filter(
 		}
 
 		$config = $configs['default'];
-	
-		$config['message']             = __( 'You use Blocks CSS. Otter Pro includes custom CSS per block, plus advanced blocks and WooCommerce integration. Built by the same team.', 'blocks-css' );
+
+		// translators: 1. Number of free licenses, 2. The price of the product.
+		$config['message']             = sprintf( __( 'You’re using Blocks CSS, and the team behind it is celebrating Black Friday by giving away %1$s licences of Otter Pro. A powerful block collection worth %2$s, with advanced blocks, custom CSS, animations, and WooCommerce integration. Claim yours before they run out.', 'blocks-css' ), 100, '$69' );
 		$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Otter Pro free', 'blocks-css' );
 		$config['sale_url']            = add_query_arg(
 			array(
 				'utm_term' => 'free',
 			),
-			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/otter-bf', 'bfcm', 'blocks-css' ) )
+			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/otter-claim-bf', 'bfcm', 'blocks-css' ) )
 		);
 
 		$configs[ BLOCKS_CSS_PRODUCT_SLUG ] = $config;
 
 		return $configs;
-	} 
+	}
 );

--- a/plugins/blocks-css/blocks-css.php
+++ b/plugins/blocks-css/blocks-css.php
@@ -69,6 +69,7 @@ add_filter(
 		$config = $configs['default'];
 	
 		$config['message']  = __( 'You use Blocks CSS. Otter Pro includes custom CSS per block, plus advanced blocks and WooCommerce integration. Built by the same team.', 'blocks-css' );
+		$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Otter Pro free', 'blocks-css' );
 		$config['sale_url'] = add_query_arg(
 			array(
 				'utm_term' => 'free',


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Change the labels for Black Friday promotion. Based on https://github.com/Codeinwp/themeisle/issues/1854

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->


<img width="2536" height="1466" alt="CleanShot 2026-03-16 at 14 19 01@2x" src="https://github.com/user-attachments/assets/14a2e8c6-b6d8-4ebb-a7a1-e9b73da6ea61" />
<img width="2212" height="1302" alt="CleanShot 2026-03-16 at 14 19 34@2x" src="https://github.com/user-attachments/assets/42bea1f4-70fe-43b8-816b-2a2e21e11fc3" />
<img width="2226" height="1598" alt="CleanShot 2026-03-16 at 14 20 08@2x" src="https://github.com/user-attachments/assets/9a631afe-5746-41ce-bf0a-4d18e1a1746b" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this plugin: https://github.com/Soare-Robert-Daniel/test-black-friday
- Test:
  - If the notice appears during the Black Friday period.
  - If the labels change based on the license status (described in the spreadsheet)
  - If the notice can be dismissed.
  - If the notice appears only if the plugin is 3 days old. Warning: You will see the notice if you have another product that is older than 3 days; in this case, better to disable them.

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

