### PR TITLE
feat: show meaningful names for Atomic Wind blocks in List View

### DIFF
--- a/src/atomic-wind/blocks/box/block.json
+++ b/src/atomic-wind/blocks/box/block.json
@@ -11,6 +11,9 @@
 		"tagName": {
 			"type": "string",
 			"default": "div"
+		},
+		"metadata": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/src/atomic-wind/blocks/box/index.js
+++ b/src/atomic-wind/blocks/box/index.js
@@ -3,6 +3,7 @@ import metadata from './block.json';
 import icon from '../icon';
 import edit from './edit';
 import save from './save';
+import { boxLabel } from '../labels';
 
 const { name, ...settings } = metadata;
 
@@ -11,7 +12,5 @@ registerBlockType( name, {
 	icon,
 	edit,
 	save,
-	__experimentalLabel( { tagName } ) {
-		return tagName ? `Box <${ tagName }>` : 'Box';
-	},
+	__experimentalLabel: boxLabel,
 } );

--- a/src/atomic-wind/blocks/icon/block.json
+++ b/src/atomic-wind/blocks/icon/block.json
@@ -11,6 +11,9 @@
 		"icon": {
 			"type": "string",
 			"default": ""
+		},
+		"metadata": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/src/atomic-wind/blocks/icon/index.js
+++ b/src/atomic-wind/blocks/icon/index.js
@@ -2,6 +2,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import metadata from './block.json';
 import blockIcon from '../icon';
 import edit from './edit';
+import { iconLabel } from '../labels';
 
 const { name, ...settings } = metadata;
 
@@ -10,4 +11,5 @@ registerBlockType( name, {
 	icon: blockIcon,
 	edit,
 	save: () => null,
+	__experimentalLabel: iconLabel,
 } );

--- a/src/atomic-wind/blocks/image/block.json
+++ b/src/atomic-wind/blocks/image/block.json
@@ -27,6 +27,9 @@
 		"className": {
 			"type": "string",
 			"default": "w-full"
+		},
+		"metadata": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/src/atomic-wind/blocks/image/index.js
+++ b/src/atomic-wind/blocks/image/index.js
@@ -3,6 +3,7 @@ import metadata from './block.json';
 import icon from '../icon';
 import edit from './edit';
 import save from './save';
+import { imageLabel } from '../labels';
 
 const { name, ...settings } = metadata;
 
@@ -11,4 +12,5 @@ registerBlockType( name, {
 	icon,
 	edit,
 	save,
+	__experimentalLabel: imageLabel,
 } );

--- a/src/atomic-wind/blocks/labels.js
+++ b/src/atomic-wind/blocks/labels.js
@@ -1,20 +1,34 @@
 import { __ } from '@wordpress/i18n';
 
-// div and span intentionally have no entry so generic wrappers fall through
-// to the block title and block variation matching.
-const TAG_LABELS = {
-	section: __( 'Section', 'otter-blocks' ),
-	article: __( 'Article', 'otter-blocks' ),
-	main: __( 'Main', 'otter-blocks' ),
-	aside: __( 'Aside', 'otter-blocks' ),
-	header: __( 'Header', 'otter-blocks' ),
-	footer: __( 'Footer', 'otter-blocks' ),
-	nav: __( 'Navigation', 'otter-blocks' ),
-	details: __( 'Details', 'otter-blocks' ),
-	summary: __( 'Summary', 'otter-blocks' ),
-};
-
 const LABEL_CONTEXTS = [ 'list-view', 'breadcrumb' ];
