### PR TITLE
Refactor Preview component

### DIFF
--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -93,6 +93,10 @@ const Preview = ({
 			</div>
 		);
 	}
+	const featuredPost = posts?.[0];
+	const featuredPostAuthor = authors?.find(
+		( author ) => author?.id === featuredPost?.author
+	);
 
 	return (
 		<div { ...blockProps } style={ inlineStyles }>
@@ -100,9 +104,9 @@ const Preview = ({
 				{ attributes.enableFeaturedPost && (
 					<FeaturedPost
 						attributes={ attributes }
-						post={ posts?.[0] }
+						post={ featuredPost }
 						categoriesList={ categoriesList }
-						author={ authors[0] }
+						author={ featuredPostAuthor }
 					/>
 				) }
 

--- a/src/blocks/blocks/posts/edit.js
+++ b/src/blocks/blocks/posts/edit.js
@@ -64,6 +64,63 @@ import { styles } from './constants.js';
 
 const { attributes: defaultAttributes } = metadata;
 
+const Preview = ({
+	posts,
+	categoriesList,
+	authors,
+	blockProps,
+	inlineStyles,
+	attributes,
+	isLoading
+}) => {
+	if ( ! posts || ! categoriesList || ! authors || isLoading ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder>
+					<Spinner />
+					{ __( 'Loading Posts', 'otter-blocks' ) }
+				</Placeholder>
+			</div>
+		);
+	}
+
+	if ( 0 === posts.length ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder>
+					{ __( 'No Posts', 'otter-blocks' ) }
+				</Placeholder>
+			</div>
+		);
+	}
+
+	return (
+		<div { ...blockProps } style={ inlineStyles }>
+			<Disabled>
+				{ attributes.enableFeaturedPost && (
+					<FeaturedPost
+						attributes={ attributes }
+						post={ posts?.[0] }
+						categoriesList={ categoriesList }
+						author={ authors[0] }
+					/>
+				) }
+
+				<Layout
+					attributes={ attributes }
+					posts={ posts }
+					categoriesList={ categoriesList }
+					authors={ authors }
+				/>
+
+			</Disabled>
+			{
+				attributes.hasPagination && <PaginationPreview />
+			}
+		</div>
+	);
+};
+
 /**
  * Posts component
  * @param {import('./types').PostProps} param0
@@ -307,62 +364,6 @@ const Edit = ({
 
 	const blockProps = useBlockProps();
 
-	const Preview = ({
-		posts,
-		categoriesList,
-		authors,
-		blockProps,
-		inlineStyles,
-		attributes
-	}) => {
-		if ( ! posts || ! categoriesList || ! authors || isLoading ) {
-			return (
-				<div { ...blockProps }>
-					<Placeholder>
-						<Spinner />
-						{ __( 'Loading Posts', 'otter-blocks' ) }
-					</Placeholder>
-				</div>
-			);
-		}
-
-		if ( 0 === posts.length ) {
-			return (
-				<div { ...blockProps }>
-					<Placeholder>
-						{ __( 'No Posts', 'otter-blocks' ) }
-					</Placeholder>
-				</div>
-			);
-		}
-
-		return (
-			<div { ...blockProps } style={ inlineStyles }>
-				<Disabled>
-					{ attributes.enableFeaturedPost && (
-						<FeaturedPost
-							attributes={ attributes }
-							post={ posts?.[0] }
-							categoriesList={ categoriesList }
-							author={ authors[0] }
-						/>
-					) }
-
-					<Layout
-						attributes={ attributes }
-						posts={ posts }
-						categoriesList={ categoriesList }
-						authors={ authors }
-					/>
-
-				</Disabled>
-				{
-					attributes.hasPagination && <PaginationPreview />
-				}
-			</div>
-		);
-	};
-
 	return (
 		<Fragment>
 			{ categoriesList && (
@@ -386,6 +387,7 @@ const Edit = ({
 				blockProps={ blockProps }
 				inlineStyles={ inlineStyles }
 				attributes={ attributes }
+				isLoading={ isLoading }
 			/>
 		</Fragment>
 	);


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2615

### Summary
`Preview` was moved to module scope (outside `Edit`), making its reference stable across renders. Since `isLoading` was previously captured via closure, it is now passed as an explicit prop.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()