### PR TITLE
fix: remove noisy CSS save notices and reset saving flag on error

### DIFF
--- a/src/blocks/plugins/css-handler/index.js
+++ b/src/blocks/plugins/css-handler/index.js
@@ -17,59 +17,39 @@ let isSavingCSS = false;
 
 const { createNotice } = dispatch( 'core/notices' );
 
+const createCSSErrorNotice = error => {
+	createNotice(
+		'error',
+		error?.message || __( 'Unable to save CSS.', 'otter-blocks' ),
+		{
+			isDismissible: true,
+			type: 'snackbar',
+			id: 'saving-css'
+		}
+	);
+};
+
 const savePostMeta = debounce( async() => {
 	const { getCurrentPostId } = select( 'core/editor' );
 	const postId = getCurrentPostId();
 
-	createNotice(
-		'info',
-		__( 'Saving CSS…', 'otter-blocks' ),
-		{
-			isDismissible: true,
-			type: 'snackbar',
-			id: 'saving-css'
-		}
-	);
-
-	await apiFetch({ path: `otter/v1/post_styles/${ postId }`, method: 'POST' });
-
-	createNotice(
-		'info',
-		__( 'CSS saved.', 'otter-blocks' ),
-		{
-			isDismissible: true,
-			type: 'snackbar',
-			id: 'saving-css'
-		}
-	);
-
-	isSavingCSS = false;
+	try {
+		await apiFetch({ path: `otter/v1/post_styles/${ postId }`, method: 'POST' });
+	} catch ( error ) {
+		createCSSErrorNotice( error );
+	} finally {
+		isSavingCSS = false;
+	}
 }, 1000 );
 
 const saveWidgets = debounce( async() => {
-	createNotice(
-		'info',
-		__( 'Saving CSS…', 'otter-blocks' ),
-		{
-			isDismissible: true,
-			type: 'snackbar',
-			id: 'saving-css'
-		}
-	);
-
-	await apiFetch({ path: 'otter/v1/widget_styles', method: 'POST' });
-
-	createNotice(
-		'info',
-		__( 'CSS saved.', 'otter-blocks' ),
-		{
-			isDismissible: true,
-			type: 'snackbar',
-			id: 'saving-css'
-		}
-	);
-
-	isSavingCSS = false;
+	try {
+		await apiFetch({ path: 'otter/v1/widget_styles', method: 'POST' });
+	} catch ( error ) {
+		createCSSErrorNotice( error );
+	} finally {
+		isSavingCSS = false;
+	}
 }, 1000 );
 
 const reusableBlocks = {};

--- a/src/blocks/test/e2e/blocks/css-handler.spec.js
+++ b/src/blocks/test/e2e/blocks/css-handler.spec.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+import { insertBlockBySlash } from '../helpers/editor';
+
+const createDeferred = () => {
+	let resolve;
+
+	const promise = new Promise( done => {
+		resolve = done;
+	});
+
+	return { promise, resolve };
+};
+
+test.describe( 'CSS Handler Notices', () => {
+	test.beforeEach( async({ admin }) => {
+		await admin.createNewPost();
+	});
+
+	test( 'does not show progress or success notices when CSS saves successfully', async({ editor, page }) => {
+		const cssSaveStarted = createDeferred();
+		const continueCssSave = createDeferred();
+
+		await page.route( '**/wp-json/otter/v1/post_styles/**', async route => {
+			cssSaveStarted.resolve();
+			await continueCssSave.promise;
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'CSS updated.' })
+			});
+		});
+
+		await insertBlockBySlash({
+			editor,
+			page,
+			shortcut: '/progress-bar',
+			blockName: 'themeisle-blocks/progress-bar'
+		});
+
+		const publish = editor.publishPost();
+
+		await cssSaveStarted.promise;
+		await expect( page.getByText( 'Saving CSS…' ) ).toBeHidden();
+
+		continueCssSave.resolve();
+		await publish;
+
+		await page.waitForTimeout( 500 );
+		await expect( page.getByText( 'CSS saved.' ) ).toBeHidden();
+	});
+
+	test( 'shows an error notice when CSS saving fails', async({ editor, page }) => {
+		await page.route( '**/wp-json/otter/v1/post_styles/**', async route => {
+			await route.fulfill({
+				status: 500,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					code: 'otter_css_error',
+					message: 'CSS failed.',
+					data: { status: 500 }
+				})
+			});
+		});
+
+		await insertBlockBySlash({
+			editor,
+			page,
+			shortcut: '/progress-bar',
+			blockName: 'themeisle-blocks/progress-bar'
+		});
+
+		await editor.publishPost();
+
+		await expect( page.getByTestId( 'snackbar' ).filter({ hasText: 'CSS failed.' }) ).toBeVisible();
+	});
+});

