### PR TITLE
Optimize wp.org listings: Otter + 3 bundled plugins

### DIFF
--- a/plugins/blocks-animation/readme.txt
+++ b/plugins/blocks-animation/readme.txt
@@ -1,6 +1,6 @@
 === Blocks Animation: CSS Animations for Gutenberg Blocks ===
 Contributors: themeisle, hardeepasrani, mariamunteanu1
-Tags: gutenberg, block, block editor, editor, animation, animations, animate, styles, block animations
+Tags: animation, gutenberg blocks, css, effects, transitions
 Requires at least: 6.2
 Tested up to: 6.9
 Requires PHP: 5.4
@@ -8,7 +8,7 @@ Stable tag: 3.1.9
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
-Blocks Animation allows you to add CSS Animations to all of your Gutenberg blocks in the most elegant way.
+Add CSS animations and scroll effects to any Gutenberg block. Choose from fade, slide, zoom & more, with delay and duration controls — no code needed.
 
 == Description ==
 

--- a/plugins/blocks-css/readme.txt
+++ b/plugins/blocks-css/readme.txt
@@ -1,6 +1,6 @@
 === Blocks CSS: CSS Editor for Gutenberg Blocks ===
 Contributors: themeisle, hardeepasrani
-Tags: gutenberg, block, css, css editor, blocks css
+Tags: gutenberg, custom css, block editor, css editor, design
 Requires at least: 6.2    
 Tested up to: 6.9
 Requires PHP: 5.4  

--- a/plugins/blocks-export-import/readme.txt
+++ b/plugins/blocks-export-import/readme.txt
@@ -1,6 +1,6 @@
-=== Blocks Export Import ===
+=== Blocks Export Import – Backup & Move Gutenberg Blocks as JSON ===
 Contributors: themeisle, hardeepasrani
-Tags: gutenberg, block, blocks, export, import, exporter, importer, block exporter, block export, block import, block importer
+Tags: gutenberg, blocks, export, import, json
 Requires at least: 6.2    
 Tested up to: 6.9
 Requires PHP: 5.4  
@@ -8,7 +8,7 @@ Stable tag: 3.1.9
 License: GPLv3  
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html  
 
-Blocks Export Import allows to Export and Import blocks as JSON in Gutenberg Block Editor.
+Export and import Gutenberg blocks as JSON files. Backup block layouts, move them between sites, or share them with your team — all without plugins.
 
 == Description ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Otter Blocks - Gutenberg Blocks, Page Builder for Gutenberg Editor & FSE ===
 Contributors: themeisle, hardeepasrani, soarerobertdaniel7, mariamunteanu1, arinat, uriahs-victor, john_pixle, wildmisha, irinelenache
-Tags: block, blocks, gutenberg, gutenberg blocks, page builder
+Tags: gutenberg blocks, gutenberg, blocks, page builder, fse
 Requires at least: 6.2
 Tested up to: 6.9
 Requires PHP: 5.6


### PR DESCRIPTION
Optimizes 4 wp.org plugin listings deployed from this repo:

| Plugin | Slug | Change |
|---|---|---|
| Otter Blocks | `otter-blocks` | Tags only — keeps the 4 universal tags from the wp.org Gutenberg-blocks leaders (Spectra, Kadence) and adds `fse` as a tier-2 differentiator. |
| Blocks Animation | `blocks-animation` | Replace 9-tag stem-collapsed cluster (`block` + `block editor` + `editor` + `animation` + `animations` + `animate` + `styles` + `block animations`) with 5 stem-distinct tags. Excerpt: rewrite to 149c. |
| Blocks CSS | `blocks-css` | Replace stem-colliding tags (`block`, `blocks css` collide with `block editor`, `css editor`) with stem-distinct coverage. |
| Blocks Export Import | `blocks-export-import` | Title expansion (was 20 chars — wasting 42 chars of boost-5 capacity), tag dedup, excerpt rewrite. |

All changes calibrated against the wp.org category leader patterns from a separate competitor scan (Spectra + Kadence for Gutenberg blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)