### PR TITLE
Add YouTube tutorials card to Otter dashboard

### DIFF
--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -229,86 +229,44 @@ class Dashboard {
 	}
 
 	/**
-	 * Get YouTube playlist latest video data.
+	 * Get the latest video from the Otter YouTube playlist.
 	 *
-	 * @return array
+	 * Uses the WordPress feed API (SimplePie under the hood), which handles
+	 * fetching, XML/namespace parsing and transient caching for us.
+	 *
+	 * @return array{videoTitle: string, videoLink: string, thumbnail: string|null}
 	 */
 	private function get_youtube_playlist_data() {
 		$playlist_id = 'PLmRasCVwuvpSep2MOsIoE0ncO9JE3FcKP';
-		$cache_key = 'otter_youtube_playlist_data';
-		$fallback_ttl = HOUR_IN_SECONDS;
-		
-		// Try to get from cache first
-		$cached_data = get_transient( $cache_key );
-		if ( false !== $cached_data ) {
-			return $cached_data;
-		}
 
-		$default_data = array(
-			'videoTitle'   => __( 'Otter Tutorials', 'otter-blocks' ),
-			'videoLink'    => 'https://youtube.com/playlist?list=' . $playlist_id,
-			'thumbnail'    => null,
+		$data = array(
+			'videoTitle' => __( 'Otter Tutorials', 'otter-blocks' ),
+			'videoLink'  => 'https://youtube.com/playlist?list=' . $playlist_id,
+			'thumbnail'  => null,
 		);
 
-		try {
-			$rss_url = 'https://www.youtube.com/feeds/videos.xml?playlist_id=' . $playlist_id;
-			$response = wp_remote_get( $rss_url, array( 'timeout' => 5 ) );
-			
-			if ( is_wp_error( $response ) ) {
-				set_transient( $cache_key, $default_data, $fallback_ttl );
-				return $default_data;
-			}
+		$feed = fetch_feed( 'https://www.youtube.com/feeds/videos.xml?playlist_id=' . $playlist_id );
 
-			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-				set_transient( $cache_key, $default_data, $fallback_ttl );
-				return $default_data;
-			}
-
-			$body = wp_remote_retrieve_body( $response );
-			if ( empty( $body ) ) {
-				set_transient( $cache_key, $default_data, $fallback_ttl );
-				return $default_data;
-			}
-
-			// Parse XML
-			$xml = simplexml_load_string( $body );
-			if ( ! $xml ) {
-				set_transient( $cache_key, $default_data, $fallback_ttl );
-				return $default_data;
-			}
-
-			// Get the first entry (latest video)
-			$entry = $xml->entry[0] ?? null;
-			if ( ! $entry ) {
-				set_transient( $cache_key, $default_data, $fallback_ttl );
-				return $default_data;
-			}
-
-			// Extract title
-			$title = (string) $entry->title;
-
-			// Extract video ID from link
-			$link = (string) $entry->link['href'];
-			preg_match( '/v=([a-zA-Z0-9_-]{11})/', $link, $matches );
-			$video_id = $matches[1] ?? null;
-
-			// Build thumbnail URL
-			$thumbnail = $video_id ? 'https://i.ytimg.com/vi/' . $video_id . '/hqdefault.jpg' : null;
-
-			$data = array(
-				'videoTitle'   => $title,
-				'videoLink'    => $link,
-				'thumbnail'    => $thumbnail,
-			);
-
-			// Cache for 24 hours
-			set_transient( $cache_key, $data, DAY_IN_SECONDS );
-
+		if ( is_wp_error( $feed ) ) {
 			return $data;
-		} catch ( Exception $e ) {
-			set_transient( $cache_key, $default_data, $fallback_ttl );
-			return $default_data;
 		}
+
+		$item = $feed->get_item();
+
+		if ( ! $item ) {
+			return $data;
+		}
+
+		// YouTube nests <media:thumbnail> inside <media:group>, so the item-level
+		// get_thumbnail() returns null; SimplePie exposes it via the enclosure.
+		$enclosure = $item->get_enclosure();
+		$thumbnail = $enclosure ? $enclosure->get_thumbnail() : '';
+
+		$data['videoTitle'] = $item->get_title();
+		$data['videoLink']  = $item->get_permalink();
+		$data['thumbnail']  = ! empty( $thumbnail ) ? $thumbnail : null;
+
+		return $data;
 	}
 
 	/**

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -110,6 +110,7 @@ class Dashboard {
 			.o-menu-submissions {
 				display: flex;
 				align-items: center;
+				gap: 6px;
 			}
 
 			.o-menu-badge {
@@ -228,6 +229,89 @@ class Dashboard {
 	}
 
 	/**
+	 * Get YouTube playlist latest video data.
+	 *
+	 * @return array
+	 */
+	private function get_youtube_playlist_data() {
+		$playlist_id = 'PLmRasCVwuvpSep2MOsIoE0ncO9JE3FcKP';
+		$cache_key = 'otter_youtube_playlist_data';
+		$fallback_ttl = HOUR_IN_SECONDS;
+		
+		// Try to get from cache first
+		$cached_data = get_transient( $cache_key );
+		if ( false !== $cached_data ) {
+			return $cached_data;
+		}
+
+		$default_data = array(
+			'videoTitle'   => __( 'Otter Tutorials', 'otter-blocks' ),
+			'videoLink'    => 'https://youtube.com/playlist?list=' . $playlist_id,
+			'thumbnail'    => null,
+		);
+
+		try {
+			$rss_url = 'https://www.youtube.com/feeds/videos.xml?playlist_id=' . $playlist_id;
+			$response = wp_remote_get( $rss_url, array( 'timeout' => 5 ) );
+			
+			if ( is_wp_error( $response ) ) {
+				set_transient( $cache_key, $default_data, $fallback_ttl );
+				return $default_data;
+			}
+
+			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				set_transient( $cache_key, $default_data, $fallback_ttl );
+				return $default_data;
+			}
+
+			$body = wp_remote_retrieve_body( $response );
+			if ( empty( $body ) ) {
+				set_transient( $cache_key, $default_data, $fallback_ttl );
+				return $default_data;
+			}
+
+			// Parse XML
+			$xml = simplexml_load_string( $body );
+			if ( ! $xml ) {
+				set_transient( $cache_key, $default_data, $fallback_ttl );
+				return $default_data;
+			}
+
+			// Get the first entry (latest video)
+			$entry = $xml->entry[0] ?? null;
+			if ( ! $entry ) {
+				set_transient( $cache_key, $default_data, $fallback_ttl );
+				return $default_data;
+			}
+
+			// Extract title
+			$title = (string) $entry->title;
+
+			// Extract video ID from link
+			$link = (string) $entry->link['href'];
+			preg_match( '/v=([a-zA-Z0-9_-]{11})/', $link, $matches );
+			$video_id = $matches[1] ?? null;
+
+			// Build thumbnail URL
+			$thumbnail = $video_id ? 'https://i.ytimg.com/vi/' . $video_id . '/hqdefault.jpg' : null;
+
+			$data = array(
+				'videoTitle'   => $title,
+				'videoLink'    => $link,
+				'thumbnail'    => $thumbnail,
+			);
+
+			// Cache for 24 hours
+			set_transient( $cache_key, $data, DAY_IN_SECONDS );
+
+			return $data;
+		} catch ( Exception $e ) {
+			set_transient( $cache_key, $default_data, $fallback_ttl );
+			return $default_data;
+		}
+	}
+
+	/**
 	 * Get the dashboard data to store in global object.
 	 *
 	 * @return array
@@ -282,6 +366,7 @@ class Dashboard {
 			),
 			'neveInstalled'          => defined( 'NEVE_VERSION' ),
 			'hasPatternSources'      => Template_Cloud::has_used_pattern_sources(),
+			'youtubePlaylistData'    => $this->get_youtube_playlist_data(),
 		);
 
 		$global_data = apply_filters( 'otter_dashboard_data', $global_data );

--- a/src/dashboard/components/Sidebar.js
+++ b/src/dashboard/components/Sidebar.js
@@ -15,7 +15,7 @@ import Infobox from './Infobox.js';
 import LicenseField from './LicenseField.js';
 import  { setUtm } from '../../blocks/helpers/helper-functions.js';
 
-const YOUTUBE_PLAYLIST_URL = 'https://youtube.com/playlist?list=PLmRasCVwuvpSep2MOsIoE0ncO9JE3FcKP&si=hjTkWi5YkPK5JgtL';
+const YOUTUBE_PLAYLIST_URL = 'https://youtube.com/playlist?list=PLmRasCVwuvpSep2MOsIoE0ncO9JE3FcKP';
 
 /**
  * Component to display YouTube playlist card

--- a/src/dashboard/components/Sidebar.js
+++ b/src/dashboard/components/Sidebar.js
@@ -15,17 +15,26 @@ import Infobox from './Infobox.js';
 import LicenseField from './LicenseField.js';
 import  { setUtm } from '../../blocks/helpers/helper-functions.js';
 
-const YOUTUBE_PLAYLIST_URL = 'https://youtube.com/playlist?list=PLmRasCVwuvpSep2MOsIoE0ncO9JE3FcKP';
-
 /**
- * Component to display YouTube playlist card
+ * YouTube tutorials card.
+ *
+ * Owns its Infobox wrapper and renders nothing unless the localized data
+ * provides a thumbnail, so a missing or failed feed never leaves an empty
+ * box or a broken card behind.
  */
