### PR TITLE
Fixed button group global settings

### DIFF
--- a/src/blocks/plugins/options/global-defaults/controls/button-group.js
+++ b/src/blocks/plugins/options/global-defaults/controls/button-group.js
@@ -129,8 +129,8 @@ const ButtonGroupBlock = ({
 						fontSize: attributes.fontSize,
 						fontFamily: attributes.fontFamily,
 						lineHeight: attributes.lineHeight,
-						appearance: attributes.fontVariant,
-						letterCase: attributes.fontStyle
+						appearance: attributes.fontStyle,
+						letterCase: attributes.textTransform
 					}}
 
 					onChange={ values => {
@@ -138,8 +138,8 @@ const ButtonGroupBlock = ({
 							fontSize: values.fontSize,
 							fontFamily: values.fontFamily,
 							lineHeight: values.lineHeight,
-							fontVariant: values.appearance,
-							fontStyle: values.letterCase
+							fontStyle: values.appearance,
+							textTransform: values.letterCase
 						});
 					} }
 				/>


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2267

### Summary
Fixed the mapping of the font-related attributes.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

