### PR TITLE
Feat/visibility conditions uix

### DIFF
--- a/src/blocks/components/select-products-control/index.js
+++ b/src/blocks/components/select-products-control/index.js
@@ -26,12 +26,12 @@ const SelectProducts = ({
 
 		const { COLLECTIONS_STORE_KEY } = window.wc.wcBlocksData;
 
-		const error = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products', { per_page: 0 });
+		const error = select( COLLECTIONS_STORE_KEY ).getCollectionError( '/wc/store', 'products', { per_page: 100 });
 
 		if ( error ) {
 			status = 'error';
 		} else {
-			results = 'error' === status ? [] : ( select( COLLECTIONS_STORE_KEY ).getCollection?.( '/wc/store', 'products', { per_page: 0 }) ?? [])?.map( result => ({
+			results = 'error' === status ? [] : ( select( COLLECTIONS_STORE_KEY ).getCollection?.( '/wc/store', 'products', { per_page: 100 }) ?? [])?.map( result => ({
 				value: result.id,
 				label: decodeEntities( result.name )
 			}) );
@@ -49,7 +49,7 @@ const SelectProducts = ({
 		return {
 			results,
 			status,
-			isLoading: select( COLLECTIONS_STORE_KEY ).isResolving( 'getCollection', [ '/wc/store', 'products', { per_page: 0 }])
+			isLoading: select( COLLECTIONS_STORE_KEY ).isResolving( 'getCollection', [ '/wc/store', 'products', { per_page: 100 }])
 		};
 	}, []);
 

--- a/src/blocks/plugins/conditions/components/condition-picker.js
+++ b/src/blocks/plugins/conditions/components/condition-picker.js
@@ -1,0 +1,139 @@
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+
+import {
+	Dropdown,
+	Icon,
+	SearchControl
+} from '@wordpress/components';
+
+import { useState } from '@wordpress/element';
+
+import { lock } from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
+import { getConditionIcon } from '../utils.js';
+
+const PickerContent = ({ conditions, onSelect }) => {
+	const [ search, setSearch ] = useState( '' );
+
+	// With Otter Pro active, the remaining disabled entries need their integration plugin instead.
+	const disabledHelp = Boolean( window.otterPro?.isActive ) ?
+		__( 'Requires a plugin that is not installed or active.', 'otter-blocks' ) :
+		__( 'Available in Otter Pro', 'otter-blocks' );
+
+	const groups = Object.keys( conditions )
+		.map( key => {
+			const group = conditions[ key ];
+			const query = search.trim().toLowerCase();
+
+			return {
+				...group,
+				items: group.conditions.filter( condition => {
+					if ( ! query ) {
+						return true;
+					}
+
+					return condition.label.toLowerCase().includes( query ) || group.label.toLowerCase().includes( query );
+				})
+			};
+		})
+		.filter( group => Boolean( group.items.length ) );
+
+	return (
+		<div className="o-conditions-picker">
+			<SearchControl
+				__nextHasNoMarginBottom
+				hideLabelFromVision
+				label={ __( 'Search conditions', 'otter-blocks' ) }
+				placeholder={ __( 'Search conditions…', 'otter-blocks' ) }
+				value={ search }
+				onChange={ setSearch }
+			/>
+
+			<div className="o-conditions-picker__list">
+				{ ! groups.length && (
+					<p className="o-conditions-picker__empty">{ __( 'No conditions found.', 'otter-blocks' ) }</p>
+				) }
+
+				{ groups.map( group => (
+					<div key={ group.label }>
+						<div className="o-conditions-picker__group-label">{ group.label }</div>
+
+						{ group.items.map( condition => {
+							const isDisabled = Boolean( condition?.isDisabled );
+
+							return (
+								<button
+									key={ condition.value }
+									type="button"
+									className={ classnames( 'o-conditions-picker__item', { 'is-disabled': isDisabled }) }
+									aria-disabled={ isDisabled }
+									title={ isDisabled ? disabledHelp : undefined }
+									onClick={ () => {
+										if ( ! isDisabled ) {
+											onSelect( condition.value );
+										}
+									} }
+								>
+									<span className="o-conditions__row-icon">
+										<Icon icon={ getConditionIcon( condition.value ) } size={ 16 } />
+									</span>
+
+									<span className="o-conditions-picker__item-content">
+										<span className="o-conditions-picker__item-label">
+											{ condition.label }
+											{ isDisabled && <Icon icon={ lock } size={ 14 } /> }
+										</span>
+
+										{ condition.help && (
+											<span className="o-conditions-picker__item-help">{ condition.help }</span>
+										) }
+									</span>
+								</button>
+							);
+						}) }
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+const ConditionPicker = ({
+	conditions,
+	onSelect,
+	renderToggle
+}) => {
+	return (
+		<Dropdown
+			className="o-conditions__picker"
+			popoverProps={ {
+				placement: 'bottom-start',
+				noArrow: true,
+				className: 'o-conditions-picker__popover'
+			} }
+			renderToggle={ renderToggle }
+			renderContent={ ({ onClose }) => (
+				<PickerContent
+					conditions={ conditions }
+					onSelect={ value => {
+						onSelect( value );
+						onClose();
+					} }
+				/>
+			) }
+		/>
+	);
+};
+
+export default ConditionPicker;

--- a/src/blocks/plugins/conditions/components/rule-group.js
+++ b/src/blocks/plugins/conditions/components/rule-group.js
@@ -1,0 +1,313 @@
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies.
+ */
+import {
+	__,
+	_n,
+	sprintf
+} from '@wordpress/i18n';
+
+import {
+	Button,
+	Icon
+} from '@wordpress/components';
+
+import {
+	Fragment,
+	useEffect,
+	useRef,
+	useState
+} from '@wordpress/element';
+
+import {
+	chevronDown,
+	chevronUp,
+	plus,
+	trash
+} from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
+import ConditionPicker from './condition-picker.js';
+
+import {
+	getConditionIcon,
+	getConditionSummary
+} from '../utils.js';
+
+const noSettingsTypes = [ 'loggedInUser', 'loggedOutUser' ];
+
+export const Separator = ({ label }) => (
+	<div className="o-conditions__separator">
+		<span className="o-conditions__separator-line" />
+		<span className="o-conditions__separator-label">{ label }</span>
+		<span className="o-conditions__separator-line" />
+	</div>
+);
+
+const ConditionRow = ({
+	condition,
+	conditions,
+	flatConditions,
+	isOpen,
+	onToggle,
+	onRemove,
+	onSelectType,
+	children
+}) => {
+	const mainRef = useRef( null );
+	const wasEmpty = useRef( ! condition.type );
+
+	/**
+	 * When a type is picked on an empty row the picker toggle unmounts,
+	 * so move focus to the row header to keep the keyboard flow.
+	 */
+	useEffect( () => {
+		if ( wasEmpty.current && condition.type ) {
+			wasEmpty.current = false;
+			mainRef.current?.focus();
+		}
+	}, [ condition.type ]);
+
+	if ( ! condition.type ) {
+		return (
+			<div className="o-conditions__row">
+				<ConditionPicker
+					conditions={ conditions }
+					onSelect={ onSelectType }
+					renderToggle={ ({ isOpen: isPickerOpen, onToggle: onTogglePicker }) => (
+						<div className="o-conditions__row-header">
+							<button
+								type="button"
+								className="o-conditions__row-main"
+								onClick={ onTogglePicker }
+								aria-expanded={ isPickerOpen }
+							>
+								<span className="o-conditions__row-icon is-empty">
+									<Icon icon={ plus } size={ 16 } />
+								</span>
+
+								<span className="o-conditions__row-text">
+									<span className="o-conditions__row-title">{ __( 'Choose a condition', 'otter-blocks' ) }</span>
+									<span className="o-conditions__row-value is-empty">{ __( 'Select a condition from the list', 'otter-blocks' ) }</span>
+								</span>
+							</button>
+
+							<Button
+								className="o-conditions__row-remove"
+								icon={ trash }
+								label={ __( 'Remove condition', 'otter-blocks' ) }
+								showTooltip={ true }
+								onClick={ onRemove }
+							/>
+						</div>
+					) }
+				/>
+			</div>
+		);
+	}
+
+	const definition = flatConditions.find( item => item.value === condition.type );
+	const summary = getConditionSummary( condition );
+	const hasSettings = ! noSettingsTypes.includes( condition.type );
+	const isExpanded = isOpen && hasSettings;
+
+	return (
+		<div className={ classnames( 'o-conditions__row', { 'is-open': isExpanded }) }>
+			<div className="o-conditions__row-header">
+				<button
+					ref={ mainRef }
+					type="button"
+					className={ classnames( 'o-conditions__row-main', { 'is-static': ! hasSettings }) }
+					onClick={ hasSettings ? onToggle : undefined }
+					aria-expanded={ hasSettings ? isExpanded : undefined }
+				>
+					<span className="o-conditions__row-icon">
+						<Icon icon={ getConditionIcon( condition.type ) } size={ 16 } />
+					</span>
+
+					<span className="o-conditions__row-text">
+						<span className="o-conditions__row-title">{ definition?.label ?? condition.type }</span>
+						{ Boolean( summary ) && <span className="o-conditions__row-value">{ summary }</span> }
+					</span>
+
+					{ hasSettings && <Icon icon={ chevronDown } size={ 20 } className="o-conditions__row-chevron" /> }
+				</button>
+
+				<Button
+					className="o-conditions__row-remove"
+					icon={ trash }
+					label={ __( 'Remove condition', 'otter-blocks' ) }
+					showTooltip={ true }
+					onClick={ onRemove }
+				/>
+			</div>
+
+			{ isExpanded && <div className="o-conditions__row-editor">{ children }</div> }
+		</div>
+	);
+};
+
+const RuleGroup = ({
+	group,
+	index,
+	conditions,
+	flatConditions,
+	onDelete,
+	onAddCondition,
+	onChangeCondition,
+	onRemoveCondition,
+	renderConditionControls
+}) => {
+	const [ isOpen, setOpen ] = useState( true );
+	const [ openRows, setOpenRows ] = useState( () => new Set() );
+
+	/**
+	 * Conditions have no stable IDs, so keep a parallel list of generated row keys.
+	 * Keys are spliced on removal so open state stays with the right row.
+	 */
+	const rowUid = useRef( 0 );
+	const rowKeys = useRef([]);
+
+	while ( rowKeys.current.length < group.length ) {
+		rowKeys.current.push( ++rowUid.current );
+	}
+	if ( rowKeys.current.length > group.length ) {
+		rowKeys.current = rowKeys.current.slice( 0, group.length );
+	}
+
+	const openRow = rowKey => setOpenRows( prev => new Set( prev ).add( rowKey ) );
+
+	const toggleRow = rowKey => setOpenRows( prev => {
+		const next = new Set( prev );
+
+		if ( next.has( rowKey ) ) {
+			next.delete( rowKey );
+		} else {
+			next.add( rowKey );
+		}
+
+		return next;
+	});
+
+	const removeRow = rowIndex => {
+		const [ rowKey ] = rowKeys.current.splice( rowIndex, 1 );
+
+		setOpenRows( prev => {
+			const next = new Set( prev );
+			next.delete( rowKey );
+			return next;
+		});
+
+		onRemoveCondition( rowIndex );
+	};
+
+	const conditionLabels = group
+		.filter( condition => condition.type )
+		.map( condition => flatConditions.find( item => item.value === condition.type )?.label ?? condition.type );
+
+	let summary;
+
+	if ( ! group.length ) {
+		summary = __( 'No conditions yet', 'otter-blocks' );
+	} else if ( isOpen ) {
+
+		/* translators: %d: the number of conditions inside the rule group */
+		summary = sprintf( _n( '%d condition', '%d conditions', group.length, 'otter-blocks' ), group.length );
+	} else {
+		summary = conditionLabels.length ? conditionLabels.join( ' · ' ) : __( 'Unfinished condition', 'otter-blocks' );
+	}
+
+	return (
+		<div className={ classnames( 'o-conditions__group', { 'is-open': isOpen }) }>
+			<div className="o-conditions__group-header">
+				<button
+					type="button"
+					className="o-conditions__group-main"
+					onClick={ () => setOpen( ! isOpen ) }
+					aria-expanded={ isOpen }
+				>
+					<span className="o-conditions__group-title">
+						{
+							/* translators: %d: the number of the rule group */
+							sprintf( __( 'Rule Group %d', 'otter-blocks' ), index + 1 )
+						}
+					</span>
+					<span className="o-conditions__group-summary">{ summary }</span>
+				</button>
+
+				<Button
+					className="o-conditions__group-toggle"
+					icon={ isOpen ? chevronUp : chevronDown }
+					label={ isOpen ? __( 'Collapse rule group', 'otter-blocks' ) : __( 'Expand rule group', 'otter-blocks' ) }
+					showTooltip={ true }
+					aria-expanded={ isOpen }
+					onClick={ () => setOpen( ! isOpen ) }
+				/>
+
+				<Button
+					className="o-conditions__group-remove"
+					icon={ trash }
+					label={ __( 'Delete rule group', 'otter-blocks' ) }
+					showTooltip={ true }
+					onClick={ onDelete }
+				/>
+			</div>
+
+			{ isOpen && (
+				<div className="o-conditions__group-body">
+					{ group.map( ( condition, condIdx ) => (
+						<Fragment key={ rowKeys.current[ condIdx ] }>
+							{ 0 < condIdx && <Separator label={ __( 'AND', 'otter-blocks' ) } /> }
+
+							<ConditionRow
+								condition={ condition }
+								conditions={ conditions }
+								flatConditions={ flatConditions }
+								isOpen={ openRows.has( rowKeys.current[ condIdx ] ) }
+								onToggle={ () => toggleRow( rowKeys.current[ condIdx ] ) }
+								onRemove={ () => removeRow( condIdx ) }
+								onSelectType={ value => {
+									onChangeCondition( value, condIdx );
+									openRow( rowKeys.current[ condIdx ] );
+								} }
+							>
+								{ renderConditionControls( condition, condIdx ) }
+							</ConditionRow>
+						</Fragment>
+					) ) }
+
+					<ConditionPicker
+						conditions={ conditions }
+						onSelect={ value => {
+							const rowKey = ++rowUid.current;
+							rowKeys.current.push( rowKey );
+							openRow( rowKey );
+							onAddCondition( value );
+						} }
+						renderToggle={ ({ isOpen: isPickerOpen, onToggle: onTogglePicker }) => (
+							<Button
+								className="o-conditions__add-condition"
+								onClick={ onTogglePicker }
+								aria-expanded={ isPickerOpen }
+							>
+								<span className="o-conditions__row-icon is-add">
+									<Icon icon={ plus } size={ 14 } />
+								</span>
+								{ __( 'Add condition', 'otter-blocks' ) }
+							</Button>
+						) }
+					/>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default RuleGroup;

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -626,9 +626,21 @@ const Edit = ({
 		</Fragment>
 	);
 
+	const hasActiveConditions = Boolean( attributes.otterConditions?.some( group => group?.some?.( condition => condition?.type ) ) );
+
 	return (
 		<PanelBody
-			title={ __( 'Visibility Conditions', 'otter-blocks' ) }
+			title={(
+				<Fragment>
+					{ __( 'Visibility Conditions', 'otter-blocks' ) }
+
+					{ hasActiveConditions && (
+						<span className="o-conditions__indicator">
+							<span className="screen-reader-text">{ __( '(has active conditions)', 'otter-blocks' ) }</span>
+						</span>
+					) }
+				</Fragment>
+			)}
 			initialOpen={ false }
 		>
 			<p className="o-conditions__intro">{ __( 'Display the block if…', 'otter-blocks' ) }</p>

--- a/src/blocks/plugins/conditions/edit.js
+++ b/src/blocks/plugins/conditions/edit.js
@@ -6,14 +6,14 @@ import { __ } from '@wordpress/i18n';
 import { cloneDeep, isEmpty } from 'lodash';
 
 import {
-	BaseControl,
 	Button,
 	ExternalLink,
 	FormTokenField,
 	PanelBody,
+	Placeholder,
 	SelectControl,
 	Spinner,
-	Placeholder, ToggleControl
+	ToggleControl
 } from '@wordpress/components';
 
 import { useSelect } from '@wordpress/data';
@@ -22,16 +22,19 @@ import {
 	Fragment,
 	memo,
 	useEffect,
+	useRef,
 	useState
 } from '@wordpress/element';
 
 import { applyFilters } from '@wordpress/hooks';
 
+import { plus } from '@wordpress/icons';
+
 /**
  * Internal dependencies.
  */
 import StripeControls from './components/stripe-controls';
-import { PanelTab } from '../../components/index.js';
+import RuleGroup, { Separator } from './components/rule-group.js';
 
 const postTypes = Object.keys( window.themeisleGutenberg.postTypes );
 
@@ -308,15 +311,35 @@ const TagsFieldToken = ( props ) => {
 	);
 };
 
-const Separator = ({ label }) => {
-	return (
-		<div className="o-conditions__operator-wrapper">
-			<div className="o-conditions__operator-line"></div>
-			<div className="o-conditions__operator-word">
-				<span>{ label }</span>
-			</div>
-		</div>
-	);
+const computeConditionsCatalog = () => {
+	const conditions = applyFilters( 'otter.blockConditions.conditions', defaultConditions );
+
+	// Labels need to resolve for every catalog group, including third-party ones.
+	const flatConditions = Object.keys( conditions ).map( i => conditions?.[i].conditions ).flat();
+	const defaultFlatConditions = Object.keys( conditions )
+		.filter( key => defaultConditionsKeys.includes( key ) )
+		.map( i => conditions?.[i].conditions )
+		.flat();
+
+	return {
+		conditions,
+		flatConditions,
+		toggleVisibility: defaultFlatConditions.filter( i => i.toogleVisibility )?.map( i => i.value )
+	};
+};
+
+const getConditionDefaults = value => {
+	const attrs = applyFilters( 'otter.blockConditions.defaults', {}, value );
+
+	if ( 'userRoles' === value || 'postAuthor' === value ) {
+		attrs.visibility = true;
+	}
+
+	if ( 'screenSize' === value ) {
+		attrs['screen_sizes'] = [];
+	}
+
+	return attrs;
 };
 
 const Edit = ({
@@ -325,10 +348,24 @@ const Edit = ({
 	name
 }) => {
 	const [ buffer, setBuffer ] = useState( null );
-	const [ conditions, setConditions ] = useState({});
-	const [ flatConditions, setFlatConditions ] = useState([]);
-	const [ toggleVisibility, setToggleVisibility ] = useState([]);
-	const [ openTabs, setOpenTabs ] = useState(new Set()); // State to track open tabs
+	const [ catalog, setCatalog ] = useState( computeConditionsCatalog );
+
+	const { conditions, flatConditions, toggleVisibility } = catalog;
+
+	/**
+	 * The conditions have no stable IDs, so keep a parallel list of generated keys.
+	 * Keys are spliced on group removal so React state stays with the right group.
+	 */
+	const groupUid = useRef( 0 );
+	const groupKeys = useRef([]);
+
+	const groupsCount = attributes.otterConditions?.length ?? 0;
+	while ( groupKeys.current.length < groupsCount ) {
+		groupKeys.current.push( ++groupUid.current );
+	}
+	if ( groupKeys.current.length > groupsCount ) {
+		groupKeys.current = groupKeys.current.slice( 0, groupsCount );
+	}
 
 	const setAttributes = ( attrs ) => {
 
@@ -372,31 +409,18 @@ const Edit = ({
 	}, []);
 
 	useEffect( () => {
-		const c = applyFilters( 'otter.blockConditions.conditions', defaultConditions );
-
-		const conditionsKeys = Object.keys( c ).filter( key => defaultConditionsKeys.includes( key ) );
-		const flat = conditionsKeys.map( i => c?.[i].conditions ).flat();
-
-		flat.splice( 0, 0, {
-			value: 'none',
-			label: __( 'Select a condition', 'otter-blocks' ),
-			help: __( 'Select a condition to control the visibility of your block.', 'otter-blocks' )
-		});
-
-		setConditions( c );
-		setFlatConditions( flat );
-		setToggleVisibility( flat.filter( i => i.toogleVisibility )?.map( i => i.value ) );
+		setCatalog( computeConditionsCatalog() );
 	}, [ attributes.otterConditions ]);
 
 	const addGroup = () => {
 		const otterConditions = cloneDeep( attributes.otterConditions || [] );
-		const newGroupIndex = otterConditions.length; // Use the index of the new group
-		otterConditions.push([{}]);
+		otterConditions.push([]);
 		setAttributes({ otterConditions });
-		setOpenTabs(prev => new Set(prev).add(newGroupIndex));
 	};
 
 	const removeGroup = n => {
+		groupKeys.current.splice( n, 1 );
+
 		let otterConditions = cloneDeep( attributes.otterConditions );
 		otterConditions.splice( n, 1 );
 
@@ -407,19 +431,23 @@ const Edit = ({
 		setAttributes({ otterConditions });
 	};
 
-	const addNewCondition = index => {
+	const addCondition = ( index, value ) => {
 		const otterConditions = cloneDeep( attributes.otterConditions );
-		otterConditions[ index ].push({});
+		const condIdx = otterConditions[ index ].length;
+
+		window.oTrk?.set( `condition-type_${attributes?.id ?? name}_${index}_${condIdx}`, { groupID: attributes?.id ?? name, feature: 'condition', featureComponent: 'condition-type', featureValue: value });
+
+		otterConditions[ index ].push({
+			type: value,
+			...getConditionDefaults( value )
+		});
+
 		setAttributes({ otterConditions });
 	};
 
 	const removeCondition = ( index, key ) => {
 		const otterConditions = cloneDeep( attributes.otterConditions );
 		otterConditions[ index ].splice( key, 1 );
-
-		if ( 0 === otterConditions[ index ]) {
-			otterConditions.splice( index, 1 );
-		}
 
 		setAttributes({ otterConditions });
 	};
@@ -429,22 +457,12 @@ const Edit = ({
 
 		const otterConditions = cloneDeep( attributes.otterConditions );
 
-		const attrs = applyFilters( 'otter.blockConditions.defaults', {}, value );
-
-		if ( 'userRoles' === value || 'postAuthor' === value ) {
-			attrs.visibility = true;
-		}
-
-		if ( 'screenSize' === value ) {
-			attrs['screen_sizes'] = [];
-		}
-
 		if ( 'none' === value ) {
 			otterConditions[ index ][ key ] = {};
 		} else {
 			otterConditions[ index ][ key ] = {
 				type: value,
-				...attrs
+				...getConditionDefaults( value )
 			};
 		}
 
@@ -499,186 +517,144 @@ const Edit = ({
 		setAttributes({ otterConditions });
 	};
 
+	const renderConditionControls = ( condObj, index, condIdx ) => (
+		<Fragment>
+			{ 'userRoles' === condObj.type && (
+				<FormTokenField
+					label={ __( 'User Roles', 'otter-blocks' ) }
+					value={ condObj.roles }
+					suggestions={ Object.keys( window.themeisleGutenberg.userRoles ) }
+					onChange={ roles => changeArrayValue( roles, index, condIdx, 'roles' ) }
+					__experimentalExpandOnFocus={ true }
+					__experimentalValidateInput={ newValue => Object.keys( window.themeisleGutenberg.userRoles ).includes( newValue ) }
+				/>
+			) }
+
+			{ 'postAuthor' === condObj.type && (
+				<AuthorsFieldToken
+					label={ __( 'Post Author', 'otter-blocks' ) }
+					value={ condObj.authors }
+					onChange={ authors => changeArrayValue( authors, index, condIdx, 'authors' ) }
+				/>
+			) }
+
+			{ 'postCategory' === condObj.type && (
+				<CategoriesFieldToken
+					label={ __( 'Post Category', 'otter-blocks' ) }
+					value={ condObj.categories }
+					onChange={ categories => changeArrayValue( categories, index, condIdx, 'categories' ) }
+				/>
+			) }
+
+			{ 'postTag' === condObj.type && (
+				<TagsFieldToken
+					label={ __( 'Post Tag', 'otter-blocks' ) }
+					value={ condObj.tags }
+					onChange={ tags => changeArrayValue( tags, index, condIdx, 'tags' ) }
+				/>
+			) }
+
+			{ 'postType' === condObj.type && (
+				<FormTokenField
+					label={ __( 'Post Types', 'otter-blocks' ) }
+					value={ condObj.post_types }
+					suggestions={ postTypes }
+					onChange={ types => changeArrayValue( types, index, condIdx, 'post_types' ) }
+					__experimentalExpandOnFocus={ true }
+					__experimentalValidateInput={ newValue => postTypes.includes( newValue ) }
+				/>
+			) }
+
+			{ 'screenSize' === condObj.type && (
+				<Fragment>
+					<ToggleControl
+						label={ __( 'Hide on Mobile', 'otter-blocks' ) }
+						checked={ condObj?.screen_sizes?.includes( 'mobile' ) }
+						onChange={ () => toggleValueInArray( 'mobile', index, condIdx, 'screen_sizes' )}
+					/>
+					<ToggleControl
+						label={ __( 'Hide on Tablet', 'otter-blocks' ) }
+						checked={ condObj?.screen_sizes?.includes( 'tablet' ) }
+						onChange={ () => toggleValueInArray( 'tablet', index, condIdx, 'screen_sizes' )}
+					/>
+					<ToggleControl
+						label={ __( 'Hide on Desktop', 'otter-blocks' ) }
+						checked={ condObj?.screen_sizes?.includes( 'desktop' ) }
+						onChange={ () => toggleValueInArray( 'desktop', index, condIdx, 'screen_sizes' )}
+					/>
+				</Fragment>
+			) }
+
+			{ 'stripePurchaseHistory' === condObj.type && (
+				<Fragment>
+					{ Boolean( window.themeisleGutenberg.hasStripeAPI ) && (
+						<StripeControls
+							product={ condObj.product }
+							onChange={ product => changeValue( product, index, condIdx, 'product' ) }
+						/>
+					) }
+
+					{ ! Boolean( window.themeisleGutenberg.hasStripeAPI ) && (
+						<p>
+							{ __( 'You need to set your Stripe API keys in the Otter Dashboard.', 'otter-blocks' ) }
+							{ ' ' }
+							<ExternalLink href={ window.themeisleGutenberg.optionsPath }>{ __( 'Visit Dashboard', 'otter-blocks' ) }</ExternalLink>
+						</p>
+					) }
+				</Fragment>
+			) }
+
+			{ applyFilters( 'otter.blockConditions.controls', '', index, condIdx, condObj, attributes.otterConditions, setAttributes, changeValue ) }
+
+			{ toggleVisibility.includes( condObj.type ) && (
+				<SelectControl
+					label={ __( 'If condition is true, the block should be:', 'otter-blocks' ) }
+					options={ [
+						{
+							value: true,
+							label: __( 'Visible', 'otter-blocks' )
+						},
+						{
+							value: false,
+							label: __( 'Hidden', 'otter-blocks' )
+						}
+					] }
+					value={ condObj.visibility }
+					onChange={ e => changeVisibility( e, index, condIdx ) }
+				/>
+			) }
+		</Fragment>
+	);
+
 	return (
 		<PanelBody
 			title={ __( 'Visibility Conditions', 'otter-blocks' ) }
 			initialOpen={ false }
 		>
-			<p>{ __( 'Control the visibility of your blocks based on the following conditions.', 'otter-blocks' ) }</p>
+			<p className="o-conditions__intro">{ __( 'Display the block if…', 'otter-blocks' ) }</p>
 
-			<p>{ __( 'Display the block if…', 'otter-blocks' ) }</p>
+			{ attributes.otterConditions && attributes.otterConditions.map( ( group, index ) => (
+				<Fragment key={ groupKeys.current[ index ] }>
+					{ 0 < index && <Separator label={ __( 'OR', 'otter-blocks' ) } /> }
 
-			{ attributes.otterConditions && attributes.otterConditions.map( ( group, index ) => {
-				return (
-					<Fragment key={ index }>
-						<PanelTab
-							label={ __( 'Rule Group', 'otter-blocks' ) }
-							onDelete={ () => removeGroup( index ) }
-							initialOpen={ openTabs.has(index) }
-						>
-							{ group && group.map( ( condObj, condIdx ) => (
-								<Fragment key={ `${ index }_${ condIdx }` }>
-									<BaseControl
-										label={ __( 'Condition', 'otter-blocks' ) }
-										help={ flatConditions.find( condition => condition.value === ( condObj.type || 'none' ) )?.help }
-										id={ `o-conditions-${ index }-${ condIdx }` }
-									>
-										<select
-											value={ condObj.type || '' }
-											onChange={ e => changeCondition( e.target.value, index, condIdx ) }
-											className="components-select-control__input w-full"
-											id={ `o-conditions-${ index }-${ condIdx }` }
-										>
-											<option value="none">{ __( 'Select a condition', 'otter-blocks' ) }</option>
-
-											{ Object.keys( conditions ).map( groupKey => {
-												return (
-													<optgroup label={ conditions[groupKey].label } key={ groupKey }>
-														{ conditions[groupKey].conditions.map( o => <option value={ o.value } key={ o.value } disabled={ o?.isDisabled }>{ o.label }</option> ) }
-													</optgroup>
-												);
-											}) }
-										</select>
-									</BaseControl>
-
-									{ 'userRoles' === condObj.type && (
-										<FormTokenField
-											label={ __( 'User Roles', 'otter-blocks' ) }
-											value={ condObj.roles }
-											suggestions={ Object.keys( window.themeisleGutenberg.userRoles ) }
-											onChange={ roles => changeArrayValue( roles, index, condIdx, 'roles' ) }
-											__experimentalExpandOnFocus={ true }
-											__experimentalValidateInput={ newValue => Object.keys( window.themeisleGutenberg.userRoles ).includes( newValue ) }
-										/>
-									) }
-
-									{ 'postAuthor' === condObj.type && (
-										<AuthorsFieldToken
-											label={ __( 'Post Author', 'otter-blocks' ) }
-											value={ condObj.authors }
-											onChange={ authors => changeArrayValue( authors, index, condIdx, 'authors' ) }
-										/>
-									) }
-
-									{ 'postCategory' === condObj.type && (
-										<CategoriesFieldToken
-											label={ __( 'Post Category', 'otter-blocks' ) }
-											value={ condObj.categories }
-											onChange={ categories => changeArrayValue( categories, index, condIdx, 'categories' ) }
-										/>
-									) }
-
-									{ 'postTag' === condObj.type && (
-										<TagsFieldToken
-											label={ __( 'Post Tag', 'otter-blocks' ) }
-											value={ condObj.tags }
-											onChange={ tags => changeArrayValue( tags, index, condIdx, 'tags' ) }
-										/>
-									) }
-
-									{ 'postType' === condObj.type && (
-										<FormTokenField
-											label={ __( 'Post Types', 'otter-blocks' ) }
-											value={ condObj.post_types }
-											suggestions={ postTypes }
-											onChange={ types => changeArrayValue( types, index, condIdx, 'post_types' ) }
-											__experimentalExpandOnFocus={ true }
-											__experimentalValidateInput={ newValue => postTypes.includes( newValue ) }
-										/>
-									) }
-
-									{ 'screenSize' === condObj.type && (
-										<Fragment>
-											<ToggleControl
-												label={ __( 'Hide on Mobile', 'otter-blocks' ) }
-												checked={ condObj?.screen_sizes?.includes( 'mobile' ) }
-												onChange={ () => toggleValueInArray( 'mobile', index, condIdx, 'screen_sizes' )}
-											/>
-											<ToggleControl
-												label={ __( 'Hide on Tablet', 'otter-blocks' ) }
-												checked={ condObj?.screen_sizes?.includes( 'tablet' ) }
-												onChange={ () => toggleValueInArray( 'tablet', index, condIdx, 'screen_sizes' )}
-											/>
-											<ToggleControl
-												label={ __( 'Hide on Desktop', 'otter-blocks' ) }
-												checked={ condObj?.screen_sizes?.includes( 'desktop' ) }
-												onChange={ () => toggleValueInArray( 'desktop', index, condIdx, 'screen_sizes' )}
-											/>
-										</Fragment>
-									) }
-
-									{ 'stripePurchaseHistory' === condObj.type && (
-										<Fragment>
-											{ Boolean( window.themeisleGutenberg.hasStripeAPI ) && (
-												<StripeControls
-													product={ condObj.product }
-													onChange={ product => changeValue( product, index, condIdx, 'product' ) }
-												/>
-											) }
-
-											{ ! Boolean( window.themeisleGutenberg.hasStripeAPI ) && (
-												<p>
-													{ __( 'You need to set your Stripe API keys in the Otter Dashboard.', 'otter-blocks' ) }
-													{ ' ' }
-													<ExternalLink href={ window.themeisleGutenberg.optionsPath }>{ __( 'Visit Dashboard', 'otter-blocks' ) }</ExternalLink>
-												</p>
-											) }
-										</Fragment>
-									) }
-
-									{ applyFilters( 'otter.blockConditions.controls', '', index, condIdx, condObj, attributes.otterConditions, setAttributes, changeValue ) }
-
-									{ toggleVisibility.includes( condObj.type ) && (
-										<SelectControl
-											label={ __( 'If condition is true, the block should be:', 'otter-blocks' ) }
-											options={ [
-												{
-													value: true,
-													label: __( 'Visible', 'otter-blocks' )
-												},
-												{
-													value: false,
-													label: __( 'Hidden', 'otter-blocks' )
-												}
-											] }
-											value={ condObj.visibility }
-											onChange={ e => changeVisibility( e, index, condIdx ) }
-										/>
-									) }
-
-									<Button
-										isDestructive
-										className="o-conditions__add"
-										onClick={ () => removeCondition( index, condIdx ) }
-									>
-										{ __( 'Delete Condition', 'otter-blocks' ) }
-									</Button>
-
-									{ ( 1 < group.length && condIdx !== group.length - 1 ) && (
-										<Separator label={ __( 'AND', 'otter-blocks' ) } />
-									) }
-								</Fragment>
-							) ) }
-
-							<Button
-								isSecondary
-								className="o-conditions__add"
-								onClick={ () => addNewCondition( index ) }
-							>
-								{ __( 'Add a New Condition', 'otter-blocks' ) }
-							</Button>
-						</PanelTab>
-
-						{ ( 1 < attributes.otterConditions.length && index !== attributes.otterConditions.length - 1 ) && (
-							<Separator label={ __( 'OR', 'otter-blocks' ) } />
-						) }
-					</Fragment>
-				);
-			}) }
+					<RuleGroup
+						group={ group }
+						index={ index }
+						conditions={ conditions }
+						flatConditions={ flatConditions }
+						onDelete={ () => removeGroup( index ) }
+						onAddCondition={ value => addCondition( index, value ) }
+						onChangeCondition={ ( value, condIdx ) => changeCondition( value, index, condIdx ) }
+						onRemoveCondition={ condIdx => removeCondition( index, condIdx ) }
+						renderConditionControls={ ( condObj, condIdx ) => renderConditionControls( condObj, index, condIdx ) }
+					/>
+				</Fragment>
+			) ) }
 
 			<Button
 				isSecondary
-				className="o-conditions__add"
+				icon={ plus }
+				className="o-conditions__add-group"
 				onClick={ addGroup }
 			>
 				{ __( 'Add Rule Group', 'otter-blocks' ) }

--- a/src/blocks/plugins/conditions/editor.scss
+++ b/src/blocks/plugins/conditions/editor.scss
@@ -23,6 +23,17 @@
 	margin: 0 0 12px;
 }
 
+// Dot shown in the panel title when the block has active conditions.
+.o-conditions__indicator {
+	display: inline-block;
+	width: 8px;
+	height: 8px;
+	margin-left: 8px;
+	border-radius: 50%;
+	background: var( --wp-admin-theme-color, #3858e9 );
+	vertical-align: middle;
+}
+
 // Rule group card.
 .o-conditions__group {
 	border: 1px solid #e0e0e0;
@@ -74,7 +85,7 @@
 }
 
 .o-conditions__group-body {
-	padding: 6px;
+	padding: 4px;
 	display: flex;
 	flex-direction: column;
 }
@@ -199,12 +210,30 @@
 	padding: 6px 6px 12px;
 }
 
+// blocks/editor.scss gives base controls in tools panel items 24px vertical
+// margins — too airy for the compact rule UI, so tighten it here.
+.components-tools-panel-item .o-conditions__group {
+	.components-base-control:not(.components-input-control) {
+		margin: 10px 0;
+	}
+}
+
+// FormTokenField renders no base-control wrapper, so the spacing rules above
+// never reach it — give it the same rhythm as the other controls.
+.o-conditions__group .components-form-token-field {
+	margin: 10px 0;
+}
+
+.o-conditions__group input[type="text"] {
+	min-height: 30px !important;
+}
+
 // AND / OR separators.
 .o-conditions__separator {
 	display: flex;
 	align-items: center;
 	gap: 10px;
-	padding: 8px 2px;
+	padding: 6px 2px;
 }
 
 .o-conditions__separator-line {
@@ -214,13 +243,13 @@
 }
 
 .o-conditions__separator-label {
-	font-size: 10px;
+	font-size: 9px;
 	font-weight: 700;
 	letter-spacing: 0.1em;
 	text-transform: uppercase;
 	color: #757575;
 	background: #f0f0f1;
-	padding: 2px 9px;
+	padding: 0 8px;
 	border-radius: 9px;
 }
 
@@ -244,7 +273,7 @@
 
 .o-conditions__add-group {
 	display: flex;
-	justify-content: center;
+	justify-content: center !important;
 	width: 100%;
 	margin-top: 14px;
 }

--- a/src/blocks/plugins/conditions/editor.scss
+++ b/src/blocks/plugins/conditions/editor.scss
@@ -1,3 +1,4 @@
+// Legacy wrapper still used by Otter Pro condition controls (e.g. Time Recurring).
 .o-conditions {
 	margin-top: 10px;
 
@@ -9,42 +10,8 @@
 	}
 }
 
-.o-conditions__operator-wrapper {
-	position: relative;
-	height: 45px;
-	margin: 10px 0;
-
-	.o-conditions__operator-line {
-		position: absolute;
-		left: 50%;
-		top: 5px;
-		bottom: 5px;
-		width: 1px;
-		background: #d4d4d4;
-		z-index: 1;
-	}
-
-	.o-conditions__operator-word {
-		text-align: center;
-		height: 12px;
-		position: absolute;
-		left: 0;
-		right: 0;
-		top: 50%;
-		margin-top: -10px;
-		z-index: 2;
-	
-		span {
-			color: #747d86;
-			text-transform: uppercase;
-			letter-spacing: 1px;
-			padding: 3px;
-			font-size: 11px;
-			background: #fff;
-		}
-	}
-}
-
+// Legacy class still used outside this panel by the Posts layout builder
+// (free upsell + pro custom field buttons).
 .o-conditions__add {
 	display: flex;
 	justify-content: center;
@@ -52,6 +19,345 @@
 	margin-top: 15px;
 }
 
+.o-conditions__intro {
+	margin: 0 0 12px;
+}
+
+// Rule group card.
+.o-conditions__group {
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	background: #fff;
+	overflow: hidden;
+}
+
+.o-conditions__group-header {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 6px 6px 6px 12px;
+	background: #fbfbfc;
+}
+
+.o-conditions__group.is-open .o-conditions__group-header {
+	border-bottom: 1px solid #e0e0e0;
+}
+
+.o-conditions__group-main {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 1px;
+	border: none;
+	background: none;
+	padding: 2px 0;
+	margin: 0;
+	cursor: pointer;
+	text-align: left;
+	font-family: inherit;
+}
+
+.o-conditions__group-title {
+	font-size: 12px;
+	font-weight: 600;
+	color: #1e1e1e;
+}
+
+.o-conditions__group-summary {
+	font-size: 11px;
+	color: #757575;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.o-conditions__group-body {
+	padding: 6px;
+	display: flex;
+	flex-direction: column;
+}
+
+.o-conditions__group-header,
+.o-conditions__row-header {
+	.components-button.has-icon {
+		width: 28px;
+		min-width: 28px;
+		height: 28px;
+		padding: 0;
+		color: #757575;
+		flex: 0 0 auto;
+	}
+
+	.o-conditions__group-remove:hover,
+	.o-conditions__row-remove:hover {
+		color: #cc1818;
+	}
+}
+
+// Condition row.
+.o-conditions__row-header {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+}
+
+.o-conditions__row-main {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 9px;
+	border: none;
+	background: none;
+	margin: 0;
+	padding: 7px 6px;
+	border-radius: 2px;
+	cursor: pointer;
+	text-align: left;
+	font-family: inherit;
+
+	&:hover {
+		background: #f6f7f7;
+	}
+
+	&.is-static {
+		cursor: default;
+
+		&:hover {
+			background: none;
+		}
+	}
+}
+
+.o-conditions__row-icon {
+	width: 26px;
+	height: 26px;
+	border-radius: 4px;
+	flex: 0 0 auto;
+	display: grid;
+	place-items: center;
+	color: var(--wp-admin-theme-color, #3858e9);
+	background: #e9edfd;
+	background: color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 10%, #fff);
+
+	svg {
+		fill: currentColor;
+	}
+
+	&.is-empty {
+		color: #757575;
+		background: #f0f0f1;
+	}
+
+	&.is-add {
+		background: transparent;
+		border: 1px dashed #949494;
+		color: var(--wp-admin-theme-color, #3858e9);
+	}
+}
+
+.o-conditions__row-text {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.o-conditions__row-title {
+	font-size: 13px;
+	font-weight: 500;
+	color: #1e1e1e;
+}
+
+.o-conditions__row-value {
+	font-size: 11px;
+	color: #757575;
+	margin-top: 1px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+
+	&.is-empty {
+		color: var(--wp-admin-theme-color, #3858e9);
+	}
+}
+
+.o-conditions__row-chevron {
+	flex: 0 0 auto;
+	color: #949494;
+	fill: currentColor;
+	transition: transform 0.18s ease;
+}
+
+.o-conditions__row.is-open .o-conditions__row-chevron {
+	transform: rotate(180deg);
+}
+
+.o-conditions__row-editor {
+	padding: 6px 6px 12px;
+}
+
+// AND / OR separators.
+.o-conditions__separator {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 2px;
+}
+
+.o-conditions__separator-line {
+	flex: 1;
+	height: 1px;
+	background: #e0e0e0;
+}
+
+.o-conditions__separator-label {
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: #757575;
+	background: #f0f0f1;
+	padding: 2px 9px;
+	border-radius: 9px;
+}
+
+// Add buttons.
+.o-conditions__picker {
+	width: 100%;
+}
+
+.o-conditions__add-condition {
+	width: 100%;
+	justify-content: flex-start;
+	gap: 9px;
+	height: auto;
+	padding: 7px 6px;
+	color: var(--wp-admin-theme-color, #3858e9);
+
+	&:hover .o-conditions__row-icon.is-add {
+		border-color: currentColor;
+	}
+}
+
+.o-conditions__add-group {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+	margin-top: 14px;
+}
+
+// Searchable condition picker popover.
+.o-conditions-picker__popover {
+	.components-popover__content {
+		width: 272px;
+		padding: 0;
+		border-radius: 4px;
+	}
+}
+
+.o-conditions-picker {
+	display: flex;
+	flex-direction: column;
+
+	.components-search-control {
+		padding: 8px;
+		border-bottom: 1px solid #e0e0e0;
+	}
+}
+
+.o-conditions-picker__list {
+	overflow-y: auto;
+	max-height: 290px;
+	padding: 4px;
+}
+
+.o-conditions-picker__group-label {
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: #949494;
+	padding: 10px 8px 4px;
+}
+
+.o-conditions-picker__item {
+	display: flex;
+	align-items: flex-start;
+	gap: 9px;
+	width: 100%;
+	text-align: left;
+	border: none;
+	background: none;
+	cursor: pointer;
+	padding: 7px 8px;
+	border-radius: 4px;
+	font-family: inherit;
+
+	.o-conditions__row-icon {
+		width: 24px;
+		height: 24px;
+	}
+
+	&:hover:not(.is-disabled),
+	&:focus-visible {
+		background: #f0f0f1;
+	}
+
+	&.is-disabled {
+		cursor: default;
+
+		.o-conditions-picker__item-label {
+			color: #757575;
+		}
+
+		.o-conditions__row-icon {
+			color: #757575;
+			background: #f0f0f1;
+		}
+	}
+}
+
+.o-conditions-picker__item-content {
+	flex: 1;
+	min-width: 0;
+}
+
+.o-conditions-picker__item-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 13px;
+	font-weight: 500;
+	color: #1e1e1e;
+
+	svg {
+		fill: currentColor;
+		flex: 0 0 auto;
+	}
+}
+
+.o-conditions-picker__item-help {
+	display: block;
+	font-size: 11px;
+	color: #757575;
+	margin-top: 1px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.o-conditions-picker__empty {
+	padding: 20px 12px;
+	text-align: center;
+	color: #757575;
+	font-size: 12px;
+	margin: 0;
+}
+
+// Indicator for blocks with conditions in the editor canvas.
 .block-editor-block-list__layout {
 	.block-editor-block-list__block {
 		&:not( .is-selected ) {

--- a/src/blocks/plugins/conditions/utils.js
+++ b/src/blocks/plugins/conditions/utils.js
@@ -1,0 +1,358 @@
+/**
+ * WordPress dependencies.
+ */
+import {
+	__,
+	_n,
+	sprintf
+} from '@wordpress/i18n';
+
+import { dateI18n } from '@wordpress/date';
+
+import { applyFilters } from '@wordpress/hooks';
+
+import {
+	archive,
+	backup,
+	calendar,
+	category,
+	code,
+	commentAuthorAvatar,
+	currencyDollar,
+	desktop,
+	globe,
+	institution,
+	listView,
+	notAllowed,
+	page,
+	payment,
+	people,
+	postAuthor,
+	receipt,
+	settings,
+	store,
+	tag,
+	update
+} from '@wordpress/icons';
+
+const conditionIcons = {
+	screenSize: desktop,
+	loggedInUser: commentAuthorAvatar,
+	loggedOutUser: notAllowed,
+	userRoles: people,
+	loggedInUserMeta: listView,
+	postAuthor,
+	postType: page,
+	postCategory: category,
+	postTag: tag,
+	postMeta: listView,
+	stripePurchaseHistory: payment,
+	dateRange: calendar,
+	dateRecurring: update,
+	timeRecurring: backup,
+	queryString: code,
+	country: globe,
+	cookie: archive,
+	wooProductsInCart: store,
+	wooTotalCartValue: currencyDollar,
+	wooPurchaseHistory: receipt,
+	wooTotalSpent: currencyDollar,
+	wooCategory: category,
+	wooTag: tag,
+	wooAttribute: listView,
+	learnDashPurchaseHistory: receipt,
+	learnDashCourseStatus: institution
+};
+
+export const getConditionIcon = type => conditionIcons[ type ] ?? settings;
+
+const screenSizeLabels = {
+	mobile: __( 'Mobile', 'otter-blocks' ),
+	tablet: __( 'Tablet', 'otter-blocks' ),
+	desktop: __( 'Desktop', 'otter-blocks' )
+};
+
+const compareLabels = {
+	'is_true': __( 'is true', 'otter-blocks' ),
+	'is_false': __( 'is false', 'otter-blocks' ),
+	'is_empty': __( 'is empty', 'otter-blocks' ),
+	'if_equals': __( 'is equal to', 'otter-blocks' ),
+	'if_contains': __( 'contains', 'otter-blocks' )
+};
+
+const dayLabels = {
+	monday: __( 'Mon', 'otter-blocks' ),
+	tuesday: __( 'Tue', 'otter-blocks' ),
+	wednesday: __( 'Wed', 'otter-blocks' ),
+	thursday: __( 'Thu', 'otter-blocks' ),
+	friday: __( 'Fri', 'otter-blocks' ),
+	saturday: __( 'Sat', 'otter-blocks' ),
+	sunday: __( 'Sun', 'otter-blocks' )
+};
+
+const courseStatusLabels = {
+	'not_started': __( 'not started', 'otter-blocks' ),
+	'in_progress': __( 'in progress', 'otter-blocks' ),
+	'completed': __( 'completed', 'otter-blocks' )
+};
+
+const compareSummary = ( key, compare, value ) => {
+	if ( ! key ) {
+		return '';
+	}
+
+	const parts = [ key, compareLabels[ compare ] ?? compareLabels['is_true'] ];
+
+	if ( value && ( 'if_equals' === compare || 'if_contains' === compare ) ) {
+		parts.push( `"${ value }"` );
+	}
+
+	return parts.join( ' ' );
+};
+
+/**
+ * Get a short human-readable summary of a condition's current value.
+ *
+ * @param {Object} condition The condition object.
+ * @return {string} The summary.
+ */
+export const getConditionSummary = condition => {
+	let summary = '';
+	let placeholder = '';
+
+	switch ( condition.type ) {
+	case 'screenSize': {
+		const sizes = ( condition['screen_sizes'] ?? []).map( size => screenSizeLabels[ size ]).filter( Boolean );
+
+		if ( sizes.length ) {
+
+			/* translators: %s: a list of devices, e.g. Mobile, Tablet */
+			summary = sprintf( __( 'Hidden on %s', 'otter-blocks' ), sizes.join( ', ' ) );
+		} else {
+			summary = __( 'Visible on all screen sizes', 'otter-blocks' );
+		}
+		break;
+	}
+	case 'loggedInUser':
+		summary = __( 'Visitor is logged in', 'otter-blocks' );
+		break;
+	case 'loggedOutUser':
+		summary = __( 'Visitor is logged out', 'otter-blocks' );
+		break;
+	case 'userRoles':
+		if ( condition.roles?.length ) {
+			summary = condition.roles.join( ', ' );
+		} else {
+			placeholder = __( 'Select user roles', 'otter-blocks' );
+		}
+		break;
+	case 'loggedInUserMeta':
+	case 'postMeta':
+		summary = compareSummary( condition['meta_key'], condition['meta_compare'], condition['meta_value']);
+		if ( ! summary ) {
+			placeholder = __( 'Set a meta key', 'otter-blocks' );
+		}
+		break;
+	case 'postAuthor':
+		if ( condition.authors?.length ) {
+			summary = condition.authors.join( ', ' );
+		} else {
+			placeholder = __( 'Select authors', 'otter-blocks' );
+		}
+		break;
+	case 'postType':
+		if ( condition['post_types']?.length ) {
+			summary = condition['post_types'].join( ', ' );
+		} else {
+			placeholder = __( 'Select post types', 'otter-blocks' );
+		}
+		break;
+	case 'postCategory':
+		if ( condition.categories?.length ) {
+			summary = condition.categories.join( ', ' );
+		} else {
+			placeholder = __( 'Select categories', 'otter-blocks' );
+		}
+		break;
+	case 'postTag':
+		if ( condition.tags?.length ) {
+			summary = condition.tags.join( ', ' );
+		} else {
+			placeholder = __( 'Select tags', 'otter-blocks' );
+		}
+		break;
+	case 'stripePurchaseHistory':
+		if ( condition.product ) {
+
+			/* translators: %s: the Stripe product ID */
+			summary = sprintf( __( 'Purchased %s', 'otter-blocks' ), condition.product );
+		} else {
+			placeholder = __( 'Select a product', 'otter-blocks' );
+		}
+		break;
+	case 'queryString': {
+		const params = ( condition['query_string'] ?? '' ).split( '\n' ).map( param => param.trim() ).filter( Boolean );
+
+		if ( ! params.length ) {
+			placeholder = __( 'Set URL parameters', 'otter-blocks' );
+		} else if ( 1 === params.length ) {
+			summary = params[0];
+		} else {
+
+			/* translators: %1$s: the first URL parameter, %2$d: the number of remaining parameters */
+			summary = sprintf( __( '%1$s + %2$d more', 'otter-blocks' ), params[0], params.length - 1 );
+		}
+		break;
+	}
+	case 'country':
+		if ( condition.value ) {
+
+			/* translators: %s: a list of country codes, e.g. US, CA */
+			summary = sprintf( __( 'Visitor is from %s', 'otter-blocks' ), condition.value );
+		} else {
+			placeholder = __( 'Set country codes', 'otter-blocks' );
+		}
+		break;
+	case 'cookie':
+		summary = compareSummary( condition['cookie_key'], condition['cookie_compare'], condition['cookie_value']);
+		if ( ! summary ) {
+			placeholder = __( 'Set a cookie key', 'otter-blocks' );
+		}
+		break;
+	case 'dateRange':
+		if ( condition['start_date'] || condition['end_date']) {
+			const startDate = condition['start_date'] ? dateI18n( 'M j, Y', condition['start_date']) : '…';
+			const endDate = condition['end_date'] ? dateI18n( 'M j, Y', condition['end_date']) : '…';
+			summary = `${ startDate } – ${ endDate }`;
+		} else {
+			placeholder = __( 'Select a date range', 'otter-blocks' );
+		}
+		break;
+	case 'dateRecurring': {
+		const days = ( condition.days ?? []).map( day => dayLabels[ day ]).filter( Boolean );
+
+		if ( days.length ) {
+			summary = days.join( ', ' );
+		} else {
+			placeholder = __( 'Select days', 'otter-blocks' );
+		}
+		break;
+	}
+	case 'timeRecurring':
+		if ( condition['start_time'] || condition['end_time']) {
+			summary = `${ condition['start_time'] ?? '…' } – ${ condition['end_time'] ?? '…' }`;
+		} else {
+			placeholder = __( 'Select a time interval', 'otter-blocks' );
+		}
+		break;
+	case 'wooProductsInCart':
+		if ( 'categories' === condition.on ) {
+			if ( condition.categories?.length ) {
+
+				/* translators: %d: the number of categories */
+				summary = sprintf( _n( '%d category in cart', '%d categories in cart', condition.categories.length, 'otter-blocks' ), condition.categories.length );
+			} else {
+				placeholder = __( 'Select categories', 'otter-blocks' );
+			}
+		} else if ( condition.products?.length ) {
+
+			/* translators: %d: the number of products */
+			summary = sprintf( _n( '%d product in cart', '%d products in cart', condition.products.length, 'otter-blocks' ), condition.products.length );
+		} else {
+			placeholder = __( 'Select products', 'otter-blocks' );
+		}
+		break;
+	case 'wooTotalCartValue':
+		if ( condition.value ) {
+
+			/* translators: %1$s: the compare operator, %2$s: the cart value */
+			summary = sprintf( __( 'Cart total %1$s %2$s', 'otter-blocks' ), 'less_than' === condition.compare ? '<' : '>', condition.value );
+		} else {
+			placeholder = __( 'Set a cart value', 'otter-blocks' );
+		}
+		break;
+	case 'wooTotalSpent':
+		if ( condition.value ) {
+
+			/* translators: %1$s: the compare operator, %2$s: the amount spent */
+			summary = sprintf( __( 'Total spent %1$s %2$s', 'otter-blocks' ), 'less_than' === condition.compare ? '<' : '>', condition.value );
+		} else {
+			placeholder = __( 'Set an amount', 'otter-blocks' );
+		}
+		break;
+	case 'wooPurchaseHistory':
+		if ( condition.products?.length ) {
+
+			/* translators: %d: the number of products */
+			summary = sprintf( _n( '%d product purchased', '%d products purchased', condition.products.length, 'otter-blocks' ), condition.products.length );
+		} else {
+			placeholder = __( 'Select products', 'otter-blocks' );
+		}
+		break;
+	case 'wooCategory':
+		if ( condition.categories?.length ) {
+
+			/* translators: %d: the number of categories */
+			summary = sprintf( _n( '%d category selected', '%d categories selected', condition.categories.length, 'otter-blocks' ), condition.categories.length );
+		} else {
+			placeholder = __( 'Select categories', 'otter-blocks' );
+		}
+		break;
+	case 'wooTag':
+		if ( condition.tags?.length ) {
+
+			/* translators: %d: the number of tags */
+			summary = sprintf( _n( '%d tag selected', '%d tags selected', condition.tags.length, 'otter-blocks' ), condition.tags.length );
+		} else {
+			placeholder = __( 'Select tags', 'otter-blocks' );
+		}
+		break;
+	case 'wooAttribute':
+		if ( condition.terms?.length ) {
+			summary = condition.terms.join( ', ' );
+		} else if ( condition.attribute ) {
+			placeholder = __( 'Select terms', 'otter-blocks' );
+		} else {
+			placeholder = __( 'Select an attribute', 'otter-blocks' );
+		}
+		break;
+	case 'learnDashPurchaseHistory':
+		if ( 'groups' === condition.on ) {
+			if ( condition.groups?.length ) {
+
+				/* translators: %d: the number of groups */
+				summary = sprintf( _n( '%d group purchased', '%d groups purchased', condition.groups.length, 'otter-blocks' ), condition.groups.length );
+			} else {
+				placeholder = __( 'Select groups', 'otter-blocks' );
+			}
+		} else if ( condition.courses?.length ) {
+
+			/* translators: %d: the number of courses */
+			summary = sprintf( _n( '%d course purchased', '%d courses purchased', condition.courses.length, 'otter-blocks' ), condition.courses.length );
+		} else {
+			placeholder = __( 'Select courses', 'otter-blocks' );
+		}
+		break;
+	case 'learnDashCourseStatus':
+		if ( condition.course ) {
+
+			/* translators: %s: the course status, e.g. completed */
+			summary = sprintf( __( 'Course %s', 'otter-blocks' ), courseStatusLabels[ condition.status ] ?? courseStatusLabels['not_started']);
+		} else {
+			placeholder = __( 'Select a course', 'otter-blocks' );
+		}
+		break;
+	}
+
+	if ( placeholder ) {
+		return applyFilters( 'otter.blockConditions.conditionSummary', placeholder, condition );
+	}
+
+	if ( summary && false === condition.visibility ) {
+
+		/* translators: %s: the condition summary, e.g. "Cart total > 50" */
+		summary = sprintf( __( 'Hidden if: %s', 'otter-blocks' ), summary );
+	}
+
+	return applyFilters( 'otter.blockConditions.conditionSummary', summary, condition );
+};

--- a/src/pro/plugins/conditions/edit.js
+++ b/src/pro/plugins/conditions/edit.js
@@ -147,16 +147,16 @@ const ProductsMultiselect = ( props ) => {
 		} = select( COLLECTIONS_STORE_KEY );
 
 		 
-		const productsError = getCollectionError?.( '/wc/store', 'products', { per_page: 0 });
+		const productsError = getCollectionError?.( '/wc/store', 'products', { 'per_page': 100 });
 
-		const products = productsError ? [] : ( getCollection?.( '/wc/store', 'products', { 'per_page': 0 }) ?? [])?.map( result => ({
+		const products = productsError ? [] : ( getCollection?.( '/wc/store', 'products', { 'per_page': 100 }) ?? [])?.map( result => ({
 			value: result.id,
 			label: decodeEntities( result.name )
 		}) );
 
 		return {
 			products,
-			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products', { 'per_page': 0 }])
+			isLoading: isResolving( 'getCollection', [ '/wc/store', 'products', { 'per_page': 100 }])
 		};
 	}, []);
 


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes Codeinwp/otter-internals#287.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
- Improves design and UX of the visibility conditions panel;
- Fixes issue with WooCommerce product queries not working with 0 `per_page` elements to fetch all posts;
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->
<img width="263" height="629" alt="image" src="https://github.com/user-attachments/assets/7023cd83-25a9-4aef-b5a2-72a18c5efc4b" />

----

### Test instructions
- Make sure you can add all the fields;
- Make sure nothing breaks;
- When migrating from a previous version, things should still be working, no conditions should be breaking;
- Make sure all conditions still work as expected individually and combined;
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

