### PR TITLE
Fixed accordion icon on large title

### DIFF
--- a/src/blocks/blocks/accordion/style.scss
+++ b/src/blocks/blocks/accordion/style.scss
@@ -162,11 +162,11 @@
 		border-bottom: 2px solid currentColor;
 		width: 8px;
 		height: 8px;
+		flex-shrink: 0;
 	}
 
 	&:not( .has-icon ) > &-item:not([open]) > &-item__title::after {
 		transform: rotate(45deg) translate(-25%, 0%);
-		flex-shrink: 0;
 	}
 
 	&:not( .has-open-icon ) > &-item[open] > &-item__title::after {

--- a/src/blocks/blocks/accordion/style.scss
+++ b/src/blocks/blocks/accordion/style.scss
@@ -166,6 +166,7 @@
 
 	&:not( .has-icon ) > &-item:not([open]) > &-item__title::after {
 		transform: rotate(45deg) translate(-25%, 0%);
+		flex-shrink: 0;
 	}
 
 	&:not( .has-open-icon ) > &-item[open] > &-item__title::after {


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/1937 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()