### PR TITLE
fix: save dynamic post content value

### DIFF
--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -727,9 +727,13 @@ class Dynamic_Content {
 			if ( 'postContent' === $data['type'] ) {
 
 				// To do not trigger postContent action if the given content contains the postContent dynamic tag, because it will cause an infinite loop.
-				$post    = get_post( $data['context'] );
+				$post = get_post( $data['context'] );
+				if ( ! $post instanceof \WP_Post ) {
+					return $data;
+				}
+
 				$content = $post->post_content;
-				if ( isset( $post ) && strpos( $content, 'data-type="postContent"' ) ) {
+				if ( strpos( $content, 'data-type="postContent"' ) ) {
 					$key = $this->get_exception_key( $data, $post->ID );
 					if ( $key ) {
 						$data[ $key ] = true;

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -438,7 +438,9 @@ class Dynamic_Content {
 			$key  = $this->get_exception_key( $data, $post->ID );
 
 			if ( ! isset( $data[ $key ] ) ) {
+				remove_filter( 'render_block', array( $this, 'apply_dynamic_content' ), 10 );
 				$excerpt = wp_trim_excerpt( '', $post );
+				add_filter( 'render_block', array( $this, 'apply_dynamic_content' ), 10 );
 			}
 		}
 

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -727,7 +727,8 @@ class Dynamic_Content {
 			if ( 'postContent' === $data['type'] ) {
 
 				// To do not trigger postContent action if the given content contains the postContent dynamic tag, because it will cause an infinite loop.
-				$content = get_the_content( $data['context'] );
+				$post    = get_post( $data['context'] );
+				$content = $post->post_content;
 				if ( isset( $post ) && strpos( $content, 'data-type="postContent"' ) ) {
 					$key = $this->get_exception_key( $data, $post->ID );
 					if ( $key ) {

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -733,8 +733,7 @@ class Dynamic_Content {
 				if ( ! $post instanceof \WP_Post ) {
 					return $data;
 				}
-
-				$content = $post->post_content;
+				$content = get_the_content( $data['context'] );
 				if ( strpos( $content, 'data-type="postContent"' ) ) {
 					$key = $this->get_exception_key( $data, $post->ID );
 					if ( $key ) {


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2618

### Summary
Retrieve the post based on the context and extract its content.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