--- a/src/blocks/test/unit/css-handler.test.js
+++ b/src/blocks/test/unit/css-handler.test.js
@@ -1,0 +1,152 @@
+const flushPromises = () => new Promise( resolve => setTimeout( resolve, 0 ) );
+
+const loadCssHandler = ({ apiFetchImplementation, editorState = {}, widgetsState = null } = {}) => {
+	jest.resetModules();
+
+	const createNotice = jest.fn();
+	const apiFetch = jest.fn( apiFetchImplementation || (() => Promise.resolve({}) ) );
+	let subscriber;
+
+	const defaultEditorState = {
+		isCurrentPostPublished: () => true,
+		isSavingPost: () => true,
+		isPublishingPost: () => false,
+		isAutosavingPost: () => false,
+		getCurrentPostId: () => 123,
+		__experimentalIsSavingReusableBlock: () => false,
+		...editorState
+	};
+
+	jest.doMock( '@wordpress/i18n', () => ({
+		__: text => text
+	}), { virtual: true } );
+
+	jest.doMock( 'lodash', () => ({
+		debounce: fn => fn
+	}) );
+
+	jest.doMock( '@wordpress/api-fetch', () => apiFetch, { virtual: true } );
+
+	jest.doMock( '@wordpress/data', () => ({
+		dispatch: jest.fn( store => {
+			if ( 'core/notices' === store ) {
+				return { createNotice };
+			}
+
+			return {};
+		}),
+		select: jest.fn( store => {
+			if ( 'core/edit-widgets' === store ) {
+				return widgetsState;
+			}
+
+			if ( 'core/editor' === store ) {
+				return defaultEditorState;
+			}
+
+			if ( 'core/block-editor' === store ) {
+				return {
+					getSettings: () => ({ __experimentalReusableBlocks: [] })
+				};
+			}
+
+			if ( 'core' === store ) {
+				return {
+					isSavingEntityRecord: () => false
+				};
+			}
+
+			return {};
+		}),
+		subscribe: jest.fn( callback => {
+			subscriber = callback;
+			return jest.fn();
+		})
+	}), { virtual: true } );
+
+	window.themeisleGutenberg = { isBlockEditor: true };
+	window.oTrk = { base: { uploadEvents: jest.fn() } };
+
+	require( '../../plugins/css-handler' );
+
+	return {
+		apiFetch,
+		createNotice,
+		runSubscriber: async() => {
+			subscriber();
+			await flushPromises();
+		}
+	};
+};
+
+describe( 'CSS handler notices', () => {
+	afterEach( () => {
+		delete window.themeisleGutenberg;
+		delete window.oTrk;
+	});
+
+	it( 'does not show progress or success notices when post CSS saves successfully', async() => {
+		const { apiFetch, createNotice, runSubscriber } = loadCssHandler();
+
+		await runSubscriber();
+
+		expect( apiFetch ).toHaveBeenCalledWith({ path: 'otter/v1/post_styles/123', method: 'POST' });
+		expect( createNotice ).not.toHaveBeenCalled();
+	});
+
+	it( 'shows an error notice when post CSS saving fails', async() => {
+		const { createNotice, runSubscriber } = loadCssHandler({
+			apiFetchImplementation: () => Promise.reject( new Error( 'CSS failed.' ) )
+		});
+
+		await runSubscriber();
+
+		expect( createNotice ).toHaveBeenCalledWith(
+			'error',
+			'CSS failed.',
+			{
+				isDismissible: true,
+				type: 'snackbar',
+				id: 'saving-css'
+			}
+		);
+	});
+
+	it( 'does not show progress or success notices when widget CSS saves successfully', async() => {
+		const widgetsState = {
+			isSavingWidgetAreas: () => true,
+			getEditedWidgetAreas: () => [ 'sidebar-1' ]
+		};
+
+		const { apiFetch, createNotice, runSubscriber } = loadCssHandler({ widgetsState });
+
+		await runSubscriber();
+
+		expect( apiFetch ).toHaveBeenCalledWith({ path: 'otter/v1/widget_styles', method: 'POST' });
+		expect( createNotice ).not.toHaveBeenCalled();
+	});
+
+	it( 'shows an error notice when widget CSS saving fails', async() => {
+		const widgetsState = {
+			isSavingWidgetAreas: () => true,
+			getEditedWidgetAreas: () => [ 'sidebar-1' ]
+		};
+
+		const { createNotice, runSubscriber } = loadCssHandler({
+			widgetsState,
+			apiFetchImplementation: () => Promise.reject( new Error( 'Widget CSS failed.' ) )
+		});
+
+		await runSubscriber();
+
+		expect( createNotice ).toHaveBeenCalledWith(
+			'error',
+			'Widget CSS failed.',
+			{
+				isDismissible: true,
+				type: 'snackbar',
+				id: 'saving-css'
+			}
+		);
+	});
+});

--- a/src/blocks/test/unit/utils.test.ts
+++ b/src/blocks/test/unit/utils.test.ts
@@ -1,3 +1,12 @@
+jest.mock( '@wordpress/blocks', () => ({
+	parse: jest.fn( () => [] )
+}) );
+
+jest.mock( '@wordpress/data', () => ({
+	dispatch: jest.fn( () => ({}) ),
+	select: jest.fn( () => ({}) )
+}) );
+
 import { findBlock } from '../../../onboarding/utils';
 
 describe( 'findBlock', () => {


### PR DESCRIPTION


<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/265
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Drop the "Saving CSS…"/"CSS saved." snackbars and only surface a notice when saving fails. Reset isSavingCSS in a finally block so a failed request no longer leaves the flag stuck true and blocking future saves.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

