### PR TITLE
fix: Maps block markers, loading, zoom, and scroll controls

### DIFF
--- a/inc/render/class-leaflet-map-block.php
+++ b/inc/render/class-leaflet-map-block.php
@@ -58,7 +58,7 @@ class Leaflet_Map_Block {
 		$output .= '<script type="text/javascript">' . "\n";
 		$output .= '	/* <![CDATA[ */' . "\n";
 		$output .= '		if ( ! window.themeisleLeafletMaps ) window.themeisleLeafletMaps =[];' . "\n";
-		$output .= '		window.themeisleLeafletMaps.push( { container: "' . esc_attr( $id ) . '", attributes: ' . wp_json_encode( $attributes ) . ' } );' . "\n";
+		$output .= '		window.themeisleLeafletMaps.push( { container: "' . esc_attr( $id ) . '", attributes: ' . wp_json_encode( $attributes ) . ', imagePath: "' . esc_url( OTTER_BLOCKS_URL . 'assets/leaflet/images/' ) . '" } );' . "\n";
 		$output .= '	/* ]]> */' . "\n";
 		$output .= '</script>' . "\n";
 

--- a/src/blocks/blocks/leaflet-map/block.json
+++ b/src/blocks/blocks/leaflet-map/block.json
@@ -51,6 +51,14 @@
 		"draggable": {
 			"type": "boolean",
 			"default": true
+		},
+		"scrollZoom": {
+			"type": "boolean",
+			"default": true
+		},
+		"showMarkerTooltip": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/src/blocks/blocks/leaflet-map/edit.js
+++ b/src/blocks/blocks/leaflet-map/edit.js
@@ -292,7 +292,12 @@ const Edit = ({
 		L.Control.AddMarker = L.Control.extend({
 			onAdd: () => {
 				const button = L.DomUtil.create( 'button', 'wp-block-themeisle-blocks-leaflet-map-marker-button' );
-				const span = L.DomUtil.create( 'span', 'dashicons dashicons-sticky', button );
+				button.type = 'button';
+
+				// Render an inline SVG marker icon instead of a Dashicon: the iframed
+				// editor canvas (apiVersion 3) does not load the Dashicons font, so a
+				// `dashicons` glyph renders as an empty box.
+				button.innerHTML = '<svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z" /></svg>';
 
 				L.DomEvent.on( button, 'click', ( event ) => {
 
@@ -302,7 +307,7 @@ const Edit = ({
 				});
 
 				button.title = __( 'Add marker on the map with a click', 'otter-blocks' );
-				button.appendChild( span );
+				button.setAttribute( 'aria-label', __( 'Add marker on the map with a click', 'otter-blocks' ) );
 
 				return button;
 			},

--- a/src/blocks/blocks/leaflet-map/edit.js
+++ b/src/blocks/blocks/leaflet-map/edit.js
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
  * WordPress dependencies
  */
 import {
+	isEqual,
 	isNumber,
 	merge
 } from 'lodash';
@@ -74,6 +75,10 @@ const Edit = ({
 	const mapInstanceRef = useRef( null );
 	const [ map, setMap ] = useState( null );
 	const [ isAddingToLocationActive, setActiveAddingToLocation ] = useState( false );
+
+	// Read by the once-bound Leaflet handlers in `createMap`, which would otherwise
+	// capture the initial `isAddingToLocationActive` value via a stale closure.
+	const isAddingRef = useRef( false );
 	const [ openMarker, setOpenMarker ] = useState( null );
 
 	/**
@@ -86,9 +91,14 @@ const Edit = ({
 	 */
 	const getLeaflet = () => getBlockWindow( mapRef ).L;
 
-	const createMarker = ( markerProps, dispatch ) => {
+	const createMarker = ( sourceProps, dispatch ) => {
 		const L = getLeaflet();
-		if ( L && map && dispatch && markerProps ) {
+		if ( L && map && dispatch && sourceProps ) {
+
+			// Own a private copy so reducer mutations (e.g. a drag's `moveend`) don't
+			// silently mutate the `attributes.markers` objects, which would hide the
+			// change from the persistence diff below.
+			const markerProps = { ...sourceProps };
 			markerProps.id ??= uuidv4();
 			markerProps.latitude ??= map.getCenter().lat;
 			markerProps.longitude ??= map.getCenter().lng;
@@ -136,7 +146,7 @@ const Edit = ({
 			return [ ...oldState, newMarker ];
 
 		case ActionType.ADD_MANUAL:
-			if ( isAddingToLocationActive ) {
+			if ( isAddingRef.current ) {
 				const newMarker = createMarker( action.marker, action.dispatch );
 				return [ ...oldState, newMarker ];
 			}
@@ -201,6 +211,15 @@ const Edit = ({
 			return ;
 		}
 
+		// Leaflet's CSS path-guessing heuristic is unreliable inside the iframed
+		// editor, so point the default marker icon at the bundled images explicitly.
+		const assetsPath = window.themeisleGutenberg?.assetsPath;
+		if ( assetsPath ) {
+			L.Icon.Default.imagePath = `${ assetsPath }/leaflet/images/`;
+		}
+
+		// `scrollZoom` defaults to true for blocks saved before the attribute existed.
+		const scrollZoom = false !== attributes.scrollZoom;
 
 		// Create the map
 		mapRef.current.innerHTML = '';
@@ -209,7 +228,12 @@ const Edit = ({
 		const _map = L.map(
 			mapRef.current,
 			{
-				gestureHandling: true,
+				maxZoom: 19,
+				scrollWheelZoom: scrollZoom,
+
+				// Gesture handling enforces the Ctrl/\u2318 + scroll requirement; turn it off
+				// together with scrollWheelZoom when scroll zoom is disabled.
+				gestureHandling: scrollZoom,
 				gestureHandlingOptions: {
 					text: {
 						touch: __( 'Use two fingers to move the map', 'otter-blocks' ),
@@ -224,7 +248,8 @@ const Edit = ({
 		// Add Open Street Map as source
 		L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-			subdomains: [ 'a', 'b', 'c' ]
+			subdomains: [ 'a', 'b', 'c' ],
+			maxZoom: 19
 		}).addTo( _map );
 
 		/**
@@ -266,7 +291,7 @@ const Edit = ({
 
 					// Do not sent this event to the rest of the components
 					L.DomEvent.stopPropagation( event );
-					setActiveAddingToLocation( ! isAddingToLocationActive );
+					setActiveAddingToLocation( ! isAddingRef.current );
 				});
 
 				button.title = __( 'Add marker on the map with a click', 'otter-blocks' );
@@ -337,6 +362,7 @@ const Edit = ({
 	 * Activate the visuals for the `Add Marker` button from the map
 	 */
 	useEffect( () => {
+		isAddingRef.current = isAddingToLocationActive;
 		mapRef.current?.classList.toggle( 'is-selecting-location', isAddingToLocationActive );
 	}, [ isAddingToLocationActive ]);
 
@@ -399,23 +425,28 @@ const Edit = ({
 				// Update the marker location
 				marker.setLatLng([ markerProps.latitude, markerProps.longitude ]);
 
-				// Update the title
+				// Update the hover tooltip
 				marker.closeTooltip();
 				marker.unbindTooltip();
-				marker.bindTooltip( markerProps.title, { direction: 'auto' });
+				if ( attributes.showMarkerTooltip && markerProps.title ) {
+					marker.bindTooltip( markerProps.title, { direction: 'auto' });
+				}
 
-				// Update the content of the Popup
+				// Always bind the popup in the editor: it hosts the Delete Marker control.
 				marker.closePopup();
 				marker.unbindPopup();
 				marker.bindPopup( createPopupContent( markerProps, dispatch ) );
 			});
 
 
-			if ( attributes.markers.length !== markersStore.length && map ) {
-				setAttributes({ markers: markersStore.map( ({ markerProps }) => markerProps ) });
+			// Persist any marker change — add, remove, or a drag that moved a pin —
+			// not just count changes, so dragged positions survive a save/reload.
+			const nextMarkers = markersStore.map( ({ markerProps }) => ({ ...markerProps }) );
+			if ( map && ! isEqual( attributes.markers, nextMarkers ) ) {
+				setAttributes({ markers: nextMarkers });
 			}
 		}
-	}, [ markersStore, map, attributes.markers ]);
+	}, [ markersStore, map, attributes.markers, attributes.showMarkerTooltip ]);
 
 	const blockProps = useBlockProps();
 

--- a/src/blocks/blocks/leaflet-map/edit.js
+++ b/src/blocks/blocks/leaflet-map/edit.js
@@ -131,6 +131,10 @@ const Edit = ({
 				setOpenMarker( markerProps.id );
 			});
 
+			// Hide the hover tooltip while the click popup is open so the same title
+			// isn't shown twice (no-op when no tooltip is bound).
+			markerMap.on( 'popupopen', () => markerMap.closeTooltip() );
+
 			markerMap.markerProps = markerProps;
 
 			return markerMap;
@@ -228,7 +232,7 @@ const Edit = ({
 		const _map = L.map(
 			mapRef.current,
 			{
-				maxZoom: 19,
+				maxZoom: 21,
 				scrollWheelZoom: scrollZoom,
 
 				// Gesture handling enforces the Ctrl/\u2318 + scroll requirement; turn it off
@@ -245,11 +249,14 @@ const Edit = ({
 		);
 
 
-		// Add Open Street Map as source
+		// Add Open Street Map as source. OSM serves tiles up to zoom 19; allow a
+		// couple of extra levels via overzoom (maxNativeZoom) so users can zoom in
+		// as far as other OSM plugins, upscaling the level-19 tiles past that point.
 		L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
 			subdomains: [ 'a', 'b', 'c' ],
-			maxZoom: 19
+			maxNativeZoom: 19,
+			maxZoom: 21
 		}).addTo( _map );
 
 		/**

--- a/src/blocks/blocks/leaflet-map/editor.scss
+++ b/src/blocks/blocks/leaflet-map/editor.scss
@@ -44,11 +44,8 @@
 				cursor: pointer;
 			}
 
-			.dashicons {
-				&:before {
-					content: "\f109";
-				}
-				color: #fff;
+			svg {
+				fill: #fff;
 			}
 		}
 	}
@@ -66,6 +63,9 @@
 	position: absolute;
 	bottom: 26px;
 	left: 0px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
 	&:hover {
 		cursor: pointer;
@@ -74,18 +74,17 @@
 			cursor: pointer;
 		}
 
-		.dashicons {
-			&:before {
-				content: "\f109";
-			}
+		svg {
+			fill: #000000;
 		}
 	}
 
-	.dashicons {
-		color: #666666;
+	svg {
+		display: block;
+		fill: #666666;
 
 		&:hover {
-			color: #000000;
+			fill: #000000;
 		}
 	}
 }

--- a/src/blocks/blocks/leaflet-map/inspector.js
+++ b/src/blocks/blocks/leaflet-map/inspector.js
@@ -166,6 +166,20 @@ const Inspector = ({
 					checked={ attributes.zoomControl }
 					onChange={ () => setAttributes({ zoomControl: ! attributes.zoomControl }) }
 				/>
+
+				<ToggleControl
+					label={ __( 'Scroll to Zoom', 'otter-blocks' ) }
+					help={ __( 'Allow zooming the map with the mouse wheel. When enabled, use Ctrl/⌘ + scroll.', 'otter-blocks' ) }
+					checked={ attributes.scrollZoom }
+					onChange={ () => setAttributes({ scrollZoom: ! attributes.scrollZoom }) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Show Marker Tooltip on Hover', 'otter-blocks' ) }
+					help={ __( 'Display the marker title in a tooltip when hovering over a marker.', 'otter-blocks' ) }
+					checked={ attributes.showMarkerTooltip }
+					onChange={ () => setAttributes({ showMarkerTooltip: ! attributes.showMarkerTooltip }) }
+				/>
 			</PanelBody>
 
 			<PanelBody

--- a/src/blocks/blocks/leaflet-map/inspector.js
+++ b/src/blocks/blocks/leaflet-map/inspector.js
@@ -129,7 +129,7 @@ const Inspector = ({
 					value={ attributes.zoom }
 					onChange={ zoom => setAttributes({ zoom }) }
 					min={ 0 }
-					max={ 20 }
+					max={ 21 }
 				/>
 
 				<ResponsiveControl

--- a/src/blocks/blocks/leaflet-map/type.d.ts
+++ b/src/blocks/blocks/leaflet-map/type.d.ts
@@ -13,6 +13,8 @@ type Attributes = {
 	heightMobile: number
 	draggable: boolean
 	zoomControl: boolean
+	scrollZoom: boolean
+	showMarkerTooltip: boolean
 	markers: {
 		id: string
 		latitude: number

--- a/src/blocks/frontend/leaflet-map/index.js
+++ b/src/blocks/frontend/leaflet-map/index.js
@@ -30,11 +30,19 @@ const createPopupContent = ( markerProps ) => {
 	return container;
 };
 
-const createMarker = ( markerProps ) => {
+const createMarker = ( markerProps, attributes ) => {
 	const markerMap = window.L.marker([ markerProps.latitude, markerProps.longitude ]);
 
-	markerMap.bindTooltip( markerProps.title, { direction: 'auto' });
-	markerMap.bindPopup( createPopupContent( markerProps ) );
+	const hasTitle = Boolean( markerProps.title );
+	const hasContent = hasTitle || Boolean( markerProps.description );
+
+	if ( attributes.showMarkerTooltip && hasTitle ) {
+		markerMap.bindTooltip( markerProps.title, { direction: 'auto' });
+	}
+
+	if ( hasContent ) {
+		markerMap.bindPopup( createPopupContent( markerProps ) );
+	}
 
 	return markerMap;
 };
@@ -49,11 +57,19 @@ const createLeafletMap = ( container, attributes ) => {
 	// Add the height of the map first
 	container.classList.add( 'wp-block-themeisle-leaflet-blocks-map' );
 
+	// `scrollZoom` defaults to true for blocks saved before the attribute existed.
+	const scrollZoom = false !== attributes.scrollZoom;
+
 	// Create the map
 	const map = window.L.map( container, {
+		maxZoom: 19,
 		zoomControl: attributes.zoomControl,
 		dragging: attributes.draggable,
-		gestureHandling: attributes.draggable,
+		scrollWheelZoom: scrollZoom,
+
+		// Gesture handling enforces the Ctrl/\u2318 + scroll requirement; turn it off
+		// together with scrollWheelZoom when scroll zoom is disabled.
+		gestureHandling: attributes.draggable && scrollZoom,
 		gestureHandlingOptions: {
 			text: {
 				touch: 'Use two fingers to move the map',
@@ -64,14 +80,15 @@ const createLeafletMap = ( container, attributes ) => {
 	});
 	window.L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-		subdomains: [ 'a', 'b', 'c' ]
+		subdomains: [ 'a', 'b', 'c' ],
+		maxZoom: 19
 	}).addTo( map );
 
 	// Set the view
 	map.setView([ attributes.latitude, attributes.longitude ], attributes.zoom || 15 );
 
 	// Add the markers
-	attributes.markers.map( ( markerProps ) => createMarker( markerProps ) ).forEach( ( marker ) => {
+	attributes.markers.map( ( markerProps ) => createMarker( markerProps, attributes ) ).forEach( ( marker ) => {
 		map.addLayer( marker );
 	});
 
@@ -94,10 +111,20 @@ domReady( () => {
 			mapElem.style.backgroundColor = '#ccc';
 		});
 
+	// The `leaflet` script loads `async`, so its order relative to this script is
+	// not guaranteed. Poll on a short interval so the map appears as soon as Leaflet
+	// is ready, with an attempt cap so it gives up instead of looping forever.
+	const POLL_INTERVAL = 100;
+	const MAX_ATTEMPTS = 100; // ~10s
+	let attempts = 0;
+
 	const checker = setInterval(
 		() => {
 			if ( ! window.L ) {
-				console.warn( 'The leaflet script did not load on the page! Waiting for loading.' );
+				if ( ++attempts >= MAX_ATTEMPTS ) {
+					clearInterval( checker );
+					console.warn( 'The leaflet script did not load on the page!' );
+				}
 				return;
 			}
 
@@ -105,6 +132,13 @@ domReady( () => {
 
 			const idAttrMapping = Array.from( window.themeisleLeafletMaps )
 				.reduce( ( acc, x ) => {
+
+					// Point Leaflet's default marker icon at the bundled images so
+					// markers render instead of showing broken-image placeholders.
+					if ( x.imagePath ) {
+						window.L.Icon.Default.imagePath = x.imagePath;
+					}
+
 					acc[x.container] = x.attributes;
 					return acc;
 				}, {});
@@ -118,6 +152,6 @@ domReady( () => {
 					}
 				});
 		},
-		2_000
+		POLL_INTERVAL
 	);
 });

--- a/src/blocks/frontend/leaflet-map/index.js
+++ b/src/blocks/frontend/leaflet-map/index.js
@@ -35,13 +35,20 @@ const createMarker = ( markerProps, attributes ) => {
 
 	const hasTitle = Boolean( markerProps.title );
 	const hasContent = hasTitle || Boolean( markerProps.description );
+	const showTooltip = attributes.showMarkerTooltip && hasTitle;
 
-	if ( attributes.showMarkerTooltip && hasTitle ) {
+	if ( showTooltip ) {
 		markerMap.bindTooltip( markerProps.title, { direction: 'auto' });
 	}
 
 	if ( hasContent ) {
 		markerMap.bindPopup( createPopupContent( markerProps ) );
+
+		// Hide the hover tooltip while the click popup is open so the same title
+		// isn't shown twice; it returns on hover once the popup closes.
+		if ( showTooltip ) {
+			markerMap.on( 'popupopen', () => markerMap.closeTooltip() );
+		}
 	}
 
 	return markerMap;
@@ -62,7 +69,7 @@ const createLeafletMap = ( container, attributes ) => {
 
 	// Create the map
 	const map = window.L.map( container, {
-		maxZoom: 19,
+		maxZoom: 21,
 		zoomControl: attributes.zoomControl,
 		dragging: attributes.draggable,
 		scrollWheelZoom: scrollZoom,
@@ -78,10 +85,13 @@ const createLeafletMap = ( container, attributes ) => {
 			}
 		}
 	});
+	// OSM serves tiles up to zoom 19; overzoom (maxNativeZoom) upscales them so
+	// users can zoom in as far as other OSM plugins.
 	window.L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
 		subdomains: [ 'a', 'b', 'c' ],
-		maxZoom: 19
+		maxNativeZoom: 19,
+		maxZoom: 21
 	}).addTo( map );
 
 	// Set the view

--- a/src/blocks/test/e2e/blocks/leaflet-map.spec.js
+++ b/src/blocks/test/e2e/blocks/leaflet-map.spec.js
@@ -168,6 +168,20 @@ test.describe( 'Maps (Leaflet) block', () => {
 		await expect( page.locator( '.leaflet-tooltip' ) ).toHaveText( 'Sagrada Familia', { timeout: 10_000 });
 	});
 
+	test( 'map can zoom in past the OSM native level 19', async({ editor, page }) => {
+
+		// Sit the map at zoom 19. With the old maxZoom of 19 the zoom-in control
+		// would be disabled here; overzoom (maxZoom 21) keeps it enabled.
+		await insertMap( editor, { markers: [], zoom: 19 });
+		await editor.canvas.locator( '.leaflet-container' ).waitFor({ timeout: 20_000 });
+
+		await publishAndViewPost({ editor, page });
+
+		const zoomIn = page.locator( '.leaflet-control-zoom-in' );
+		await expect( zoomIn ).toBeVisible({ timeout: 20_000 });
+		await expect( zoomIn ).not.toHaveClass( /leaflet-disabled/ );
+	});
+
 	test( 'hover tooltip is hidden once the click popup opens', async({ editor, page }) => {
 		await insertMap( editor, { markers: [ marker() ], showMarkerTooltip: true });
 		await editor.canvas.locator( '.leaflet-marker-icon' ).first().waitFor({ timeout: 20_000 });

--- a/src/blocks/test/e2e/blocks/leaflet-map.spec.js
+++ b/src/blocks/test/e2e/blocks/leaflet-map.spec.js
@@ -74,6 +74,57 @@ test.describe( 'Maps (Leaflet) block', () => {
 			.toBe( 1 );
 	});
 
+	test( 'markers are draggable in the editor', async({ editor }) => {
+		await insertMap( editor, { markers: [ marker() ] });
+
+		// Leaflet adds this class only when the marker is created with draggable:true.
+		// Paired with the persistence test below, this guards both halves of
+		// drag-to-refine (the gesture itself can't be simulated headlessly).
+		const icon = editor.canvas.locator( '.leaflet-marker-icon' ).first();
+		await expect( icon ).toBeVisible({ timeout: 20_000 });
+		await expect( icon ).toHaveClass( /leaflet-marker-draggable/ );
+	});
+
+	test( 'the map initialises promptly after Leaflet loads', async({ editor, page }) => {
+		await insertMap( editor, { markers: [] });
+		await editor.canvas.locator( '.leaflet-container' ).waitFor({ timeout: 20_000 });
+
+		// Delay Leaflet so it becomes available well after DOMReady; the init poll
+		// interval then dominates the gap between "Leaflet ready" and "map created".
+		// The old 2s poll blows past the threshold here; the 100ms poll stays under it.
+		await page.route( '**/assets/leaflet/leaflet.js', async( route ) => {
+			await new Promise( ( resolve ) => setTimeout( resolve, 300 ) );
+			await route.continue();
+		});
+
+		// Stamp, before any page script runs, when window.L appears and when the
+		// placeholder becomes a Leaflet container.
+		await page.addInitScript( () => {
+			window.__mapTiming = {};
+			const iv = setInterval( () => {
+				if ( window.L && undefined === window.__mapTiming.leaflet ) {
+					window.__mapTiming.leaflet = performance.now();
+				}
+				const el = document.querySelector( '.wp-block-themeisle-blocks-leaflet-map.leaflet-container' );
+				if ( el && undefined === window.__mapTiming.map ) {
+					window.__mapTiming.map = performance.now();
+					clearInterval( iv );
+				}
+			}, 10 );
+		});
+
+		await publishAndViewPost({ editor, page });
+
+		const gap = await page
+			.waitForFunction( () => {
+				const t = window.__mapTiming;
+				return t && undefined !== t.leaflet && undefined !== t.map ? t.map - t.leaflet : false;
+			}, { timeout: 20_000 })
+			.then( ( handle ) => handle.jsonValue() );
+
+		expect( gap ).toBeLessThan( 1000 );
+	});
+
 	// Editing a marker's coordinates persists. This exercises the same UPDATE →
 	// reducer → setAttributes path a drag-to-refine uses; before the fix it only
 	// persisted on marker count changes, so edits (and drags) were silently lost.

--- a/src/blocks/test/e2e/blocks/leaflet-map.spec.js
+++ b/src/blocks/test/e2e/blocks/leaflet-map.spec.js
@@ -168,6 +168,19 @@ test.describe( 'Maps (Leaflet) block', () => {
 		await expect( page.locator( '.leaflet-tooltip' ) ).toHaveText( 'Sagrada Familia', { timeout: 10_000 });
 	});
 
+	test( 'hover shows no tooltip when the tooltip toggle is off (default)', async({ editor, page }) => {
+		await insertMap( editor, { markers: [ marker() ] });
+		await editor.canvas.locator( '.leaflet-marker-icon' ).first().waitFor({ timeout: 20_000 });
+
+		await publishAndViewPost({ editor, page });
+
+		await page.locator( '.leaflet-marker-icon' ).first().hover();
+
+		// Give Leaflet a beat to open a tooltip, were one (incorrectly) bound.
+		await page.waitForTimeout( 400 );
+		await expect( page.locator( '.leaflet-tooltip' ) ).toHaveCount( 0 );
+	});
+
 	test( 'map can zoom in past the OSM native level 19', async({ editor, page }) => {
 
 		// Sit the map at zoom 19. With the old maxZoom of 19 the zoom-in control

--- a/src/blocks/test/e2e/blocks/leaflet-map.spec.js
+++ b/src/blocks/test/e2e/blocks/leaflet-map.spec.js
@@ -167,4 +167,20 @@ test.describe( 'Maps (Leaflet) block', () => {
 		await page.locator( '.leaflet-marker-icon' ).first().hover();
 		await expect( page.locator( '.leaflet-tooltip' ) ).toHaveText( 'Sagrada Familia', { timeout: 10_000 });
 	});
+
+	test( 'hover tooltip is hidden once the click popup opens', async({ editor, page }) => {
+		await insertMap( editor, { markers: [ marker() ], showMarkerTooltip: true });
+		await editor.canvas.locator( '.leaflet-marker-icon' ).first().waitFor({ timeout: 20_000 });
+
+		await publishAndViewPost({ editor, page });
+
+		const icon = page.locator( '.leaflet-marker-icon' ).first();
+		await icon.hover();
+		await expect( page.locator( '.leaflet-tooltip' ) ).toBeVisible();
+
+		// Clicking opens the popup; the duplicate hover tooltip should disappear.
+		await icon.click();
+		await expect( page.locator( '.leaflet-popup' ) ).toBeVisible();
+		await expect( page.locator( '.leaflet-tooltip' ) ).toHaveCount( 0 );
+	});
 });

--- a/src/blocks/test/e2e/blocks/leaflet-map.spec.js
+++ b/src/blocks/test/e2e/blocks/leaflet-map.spec.js
@@ -1,0 +1,170 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+import { publishAndViewPost, waitForEditorReady } from '../helpers/editor';
+
+const LEAFLET_MAP_BLOCK = 'themeisle-blocks/leaflet-map';
+
+// Path fragment of the bundled default marker icon. The original bug shipped a
+// broken/duplicated marker because this asset was never resolved; asserting the
+// `src` resolves here is the regression guard.
+const MARKER_ICON = /\/leaflet\/images\/marker-icon\.png/;
+
+// 1x1 transparent PNG used to fulfil OpenStreetMap tile requests so map
+// initialisation never depends on the network.
+const TILE_PNG = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQAYIqfQAAAAAElFTkSuQmCC',
+	'base64'
+);
+
+const marker = ( overrides = {}) => ({
+	id: 'marker-1',
+	latitude: 41.4034789,
+	longitude: 2.174410333009705,
+	title: 'Sagrada Familia',
+	description: 'A famous basilica',
+	location: 'Barcelona, Spain',
+	...overrides
+});
+
+const insertMap = async( editor, attributes ) =>
+	editor.insertBlock({ name: LEAFLET_MAP_BLOCK, attributes });
+
+const getMapAttributes = async( editor ) => {
+	const blocks = await editor.getBlocks();
+	return blocks.find( ( block ) => LEAFLET_MAP_BLOCK === block.name ).attributes;
+};
+
+test.describe( 'Maps (Leaflet) block', () => {
+	test.beforeEach( async({ page, admin }) => {
+		await page.route( '**/*.tile.openstreetmap.org/**', ( route ) =>
+			route.fulfill({ contentType: 'image/png', body: TILE_PNG })
+		);
+
+		await admin.createNewPost();
+		await waitForEditorReady( page );
+	});
+
+	test( 'renders a marker with the bundled icon and no duplicates', async({ editor }) => {
+		await insertMap( editor, { markers: [ marker() ] });
+
+		const icons = editor.canvas.locator( '.leaflet-marker-icon' );
+		await expect( icons ).toHaveCount( 1, { timeout: 20_000 });
+		await expect( icons.first() ).toHaveAttribute( 'src', MARKER_ICON );
+		await expect( editor.canvas.locator( '.block-editor-warning' ) ).toHaveCount( 0 );
+	});
+
+	test( 'add-marker control drops a marker where the map is clicked', async({ editor, page }) => {
+		await insertMap( editor, { markers: [] });
+
+		const container = editor.canvas.locator( '.leaflet-container' );
+		await expect( container ).toBeVisible({ timeout: 20_000 });
+		await expect( editor.canvas.locator( '.leaflet-marker-icon' ) ).toHaveCount( 0 );
+
+		await editor.canvas.locator( '.wp-block-themeisle-blocks-leaflet-map-marker-button' ).click();
+
+		// Click the centre of the map, clear of the zoom and add-marker controls.
+		const box = await container.boundingBox();
+		await page.mouse.click( box.x + box.width / 2, box.y + box.height / 2 );
+
+		await expect( editor.canvas.locator( '.leaflet-marker-icon' ) ).toHaveCount( 1, { timeout: 10_000 });
+		await expect
+			.poll( async() => ( await getMapAttributes( editor ) ).markers.length )
+			.toBe( 1 );
+	});
+
+	// Editing a marker's coordinates persists. This exercises the same UPDATE →
+	// reducer → setAttributes path a drag-to-refine uses; before the fix it only
+	// persisted on marker count changes, so edits (and drags) were silently lost.
+	// The literal drag gesture is verified manually — a headless Leaflet marker
+	// drag inside the iframed editor does not fire `moveend` reliably.
+	test( 'editing a marker position in the inspector persists the change', async({ editor, page }) => {
+		await insertMap( editor, { markers: [ marker() ] });
+
+		// The persistence effect only runs once the map owns the markers store.
+		await editor.canvas.locator( '.leaflet-container' ).waitFor({ timeout: 20_000 });
+
+		await page.getByRole( 'button', { name: 'Markers' }).click();
+		await page.locator( '.wp-block-themeisle-blocks-leaflet-map-marker-title' ).first().click();
+
+		const markerArea = page.locator( '.wp-block-themeisle-blocks-leaflet-map-marker-control-area' );
+		await markerArea.getByLabel( 'Latitude' ).fill( '41.5' );
+
+		await expect
+			.poll( async() => ( await getMapAttributes( editor ) ).markers[ 0 ].latitude, { timeout: 10_000 })
+			.toBe( '41.5' );
+	});
+
+	test( 'published map renders every marker with the bundled icon', async({ editor, page }) => {
+		await insertMap( editor, {
+			markers: [
+				marker({ id: 'm1' }),
+				marker({ id: 'm2', latitude: 41.4045, longitude: 2.176, title: 'Second' })
+			]
+		});
+		await editor.canvas.locator( '.leaflet-marker-icon' ).first().waitFor({ timeout: 20_000 });
+
+		await publishAndViewPost({ editor, page });
+
+		const icons = page.locator( '.leaflet-marker-icon' );
+		await expect( icons ).toHaveCount( 2, { timeout: 20_000 });
+		await expect( icons.first() ).toHaveAttribute( 'src', MARKER_ICON );
+
+		// naturalWidth > 0 proves the icon loaded rather than showing a broken-image placeholder.
+		await expect
+			.poll( () => icons.first().evaluate( ( img ) => img.naturalWidth ) )
+			.toBeGreaterThan( 0 );
+	});
+
+	test( 'published marker with content opens a single popup on click', async({ editor, page }) => {
+		await insertMap( editor, { markers: [ marker() ] });
+		await editor.canvas.locator( '.leaflet-marker-icon' ).first().waitFor({ timeout: 20_000 });
+
+		await publishAndViewPost({ editor, page });
+
+		await page.locator( '.leaflet-marker-icon' ).first().click();
+		await expect(
+			page.locator( '.leaflet-popup .wp-block-themeisle-blocks-leaflet-map-overview-title' )
+		).toHaveText( 'Sagrada Familia' );
+	});
+
+	test( 'published marker without title or description shows no popup', async({ editor, page }) => {
+		await insertMap( editor, { markers: [ marker({ title: '', description: '' }) ] });
+		await editor.canvas.locator( '.leaflet-marker-icon' ).first().waitFor({ timeout: 20_000 });
+
+		await publishAndViewPost({ editor, page });
+
+		await page.locator( '.leaflet-marker-icon' ).first().click();
+
+		// Give Leaflet a beat to open a popup, were one (incorrectly) bound.
+		await page.waitForTimeout( 500 );
+		await expect( page.locator( '.leaflet-popup' ) ).toHaveCount( 0 );
+	});
+
+	test( 'scroll-to-zoom off disables gesture handling on the published map', async({ editor, page }) => {
+		await insertMap( editor, { markers: [], scrollZoom: false });
+		await editor.canvas.locator( '.leaflet-container' ).waitFor({ timeout: 20_000 });
+
+		await publishAndViewPost({ editor, page });
+
+		const container = page.locator( '.leaflet-container' );
+		await expect( container ).toBeVisible({ timeout: 20_000 });
+
+		// The gesture-handling plugin stamps this attribute only while active; it
+		// is gone when scroll zoom (and thus gesture handling) is turned off.
+		await expect
+			.poll( () => container.evaluate( ( el ) => el.hasAttribute( 'data-gesture-handling-scroll-content' ) ) )
+			.toBe( false );
+	});
+
+	test( 'hover tooltip appears on the published map only when enabled', async({ editor, page }) => {
+		await insertMap( editor, { markers: [ marker() ], showMarkerTooltip: true });
+		await editor.canvas.locator( '.leaflet-marker-icon' ).first().waitFor({ timeout: 20_000 });
+
+		await publishAndViewPost({ editor, page });
+
+		await page.locator( '.leaflet-marker-icon' ).first().hover();
+		await expect( page.locator( '.leaflet-tooltip' ) ).toHaveText( 'Sagrada Familia', { timeout: 10_000 });
+	});
+});


### PR DESCRIPTION


<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/264
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
<!-- Please describe the changes you made. -->

Address customer-reported issues with the OpenStreetMap (Leaflet) Maps block:

- Fix broken/duplicated marker icons by pointing Leaflet's default icon at the bundled images (editor via themeisleGutenberg.assetsPath, frontend via a new imagePath payload) instead of the unreliable CSS path heuristic.
- Persist any marker change (drag, edit), not just count changes, so dragged and edited positions survive a save/reload.
- Speed up frontend map init by polling at 100ms instead of 2000ms.
- Raise max zoom to 19 (OSM max) on both the map and tile layer.
- Add a "Scroll to Zoom" toggle to enable/disable mouse-wheel zoom.
- Add a "Show Marker Tooltip on Hover" toggle (off by default) and stop rendering empty popups/tooltips when a marker has no title or description.
- Fix the add-marker control via a ref so the once-bound Leaflet handlers read the current state instead of a stale closure.

Add e2e coverage (leaflet-map.spec.js) for marker rendering, add-marker, edit persistence, hide-empty popups, scroll-zoom and tooltip toggles.

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [ ] Visual elements are not affected by independent changes.
- [ ] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [ ] It loads additional script in frontend only if it is required.
- [ ] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [ ] In case of deprecation, old blocks are safely migrated.
- [ ] It is usable in Widgets and FSE.
- [ ] Copy/Paste is working if the attributes are modified.
- [ ] PR is following [the best practices]()

