### PR TITLE
feat: add Content Slider block

### DIFF
--- a/blocks.json
+++ b/blocks.json
@@ -56,6 +56,13 @@
 			"circle-counter/style.css": "blocks/blocks/circle-counter/style.scss"
 		}
 	},
+	"content-slider": {
+		"block": "blocks/blocks/content-slider/block.json",
+		"assets": {
+			"content-slider/editor.css": "blocks/blocks/content-slider/editor.scss",
+			"content-slider/style.css": "blocks/blocks/content-slider/style.scss"
+		}
+	},
 	"countdown": {
 		"block": "blocks/blocks/countdown/block.json",
 		"assets": {

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -53,6 +53,7 @@ class Registration {
 	 */
 	public static $scripts_loaded = array(
 		'circle-counter'    => false,
+		'content-slider'    => false,
 		'countdown'         => false,
 		'form'              => false,
 		'google-map'        => false,
@@ -666,6 +667,29 @@ class Registration {
 			);
 		}
 
+		if ( ! self::$scripts_loaded['content-slider'] && has_block( 'themeisle-blocks/content-slider', $post ) ) {
+			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/content-slider.asset.php';
+
+			wp_register_script(
+				'otter-content-slider',
+				OTTER_BLOCKS_URL . 'build/blocks/content-slider.js',
+				$asset_file['dependencies'],
+				$asset_file['version'],
+				true
+			);
+
+			wp_script_add_data( 'otter-content-slider', 'defer', true );
+
+			wp_localize_script(
+				'otter-content-slider',
+				'themeisleGutenbergContentSlider',
+				array(
+					/* translators: %d: slide number. */
+					'goToSlide' => __( 'Go to slide %d', 'otter-blocks' ),
+				)
+			);
+		}
+
 		if ( ! self::$scripts_loaded['tabs'] && has_block( 'themeisle-blocks/tabs', $post ) ) {
 			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/tabs.asset.php';
 			wp_register_script( 'otter-tabs', OTTER_BLOCKS_URL . 'build/blocks/tabs.js', $asset_file['dependencies'], $asset_file['version'], true );
@@ -793,6 +817,7 @@ class Registration {
 			'button',
 			'button-group',
 			'circle-counter',
+			'content-slider',
 			'countdown',
 			'flip',
 			'font-awesome-icons',

--- a/packages/e2e-tests/mu-plugins/otter-e2e-bootstrap.php
+++ b/packages/e2e-tests/mu-plugins/otter-e2e-bootstrap.php
@@ -202,6 +202,10 @@ function stub_wp_mail_for_e2e( $short_circuit, $atts = array() ) {
 
 add_filter( 'pre_wp_mail', __NAMESPACE__ . '\\stub_wp_mail_for_e2e', 10, 2 );
 
+// Skip the themeisle-sdk survey (Formbricks) + tracking scripts in e2e so their
+// network errors don't pollute the console. Bails Script_loader::setup_actions().
+add_filter( 'themeisle_sdk_script_setup', '__return_true' );
+
 /**
  * Mock the reCAPTCHA verification endpoint per the captcha scenario mode, so specs can
  * exercise the provider-failure (infrastructure failure) and invalid-token paths without

--- a/src/blocks/blocks/content-slider/_chrome.scss
+++ b/src/blocks/blocks/content-slider/_chrome.scss
@@ -1,0 +1,60 @@
+// :where() keeps specificity at zero so chrome never competes with slide content.
+:where(.o-content-slider) {
+	position: relative;
+
+	.o-content-arrows {
+		pointer-events: none;
+	}
+
+	:is(.o-content-arrow, .o-content-dot) {
+		padding: 0;
+		border: 0;
+		cursor: pointer;
+		border-radius: 50%;
+	}
+
+	.o-content-arrow {
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 40px;
+		height: 40px;
+		pointer-events: auto;
+		color: var(--o-arrow-color, #ffffff);
+		background: var(--o-arrow-bg, rgba(0, 0, 0, 0.5));
+
+		&--prev {
+			left: 10px;
+		}
+
+		&--next {
+			right: 10px;
+
+			svg {
+				transform: rotate(180deg);
+			}
+		}
+	}
+
+	.o-content-dots {
+		display: flex;
+		justify-content: center;
+		gap: 8px;
+		margin-top: 12px;
+		padding: 0;
+	}
+
+	.o-content-dot {
+		width: 10px;
+		height: 10px;
+		background: var(--o-dot-color, rgba(0, 0, 0, 0.3));
+		transition: background-color 0.15s ease;
+
+		&--active {
+			background: var(--o-dot-active-color, #000000);
+		}
+	}
+}

--- a/src/blocks/blocks/content-slider/block.json
+++ b/src/blocks/blocks/content-slider/block.json
@@ -1,0 +1,66 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "themeisle-blocks/content-slider",
+	"title": "Content Slider",
+	"category": "themeisle-blocks",
+	"description": "A lightweight slider where each inner block becomes a slide. Powered by Otter.",
+	"keywords": [ "slider", "carousel", "content", "slides" ],
+	"textdomain": "otter-blocks",
+	"attributes": {
+		"id": {
+			"type": "string"
+		},
+		"autoplay": {
+			"type": "boolean",
+			"default": false
+		},
+		"delay": {
+			"type": "number",
+			"default": 5
+		},
+		"showArrows": {
+			"type": "boolean",
+			"default": true
+		},
+		"showDots": {
+			"type": "boolean",
+			"default": true
+		},
+		"loop": {
+			"type": "boolean",
+			"default": true
+		},
+		"slidesPerView": {
+			"type": "number",
+			"default": 1
+		},
+		"gap": {
+			"type": "number",
+			"default": 0
+		},
+		"height": {
+			"type": "string",
+			"default": "auto"
+		},
+		"arrowsColor": {
+			"type": "string"
+		},
+		"arrowsBackgroundColor": {
+			"type": "string"
+		},
+		"dotsColor": {
+			"type": "string"
+		},
+		"dotsActiveColor": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false
+	},
+	"editorStyle": "otter-content-slider-editor",
+	"style": "otter-content-slider-style",
+	"script": "otter-content-slider"
+}

--- a/src/blocks/blocks/content-slider/components/icons.js
+++ b/src/blocks/blocks/content-slider/components/icons.js
@@ -1,0 +1,21 @@
+// Chevron used for both arrows; the next button is flipped via CSS rotation.
+export const ArrowIcon = () => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="18"
+		height="18"
+		viewBox="0 0 24 24"
+		role="img"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<path
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			d="M15 6l-6 6 6 6"
+		/>
+	</svg>
+);

--- a/src/blocks/blocks/content-slider/edit.js
+++ b/src/blocks/blocks/content-slider/edit.js
@@ -1,0 +1,236 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+import { createBlock } from '@wordpress/blocks';
+
+import {
+	BlockControls,
+	useBlockProps,
+	useInnerBlocksProps
+} from '@wordpress/block-editor';
+
+import {
+	ToolbarButton,
+	ToolbarGroup
+} from '@wordpress/components';
+
+import { useDispatch, useSelect } from '@wordpress/data';
+
+import {
+	Fragment,
+	useEffect,
+	useState
+} from '@wordpress/element';
+
+import {
+	chevronLeft,
+	chevronRight,
+	plus
+} from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Inspector from './inspector.js';
+import { ArrowIcon } from './components/icons.js';
+import { blockInit } from '../../helpers/block-utility.js';
+
+const { attributes: defaultAttributes } = metadata;
+
+const TEMPLATE = [
+	[ 'core/group', { layout: { type: 'constrained' }, style: { spacing: { blockGap: '0.5rem' } } }, [
+		[ 'core/image', {
+			url: 'https://s.w.org/images/core/5.3/Glacial_lakes%2C_Bhutan.jpg',
+			alt: __( 'Glacial lakes, Bhutan', 'otter-blocks' ),
+			align: 'center',
+			sizeSlug: 'large'
+		} ],
+		[ 'core/paragraph', { align: 'center', content: __( 'Compose each slide from any blocks.', 'otter-blocks' ) } ]
+	] ],
+	[ 'core/group', { layout: { type: 'constrained' }, style: { spacing: { blockGap: '0.5rem' } } }, [
+		[ 'core/image', {
+			url: 'https://s.w.org/images/core/5.3/Sediment_off_the_Yucatan_Peninsula.jpg',
+			alt: __( 'Sediment off the Yucatan Peninsula', 'otter-blocks' ),
+			align: 'center',
+			sizeSlug: 'large'
+		} ],
+		[ 'core/paragraph', { align: 'center', content: __( 'Mix images, text, buttons and more.', 'otter-blocks' ) } ]
+	] ],
+	[ 'core/group', { layout: { type: 'constrained' }, style: { spacing: { blockGap: '0.5rem' } } }, [
+		[ 'core/image', {
+			url: 'https://s.w.org/images/core/5.3/MtBlanc1.jpg',
+			alt: __( 'Mont Blanc', 'otter-blocks' ),
+			align: 'center',
+			sizeSlug: 'large'
+		} ],
+		[ 'core/paragraph', { align: 'center', content: __( 'Each group becomes one slide.', 'otter-blocks' ) } ]
+	] ]
+];
+
+// Single slide at a time (mode B); the active index is UI-only, never persisted.
+const Edit = ({
+	attributes,
+	setAttributes,
+	clientId
+}) => {
+	useEffect( () => {
+		const unsubscribe = blockInit( clientId, defaultAttributes );
+		return () => unsubscribe( attributes.id );
+	}, [ attributes.id ]);
+
+	const [ activeSlide, setActiveSlide ] = useState( 0 );
+
+	const children = useSelect( select => {
+		return select( 'core/block-editor' ).getBlock( clientId )?.innerBlocks ?? [];
+	}, [ clientId ]);
+
+	const { insertBlock } = useDispatch( 'core/block-editor' );
+
+	const slideCount = children.length;
+
+	// Derived (not synced via effect) so it stays valid as slides are added/removed.
+	const current = Math.min( activeSlide, Math.max( 0, slideCount - 1 ) );
+
+	const goToPrev = () => setActiveSlide( 0 < current ? current - 1 : ( attributes.loop ? slideCount - 1 : 0 ) );
+
+	const goToNext = () => setActiveSlide( current < slideCount - 1 ? current + 1 : ( attributes.loop ? 0 : current ) );
+
+	const addSlide = () => {
+		const slide = createBlock(
+			'core/group',
+			{ layout: { type: 'constrained' } },
+			[ createBlock( 'core/paragraph', { placeholder: __( 'Add slide content…', 'otter-blocks' ) }) ]
+		);
+		insertBlock( slide, slideCount, clientId, false );
+		setActiveSlide( slideCount );
+	};
+
+	const inlineStyles = {
+		'--o-per-view': attributes.slidesPerView || 1,
+		'--o-gap': `${ attributes.gap ?? 0 }px`,
+		'--o-height': attributes.height || undefined,
+		'--o-arrow-color': attributes.arrowsColor || undefined,
+		'--o-arrow-bg': attributes.arrowsBackgroundColor || undefined,
+		'--o-dot-color': attributes.dotsColor || undefined,
+		'--o-dot-active-color': attributes.dotsActiveColor || undefined
+	};
+
+	const blockProps = useBlockProps({
+		className: 'o-content-slider is-editor',
+		style: inlineStyles
+	});
+
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'o-content-track'
+		},
+		{
+			template: TEMPLATE,
+			renderAppender: false
+		}
+	);
+
+	return (
+		<Fragment>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ chevronLeft }
+						label={ __( 'Previous slide', 'otter-blocks' ) }
+						onClick={ goToPrev }
+						disabled={ 0 === slideCount }
+					/>
+					<ToolbarButton
+						label={ sprintf(
+							// translators: %1$d: current slide, %2$d: total slides.
+							__( 'Slide %1$d of %2$d', 'otter-blocks' ),
+							0 === slideCount ? 0 : current + 1,
+							slideCount
+						) }
+						className="o-content-slider__indicator"
+					>
+						{ `${ 0 === slideCount ? 0 : current + 1 } / ${ slideCount }` }
+					</ToolbarButton>
+					<ToolbarButton
+						icon={ chevronRight }
+						label={ __( 'Next slide', 'otter-blocks' ) }
+						onClick={ goToNext }
+						disabled={ 0 === slideCount }
+					/>
+				</ToolbarGroup>
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ plus }
+						label={ __( 'Add slide', 'otter-blocks' ) }
+						onClick={ addSlide }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+
+			<Inspector
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+
+			<div { ...blockProps }>
+				<style>
+					{ `#block-${ clientId } .o-content-track > * { display: none; }
+					#block-${ clientId } .o-content-track > *:nth-child(${ current + 1 }) { display: block; }` }
+				</style>
+
+				<div { ...innerBlocksProps } />
+
+				{ attributes.showArrows && 1 < slideCount && (
+					<div className="o-content-arrows">
+						<button
+							type="button"
+							className="o-content-arrow o-content-arrow--prev"
+							aria-label={ __( 'Previous slide', 'otter-blocks' ) }
+							onClick={ goToPrev }
+						>
+							<ArrowIcon />
+						</button>
+						<button
+							type="button"
+							className="o-content-arrow o-content-arrow--next"
+							aria-label={ __( 'Next slide', 'otter-blocks' ) }
+							onClick={ goToNext }
+						>
+							<ArrowIcon />
+						</button>
+					</div>
+				) }
+
+				{ attributes.showDots && 0 < slideCount && (
+					<div className="o-content-dots">
+						{ children.map( ( block, index ) => (
+							<button
+								key={ block.clientId }
+								type="button"
+								className={ classnames( 'o-content-dot', {
+									'o-content-dot--active': index === current
+								}) }
+								aria-label={ sprintf(
+									// translators: %d: slide number.
+									__( 'Go to slide %d', 'otter-blocks' ),
+									index + 1
+								) }
+								onClick={ () => setActiveSlide( index ) }
+							/>
+						) ) }
+					</div>
+				) }
+			</div>
+		</Fragment>
+	);
+};
+
+export default Edit;

--- a/src/blocks/blocks/content-slider/editor.scss
+++ b/src/blocks/blocks/content-slider/editor.scss
@@ -1,0 +1,15 @@
+// Editor-only styles. Active slide is shown via a scoped nth-child <style> from edit.js.
+
+@import 'chrome';
+
+.o-content-slider.is-editor {
+	.o-content-track {
+		display: block;
+		overflow: visible;
+		scroll-snap-type: none;
+
+		> [data-block] {
+			margin: 0;
+		}
+	}
+}

--- a/src/blocks/blocks/content-slider/index.js
+++ b/src/blocks/blocks/content-slider/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import { sliderIcon as icon } from '../../helpers/icons.js';
+import edit from './edit.js';
+import save from './save.js';
+
+const { name } = metadata;
+
+registerBlockType( name, {
+	...metadata,
+	title: __( 'Content Slider', 'otter-blocks' ),
+	description: __( 'A lightweight slider where each inner block becomes a slide. Powered by Otter.', 'otter-blocks' ),
+	icon,
+	keywords: [
+		'slider',
+		'carousel',
+		'content',
+		'slides'
+	],
+	edit,
+	save
+});

--- a/src/blocks/blocks/content-slider/inspector.js
+++ b/src/blocks/blocks/content-slider/inspector.js
@@ -1,0 +1,134 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import { InspectorControls } from '@wordpress/block-editor';
+
+import {
+	PanelBody,
+	RangeControl,
+	TextControl,
+	ToggleControl
+} from '@wordpress/components';
+
+import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ColorDropdownControl } from '../../components/index.js';
+
+const Inspector = ({
+	attributes,
+	setAttributes
+}) => {
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Settings', 'otter-blocks' ) }
+				initialOpen={ true }
+			>
+				<RangeControl
+					label={ __( 'Slides per View', 'otter-blocks' ) }
+					value={ attributes.slidesPerView }
+					onChange={ value => setAttributes({ slidesPerView: Number( value ) }) }
+					min={ 1 }
+					max={ 6 }
+				/>
+
+				<RangeControl
+					label={ __( 'Gap (px)', 'otter-blocks' ) }
+					value={ attributes.gap }
+					onChange={ value => setAttributes({ gap: Number( value ?? 0 ) }) }
+					min={ 0 }
+					max={ 100 }
+				/>
+
+				<TextControl
+					label={ __( 'Height', 'otter-blocks' ) }
+					help={ __( 'A CSS value, e.g. 400px or auto.', 'otter-blocks' ) }
+					value={ attributes.height }
+					onChange={ value => setAttributes({ height: value }) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Loop', 'otter-blocks' ) }
+					help={ __( 'Wrap around to the first slide after the last one.', 'otter-blocks' ) }
+					checked={ attributes.loop }
+					onChange={ value => setAttributes({ loop: value }) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Autoplay', 'otter-blocks' ) }
+					checked={ attributes.autoplay }
+					onChange={ value => setAttributes({ autoplay: value }) }
+				/>
+
+				{ attributes.autoplay && (
+					<RangeControl
+						label={ __( 'Delay (seconds)', 'otter-blocks' ) }
+						value={ attributes.delay }
+						onChange={ value => setAttributes({ delay: Number( value ?? 5 ) }) }
+						min={ 1 }
+						max={ 30 }
+					/>
+				) }
+			</PanelBody>
+
+			<PanelBody
+				title={ __( 'Navigation', 'otter-blocks' ) }
+				initialOpen={ false }
+			>
+				<ToggleControl
+					label={ __( 'Show Arrows', 'otter-blocks' ) }
+					checked={ attributes.showArrows }
+					onChange={ value => setAttributes({ showArrows: value }) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Show Dots', 'otter-blocks' ) }
+					checked={ attributes.showDots }
+					onChange={ value => setAttributes({ showDots: value }) }
+				/>
+			</PanelBody>
+
+			<PanelBody
+				title={ __( 'Slider Chrome', 'otter-blocks' ) }
+				initialOpen={ false }
+			>
+				<Fragment>
+					<ColorDropdownControl
+						label={ __( 'Arrow Color', 'otter-blocks' ) }
+						colorValue={ attributes.arrowsColor }
+						onColorChange={ value => setAttributes({ arrowsColor: value }) }
+						className="is-list is-first"
+					/>
+
+					<ColorDropdownControl
+						label={ __( 'Arrow Background', 'otter-blocks' ) }
+						colorValue={ attributes.arrowsBackgroundColor }
+						onColorChange={ value => setAttributes({ arrowsBackgroundColor: value }) }
+						className="is-list"
+					/>
+
+					<ColorDropdownControl
+						label={ __( 'Dots Color', 'otter-blocks' ) }
+						colorValue={ attributes.dotsColor }
+						onColorChange={ value => setAttributes({ dotsColor: value }) }
+						className="is-list"
+					/>
+
+					<ColorDropdownControl
+						label={ __( 'Active Dot Color', 'otter-blocks' ) }
+						colorValue={ attributes.dotsActiveColor }
+						onColorChange={ value => setAttributes({ dotsActiveColor: value }) }
+						className="is-list"
+					/>
+				</Fragment>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default Inspector;

--- a/src/blocks/blocks/content-slider/save.js
+++ b/src/blocks/blocks/content-slider/save.js
@@ -1,0 +1,91 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+import {
+	useBlockProps,
+	useInnerBlocksProps
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { ArrowIcon } from './components/icons.js';
+
+const Save = ({
+	attributes
+}) => {
+	const {
+		id,
+		autoplay,
+		delay,
+		showArrows,
+		showDots,
+		loop,
+		slidesPerView,
+		gap,
+		height,
+		arrowsColor,
+		arrowsBackgroundColor,
+		dotsColor,
+		dotsActiveColor
+	} = attributes;
+
+	const style = {
+		'--o-per-view': slidesPerView || 1,
+		'--o-gap': undefined !== gap ? `${ gap }px` : undefined,
+		'--o-height': height || undefined,
+		'--o-arrow-color': arrowsColor || undefined,
+		'--o-arrow-bg': arrowsBackgroundColor || undefined,
+		'--o-dot-color': dotsColor || undefined,
+		'--o-dot-active-color': dotsActiveColor || undefined
+	};
+
+	const blockProps = useBlockProps.save({
+		id,
+		className: 'o-content-slider',
+		style,
+		role: 'region',
+		'aria-roledescription': 'carousel',
+		'aria-label': __( 'Content slider', 'otter-blocks' ),
+		'data-autoplay': autoplay ? 'true' : 'false',
+		'data-delay': delay,
+		'data-loop': loop ? 'true' : 'false'
+	});
+
+	const innerBlocksProps = useInnerBlocksProps.save({
+		className: 'o-content-track'
+	});
+
+	return (
+		<div { ...blockProps }>
+			<div { ...innerBlocksProps } />
+
+			{ showArrows && (
+				<div className="o-content-arrows">
+					<button
+						type="button"
+						className="o-content-arrow o-content-arrow--prev"
+						aria-label={ __( 'Previous slide', 'otter-blocks' ) }
+					>
+						<ArrowIcon />
+					</button>
+					<button
+						type="button"
+						className="o-content-arrow o-content-arrow--next"
+						aria-label={ __( 'Next slide', 'otter-blocks' ) }
+					>
+						<ArrowIcon />
+					</button>
+				</div>
+			) }
+
+			{ showDots && (
+				<div className="o-content-dots" />
+			) }
+		</div>
+	);
+};
+
+export default Save;

--- a/src/blocks/blocks/content-slider/style.scss
+++ b/src/blocks/blocks/content-slider/style.scss
@@ -1,0 +1,31 @@
+@import 'chrome';
+
+.wp-block-themeisle-blocks-content-slider {
+	.o-content-track {
+		display: flex;
+		gap: var(--o-gap, 0px);
+		height: var(--o-height, auto);
+		overflow-x: auto;
+		overflow-y: hidden;
+		scroll-snap-type: x mandatory;
+		scroll-behavior: smooth;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
+
+		> * {
+			flex: 0 0 calc((100% - (var(--o-per-view, 1) - 1) * var(--o-gap, 0px)) / var(--o-per-view, 1));
+			margin: 0;
+			scroll-snap-align: start;
+		}
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.wp-block-themeisle-blocks-content-slider .o-content-track {
+		scroll-behavior: auto;
+	}
+}

--- a/src/blocks/blocks/index.js
+++ b/src/blocks/blocks/index.js
@@ -5,6 +5,7 @@ import './accordion/index.js';
 import './advanced-heading/index.js';
 import './button-group/index.js';
 import './circle-counter/index.js';
+import './content-slider/index.js';
 import './countdown/index.js';
 import './flip/index.js';
 import './font-awesome-icons/index.js';

--- a/src/blocks/frontend/content-slider/index.js
+++ b/src/blocks/frontend/content-slider/index.js
@@ -101,14 +101,25 @@ const initSlider = ( slider ) => {
 		{ passive: true }
 	);
 
+	// Arrow keys navigate slides, but inner controls (form fields, editable
+	// content, selects) need them for their own caret/option movement, so the
+	// slider only claims the keys when focus is not inside such an element.
+	const isFromInteractiveElement = ( target ) => {
+		const el = target?.closest?.( 'input, textarea, select, [contenteditable=""], [contenteditable="true"]' );
+		return Boolean( el );
+	};
+
 	slider.addEventListener( 'keydown', ( event ) => {
-		if ( 'ArrowLeft' === event.key ) {
-			event.preventDefault();
-			goTo( current - 1 );
-		} else if ( 'ArrowRight' === event.key ) {
-			event.preventDefault();
-			goTo( current + 1 );
+		if ( 'ArrowLeft' !== event.key && 'ArrowRight' !== event.key ) {
+			return;
 		}
+
+		if ( isFromInteractiveElement( event.target ) ) {
+			return;
+		}
+
+		event.preventDefault();
+		goTo( 'ArrowLeft' === event.key ? current - 1 : current + 1 );
 	});
 
 	let timer = null;

--- a/src/blocks/frontend/content-slider/index.js
+++ b/src/blocks/frontend/content-slider/index.js
@@ -1,0 +1,146 @@
+import { domReady } from '../../helpers/frontend-helper-functions.js';
+
+const goToSlideLabel = window.themeisleGutenbergContentSlider?.goToSlide || 'Go to slide %d';
+
+// Core motion is CSS scroll-snap; this only wires arrows, dots, autoplay, keyboard and soft-wrap loop.
+const initSlider = ( slider ) => {
+	const track = slider.querySelector( '.o-content-track' );
+
+	if ( ! track ) {
+		return;
+	}
+
+	const slides = Array.from( track.children );
+
+	if ( 0 === slides.length ) {
+		return;
+	}
+
+	const autoplay = 'true' === slider.dataset.autoplay;
+	const loop = 'false' !== slider.dataset.loop;
+	const delay = Math.max( 1, parseFloat( slider.dataset.delay ) || 5 ) * 1000;
+	const reduceMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
+	let current = 0;
+
+	// Slide index closest to the current scroll position (keeps dots synced on manual scroll/swipe).
+	const getCurrent = () => {
+		const base = track.getBoundingClientRect().left;
+		let index = 0;
+		let min = Infinity;
+
+		slides.forEach( ( slide, i ) => {
+			const distance = Math.abs( slide.getBoundingClientRect().left - base );
+
+			if ( distance < min ) {
+				min = distance;
+				index = i;
+			}
+		});
+
+		return index;
+	};
+
+	const dotsContainer = slider.querySelector( '.o-content-dots' );
+	const dots = [];
+
+	const updateDots = () => {
+		dots.forEach( ( dot, i ) => dot.classList.toggle( 'o-content-dot--active', i === current ) );
+	};
+
+	const goTo = ( index ) => {
+		const count = slides.length;
+
+		if ( loop ) {
+			index = ( index + count ) % count;
+		} else {
+			index = Math.max( 0, Math.min( index, count - 1 ) );
+		}
+
+		current = index;
+
+		const left = slides[ index ].getBoundingClientRect().left - track.getBoundingClientRect().left + track.scrollLeft;
+
+		track.scrollTo({
+			left,
+			behavior: reduceMotion ? 'auto' : 'smooth'
+		});
+
+		updateDots();
+	};
+
+	// Dots are built here since the slide count is only known at runtime.
+	if ( dotsContainer ) {
+		slides.forEach( ( _, i ) => {
+			const dot = document.createElement( 'button' );
+			dot.type = 'button';
+			dot.className = 'o-content-dot';
+			dot.setAttribute( 'aria-label', goToSlideLabel.replace( '%d', i + 1 ) );
+			dot.addEventListener( 'click', () => goTo( i ) );
+			dotsContainer.appendChild( dot );
+			dots.push( dot );
+		});
+	}
+
+	const prevArrow = slider.querySelector( '.o-content-arrow--prev' );
+	const nextArrow = slider.querySelector( '.o-content-arrow--next' );
+
+	prevArrow?.addEventListener( 'click', () => goTo( current - 1 ) );
+	nextArrow?.addEventListener( 'click', () => goTo( current + 1 ) );
+
+	let scrollTimer;
+	track.addEventListener(
+		'scroll',
+		() => {
+			window.clearTimeout( scrollTimer );
+			scrollTimer = window.setTimeout( () => {
+				current = getCurrent();
+				updateDots();
+			}, 100 );
+		},
+		{ passive: true }
+	);
+
+	slider.addEventListener( 'keydown', ( event ) => {
+		if ( 'ArrowLeft' === event.key ) {
+			event.preventDefault();
+			goTo( current - 1 );
+		} else if ( 'ArrowRight' === event.key ) {
+			event.preventDefault();
+			goTo( current + 1 );
+		}
+	});
+
+	let timer = null;
+
+	const stop = () => {
+		if ( timer ) {
+			window.clearInterval( timer );
+			timer = null;
+		}
+	};
+
+	const start = () => {
+		if ( ! autoplay || reduceMotion ) {
+			return;
+		}
+		stop();
+		timer = window.setInterval( () => goTo( current + 1 ), delay );
+	};
+
+	if ( autoplay && ! reduceMotion ) {
+		slider.addEventListener( 'mouseenter', stop );
+		slider.addEventListener( 'mouseleave', start );
+		slider.addEventListener( 'focusin', stop );
+		slider.addEventListener( 'focusout', start );
+		start();
+	}
+
+	updateDots();
+};
+
+domReady( () => {
+	document
+		.querySelectorAll( '.wp-block-themeisle-blocks-content-slider' )
+		.forEach( ( slider ) => initSlider( slider ) );
+});

--- a/src/blocks/test/e2e/blocks/content-slider.spec.js
+++ b/src/blocks/test/e2e/blocks/content-slider.spec.js
@@ -240,4 +240,85 @@ test.describe( 'Content Slider Block', () => {
 		await expect( track.locator( '.wp-block-themeisle-blocks-button-group .wp-block-button__link' ) ).toContainText( 'Otter button slide' );
 		await expect( track.locator( '.wp-block-themeisle-blocks-accordion' ) ).toContainText( 'Otter accordion slide' );
 	});
+
+	test( 'renders diverse core blocks and a content-heavy slide', async({ editor, page }) => {
+		const listItem = content => ({ name: 'core/list-item', attributes: { content } });
+		const paragraph = content => ({ name: 'core/paragraph', attributes: { content } });
+
+		await editor.insertBlock({
+			name: BLOCK,
+			innerBlocks: [
+				// Slide 1 — a mix of core blocks.
+				{
+					name: 'core/group',
+					attributes: { className: 'core-mix-slide', layout: { type: 'constrained' } },
+					innerBlocks: [
+						{ name: 'core/heading', attributes: { content: 'Core mix heading', level: 2 } },
+						{ name: 'core/image', attributes: { url: 'https://s.w.org/images/core/5.3/MtBlanc1.jpg', alt: 'Peak' } },
+						paragraph( 'An intro paragraph for the core mix slide.' ),
+						{ name: 'core/list', innerBlocks: [ listItem( 'Alpha' ), listItem( 'Beta' ), listItem( 'Gamma' ) ] },
+						{ name: 'core/quote', innerBlocks: [ paragraph( 'A quoted line of text.' ) ] },
+						{ name: 'core/buttons', innerBlocks: [ { name: 'core/button', attributes: { text: 'Core button' } } ] }
+					]
+				},
+
+				// Slide 2 — content-heavy: many blocks nested inside one slide.
+				{
+					name: 'core/group',
+					attributes: { className: 'huge-slide', layout: { type: 'constrained' } },
+					innerBlocks: [
+						{ name: 'core/heading', attributes: { content: 'Content-heavy slide', level: 2 } },
+						...Array.from({ length: 10 }, ( _, i ) => paragraph( `Body paragraph number ${ i + 1 } with a sentence of content.` ) ),
+						{ name: 'core/list', innerBlocks: Array.from({ length: 8 }, ( _, i ) => listItem( `Feature ${ i + 1 }` ) ) },
+						{
+							name: 'core/columns',
+							innerBlocks: [
+								{ name: 'core/column', innerBlocks: [ paragraph( 'Left column copy.' ) ] },
+								{ name: 'core/column', innerBlocks: [ paragraph( 'Middle column copy.' ) ] },
+								{ name: 'core/column', innerBlocks: [ paragraph( 'Right column copy.' ) ] }
+							]
+						},
+						{ name: 'core/quote', innerBlocks: [ paragraph( 'A closing pull quote.' ) ] }
+					]
+				},
+
+				// Slide 3 — core and Otter blocks together in one slide.
+				{
+					name: 'core/group',
+					attributes: { className: 'mixed-slide', layout: { type: 'constrained' } },
+					innerBlocks: [
+						{ name: 'core/heading', attributes: { content: 'Mixed slide', level: 3 } },
+						{ name: 'themeisle-blocks/advanced-heading', attributes: { content: 'Otter advanced heading', tag: 'h4' } },
+						{ name: 'themeisle-blocks/button-group', innerBlocks: [ { name: 'themeisle-blocks/button', attributes: { text: 'Otter CTA', link: 'https://example.com' } } ] }
+					]
+				}
+			]
+		});
+
+		await publishAndViewPost({ editor, page });
+
+		const track = page.locator( '.o-content-track' );
+		await expect( track.locator( '> *' ) ).toHaveCount( 3 );
+
+		// Slide 1 — core blocks render.
+		const coreMix = track.locator( '.core-mix-slide' );
+		await expect( coreMix.locator( 'h2.wp-block-heading' ) ).toContainText( 'Core mix heading' );
+		await expect( coreMix.locator( '.wp-block-image img' ) ).toBeVisible();
+		await expect( coreMix.locator( '.wp-block-list li' ) ).toContainText([ 'Alpha', 'Beta', 'Gamma' ]);
+		await expect( coreMix.locator( '.wp-block-quote' ) ).toContainText( 'A quoted line of text.' );
+		await expect( coreMix.locator( '.wp-block-button__link' ) ).toContainText( 'Core button' );
+
+		// Slide 2 — the content-heavy slide renders all of its blocks.
+		const huge = track.locator( '.huge-slide' );
+		expect( await huge.locator( 'p' ).count() ).toBeGreaterThanOrEqual( 10 );
+		await expect( huge.locator( '.wp-block-list li' ) ).toHaveCount( 8 );
+		await expect( huge.locator( '.wp-block-columns .wp-block-column' ) ).toHaveCount( 3 );
+		await expect( huge.locator( '.wp-block-quote' ) ).toContainText( 'A closing pull quote.' );
+
+		// Slide 3 — core + Otter blocks coexist in one slide.
+		const mixed = track.locator( '.mixed-slide' );
+		await expect( mixed.locator( 'h3.wp-block-heading' ) ).toContainText( 'Mixed slide' );
+		await expect( mixed.locator( '.wp-block-themeisle-blocks-advanced-heading' ) ).toContainText( 'Otter advanced heading' );
+		await expect( mixed.locator( '.wp-block-themeisle-blocks-button-group .wp-block-button__link' ) ).toContainText( 'Otter CTA' );
+	});
 });

--- a/src/blocks/test/e2e/blocks/content-slider.spec.js
+++ b/src/blocks/test/e2e/blocks/content-slider.spec.js
@@ -1,0 +1,203 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import {
+	expectBlockByName,
+	insertBlockBySlash,
+	publishAndViewPost
+} from '../helpers/editor';
+
+const BLOCK = 'themeisle-blocks/content-slider';
+
+/**
+ * Build a Content Slider block representation with N paragraph slides.
+ *
+ * @param {number} count      Number of slides.
+ * @param {Object} attributes Extra block attributes.
+ * @return {Object} Block representation for editor.insertBlock.
+ */
+const sliderWithSlides = ( count, attributes = {}) => ({
+	name: BLOCK,
+	attributes,
+	innerBlocks: Array.from({ length: count }, ( _, i ) => ({
+		name: 'core/paragraph',
+		attributes: { content: `Slide ${ i + 1 }` }
+	}) )
+});
+
+test.describe( 'Content Slider Block', () => {
+	test.beforeEach( async({ admin }) => {
+		await admin.createNewPost();
+	});
+
+	test( 'can be created by typing "/content slider"', async({ editor, page }) => {
+		await insertBlockBySlash({
+			editor,
+			page,
+			shortcut: '/content slider',
+			blockName: BLOCK
+		});
+
+		await expectBlockByName( editor, BLOCK );
+	});
+
+	test( 'editor shows one slide at a time and toolbar navigates (mode B)', async({ editor, page }) => {
+		await editor.insertBlock( sliderWithSlides( 3 ) );
+
+		const block = editor.canvas.getByRole( 'document', { name: 'Block: Content Slider' });
+		await editor.selectBlocks( block );
+
+		// Only the active slide is visible at a time.
+		await expect( editor.canvas.getByText( 'Slide 1', { exact: true }) ).toBeVisible();
+		await expect( editor.canvas.getByText( 'Slide 2', { exact: true }) ).toBeHidden();
+
+		// Toolbar "Next slide" advances the active slide.
+		await page.getByRole( 'button', { name: 'Next slide', exact: true }).click();
+		await expect( editor.canvas.getByText( 'Slide 2', { exact: true }) ).toBeVisible();
+		await expect( editor.canvas.getByText( 'Slide 1', { exact: true }) ).toBeHidden();
+
+		// "Add slide" appends a fourth slide.
+		await page.getByRole( 'button', { name: 'Add slide', exact: true }).click();
+		const stored = await expectBlockByName( editor, BLOCK );
+		expect( stored.innerBlocks.length ).toBe( 4 );
+	});
+
+	test( 'frontend renders slides, arrows and dots', async({ editor, page }) => {
+		await editor.insertBlock( sliderWithSlides( 3 ) );
+		await publishAndViewPost({ editor, page });
+
+		await expect( page.locator( '.wp-block-themeisle-blocks-content-slider' ) ).toBeVisible();
+		await expect( page.locator( '.o-content-track > *' ) ).toHaveCount( 3 );
+		await expect( page.locator( '.o-content-arrow--prev' ) ).toBeVisible();
+		await expect( page.locator( '.o-content-arrow--next' ) ).toBeVisible();
+
+		// Dots are built by JS, one per slide.
+		await expect( page.locator( '.o-content-dots .o-content-dot' ) ).toHaveCount( 3 );
+
+		// Carousel semantics for assistive tech.
+		await expect( page.locator( '.wp-block-themeisle-blocks-content-slider' ) ).toHaveAttribute( 'aria-roledescription', 'carousel' );
+	});
+
+	test( 'arrows and dots change the active slide; loop wraps around', async({ editor, page }) => {
+		await editor.insertBlock( sliderWithSlides( 3, { loop: true }) );
+		await publishAndViewPost({ editor, page });
+
+		const dots = page.locator( '.o-content-dots .o-content-dot' );
+		const next = page.locator( '.o-content-arrow--next' );
+		const prev = page.locator( '.o-content-arrow--prev' );
+
+		// Initially the first dot is active.
+		await expect( dots.nth( 0 ) ).toHaveClass( /o-content-dot--active/ );
+
+		// Next advances the active dot.
+		await next.click();
+		await expect( dots.nth( 1 ) ).toHaveClass( /o-content-dot--active/ );
+
+		// Clicking a dot jumps to that slide.
+		await dots.nth( 2 ).click();
+		await expect( dots.nth( 2 ) ).toHaveClass( /o-content-dot--active/ );
+
+		// Next from the last slide wraps to the first (soft loop).
+		await next.click();
+		await expect( dots.nth( 0 ) ).toHaveClass( /o-content-dot--active/ );
+
+		// Prev from the first slide wraps to the last.
+		await prev.click();
+		await expect( dots.nth( 2 ) ).toHaveClass( /o-content-dot--active/ );
+	});
+
+	test( 'keyboard arrow keys navigate slides', async({ editor, page }) => {
+		await editor.insertBlock( sliderWithSlides( 3 ) );
+		await publishAndViewPost({ editor, page });
+
+		const dots = page.locator( '.o-content-dots .o-content-dot' );
+
+		await page.locator( '.o-content-arrow--next' ).focus();
+		await page.keyboard.press( 'ArrowRight' );
+		await expect( dots.nth( 1 ) ).toHaveClass( /o-content-dot--active/ );
+
+		await page.keyboard.press( 'ArrowLeft' );
+		await expect( dots.nth( 0 ) ).toHaveClass( /o-content-dot--active/ );
+	});
+
+	test( 'showArrows and showDots toggles hide chrome', async({ editor, page }) => {
+		await editor.insertBlock( sliderWithSlides( 2, { showArrows: false, showDots: false }) );
+		await publishAndViewPost({ editor, page });
+
+		await expect( page.locator( '.wp-block-themeisle-blocks-content-slider' ) ).toBeVisible();
+		await expect( page.locator( '.o-content-arrows' ) ).toHaveCount( 0 );
+		await expect( page.locator( '.o-content-dots' ) ).toHaveCount( 0 );
+	});
+
+	test( 'chrome color attributes apply as scoped CSS variables', async({ editor, page }) => {
+		await editor.insertBlock( sliderWithSlides( 2, {
+			arrowsColor: '#ff0000',
+			dotsActiveColor: '#00ff00'
+		}) );
+		await publishAndViewPost({ editor, page });
+
+		const slider = page.locator( '.wp-block-themeisle-blocks-content-slider' );
+		const arrowColor = await slider.evaluate( el => window.getComputedStyle( el ).getPropertyValue( '--o-arrow-color' ).trim() );
+		const dotActive = await slider.evaluate( el => window.getComputedStyle( el ).getPropertyValue( '--o-dot-active-color' ).trim() );
+
+		expect( arrowColor ).toBe( '#ff0000' );
+		expect( dotActive ).toBe( '#00ff00' );
+	});
+
+	test( 'autoplay advances slides and pauses on hover', async({ editor, page }) => {
+		// The shared config forces prefers-reduced-motion: reduce, which would
+		// (correctly) disable autoplay. Opt out for this specific test.
+		await page.emulateMedia({ reducedMotion: 'no-preference' });
+
+		await editor.insertBlock( sliderWithSlides( 3, { autoplay: true, delay: 1 }) );
+		await publishAndViewPost({ editor, page });
+
+		const dots = page.locator( '.o-content-dots .o-content-dot' );
+
+		// Autoplay moves forward on its own.
+		await expect( dots.nth( 1 ) ).toHaveClass( /o-content-dot--active/, { timeout: 4000 });
+
+		// Hovering pauses autoplay: the active dot should not change while hovered.
+		await page.locator( '.wp-block-themeisle-blocks-content-slider' ).hover();
+		const activeAfterHover = await page.locator( '.o-content-dot--active' ).getAttribute( 'aria-label' );
+		await page.waitForTimeout( 1500 );
+		const activeStill = await page.locator( '.o-content-dot--active' ).getAttribute( 'aria-label' );
+		expect( activeStill ).toBe( activeAfterHover );
+	});
+
+	test( 'reduced motion disables autoplay', async({ editor, page }) => {
+		await editor.insertBlock( sliderWithSlides( 3, { autoplay: true, delay: 1 }) );
+		await page.emulateMedia({ reducedMotion: 'reduce' });
+		await publishAndViewPost({ editor, page });
+
+		const dots = page.locator( '.o-content-dots .o-content-dot' );
+
+		// With reduced motion, autoplay never starts: first slide stays active.
+		await page.waitForTimeout( 2000 );
+		await expect( dots.nth( 0 ) ).toHaveClass( /o-content-dot--active/ );
+	});
+
+	test( 'no console errors on the frontend', async({ editor, page }) => {
+		// Third-party survey/tracking scripts (Formbricks) are disabled in the
+		// e2e environment by the otter-e2e bootstrap mu-plugin, so the console
+		// should be free of unrelated noise here.
+		const errors = [];
+		page.on( 'console', msg => {
+			if ( 'error' === msg.type() ) {
+				errors.push( msg.text() );
+			}
+		});
+		page.on( 'pageerror', err => errors.push( err.message ) );
+
+		await editor.insertBlock( sliderWithSlides( 3 ) );
+		await publishAndViewPost({ editor, page });
+
+		await page.locator( '.o-content-arrow--next' ).click({ clickCount: 3 });
+		expect( errors ).toEqual([]);
+	});
+});

--- a/src/blocks/test/e2e/blocks/content-slider.spec.js
+++ b/src/blocks/test/e2e/blocks/content-slider.spec.js
@@ -125,6 +125,41 @@ test.describe( 'Content Slider Block', () => {
 		await expect( dots.nth( 0 ) ).toHaveClass( /o-content-dot--active/ );
 	});
 
+	test( 'arrow keys inside a form field edit text instead of navigating slides', async({ editor, page }) => {
+
+		// A form field as a slide needs Left/Right for its own caret movement;
+		// the slider must not hijack those keys when focus is inside the field.
+		await editor.insertBlock({
+			name: BLOCK,
+			attributes: { loop: true },
+			innerBlocks: [
+				{
+					name: 'themeisle-blocks/form',
+					innerBlocks: [
+						{ name: 'themeisle-blocks/form-input', attributes: { label: 'Name', type: 'text' } }
+					]
+				},
+				{ name: 'core/paragraph', attributes: { content: 'Second slide' } }
+			]
+		});
+		await publishAndViewPost({ editor, page });
+
+		const dots = page.locator( '.o-content-dots .o-content-dot' );
+		await expect( dots.nth( 0 ) ).toHaveClass( /o-content-dot--active/ );
+
+		const input = page.locator( '.o-content-track input[type="text"]' ).first();
+		await input.fill( 'abc' );
+
+		// Caret sits after "abc"; ArrowLeft should move it within the field.
+		await input.press( 'ArrowLeft' );
+
+		// The slide did not change (the key was not hijacked by the slider).
+		await expect( dots.nth( 0 ) ).toHaveClass( /o-content-dot--active/ );
+
+		// The caret moved left inside the field instead of being suppressed.
+		expect( await input.evaluate( el => el.selectionStart ) ).toBe( 2 );
+	});
+
 	test( 'showArrows and showDots toggles hide chrome', async({ editor, page }) => {
 		await editor.insertBlock( sliderWithSlides( 2, { showArrows: false, showDots: false }) );
 		await publishAndViewPost({ editor, page });

--- a/src/blocks/test/e2e/blocks/content-slider.spec.js
+++ b/src/blocks/test/e2e/blocks/content-slider.spec.js
@@ -200,4 +200,44 @@ test.describe( 'Content Slider Block', () => {
 		await page.locator( '.o-content-arrow--next' ).click({ clickCount: 3 });
 		expect( errors ).toEqual([]);
 	});
+
+	test( 'renders other Otter blocks as slides', async({ editor, page }) => {
+		await editor.insertBlock({
+			name: BLOCK,
+			innerBlocks: [
+				{
+					name: 'themeisle-blocks/advanced-heading',
+					attributes: { content: 'Otter heading slide', tag: 'h3' }
+				},
+				{
+					name: 'themeisle-blocks/button-group',
+					innerBlocks: [
+						{
+							name: 'themeisle-blocks/button',
+							attributes: { text: 'Otter button slide', link: 'https://example.com' }
+						}
+					]
+				},
+				{
+					name: 'themeisle-blocks/accordion',
+					innerBlocks: [
+						{
+							name: 'themeisle-blocks/accordion-item',
+							attributes: { title: 'Otter accordion slide' }
+						}
+					]
+				}
+			]
+		});
+
+		await publishAndViewPost({ editor, page });
+
+		const track = page.locator( '.o-content-track' );
+
+		// Each Otter block is a direct child (slide) and renders its own markup.
+		await expect( track.locator( '> *' ) ).toHaveCount( 3 );
+		await expect( track.locator( '.wp-block-themeisle-blocks-advanced-heading' ) ).toContainText( 'Otter heading slide' );
+		await expect( track.locator( '.wp-block-themeisle-blocks-button-group .wp-block-button__link' ) ).toContainText( 'Otter button slide' );
+		await expect( track.locator( '.wp-block-themeisle-blocks-accordion' ) ).toContainText( 'Otter accordion slide' );
+	});
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -188,6 +188,7 @@ module.exports = [
 			'leaflet-gesture-handling': './src/blocks/frontend/leaflet-map/leaflet-gesture-handling.js',
 			maps: './src/blocks/frontend/google-map/index.js',
 			slider: './src/blocks/frontend/slider/index.js',
+			'content-slider': './src/blocks/frontend/content-slider/index.js',
 			'progress-bar': './src/blocks/frontend/progress-bar/index.js',
 			'circle-counter': './src/blocks/frontend/circle-counter/index.js',
 			lottie: './src/blocks/frontend/lottie/index.js',


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/272
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

- Add a general block that acts as a slider for any type of content.

### Screenshots <!-- if applicable -->

<img width="4208" height="1844" alt="CleanShot 2026-06-18 at 14 21 23@2x" src="https://github.com/user-attachments/assets/fbd7511d-d42e-4c02-a630-a272a64965ea" />


----

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check if the basic functionality works
- Check if you can create a basic slider image
- Check if you can create a slider with mixed content (maps blocks, forms)

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