-const YouTubePlaylistCard = ({ playlistUrl, playlistData }) => {
-	const { videoTitle, thumbnail } = playlistData || {};
+const YouTubePlaylistCard = () => {
+	const playlistUrl = 'https://youtube.com/playlist?list=PLmRasCVwuvpSep2MOsIoE0ncO9JE3FcKP';
+	const { videoTitle, thumbnail } = window.otterObj?.youtubePlaylistData || {};
+
+	if ( ! thumbnail ) {
+		return null;
+	}
 
 	return (
-		<div className="otter-youtube-card">
-			{ thumbnail && (
+		<Infobox
+			title={ __( 'Otter YouTube Tutorials', 'otter-blocks' ) }
+		>
+			<div className="otter-youtube-card">
 				<a
 					href={ playlistUrl }
 					target="_blank"
@@ -41,25 +50,25 @@ const YouTubePlaylistCard = ({ playlistUrl, playlistData }) => {
 						loading="lazy"
 					/>
 				</a>
-			) }
-			<div className="otter-youtube-card__content">
-				{ videoTitle && (
-					<p className="otter-youtube-card__title">
-						<strong>{ videoTitle }</strong>
-					</p>
-				) }
+				<div className="otter-youtube-card__content">
+					{ videoTitle && (
+						<p className="otter-youtube-card__title">
+							<strong>{ videoTitle }</strong>
+						</p>
+					) }
+				</div>
+				<div className="otter-info-button-group is-single">
+					<Button
+						variant="secondary"
+						isSecondary
+						target="_blank"
+						href={ playlistUrl }
+					>
+						{ __( 'Watch the complete playlist', 'otter-blocks' ) }
+					</Button>
+				</div>
 			</div>
-			<div className="otter-info-button-group is-single">
-				<Button
-					variant="secondary"
-					isSecondary
-					target="_blank"
-					href={ playlistUrl }
-				>
-					{ __( 'Watch the complete playlist', 'otter-blocks' ) }
-				</Button>
-			</div>
-		</div>
+		</Infobox>
 	);
 };
 
@@ -125,14 +134,7 @@ const Sidebar = ({
 				</div>
 			</Infobox>
 
-			<Infobox
-				title={ __( 'Otter YouTube Tutorials', 'otter-blocks' ) }
-			>
-				<YouTubePlaylistCard
-					playlistUrl={ YOUTUBE_PLAYLIST_URL }
-					playlistData={ window.otterObj?.youtubePlaylistData }
-				/>
-			</Infobox>
+			<YouTubePlaylistCard />
 		</Fragment>
 	);
 };

--- a/src/dashboard/components/Sidebar.js
+++ b/src/dashboard/components/Sidebar.js
@@ -14,6 +14,55 @@ import Infobox from './Infobox.js';
 
 import LicenseField from './LicenseField.js';
 import  { setUtm } from '../../blocks/helpers/helper-functions.js';
+
+const YOUTUBE_PLAYLIST_URL = 'https://youtube.com/playlist?list=PLmRasCVwuvpSep2MOsIoE0ncO9JE3FcKP&si=hjTkWi5YkPK5JgtL';
+
+/**
+ * Component to display YouTube playlist card
+ */
+const YouTubePlaylistCard = ({ playlistUrl, playlistData }) => {
+	const { videoTitle, thumbnail } = playlistData || {};
+
+	return (
+		<div className="otter-youtube-card">
+			{ thumbnail && (
+				<a
+					href={ playlistUrl }
+					target="_blank"
+					rel="noreferrer"
+					className="otter-youtube-card__thumbnail"
+				>
+					<span className="otter-youtube-card__play-button" aria-hidden="true">
+						<span className="otter-youtube-card__play-icon" />
+					</span>
+					<img
+						src={ thumbnail }
+						alt={ videoTitle || __( 'Otter YouTube playlist', 'otter-blocks' ) }
+						loading="lazy"
+					/>
+				</a>
+			) }
+			<div className="otter-youtube-card__content">
+				{ videoTitle && (
+					<p className="otter-youtube-card__title">
+						<strong>{ videoTitle }</strong>
+					</p>
+				) }
+			</div>
+			<div className="otter-info-button-group is-single">
+				<Button
+					variant="secondary"
+					isSecondary
+					target="_blank"
+					href={ playlistUrl }
+				>
+					{ __( 'Watch the complete playlist', 'otter-blocks' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
 const Sidebar = ({
 	setTab
 }) => {
@@ -74,6 +123,15 @@ const Sidebar = ({
 						{ __( 'Documentation', 'otter-blocks' ) }
 					</Button>
 				</div>
+			</Infobox>
+
+			<Infobox
+				title={ __( 'Otter YouTube Tutorials', 'otter-blocks' ) }
+			>
+				<YouTubePlaylistCard
+					playlistUrl={ YOUTUBE_PLAYLIST_URL }
+					playlistData={ window.otterObj?.youtubePlaylistData }
+				/>
 			</Infobox>
 		</Fragment>
 	);

--- a/src/dashboard/components/Sidebar.js
+++ b/src/dashboard/components/Sidebar.js
@@ -29,7 +29,7 @@ const YouTubePlaylistCard = ({ playlistUrl, playlistData }) => {
 				<a
 					href={ playlistUrl }
 					target="_blank"
-					rel="noreferrer"
+					rel="noopener noreferrer"
 					className="otter-youtube-card__thumbnail"
 				>
 					<span className="otter-youtube-card__play-button" aria-hidden="true">

--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -395,6 +395,78 @@
 						}
 					}
 				}
+
+				.otter-youtube-card {
+					.otter-youtube-card__thumbnail {
+						position: relative;
+						display: block;
+						margin-bottom: 15px;
+						border-radius: 8px;
+						overflow: hidden;
+						border: 1px solid #d6e2ed;
+
+						&::after {
+							content: '';
+							position: absolute;
+							inset: 0;
+							background: linear-gradient(180deg, rgba(0, 0, 0, 0.08) 0%, rgba(0, 0, 0, 0.2) 100%);
+							pointer-events: none;
+						}
+
+						img {
+							display: block;
+							width: 100%;
+							height: auto;
+							aspect-ratio: 16 / 9;
+							object-fit: cover;
+						}
+					}
+
+					.otter-youtube-card__play-button {
+						position: absolute;
+						top: 50%;
+						left: 50%;
+						z-index: 1;
+						display: flex;
+						align-items: center;
+						justify-content: center;
+						width: 64px;
+						height: 46px;
+						border-radius: 14px;
+						background: rgba(255, 0, 0, 0.92);
+						box-shadow: 0 8px 20px rgba(0, 0, 0, 0.22);
+						transform: translate(-50%, -50%);
+						pointer-events: none;
+					}
+
+					.otter-youtube-card__play-icon {
+						width: 0;
+						height: 0;
+						margin-left: 4px;
+						border-top: 10px solid transparent;
+						border-bottom: 10px solid transparent;
+						border-left: 16px solid #fff;
+					}
+
+					.otter-youtube-card__content {
+						margin-bottom: 15px;
+					}
+
+					.otter-youtube-card__title {
+						margin: 0 0 10px 0;
+						font-size: 14px;
+						color: var(--o-dash-block-text);
+						line-height: 1.5;
+						font-weight: 500;
+					}
+
+					.otter-youtube-card__description {
+						margin: 0;
+						font-size: 14px;
+						color: var(--o-dash-secondary-text);
+						line-height: 1.5;
+					}
+				}
 			}
 		}
 

--- a/src/dashboard/style.scss
+++ b/src/dashboard/style.scss
@@ -459,13 +459,6 @@
 						line-height: 1.5;
 						font-weight: 500;
 					}
-
-					.otter-youtube-card__description {
-						margin: 0;
-						font-size: 14px;
-						color: var(--o-dash-secondary-text);
-						line-height: 1.5;
-					}
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/304


<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

This PR adds a new YouTube tutorials card to the Otter settings dashboard. The card shows the latest video information from a YouTube playlist, includes a playlist thumbnail with a play overlay, and links users to the full playlist. It also fetches the playlist data automatically through YouTube RSS and caches it so the dashboard stays fast and does not depend on manual updates. As part of the same work, it also includes a small spacing fix in the Submissions menu label. 


### Screenshots <!-- if applicable -->

----

<img width="1173" height="1482" alt="chrome-capture-2026-06-04 (1)" src="https://github.com/user-attachments/assets/65493f70-81bd-4f69-a78f-863b8347eb48" />


### Test instructions
<!-- Describe how this pull request can be tested. -->


1. Open the Otter settings dashboard.
2. Verify the new Otter YouTube Tutorials card appears in the sidebar.
3. Confirm the card shows the latest playlist video thumbnail and title.
4. Click the play thumbnail or the CTA button and verify it opens the YouTube playlist.




<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

