### PR TITLE
Fix undefined array key warning in Live Search when no category is selected

### DIFF
--- a/plugins/otter-pro/inc/plugins/class-live-search.php
+++ b/plugins/otter-pro/inc/plugins/class-live-search.php
@@ -47,7 +47,7 @@ class Live_Search {
 			$post_types_data = 'data-post-types=' . wp_json_encode( $block['attrs']['otterSearchQuery']['post_type'] );
 
 			if ( count( $block['attrs']['otterSearchQuery']['post_type'] ) === 1 && in_array( 'post', $block['attrs']['otterSearchQuery']['post_type'] ) ) {
-				$post_types_data .= ' data-cat="' . esc_attr( $block['attrs']['otterSearchQuery']['cat'] ) . '"';
+				$post_types_data .= ' data-cat="' . esc_attr( $block['attrs']['otterSearchQuery']['cat'] ?? '' ) . '"';
 			}
 		}
 

--- a/tests/test-live-search-render.php
+++ b/tests/test-live-search-render.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class Live Search Render
+ *
+ * @package gutenberg-blocks
+ */
+
+use ThemeIsle\OtterPro\Plugins\Live_Search;
+
+/**
+ * Live Search render_blocks test case.
+ */
+class TestLiveSearchRender extends WP_UnitTestCase {
+
+	/**
+	 * Set up a valid license so render_blocks runs past the gate.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		update_option(
+			'otter_pro_license_data',
+			(object) array(
+				'license'  => 'valid',
+				'price_id' => 2,
+				'otter_pro' => true,
+			)
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		delete_option( 'otter_pro_license_data' );
+		parent::tear_down();
+	}
+
+	/**
+	 * A live search core/search block restricted to posts but without a category
+	 * selected must not raise an "Undefined array key" warning on PHP 8.
+	 */
+	public function test_render_blocks_post_without_category() {
+		$live_search = new Live_Search();
+
+		$block = array(
+			'blockName' => 'core/search',
+			'attrs'     => array(
+				'otterIsLive'     => true,
+				'otterSearchQuery' => array(
+					'post_type' => array( 'post' ),
+				),
+			),
+		);
+
+		$content = $live_search->render_blocks( '<form></form>', $block );
+
+		$this->assertStringContainsString( 'data-cat=""', $content );
+	}
+}


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #2849.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary

When a Live Search block restricts results to `post` but no category is selected, `otterSearchQuery['cat']` is never written to the block attributes, so `render_blocks()` accesses a missing key and PHP 8 emits `Undefined array key "cat"`. Guarded the read in `class-live-search.php` with `?? ''` so the absent key falls back to an empty `data-cat` attribute, matching how the surrounding `post_type` access is already protected.

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add a Search block and enable Live Search.
2. Set "Search in" to **post** and leave **Post Category** empty.
3. View the page on the frontend; no PHP warning should appear and search works with no category filter.

Added `tests/test-live-search-render.php`, which activates a license, renders a post-only Live Search block without a `cat` key, and asserts the output contains `data-cat=""`. It fails on the warning before the fix and passes after.

----

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()
