### PR TITLE
Enhanced file type validation

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -128,10 +128,11 @@ class Form_Pro_Features {
 
 						$file_data = $files[ $file_data_key ];
 
-						// Get the extension from file using WordPress functions.
-						$extension = wp_check_filetype( $file_data['name'] );
+						// Validate file type based on actual file content, not just filename extension.
+						// This prevents spoofing by renaming malicious files with allowed extensions.
+						$file_validation = wp_check_filetype_and_ext( $file_data['tmp_name'], $file_data['name'] );
 
-						if ( ! $extension['ext'] ) {
+						if ( ! $file_validation['ext'] || ! $file_validation['type'] ) {
 							$form_data->set_error( \ThemeIsle\GutenbergBlocks\Integration\Form_Data_Response::ERROR_FILE_UPLOAD_TYPE_WP );
 							break;
 						}
@@ -142,24 +143,33 @@ class Form_Pro_Features {
 							$mime_types    = wp_get_mime_types();
 							$allowed_mimes = array();
 
+							$ext_to_mime = array();
+							foreach ( $mime_types as $exts => $mime ) {
+								$ext_list = explode( '|', $exts );
+								foreach ( $ext_list as $ext ) {
+									$ext_to_mime[ $ext ] = $mime;
+								}
+							}
+
 							foreach ( $form_files_ext as $type ) {
 								$type = strtolower( trim( str_replace( '.', '', $type ) ) );
 
 								// Handle wildcard mime types like image/*.
-								if ( str_contains( $type, '/' ) ) {
+								if ( false !== strpos( $type, '/' ) ) {
 									$allowed_mimes[] = $type;
 									continue;
 								}
 
-								foreach ( $mime_types as $exts => $mime ) {
-									$ext_list = explode( '|', $exts );
-									if ( in_array( $type, $ext_list, true ) ) {
-										$allowed_mimes[] = $mime;
-									}
+								// Use lookup map for direct access.
+								if ( isset( $ext_to_mime[ $type ] ) ) {
+									$allowed_mimes[] = $ext_to_mime[ $type ];
 								}
 							}
 
-							$mime_match = wp_match_mime_types( $allowed_mimes, $extension['type'] );
+							// Remove duplicate MIME types.
+							$allowed_mimes = array_unique( $allowed_mimes );
+
+							$mime_match = wp_match_mime_types( $allowed_mimes, $file_validation['type'] );
 
 							if ( 0 == count( $mime_match ) ) {
 								$form_data->set_error( \ThemeIsle\GutenbergBlocks\Integration\Form_Data_Response::ERROR_FILE_UPLOAD_TYPE );

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -128,9 +128,8 @@ class Form_Pro_Features {
 
 						$file_data = $files[ $file_data_key ];
 
-						// Validate file type based on actual file content, not just filename extension.
-						// This prevents spoofing by renaming malicious files with allowed extensions.
-						$file_validation = wp_check_filetype_and_ext( $file_data['tmp_name'], $file_data['name'] );
+						// Get the extension from file using WordPress functions.
+						$file_validation = wp_check_filetype( $file_data['name'] );
 
 						if ( ! $file_validation['ext'] || ! $file_validation['type'] ) {
 							$form_data->set_error( \ThemeIsle\GutenbergBlocks\Integration\Form_Data_Response::ERROR_FILE_UPLOAD_TYPE_WP );

--- a/plugins/otter-pro/inc/plugins/class-form-pro-features.php
+++ b/plugins/otter-pro/inc/plugins/class-form-pro-features.php
@@ -139,10 +139,27 @@ class Form_Pro_Features {
 						$form_files_ext = $field_option->get_option( 'allowedFileTypes' );
 
 						if ( ! empty( $form_files_ext ) ) {
-							$form_files_ext = str_replace( '.', '', $form_files_ext );
-							$form_files_ext = str_replace( '/*', '', $form_files_ext );
+							$mime_types    = wp_get_mime_types();
+							$allowed_mimes = array();
 
-							$mime_match = wp_match_mime_types( $form_files_ext, $extension['type'] );
+							foreach ( $form_files_ext as $type ) {
+								$type = strtolower( trim( str_replace( '.', '', $type ) ) );
+
+								// Handle wildcard mime types like image/*.
+								if ( str_contains( $type, '/' ) ) {
+									$allowed_mimes[] = $type;
+									continue;
+								}
+
+								foreach ( $mime_types as $exts => $mime ) {
+									$ext_list = explode( '|', $exts );
+									if ( in_array( $type, $ext_list, true ) ) {
+										$allowed_mimes[] = $mime;
+									}
+								}
+							}
+
+							$mime_match = wp_match_mime_types( $allowed_mimes, $extension['type'] );
 
 							if ( 0 == count( $mime_match ) ) {
 								$form_data->set_error( \ThemeIsle\GutenbergBlocks\Integration\Form_Data_Response::ERROR_FILE_UPLOAD_TYPE );


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-internals/issues/245

### Summary
Enhance the validation of uploaded file MIME types. 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()