### PR TITLE
Fix/onboarding final step checkbox spacing

### DIFF
--- a/src/blocks/plugins/welcome-guide/editor.scss
+++ b/src/blocks/plugins/welcome-guide/editor.scss
@@ -27,6 +27,26 @@
     .o-welcome-guide__input {
         font-size: 13px;
         padding: 0 32px;
+        margin-bottom: 8px;
+    }
+
+    .o-welcome-guide__checkbox {
+        padding: 0 32px;
+        margin: 0 0 8px;
+
+        .components-base-control__field {
+            margin-bottom: 0;
+        }
+
+        .components-checkbox-control__input-container {
+            align-items: flex-start;
+            gap: 8px;
+        }
+
+        .components-checkbox-control__label {
+            line-height: 1.5;
+            margin-top: 1px;
+        }
     }
 
     .components-external-link {

--- a/src/blocks/plugins/welcome-guide/editor.scss
+++ b/src/blocks/plugins/welcome-guide/editor.scss
@@ -24,15 +24,32 @@
         padding: 0 32px;
     }
 
+    .o-welcome-guide__page-content--finish {
+        .o-welcome-guide__text {
+            margin-bottom: 20px;
+        }
+    }
+
+    .o-welcome-guide__form-fields {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 0 32px 12px;
+    }
+
     .o-welcome-guide__input {
         font-size: 13px;
-        padding: 0 32px;
-        margin-bottom: 8px;
+        padding: 0;
+        margin: 0;
+
+        .components-base-control__field {
+            margin-bottom: 0;
+        }
     }
 
     .o-welcome-guide__checkbox {
-        padding: 0 32px;
-        margin: 0 0 8px;
+        padding: 0;
+        margin: 0;
 
         .components-base-control__field {
             margin-bottom: 0;

--- a/src/blocks/plugins/welcome-guide/index.js
+++ b/src/blocks/plugins/welcome-guide/index.js
@@ -191,7 +191,7 @@ const WelcomeGuide = () => {
 								label={ __( 'Yes, count me in!', 'otter-blocks' ) }
 								checked={ hasConsent }
 								onChange={ () => setConsent( ! hasConsent ) }
-								className="o-welcome-guide__input"
+								className="o-welcome-guide__checkbox"
 							/>
 
 							{ 'yes' !== getOption( 'otter_blocks_logger_flag' ) && (
@@ -199,7 +199,7 @@ const WelcomeGuide = () => {
 									label={ __( 'Become a contributor by opting in to our anonymous data tracking.', 'otter-blocks' ) }
 									checked={ canTrack }
 									onChange={ () => setTrack( ! canTrack )}
-									className="o-welcome-guide__input"
+									className="o-welcome-guide__checkbox"
 								/>
 							) }
 						</Fragment>

--- a/src/blocks/plugins/welcome-guide/index.js
+++ b/src/blocks/plugins/welcome-guide/index.js
@@ -174,35 +174,37 @@ const WelcomeGuide = () => {
 				{
 					image: <img src={ window.themeisleGutenberg.assetsPath + '/images/guide/welcome-finish.png' } />,
 					content: (
-						<Fragment>
+						<div className="o-welcome-guide__page-content--finish">
 							<h1 className="o-welcome-guide__heading">{ __( 'Thank you for chosing Otter!', 'otter-blocks' ) }</h1>
 
 							<p className="o-welcome-guide__text">{ __( 'Join Otter\'s mailing list to get first access to product updates, tutorials and promotions.', 'otter-blocks' ) }</p>
 
-							<TextControl
-								aria-label={ __( 'Enter your email', 'otter-blocks' ) }
-								type="email"
-								value={ email }
-								onChange={ setEmail }
-								className="o-welcome-guide__input"
-							/>
+							<div className="o-welcome-guide__form-fields">
+								<TextControl
+									aria-label={ __( 'Enter your email', 'otter-blocks' ) }
+									type="email"
+									value={ email }
+									onChange={ setEmail }
+									className="o-welcome-guide__input"
+								/>
 
-							<CheckboxControl
-								label={ __( 'Yes, count me in!', 'otter-blocks' ) }
-								checked={ hasConsent }
-								onChange={ () => setConsent( ! hasConsent ) }
-								className="o-welcome-guide__checkbox"
-							/>
-
-							{ 'yes' !== getOption( 'otter_blocks_logger_flag' ) && (
 								<CheckboxControl
-									label={ __( 'Become a contributor by opting in to our anonymous data tracking.', 'otter-blocks' ) }
-									checked={ canTrack }
-									onChange={ () => setTrack( ! canTrack )}
+									label={ __( 'Yes, count me in!', 'otter-blocks' ) }
+									checked={ hasConsent }
+									onChange={ () => setConsent( ! hasConsent ) }
 									className="o-welcome-guide__checkbox"
 								/>
-							) }
-						</Fragment>
+
+								{ 'yes' !== getOption( 'otter_blocks_logger_flag' ) && (
+									<CheckboxControl
+										label={ __( 'Become a contributor by opting in to our anonymous data tracking.', 'otter-blocks' ) }
+										checked={ canTrack }
+										onChange={ () => setTrack( ! canTrack )}
+										className="o-welcome-guide__checkbox"
+									/>
+								) }
+							</div>
+						</div>
 					)
 				}
 			] }

--- a/src/blocks/plugins/welcome-guide/index.js
+++ b/src/blocks/plugins/welcome-guide/index.js
@@ -175,7 +175,7 @@ const WelcomeGuide = () => {
 					image: <img src={ window.themeisleGutenberg.assetsPath + '/images/guide/welcome-finish.png' } />,
 					content: (
 						<div className="o-welcome-guide__page-content--finish">
-							<h1 className="o-welcome-guide__heading">{ __( 'Thank you for chosing Otter!', 'otter-blocks' ) }</h1>
+							<h1 className="o-welcome-guide__heading">{ __( 'Thank you for choosing Otter!', 'otter-blocks' ) }</h1>
 
 							<p className="o-welcome-guide__text">{ __( 'Join Otter\'s mailing list to get first access to product updates, tutorials and promotions.', 'otter-blocks' ) }</p>
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/302
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Fixed spacing of the final onboarding step checkboxes.


### Screenshots <!-- if applicable -->

<img width="382" height="639" alt="Screenshot 2026-06-05 at 5 52 42 PM" src="https://github.com/user-attachments/assets/dd85912e-d4ca-4a42-b3d1-1f797a43b94c" />


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Open the Otter onboarding modal and go to the last step.
2. Check spacing after email, between checkboxes, and before buttons.
3. Confirm no internal scrollbar appears on that step.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

