### PR TITLE
dashboard: route active pro users to pro support link

### DIFF
--- a/src/dashboard/components/Sidebar.js
+++ b/src/dashboard/components/Sidebar.js
@@ -17,12 +17,7 @@ import  { setUtm } from '../../blocks/helpers/helper-functions.js';
 const Sidebar = ({
 	setTab
 }) => {
-	const isProLicenseActive = Boolean( window.otterObj.hasPro ) && (
-		true === window.otterObj?.license?.valid ||
-		'valid' === window.otterObj?.license?.valid ||
-		true === window.otterObj?.license?.license ||
-		'valid' === window.otterObj?.license?.license
-	);
+	const isProLicenseActive = Boolean( window.otterObj.hasPro ) && 'valid' === window.otterObj?.license?.valid;
 
 	const supportLink = isProLicenseActive ? 'https://store.themeisle.com/' : 'https://wordpress.org/support/plugin/otter-blocks';
 	const supportLabel = isProLicenseActive ? __( 'Contact Pro Support', 'otter-blocks' ) : __( 'Support', 'otter-blocks' );

--- a/src/dashboard/components/Sidebar.js
+++ b/src/dashboard/components/Sidebar.js
@@ -17,6 +17,16 @@ import  { setUtm } from '../../blocks/helpers/helper-functions.js';
 const Sidebar = ({
 	setTab
 }) => {
+	const isProLicenseActive = Boolean( window.otterObj.hasPro ) && (
+		true === window.otterObj?.license?.valid ||
+		'valid' === window.otterObj?.license?.valid ||
+		true === window.otterObj?.license?.license ||
+		'valid' === window.otterObj?.license?.license
+	);
+
+	const supportLink = isProLicenseActive ? 'https://store.themeisle.com/' : 'https://wordpress.org/support/plugin/otter-blocks';
+	const supportLabel = isProLicenseActive ? __( 'Contact Pro Support', 'otter-blocks' ) : __( 'Support', 'otter-blocks' );
+
 	return (
 		<Fragment>
 			{ Boolean( window.otterObj.hasPro ) ? (
@@ -59,7 +69,7 @@ const Sidebar = ({
 				title={ __( 'Useful links', 'otter-blocks' ) }
 			>
 				<ul className="otter-info-links">
-					<li><a href="https://wordpress.org/support/plugin/otter-blocks" target="_blank" rel="noreferrer">{ __( 'Support', 'otter-blocks' ) }</a></li>
+					<li><a href={ supportLink } target="_blank" rel="noreferrer">{ supportLabel }</a></li>
 					<li><a href="https://github.com/Codeinwp/otter-blocks/discussions" target="_blank" rel="noreferrer">{ __( 'Feature request', 'otter-blocks' ) }</a></li>
 					<li><a href="https://wordpress.org/support/plugin/otter-blocks/reviews/#new-post" target="_blank" rel="noreferrer">{ __( 'Leave a review', 'otter-blocks' ) }</a></li>
 				</ul>


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/303
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- keep existing WordPress support link for free users
- show "Contact Pro Support" for Otter Pro users with an active license
- route active Pro support CTA to https://store.themeisle.com/

### Screenshots <!-- if applicable -->

<img width="2110" height="1318" alt="chrome-capture-2026-06-05" src="https://github.com/user-attachments/assets/3842c6ed-2183-44c6-83f6-00a731d94772" />

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Activate Otter Pro with a valid license
- Verify the " Useful Links " item changes to "Contact Pro Support" and points to the store URL
- Verify free/default behavior remains unchanged.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

