### PR TITLE
Fixed missing authorization in purchase verification

### DIFF
--- a/inc/plugins/class-stripe-api.php
+++ b/inc/plugins/class-stripe-api.php
@@ -232,17 +232,38 @@ class Stripe_API {
 
 		$items            = $this->create_request( 'session_items', $session_id );
 		$paid_product_ids = array();
-		if ( ! empty( $items['data'] ) ) {
-			foreach ( $items['data'] as $item ) {
+		if ( is_wp_error( $items ) || empty( $items['data'] ) || ! is_array( $items['data'] ) ) {
+			return;
+		}
+	
+		foreach ( $items['data'] as $item ) {
+			$product_id = null;
+
+			if ( isset( $item['price']['product'] ) && ! empty( $item['price']['product'] ) ) {
+				$product_id = $item['price']['product'];
+			} elseif ( isset( $item['price']['id'] ) && ! empty( $item['price']['id'] ) ) {
 				$price = $this->create_request( 'price', $item['price']['id'] );
-				if ( isset( $price['product'] ) ) {
-					$paid_product_ids[] = $price['product'];
+
+				if ( is_wp_error( $price ) || ! isset( $price['product'] ) ) {
+					continue;
 				}
+
+				if ( isset( $price['product'] ) ) {
+					$product_id = $price['product'];
+				}
+			}
+
+			if ( null !== $product_id ) {
+				$paid_product_ids[] = $product_id;
 			}
 		}
 
-		$queries = [];
-		parse_str( $session['success_url'], $queries );
+		$queries      = [];
+		$query_string = wp_parse_url( $session['success_url'], PHP_URL_QUERY );
+		if ( ! empty( $query_string ) ) {
+			parse_str( $query_string, $queries );
+		}
+
 		if ( isset( $queries['product_id'] ) && in_array( $queries['product_id'], $paid_product_ids, true ) ) {
 			$object['product_id'] = $queries['product_id'];
 		} else {

--- a/inc/plugins/class-stripe-api.php
+++ b/inc/plugins/class-stripe-api.php
@@ -230,10 +230,23 @@ class Stripe_API {
 			$object['subscription_id'] = $session['subscription'];
 		}
 
+		$items            = $this->create_request( 'session_items', $session_id );
+		$paid_product_ids = array();
+		if ( ! empty( $items['data'] ) ) {
+			foreach ( $items['data'] as $item ) {
+				$price = $this->create_request( 'price', $item['price']['id'] );
+				if ( isset( $price['product'] ) ) {
+					$paid_product_ids[] = $price['product'];
+				}
+			}
+		}
+
 		$queries = [];
 		parse_str( $session['success_url'], $queries );
-		if ( isset( $queries['product_id'] ) ) {
+		if ( isset( $queries['product_id'] ) && in_array( $queries['product_id'], $paid_product_ids, true ) ) {
 			$object['product_id'] = $queries['product_id'];
+		} else {
+			return;
 		}
 
 		array_push( $data, $object );

--- a/tests/stripe-http-client-mock.php
+++ b/tests/stripe-http-client-mock.php
@@ -155,63 +155,80 @@ class StripeHttpClientMock implements ClientInterface
 		);
 	}
 
-	private function mockGetSession()
+	private function mockGetSession( $path = '' )
 	{
-		return json_encode(
-			[
-				'id' => 'sess_1',
-				'status' => 'complete',
-				'customer' => 'cus_1',
-				'customer_details' => [
-					'email' => 'test@test.com'
-				],
-				'mode' => 'payment',
-				'payment_status' => 'paid',
-				'payment_intent' => 'pi_1',
-				'object' => 'checkout.session',
-				'success_url' => 'https://example.com/success?product_id=prod_1',
-				'complete' => true
-			]
+		preg_match( '#^/v1/checkout/sessions/(\w+)$#', $path, $matches );
+		$session_id = isset( $matches[1] ) ? $matches[1] : 'sess_1';
+
+		$base = array(
+			'status'           => 'complete',
+			'customer'         => 'cus_1',
+			'customer_details' => array( 'email' => 'test@test.com' ),
+			'mode'             => 'payment',
+			'payment_status'   => 'paid',
+			'payment_intent'   => 'pi_1',
+			'object'           => 'checkout.session',
 		);
+
+		switch ( $session_id ) {
+			case 'sess_wrong_price_product':
+				return json_encode( array_merge( $base, array(
+					'id'          => 'sess_wrong_price_product',
+					'success_url' => 'https://example.com/success?product_id=prod_1',
+				) ) );
+
+			default:
+				return json_encode( array_merge( $base, array(
+					'id'          => 'sess_1',
+					'success_url' => 'https://example.com/success?product_id=prod_1',
+					'complete'    => true,
+				) ) );
+		}
 	}
 
-	private function mockSessionItems()
+	private function mockSessionItems( $path = '' )
 	{
-		return json_encode(
-			[
-				'object' => 'list',
-				'data' => [
-					[
-						'id' => 'item_1',
-						'quantity' => 1,
-						'object' => 'item',
-						'price' => [
-							'id' => 'price_1',
-							'product' => 'prod_1',
-							'unit_amount' => 1000,
-							'currency' => 'USD',
-							'object' => 'price',
-							'active' => true,
-							'billing_scheme' => 'per_unit',
-						]
-					],
-					[
-						'id' => 'item_2',
-						'quantity' => 2,
-						'object' => 'item',
-						'price' => [
-							'id' => 'price_1',
-							'product' => 'prod_1',
-							'unit_amount' => 1000,
-							'currency' => 'USD',
-							'object' => 'price',
-							'active' => true,
-							'billing_scheme' => 'per_unit',
-						]
-					]
-				]
-			]
+		preg_match( '#^/v1/checkout/sessions/(\w+)/line_items$#', $path, $matches );
+		$session_id = isset( $matches[1] ) ? $matches[1] : 'sess_1';
+
+		$premium_item = array(
+			'id'       => 'item_1',
+			'quantity' => 1,
+			'object'   => 'item',
+			'price'    => array(
+				'id'             => 'price_1',
+				'product'        => 'prod_1',
+				'unit_amount'    => 10000,
+				'currency'       => 'USD',
+				'object'         => 'price',
+				'active'         => true,
+				'billing_scheme' => 'per_unit',
+			),
 		);
+
+		switch ( $session_id ) {
+			case 'sess_wrong_price_product':
+				// User actually paid with price_2 — NOT price_1 as the URL claims.
+				$item          = $premium_item;
+				$item['price'] = array(
+					'id'             => 'price_2',
+					'product'        => 'prod_2',
+					'unit_amount'    => 100,
+					'currency'       => 'USD',
+					'object'         => 'price',
+					'active'         => true,
+					'billing_scheme' => 'per_unit',
+				);
+				break;
+			default:
+				$item = $premium_item;
+				break;
+		}
+
+		return json_encode( array(
+			'object' => 'list',
+			'data'   => array( $item ),
+		) );
 	}
 
 	private function mockGetSubscription()

--- a/tests/test-stripe-api-class.php
+++ b/tests/test-stripe-api-class.php
@@ -109,4 +109,17 @@ class TestStripeAPI extends WP_UnitTestCase {
 
 		$this->assertTrue( 'success' === $status );
 	}
+
+	/**
+	 * Test user purchase the product with correct price id.
+	 */
+	public function test_user_purchase_with_correct_price_id() {
+		wp_set_current_user( 1 );
+
+		$this->stripe_api->save_customer_data( 'sess_wrong_price_product' );
+		$data = $this->stripe_api->get_customer_data();
+
+		$this->assertEmpty( $data );
+		$this->assertFalse( $this->stripe_api->check_purchase( 'prod_1' ) );
+	}
 }


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-internals/issues/270

### Summary
Get the Stripe product ID from the price ID to get only the granted content based on the selected product.

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()