### PR TITLE
fix: fse onboarding not showing patterns

### DIFF
--- a/src/onboarding/components/TemplateSelector.js
+++ b/src/onboarding/components/TemplateSelector.js
@@ -14,10 +14,17 @@ import { BlockPreview } from '@wordpress/block-editor';
 
 import { Icon } from '@wordpress/components';
 
+import { useSelect } from '@wordpress/data';
+
 import {
 	useRef,
 	useMemo
 } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import { resolvePatternBlocks } from '../utils';
 
 const TemplateSelector = ({
 	template,
@@ -28,9 +35,15 @@ const TemplateSelector = ({
 }) => {
 	const ref = useRef();
 
+	const patterns = useSelect( select => {
+		const core = select( 'core' );
+		return ( 'function' === typeof core?.getBlockPatterns ) ? ( core.getBlockPatterns() ?? []) : [];
+	}, []);
+
 	const parsedTemplate = useMemo( () => {
-		return isParsed ? template : ( template?.content?.raw ? parse( template?.content?.raw ) : []);
-	}, [ template, isParsed ]);
+		const blocks = isParsed ? template : ( template?.content?.raw ? parse( template?.content?.raw ) : []);
+		return resolvePatternBlocks( blocks, patterns );
+	}, [ template, isParsed, patterns ]);
 
 	return (
 		<div

--- a/src/onboarding/components/steps/Homepage.js
+++ b/src/onboarding/components/steps/Homepage.js
@@ -7,15 +7,22 @@ import { BlockPreview } from '@wordpress/block-editor';
 
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies.
+ */
+import { resolvePatternBlocks } from '../../utils';
+
 const Homepage = () => {
 	const { template } = useSelect( select => {
 		const { getTemplate } = select( 'otter/onboarding' );
+		const core = select( 'core' );
+		const patterns = ( 'function' === typeof core?.getBlockPatterns ) ? ( core.getBlockPatterns() ?? []) : [];
 
 		const template = getTemplate({ slug: 'front-page' });
 		const parsedTemplate = template?.content?.raw ? parse( template?.content?.raw ) : [];
 
 		return {
-			template: parsedTemplate
+			template: resolvePatternBlocks( parsedTemplate, patterns )
 		};
 	});
 

--- a/src/onboarding/utils.js
+++ b/src/onboarding/utils.js
@@ -1,10 +1,67 @@
 /**
  * WordPress dependencies.
  */
+import { parse } from '@wordpress/blocks';
+
 import {
 	dispatch,
 	select
 } from '@wordpress/data';
+
+/**
+ * Recursively inline `core/pattern` blocks by replacing each with the parsed
+ * content of the pattern it references. BlockPreview renders patterns via the
+ * block-editor data store, which isn't hydrated in the onboarding wizard's
+ * isolated provider, so without this step every `wp:pattern` reference shows
+ * up as blank in the preview.
+ *
+ * @param {Array}  blocks   Parsed blocks.
+ * @param {Array}  patterns Registered patterns from `select('core').getBlockPatterns()`.
+ * @param {number} depth    Recursion guard for pattern-in-pattern cycles.
+ * @return {Array}
+ */
+export const resolvePatternBlocks = ( blocks, patterns, depth = 0 ) => {
+	if ( ! Array.isArray( blocks ) || ! Array.isArray( patterns ) || ! patterns.length || 4 < depth ) {
+		return blocks;
+	}
+
+	const byName = patterns.reduce( ( acc, pattern ) => {
+		if ( pattern?.name ) {
+			acc[ pattern.name ] = pattern;
+		}
+		return acc;
+	}, {});
+
+	const resolve = block => {
+		if ( ! block ) {
+			return [];
+		}
+
+		if ( 'core/pattern' === block.name ) {
+			const slug = block.attributes?.slug;
+			const pattern = slug ? byName[ slug ] : null;
+
+			if ( pattern?.content ) {
+				return resolvePatternBlocks( parse( pattern.content ), patterns, depth + 1 );
+			}
+
+			return [];
+		}
+
+		if ( block.innerBlocks?.length ) {
+			return [
+				{
+					...block,
+					innerBlocks: block.innerBlocks.flatMap( resolve )
+				}
+			];
+		}
+
+		return [ block ];
+	};
+
+	return blocks.flatMap( resolve );
+};
 
 export const findBlock = ( blocksAr, name ) => {
 	const foundBlock = blocksAr.find( block => block.name === name );


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-blocks/issues/2814.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->
The FSE onboarding wizard renders template previews via BlockPreview (@wordpress/block-editor). In recent versions, BlockPreview no longer inherits pattern settings from a parent BlockEditorProvider, so any <!-- wp:pattern {"slug":"..."} /--> reference inside an onboarding template renders blank. Themes whose front-page / archive / single / page templates are composed primarily of pattern references end up with empty previews.

This PR resolves patterns in the React layer before they reach BlockPreview:

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure in WP 7.0 and 6.9, both versions, the Frontpage templates of Raft onboarding appear properly.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