+
+// Resolved lazily so locale data registered after module init still applies.
+// div and span intentionally have no label so generic wrappers fall through
+// to the block title and block variation matching.
+const getTagLabel = ( tagName ) => {
+	switch ( tagName ) {
+	case 'section':
+		return __( 'Section', 'otter-blocks' );
+	case 'article':
+		return __( 'Article', 'otter-blocks' );
+	case 'main':
+		return __( 'Main', 'otter-blocks' );
+	case 'aside':
+		return __( 'Aside', 'otter-blocks' );
+	case 'header':
+		return __( 'Header', 'otter-blocks' );
+	case 'footer':
+		return __( 'Footer', 'otter-blocks' );
+	case 'nav':
+		return __( 'Navigation', 'otter-blocks' );
+	case 'details':
+		return __( 'Details', 'otter-blocks' );
+	case 'summary':
+		return __( 'Summary', 'otter-blocks' );
+	default:
+		return undefined;
+	}
+};
 
 export const toPlainText = ( value ) => {
 	if ( ! value ) {
@@ -28,6 +42,8 @@ export const toPlainText = ( value ) => {
 // Rename UI (attributes.metadata.name) must win, because defining our own
 // label callback prevents core from displaying it; returning undefined when
 // there is no better label keeps the block title and variation titles working.
+// Content fallbacks return the raw attribute value (string or RichTextData)
+// so core converts and decodes it exactly once.
 const createLabel = ( getFallback ) => ( attributes, { context } = {} ) => {
 	if ( ! LABEL_CONTEXTS.includes( context ) ) {
 		return undefined;
@@ -39,15 +55,15 @@ const createLabel = ( getFallback ) => ( attributes, { context } = {} ) => {
 	return getFallback ? getFallback( attributes ) : undefined;
 };
 
-export const boxLabel = createLabel( ( { tagName } ) => TAG_LABELS[ tagName ] );
+export const boxLabel = createLabel( ( { tagName } ) => getTagLabel( tagName ) );
 
-export const textLabel = createLabel( ( { content } ) => toPlainText( content ) || undefined );
+export const textLabel = createLabel( ( { content } ) => ( toPlainText( content ) ? content : undefined ) );
 
 export const linkLabel = createLabel( ( { mode, text } ) => {
 	if ( mode === 'inner-blocks' ) {
 		return undefined;
 	}
-	return toPlainText( text ) || undefined;
+	return toPlainText( text ) ? text : undefined;
 } );
 
 export const imageLabel = createLabel( ( { alt } ) => toPlainText( alt ) || undefined );
@@ -58,5 +74,5 @@ export const getStructuralLabel = ( blockName, attributes ) => {
 	if ( attributes?.metadata?.name ) {
 		return attributes.metadata.name;
 	}
-	return blockName === 'atomic-wind/box' ? TAG_LABELS[ attributes?.tagName ] : undefined;
+	return blockName === 'atomic-wind/box' ? getTagLabel( attributes?.tagName ) : undefined;
 };

--- a/src/atomic-wind/blocks/labels.js
+++ b/src/atomic-wind/blocks/labels.js
@@ -1,0 +1,62 @@
+import { __ } from '@wordpress/i18n';
+
+// div and span intentionally have no entry so generic wrappers fall through
+// to the block title and block variation matching.
+const TAG_LABELS = {
+	section: __( 'Section', 'otter-blocks' ),
+	article: __( 'Article', 'otter-blocks' ),
+	main: __( 'Main', 'otter-blocks' ),
+	aside: __( 'Aside', 'otter-blocks' ),
+	header: __( 'Header', 'otter-blocks' ),
+	footer: __( 'Footer', 'otter-blocks' ),
+	nav: __( 'Navigation', 'otter-blocks' ),
+	details: __( 'Details', 'otter-blocks' ),
+	summary: __( 'Summary', 'otter-blocks' ),
+};
+
+const LABEL_CONTEXTS = [ 'list-view', 'breadcrumb' ];
+
+export const toPlainText = ( value ) => {
+	if ( ! value ) {
+		return '';
+	}
+	const text = typeof value === 'string' ? value.replace( /<[^>]+>/g, ' ' ) : value.toPlainText?.() ?? '';
+	return text.replace( /\s+/g, ' ' ).trim();
+};
+
+// Builds an __experimentalLabel callback. The custom name written by the core
+// Rename UI (attributes.metadata.name) must win, because defining our own
+// label callback prevents core from displaying it; returning undefined when
+// there is no better label keeps the block title and variation titles working.
+const createLabel = ( getFallback ) => ( attributes, { context } = {} ) => {
+	if ( ! LABEL_CONTEXTS.includes( context ) ) {
+		return undefined;
+	}
+	const customName = attributes?.metadata?.name;
+	if ( customName ) {
+		return customName;
+	}
+	return getFallback ? getFallback( attributes ) : undefined;
+};
+
+export const boxLabel = createLabel( ( { tagName } ) => TAG_LABELS[ tagName ] );
+
+export const textLabel = createLabel( ( { content } ) => toPlainText( content ) || undefined );
+
+export const linkLabel = createLabel( ( { mode, text } ) => {
+	if ( mode === 'inner-blocks' ) {
+		return undefined;
+	}
+	return toPlainText( text ) || undefined;
+} );
+
+export const imageLabel = createLabel( ( { alt } ) => toPlainText( alt ) || undefined );
+
+export const iconLabel = createLabel();
+
+export const getStructuralLabel = ( blockName, attributes ) => {
+	if ( attributes?.metadata?.name ) {
+		return attributes.metadata.name;
+	}
+	return blockName === 'atomic-wind/box' ? TAG_LABELS[ attributes?.tagName ] : undefined;
+};

--- a/src/atomic-wind/blocks/link/block.json
+++ b/src/atomic-wind/blocks/link/block.json
@@ -33,6 +33,9 @@
 		"mode": {
 			"type": "string",
 			"default": "text"
+		},
+		"metadata": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/src/atomic-wind/blocks/link/index.js
+++ b/src/atomic-wind/blocks/link/index.js
@@ -3,6 +3,7 @@ import metadata from './block.json';
 import icon from '../icon';
 import edit from './edit';
 import save from './save';
+import { linkLabel } from '../labels';
 
 const { name, ...settings } = metadata;
 
@@ -11,4 +12,5 @@ registerBlockType( name, {
 	icon,
 	edit,
 	save,
+	__experimentalLabel: linkLabel,
 } );

--- a/src/atomic-wind/blocks/test/labels.test.js
+++ b/src/atomic-wind/blocks/test/labels.test.js
@@ -1,0 +1,81 @@
+import { boxLabel, textLabel, linkLabel, imageLabel, iconLabel, getStructuralLabel } from '../labels';
+
+describe( 'atomic-wind block labels', () => {
+	describe( 'boxLabel', () => {
+		it( 'prefers the custom name from metadata.name (core Rename UI)', () => {
+			expect( boxLabel( { metadata: { name: 'Testimonial Section' }, tagName: 'section' }, { context: 'list-view' } ) ).toBe( 'Testimonial Section' );
+			expect( boxLabel( { metadata: { name: 'Hero' }, tagName: 'div' }, { context: 'breadcrumb' } ) ).toBe( 'Hero' );
+		} );
+
+		it( 'falls back to a semantic tag label', () => {
+			expect( boxLabel( { tagName: 'section' }, { context: 'list-view' } ) ).toBe( 'Section' );
+			expect( boxLabel( { tagName: 'nav' }, { context: 'list-view' } ) ).toBe( 'Navigation' );
+			expect( boxLabel( { tagName: 'footer' }, { context: 'breadcrumb' } ) ).toBe( 'Footer' );
+		} );
+
+		it( 'returns undefined for generic wrappers so the block title and variations apply', () => {
+			expect( boxLabel( { tagName: 'div' }, { context: 'list-view' } ) ).toBeUndefined();
+			expect( boxLabel( { tagName: 'span' }, { context: 'list-view' } ) ).toBeUndefined();
+		} );
+
+		it( 'returns undefined outside list-view and breadcrumb contexts', () => {
+			expect( boxLabel( { metadata: { name: 'Hero' }, tagName: 'section' }, { context: 'visual' } ) ).toBeUndefined();
+			expect( boxLabel( { metadata: { name: 'Hero' }, tagName: 'section' }, { context: 'accessibility' } ) ).toBeUndefined();
+			expect( boxLabel( { tagName: 'section' }, {} ) ).toBeUndefined();
+			expect( boxLabel( { tagName: 'section' } ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'textLabel', () => {
+		it( 'uses the plain text content', () => {
+			expect( textLabel( { content: '<strong>Hello</strong>  world' }, { context: 'list-view' } ) ).toBe( 'Hello world' );
+		} );
+
+		it( 'supports RichTextData-like values', () => {
+			expect( textLabel( { content: { toPlainText: () => 'Rich text' }}, { context: 'list-view' } ) ).toBe( 'Rich text' );
+		} );
+
+		it( 'returns undefined when the content is empty', () => {
+			expect( textLabel( { content: '' }, { context: 'list-view' } ) ).toBeUndefined();
+			expect( textLabel( {}, { context: 'list-view' } ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'linkLabel', () => {
+		it( 'uses the link text in text mode', () => {
+			expect( linkLabel( { mode: 'text', text: 'Get started' }, { context: 'list-view' } ) ).toBe( 'Get started' );
+		} );
+
+		it( 'returns undefined in inner-blocks mode', () => {
+			expect( linkLabel( { mode: 'inner-blocks', text: 'Get started' }, { context: 'list-view' } ) ).toBeUndefined();
+		} );
+
+		it( 'still honors the custom name in inner-blocks mode', () => {
+			expect( linkLabel( { metadata: { name: 'CTA Button' }, mode: 'inner-blocks' }, { context: 'list-view' } ) ).toBe( 'CTA Button' );
+		} );
+	} );
+
+	describe( 'imageLabel', () => {
+		it( 'uses the alt text', () => {
+			expect( imageLabel( { alt: 'Team photo' }, { context: 'list-view' } ) ).toBe( 'Team photo' );
+			expect( imageLabel( { alt: '' }, { context: 'list-view' } ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'iconLabel', () => {
+		it( 'only honors the custom name', () => {
+			expect( iconLabel( { metadata: { name: 'Star icon' }, icon: 'star' }, { context: 'list-view' } ) ).toBe( 'Star icon' );
+			expect( iconLabel( { icon: 'star' }, { context: 'list-view' } ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'getStructuralLabel', () => {
+		it( 'resolves the custom name, then the semantic tag for boxes', () => {
+			expect( getStructuralLabel( 'atomic-wind/box', { metadata: { name: 'Hero' }, tagName: 'section' } ) ).toBe( 'Hero' );
+			expect( getStructuralLabel( 'atomic-wind/box', { tagName: 'footer' } ) ).toBe( 'Footer' );
+			expect( getStructuralLabel( 'atomic-wind/box', { tagName: 'div' } ) ).toBeUndefined();
+			expect( getStructuralLabel( 'atomic-wind/text', { content: 'Hello' } ) ).toBeUndefined();
+			expect( getStructuralLabel( 'atomic-wind/text', { metadata: { name: 'Tagline' }} ) ).toBe( 'Tagline' );
+		} );
+	} );
+} );

--- a/src/atomic-wind/blocks/test/labels.test.js
+++ b/src/atomic-wind/blocks/test/labels.test.js
@@ -18,6 +18,11 @@ describe( 'atomic-wind block labels', () => {
 			expect( boxLabel( { tagName: 'span' }, { context: 'list-view' } ) ).toBeUndefined();
 		} );
 
+		it( 'ignores tag names that collide with Object.prototype members', () => {
+			expect( boxLabel( { tagName: 'constructor' }, { context: 'list-view' } ) ).toBeUndefined();
+			expect( boxLabel( { tagName: 'hasOwnProperty' }, { context: 'list-view' } ) ).toBeUndefined();
+		} );
+
 		it( 'returns undefined outside list-view and breadcrumb contexts', () => {
 			expect( boxLabel( { metadata: { name: 'Hero' }, tagName: 'section' }, { context: 'visual' } ) ).toBeUndefined();
 			expect( boxLabel( { metadata: { name: 'Hero' }, tagName: 'section' }, { context: 'accessibility' } ) ).toBeUndefined();
@@ -27,16 +32,16 @@ describe( 'atomic-wind block labels', () => {
 	} );
 
 	describe( 'textLabel', () => {
-		it( 'uses the plain text content', () => {
-			expect( textLabel( { content: '<strong>Hello</strong>  world' }, { context: 'list-view' } ) ).toBe( 'Hello world' );
-		} );
+		it( 'passes non-empty content through for core to convert once', () => {
+			expect( textLabel( { content: '<strong>Hello</strong>  world' }, { context: 'list-view' } ) ).toBe( '<strong>Hello</strong>  world' );
 
-		it( 'supports RichTextData-like values', () => {
-			expect( textLabel( { content: { toPlainText: () => 'Rich text' }}, { context: 'list-view' } ) ).toBe( 'Rich text' );
+			const richText = { toPlainText: () => 'Rich text' };
+			expect( textLabel( { content: richText }, { context: 'list-view' } ) ).toBe( richText );
 		} );
 
 		it( 'returns undefined when the content is empty', () => {
 			expect( textLabel( { content: '' }, { context: 'list-view' } ) ).toBeUndefined();
+			expect( textLabel( { content: { toPlainText: () => ' ' }}, { context: 'list-view' } ) ).toBeUndefined();
 			expect( textLabel( {}, { context: 'list-view' } ) ).toBeUndefined();
 		} );
 	} );

--- a/src/atomic-wind/blocks/text/block.json
+++ b/src/atomic-wind/blocks/text/block.json
@@ -17,6 +17,9 @@
 			"source": "rich-text",
 			"selector": "[data-rich-text]",
 			"role": "content"
+		},
+		"metadata": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/src/atomic-wind/blocks/text/index.js
+++ b/src/atomic-wind/blocks/text/index.js
@@ -3,6 +3,7 @@ import metadata from './block.json';
 import icon from '../icon';
 import edit from './edit';
 import save from './save';
+import { textLabel } from '../labels';
 
 const { name, ...settings } = metadata;
 
@@ -11,4 +12,5 @@ registerBlockType( name, {
 	icon,
 	edit,
 	save,
+	__experimentalLabel: textLabel,
 } );

--- a/src/atomic-wind/class-editor/panel.js
+++ b/src/atomic-wind/class-editor/panel.js
@@ -6,6 +6,7 @@ import { close, chevronLeft, chevronRight, copy, upload, undo } from '@wordpress
 import { createPortal, useState, useEffect, useRef, useCallback, memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import blockIcon from '../blocks/icon';
+import { getStructuralLabel, toPlainText } from '../blocks/labels';
 import { StateControls } from '../states';
 import { AnimationControls } from '../animations';
 
@@ -17,13 +18,11 @@ function decodeEntities( html ) {
 
 function getTextPreview( block ) {
 	if ( block.name === 'atomic-wind/text' ) {
-		const raw = block.attributes?.content || '';
-		const text = decodeEntities( raw.replace( /<[^>]+>/g, '' ) ).trim();
+		const text = decodeEntities( toPlainText( block.attributes?.content ) );
 		return text.length > 30 ? text.slice( 0, 30 ) + '…' : text;
 	}
 	if ( block.name === 'atomic-wind/link' && block.attributes?.mode !== 'inner-blocks' ) {
-		const raw = block.attributes?.content || '';
-		const text = decodeEntities( raw.replace( /<[^>]+>/g, '' ) ).trim();
+		const text = decodeEntities( toPlainText( block.attributes?.text ) );
 		return text.length > 30 ? text.slice( 0, 30 ) + '…' : text;
 	}
 	return '';
@@ -39,9 +38,9 @@ const TreeNode = memo( ( { block, depth, selectedId, onSelect, collapsed, onTogg
 	const title = useSelect(
 		( select ) => {
 			const type = select( blocksStore ).getBlockType( block.name );
-			return type ? type.title : block.name;
+			return getStructuralLabel( block.name, block.attributes ) || ( type ? type.title : block.name );
 		},
-		[ block.name ]
+		[ block.name, block.attributes ]
 	);
 
 	const hasChildren = block.innerBlocks && block.innerBlocks.length > 0;
@@ -132,7 +131,7 @@ const Panel = ( { onClose } ) => {
 			if ( ! block ) {return { selectedTitle: '', selectedPreview: '', selectedAttributes: {}};}
 			const type = select( blocksStore ).getBlockType( block.name );
 			return {
-				selectedTitle: type ? type.title : block.name,
+				selectedTitle: getStructuralLabel( block.name, block.attributes ) || ( type ? type.title : block.name ),
 				selectedPreview: getTextPreview( block ),
 				selectedAttributes: block.attributes || {},
 			};

--- a/src/atomic-wind/class-editor/panel.js
+++ b/src/atomic-wind/class-editor/panel.js
@@ -16,14 +16,20 @@ function decodeEntities( html ) {
 	return _decodeEl.value;
 }
 
+// RichTextData.toPlainText() output is already decoded; only raw strings
+// still carry entities.
+function previewText( value ) {
+	const plain = toPlainText( value );
+	const text = typeof value === 'string' ? decodeEntities( plain ) : plain;
+	return text.length > 30 ? text.slice( 0, 30 ) + '…' : text;
+}
+
 function getTextPreview( block ) {
 	if ( block.name === 'atomic-wind/text' ) {
-		const text = decodeEntities( toPlainText( block.attributes?.content ) );
-		return text.length > 30 ? text.slice( 0, 30 ) + '…' : text;
+		return previewText( block.attributes?.content );
 	}
 	if ( block.name === 'atomic-wind/link' && block.attributes?.mode !== 'inner-blocks' ) {
-		const text = decodeEntities( toPlainText( block.attributes?.text ) );
-		return text.length > 30 ? text.slice( 0, 30 ) + '…' : text;
+		return previewText( block.attributes?.text );
 	}
 	return '';
 }


### PR DESCRIPTION
### Summary

Pages built with Atomic Wind show **Box, Box, Box, Box…** in the editor List View — every wrapper is the generic `atomic-wind/box` block, so users can't tell their hero from their testimonials.

On top of that, the box block's existing `__experimentalLabel` (`Box <tagName>`) silently **broke core's native Rename feature**: core only displays `attributes.metadata.name` through an auto-injected label callback, and it bails when a block defines its own. So renaming a Box via the List View Rename modal saved the name but never displayed it.

**Solution:** a shared label ladder (`src/atomic-wind/blocks/labels.js`) registered as `__experimentalLabel` on all five blocks, resolving in List View/breadcrumb contexts:

1. `attributes.metadata.name` — the custom name from core's Rename UI, or set at content-generation time (`<!-- wp:atomic-wind/box {"metadata":{"name":"Testimonial Section"}} -->`)
2. attribute-derived fallback — semantic tag label for box (`section` → *Section*, `nav` → *Navigation*, …), text content for text, link text for link, alt for image
3. `undefined` — falls through to the block title, keeping future block-variation titles working

This is the same precedence GenerateBlocks 2.x ships for its generic Element block, and what core blocks (heading, paragraph, image) do. Content values are returned raw (string or RichTextData) so core converts and decodes them exactly once.

Also:
- declares `"metadata": { "type": "object" }` in the five `block.json` files — defensive for older WP: the client-side editor already preserves the attribute everywhere, and core's server-side global registration (WP 6.5+) skips already-defined keys, so this is conflict-free
- the Atomic Wind class-editor panel tree/header now resolves the same names instead of always showing the block title
- fixes a latent panel bug: the link preview read `attributes.content` but the link block stores its label in `text` (it was always empty)

**Why it's safe:** names live only in the block-comment JSON and display-only code paths — `save()` output is untouched, so no block validation/deprecation risk, and existing pages get readable names retroactively on update. `div`/`span` boxes intentionally keep showing *Box* (no semantic signal to derive from). The Rename UI is core's own (WP 6.5+, on by default); this PR just stops suppressing it.

**Follow-up (separate concern):** the atomic-wind `block.json` files declare `"textdomain": "atomic-wind"` while all JS strings (pre-existing and new) use `otter-blocks`, so none of these strings currently get translations. Worth aligning repo-wide in its own PR.

----

### Test instructions

1. Create a page with Atomic Wind blocks (e.g. a Box with `tagName: section` containing text/images), open the List View.
2. Boxes with semantic tags show *Section* / *Header* / *Navigation* etc.; text blocks show their content; links show their label; images show their alt text.
3. Right-click a block in List View → **Rename** → the custom name now displays in List View and the breadcrumb (previously it saved but never showed).
4. Open the Atomic Wind floating panel (class editor): the tree and header show the same names, and link blocks show their text preview (previously empty).
5. Re-save the page and reload: names persist; front-end markup is byte-identical (labels never touch `save()`).
6. `npm run test:unit` — `src/atomic-wind/blocks/test/labels.test.js` covers the ladder precedence, contexts, and edge cases.

----

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

🤖 Generated with [Claude Code](https://claude.com/claude-code)
