### PR TITLE
feat: atomic-wind CSS generator warmup

### DIFF
--- a/inc/plugins/class-atomic-wind-blocks.php
+++ b/inc/plugins/class-atomic-wind-blocks.php
@@ -55,6 +55,7 @@ class Atomic_Wind_Blocks {
 		add_filter( 'render_block', array( $this, 'render_post_fields' ), 20, 2 );
 		add_filter( 'render_block', array( $this, 'render_animation_attrs' ), 10, 2 );
 		add_filter( 'render_block', array( $this, 'render_state_attrs' ), 10, 2 );
+		add_action( 'template_redirect', array( $this, 'maybe_render_css_warm_page' ), 0 );
 		add_action( 'save_post', array( $this, 'clear_cached_css' ) );
 		add_filter( 'block_categories_all', array( $this, 'register_category' ) );
 	}
@@ -210,8 +211,10 @@ class Atomic_Wind_Blocks {
 			) . ';' .
 			'window.atomicWindEditor = ' . wp_json_encode(
 				array(
-					'restUrl' => rest_url( 'otter/v1/atomic-wind' ),
-					'nonce'   => wp_create_nonce( 'wp_rest' ),
+					'restUrl'   => rest_url( 'otter/v1/atomic-wind' ),
+					'nonce'     => wp_create_nonce( 'wp_rest' ),
+					'warmUrl'   => home_url( '/' ),
+					'warmNonce' => wp_create_nonce( 'atomic_wind_css_warm' ),
 				)
 			) . ';',
 			'before'
@@ -381,6 +384,130 @@ class Atomic_Wind_Blocks {
 	 */
 	public function clear_cached_css( $post_id ) {
 		delete_post_meta( $post_id, '_atomic_wind_css' );
+	}
+
+	/**
+	 * Render a stripped, frontend-shaped page for warming the CSS cache.
+	 *
+	 * @return void
+	 */
+	public function maybe_render_css_warm_page() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- nonce is verified below via can_render_css_warm().
+		if ( empty( $_GET['atomic_wind_css_warm'] ) || empty( $_GET['post_id'] ) ) {
+			return;
+		}
+
+		$nonce   = sanitize_text_field( wp_unslash( $_GET['atomic_wind_css_warm'] ) );
+		$post_id = absint( wp_unslash( $_GET['post_id'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( ! $this->can_render_css_warm( $post_id, $nonce ) ) {
+			return;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post || ! $this->post_has_atomic_wind_blocks( $post ) ) {
+			// Nothing to warm — leave the (already-cleared) cache empty.
+			return;
+		}
+
+		nocache_headers();
+		header( 'Content-Type: text/html; charset=' . get_option( 'blog_charset' ) );
+		header( 'X-Robots-Tag: noindex, nofollow', true );
+
+		echo $this->render_css_warm_page_html( $post ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- self-contained document built below with per-part escaping.
+		exit;
+	}
+
+	/**
+	 * Whether the current request may render the CSS warm page for a post.
+	 *
+	 * @param int    $post_id Post ID from the request.
+	 * @param string $nonce   Nonce from the request.
+	 * @return bool
+	 */
+	private function can_render_css_warm( $post_id, $nonce ) {
+		return $post_id > 0
+			&& false !== wp_verify_nonce( $nonce, 'atomic_wind_css_warm' )
+			&& current_user_can( 'edit_post', $post_id );
+	}
+
+	/**
+	 * Build the minimal HTML document for the CSS warm iframe.
+	 *
+	 * Kept separate from the request handling so it stays pure/testable: it
+	 * returns a string and neither reads superglobals nor calls exit().
+	 *
+	 * @param \WP_Post $post_obj Post to render.
+	 * @return string
+	 */
+	private function render_css_warm_page_html( \WP_Post $post_obj ) {
+		global $post;
+
+		$previous = $post;
+		$post     = $post_obj; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- temporary, restored below, so render_block filters see the warmed post.
+		setup_postdata( $post );
+		$content = do_blocks( $post_obj->post_content );
+		wp_reset_postdata();
+		$post = $previous; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- restore the original global.
+
+		$generator = $this->build_asset_url( 'tailwind-generator-frontend' );
+		$builder   = $this->build_asset_url( 'style-builder' );
+
+		$config = wp_json_encode(
+			array(
+				'postId'  => (int) $post_obj->ID,
+				'restUrl' => rest_url( 'otter/v1/atomic-wind' ),
+				'nonce'   => wp_create_nonce( 'wp_rest' ),
+			)
+		);
+
+		$post_id_json = wp_json_encode( (int) $post_obj->ID );
+
+		// Base reset so the in-browser generator measures the real frontend layout.
+		$base_css = '[class*="wp-block-atomic-wind-"]{margin:0;max-width:unset;}[class*="wp-block-atomic-wind-"] p{margin:0;}';
+
+		// On css-saved, notify the opener (the editor) so it can drop the iframe.
+		// The payload carries no secret; the editor still validates the message origin.
+		$ping = 'document.addEventListener("atomic-wind:css-saved",function(){'
+			. 'if(window.parent&&window.parent!==window){'
+			. 'var t="*";try{if(document.referrer){t=new URL(document.referrer).origin;}}catch(e){}'
+			. 'window.parent.postMessage({type:"atomic-wind:css-warmed",postId:' . $post_id_json . '},t);}});';
+
+		$html  = '<!DOCTYPE html><html ' . get_language_attributes() . '><head>';
+		$html .= '<meta charset="' . esc_attr( get_option( 'blog_charset' ) ) . '">';
+		$html .= '<meta name="viewport" content="width=1024">';
+		$html .= '<meta name="robots" content="noindex,nofollow">';
+		$html .= '<style id="atomic-wind-base-inline-css">' . $base_css . '</style>';
+		$html .= '</head><body class="atomic-wind-css-warm">';
+		$html .= $content;
+		$html .= '<script>window.atomicWindStyleBuilder = ' . $config . ';</script>';
+		$html .= '<script src="' . esc_url( $generator ) . '"></script>';
+		$html .= '<script src="' . esc_url( $builder ) . '"></script>';
+		$html .= '<script>' . $ping . '</script>';
+		$html .= '</body></html>';
+
+		return $html;
+	}
+
+	/**
+	 * Build a versioned URL for an atomic-wind build script.
+	 *
+	 * @param string $name Script base name (without extension), e.g. `style-builder`.
+	 * @return string
+	 */
+	private function build_asset_url( $name ) {
+		$asset_file = $this->build_path() . '/' . $name . '.asset.php';
+		$version    = OTTER_BLOCKS_VERSION;
+
+		if ( file_exists( $asset_file ) ) {
+			$asset = include $asset_file;
+			if ( isset( $asset['version'] ) ) {
+				$version = $asset['version'];
+			}
+		}
+
+		return add_query_arg( 'ver', $version, $this->plugin_url( 'build/atomic-wind/' . $name . '.js' ) );
 	}
 
 	/**

--- a/src/atomic-wind/css-warm/index.js
+++ b/src/atomic-wind/css-warm/index.js
@@ -1,0 +1,99 @@
+/**
+ * Warm the atomic-wind CSS cache after a successful editor save.
+ */
+import { select, subscribe } from '@wordpress/data';
+
+const IFRAME_ID = 'atomic-wind-css-warm-frame';
+
+// Safety net: drop the iframe even if the in-iframe "done" message never
+// arrives (e.g. the generator errored before persisting).
+const DONE_TIMEOUT = 20000;
+
+function removeFrame() {
+	const existing = document.getElementById( IFRAME_ID );
+	if ( existing?.parentNode ) {
+		existing.parentNode.removeChild( existing );
+	}
+}
+
+function warm() {
+	const config = window.atomicWindEditor;
+	const editor = select( 'core/editor' );
+
+	if ( ! config?.warmUrl || ! config?.warmNonce || ! editor ) {
+		return;
+	}
+
+	const postId = editor.getCurrentPostId();
+	const content = editor.getEditedPostContent();
+	if ( ! postId || ! content || ! content.includes( 'wp:atomic-wind/' ) ) {
+		return;
+	}
+
+	let url;
+	try {
+		url = new URL( config.warmUrl );
+	} catch {
+		return;
+	}
+	url.searchParams.set( 'atomic_wind_css_warm', config.warmNonce );
+	url.searchParams.set( 'post_id', String( postId ) );
+	// Cache-bust so each save re-renders the latest content.
+	url.searchParams.set( 'v', String( Date.now() ) );
+
+	// Only one warm pass in flight at a time.
+	removeFrame();
+
+	const frame = document.createElement( 'iframe' );
+	frame.id = IFRAME_ID;
+	frame.setAttribute( 'aria-hidden', 'true' );
+	frame.tabIndex = -1;
+	frame.style.cssText =
+		'position:fixed;left:-9999px;top:0;width:1024px;height:768px;border:0;opacity:0;pointer-events:none;';
+
+	const { origin } = url;
+	// Held in an object so cleanup() can clear it without a reassigned binding.
+	const handle = { timer: 0 };
+
+	const cleanup = () => {
+		window.removeEventListener( 'message', onMessage );
+		clearTimeout( handle.timer );
+		removeFrame();
+	};
+
+	const onMessage = ( event ) => {
+		if ( event.origin !== origin || event.source !== frame.contentWindow ) {
+			return;
+		}
+		if (
+			event.data?.type === 'atomic-wind:css-warmed' &&
+			Number( event.data.postId ) === Number( postId )
+		) {
+			cleanup();
+		}
+	};
+
+	window.addEventListener( 'message', onMessage );
+	handle.timer = setTimeout( cleanup, DONE_TIMEOUT );
+
+	frame.src = url.toString();
+	document.body.appendChild( frame );
+}
+
+let wasSaving = false;
+
+subscribe( () => {
+	const editor = select( 'core/editor' );
+	if ( ! editor ) {
+		return;
+	}
+
+	const isSaving = editor.isSavingPost() && ! editor.isAutosavingPost();
+
+	// Edge: a real save just transitioned from in-flight to finished.
+	if ( wasSaving && ! isSaving && ! editor.didPostSaveRequestFail() ) {
+		warm();
+	}
+
+	wasSaving = isSaving;
+} );

--- a/src/atomic-wind/editor.js
+++ b/src/atomic-wind/editor.js
@@ -3,3 +3,4 @@ import './states';
 import './query';
 import './class-editor';
 import './wrap-in';
+import './css-warm';

--- a/src/atomic-wind/style-builder/index.js
+++ b/src/atomic-wind/style-builder/index.js
@@ -1,11 +1,16 @@
+/**
+ * Persist the compiled atomic-wind CSS to post meta.
+ */
+function signalDone() {
+	document.dispatchEvent( new CustomEvent( 'atomic-wind:css-saved' ) );
+}
+
 document.addEventListener( 'atomic-wind:css-ready', () => {
 	const styleTag = document.getElementById( 'atomic-wind-tailwind' );
-	if ( ! styleTag ) {
-		return;
-	}
+	const css = styleTag ? styleTag.textContent : '';
 
-	const css = styleTag.textContent;
 	if ( ! css || ! window.atomicWindStyleBuilder ) {
+		signalDone();
 		return;
 	}
 
@@ -19,5 +24,5 @@ document.addEventListener( 'atomic-wind:css-ready', () => {
 			css,
 			postId: parseInt( window.atomicWindStyleBuilder.postId, 10 ),
 		} ),
-	} ).catch( () => {} );
+	} ).catch( () => {} ).finally( signalDone );
 } );

--- a/src/blocks/test/e2e/blocks/alt-attributes.spec.js
+++ b/src/blocks/test/e2e/blocks/alt-attributes.spec.js
@@ -120,18 +120,19 @@ test.describe( 'Alt attributes', () => {
 			]
 		});
 
-		// themeisle-blocks/icon-list is apiVersion 2, which opts the post editor out of the iframed canvas, so blocks render at page level.
-		const icons = page.locator( '.wp-block-themeisle-blocks-icon-list-item img' );
+		const editorIcons = editor.canvas.locator( '.wp-block-themeisle-blocks-icon-list-item img' );
 
-		await expect( icons ).toHaveCount( 2 );
-		await expect( icons.first() ).toHaveAttribute( 'alt', 'Parent default alt' );
-		await expect( icons.nth( 1 ) ).toHaveAttribute( 'alt', 'Item override alt' );
+		await expect( editorIcons ).toHaveCount( 2 );
+		await expect( editorIcons.first() ).toHaveAttribute( 'alt', 'Parent default alt' );
+		await expect( editorIcons.nth( 1 ) ).toHaveAttribute( 'alt', 'Item override alt' );
 
 		await publishAndViewPost({ editor, page });
 
-		await expect( icons ).toHaveCount( 2 );
-		await expect( icons.first() ).toHaveAttribute( 'alt', 'Parent default alt' );
-		await expect( icons.nth( 1 ) ).toHaveAttribute( 'alt', 'Item override alt' );
+		const frontendIcons = page.locator( '.wp-block-themeisle-blocks-icon-list-item img' );
+
+		await expect( frontendIcons ).toHaveCount( 2 );
+		await expect( frontendIcons.first() ).toHaveAttribute( 'alt', 'Parent default alt' );
+		await expect( frontendIcons.nth( 1 ) ).toHaveAttribute( 'alt', 'Item override alt' );
 	});
 
 	test( 'Icon List image icon alt is editable from the inspector', async({ editor, page }) => {
@@ -151,8 +152,7 @@ test.describe( 'Alt attributes', () => {
 			]
 		});
 
-		// themeisle-blocks/icon-list is apiVersion 2, which opts the post editor out of the iframed canvas, so blocks render at page level.
-		await page.getByRole( 'document', { name: 'Block: Icon List Item' }).click();
+		await editor.canvas.getByRole( 'document', { name: 'Block: Icon List Item' }).click();
 		await editor.openDocumentSettingsSidebar();
 
 		const altField = page.getByLabel( 'Alt text (alternative text)' );
@@ -267,8 +267,7 @@ test.describe( 'Alt attributes', () => {
 			}
 		});
 
-		// themeisle-blocks/slider opts out of the iframed canvas, so the block renders at page level.
-		await page.getByRole( 'document', { name: 'Block: Image Slider' }).click();
+		await editor.canvas.getByRole( 'document', { name: 'Block: Image Slider' }).click();
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'button', { name: 'Images' }).click();
 
@@ -289,8 +288,8 @@ test.describe( 'Alt attributes', () => {
 <!-- /wp:themeisle-blocks/slider -->
 ` );
 
-		await expect( page.getByRole( 'button', { name: 'Attempt Block Recovery' }) ).toHaveCount( 0 );
-		await expect( page.locator( '.wp-block-themeisle-blocks-slider-item' ).first() ).toBeVisible();
+		await expect( editor.canvas.getByRole( 'button', { name: 'Attempt Block Recovery' }) ).toHaveCount( 0 );
+		await expect( editor.canvas.locator( '.wp-block-themeisle-blocks-slider-item' ).first() ).toBeVisible();
 
 		// Touch the block so the post re-serializes with the current save (no title on img).
 		await selectBlockByName( page, 'themeisle-blocks/slider' );
@@ -361,9 +360,8 @@ test.describe( 'Alt attributes', () => {
 <!-- /wp:themeisle-blocks/icon-list -->
 ` );
 
-		// themeisle-blocks/icon-list is apiVersion 2, which opts the post editor out of the iframed canvas, so blocks render at page level.
-		await expect( page.getByRole( 'button', { name: 'Attempt Block Recovery' }) ).toHaveCount( 0 );
-		await expect( page.getByRole( 'document', { name: 'Block: Icon List Item' }).locator( 'img' ) ).toBeVisible();
+		await expect( editor.canvas.getByRole( 'button', { name: 'Attempt Block Recovery' }) ).toHaveCount( 0 );
+		await expect( editor.canvas.getByRole( 'document', { name: 'Block: Icon List Item' }).locator( 'img' ) ).toBeVisible();
 
 		// The migrated block re-serializes with an explicit empty (decorative) alt.
 		expect( await editor.getEditedPostContent() ).toContain( 'alt=""' );

--- a/tests/test-atomic-wind-blocks.php
+++ b/tests/test-atomic-wind-blocks.php
@@ -842,4 +842,109 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 
 		wp_reset_postdata();
 	}
+
+	// -------------------------------------------------------
+	// Save-time CSS warm helpers
+	// -------------------------------------------------------
+
+	/**
+	 * Helper: invoke a private method on the instance.
+	 */
+	private function call_private( $name, ...$args ) {
+		$ref = new ReflectionMethod( Atomic_Wind_Blocks::class, $name );
+		$ref->setAccessible( true );
+		return $ref->invoke( $this->instance, ...$args );
+	}
+
+	/**
+	 * Helper: build a post whose atomic-wind block carries the given classes.
+	 *
+	 * @param string $classes Space-separated Tailwind classes (in the className attr).
+	 * @return int
+	 */
+	private function make_atomic_wind_post( $classes ) {
+		return $this->factory()->post->create(
+			array(
+				'post_content' => '<!-- wp:atomic-wind/box {"className":"' . $classes . '"} --><div class="wp-block-atomic-wind-box ' . $classes . '"></div><!-- /wp:atomic-wind/box -->',
+			)
+		);
+	}
+
+	// -------------------------------------------------------
+	// Save-time CSS warm (hidden-iframe render)
+	// -------------------------------------------------------
+
+	public function test_run_registers_warm_template_redirect() {
+		// Blocks may already be registered by an earlier run() in the suite.
+		$this->setExpectedIncorrectUsage( 'WP_Block_Type_Registry::register' );
+		update_option( 'themeisle_blocks_settings_atomic_wind_blocks', true );
+
+		$this->instance->run();
+
+		$this->assertNotFalse(
+			has_action( 'template_redirect', array( $this->instance, 'maybe_render_css_warm_page' ) )
+		);
+	}
+
+	public function test_warm_gate_allows_editor_with_valid_nonce() {
+		// Current user is an administrator (set in set_up()).
+		$nonce = wp_create_nonce( 'atomic_wind_css_warm' );
+
+		$this->assertTrue( $this->call_private( 'can_render_css_warm', $this->post_id, $nonce ) );
+	}
+
+	public function test_warm_gate_rejects_invalid_nonce() {
+		$this->assertFalse( $this->call_private( 'can_render_css_warm', $this->post_id, 'bogus-nonce' ) );
+	}
+
+	public function test_warm_gate_rejects_user_without_edit_cap() {
+		$subscriber = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		// A subscriber can mint a valid nonce, but lacks edit_post on the target.
+		$nonce = wp_create_nonce( 'atomic_wind_css_warm' );
+
+		$this->assertFalse( $this->call_private( 'can_render_css_warm', $this->post_id, $nonce ) );
+	}
+
+	public function test_warm_gate_rejects_missing_post_id() {
+		$nonce = wp_create_nonce( 'atomic_wind_css_warm' );
+
+		$this->assertFalse( $this->call_private( 'can_render_css_warm', 0, $nonce ) );
+	}
+
+	public function test_warm_html_includes_content_scripts_and_config() {
+		$post_id = $this->make_atomic_wind_post( 'bg-orange-500 md:py-36' );
+		$post    = get_post( $post_id );
+
+		$html = $this->call_private( 'render_css_warm_page_html', $post );
+
+		// The rendered block classes must be in the DOM for the generator to compile them.
+		$this->assertStringContainsString( 'bg-orange-500', $html );
+		$this->assertStringContainsString( 'md:py-36', $html );
+
+		// The two scripts that compile + persist the CSS.
+		$this->assertStringContainsString( 'tailwind-generator-frontend.js', $html );
+		$this->assertStringContainsString( 'style-builder.js', $html );
+
+		// Style-builder config targets the warmed post.
+		$this->assertStringContainsString( 'atomicWindStyleBuilder', $html );
+		$this->assertStringContainsString( '"postId":' . $post_id, $html );
+
+		// Stripped page must not be indexed, and must ping the opener when done.
+		$this->assertStringContainsString( 'noindex', $html );
+		$this->assertStringContainsString( 'atomic-wind:css-warmed', $html );
+	}
+
+	public function test_warm_html_does_not_leak_globals() {
+		global $post;
+
+		$sentinel = get_post( $this->post_id );
+		$post     = $sentinel;
+
+		$target = get_post( $this->make_atomic_wind_post( 'flex' ) );
+		$this->call_private( 'render_css_warm_page_html', $target );
+
+		$this->assertSame( $sentinel, $post, 'The global $post must be restored after rendering the warm page.' );
+	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
- Adds Atomic Wind blocks style builder warmup when saving the editor content.
----

### Test instructions
  - [ ] Logged in as Admin/Editor in wp-admin
  - [ ] Page/post created with Atomic Wind blocks using visually obvious classes (e.g. `bg-orange-500`, `md:py-36`, columns)

  ### Happy path — cache warms at save
  - [ ] Open DevTools → **Network**; click **Publish/Update**
  - [ ] A request fires to `/?atomic_wind_css_warm=<nonce>&post_id=<id>&v=<timestamp>` → **200**, header `X-Robots-Tag: noindex`
  - [ ] A follow-up **POST** to `otter/v1/atomic-wind` (style-builder saving the CSS)
  - [ ] In DevTools → **Elements**, a hidden iframe `#atomic-wind-css-warm-frame` appears briefly, then is removed
  - [ ] Post meta `_atomic_wind_css` is now populated and contains the expected classes — **without** visiting the front end
    - `wp post meta get <post_id> _atomic_wind_css`
  - [ ] Front end (Incognito/fresh visitor) renders fully styled immediately — no flash of unstyled content

  ### Re-save / updates
  - [ ] Change a class (e.g. `bg-orange-500` → `bg-blue-500`), **Update**
  - [ ] `_atomic_wind_css` reflects the new class (the `v=<timestamp>` cache-bust forces a fresh render)
  - [ ] Front end shows the updated styling after refresh

  ### Edge cases
  - [ ] **No Atomic Wind blocks:** plain post saves → **no** warm request fires, no errors
  - [ ] **Autosave:** wait for autosave (don't manually save) → **no** warm pass triggered
  - [ ] **Failed save:** simulate/observe a save failure → **no** warm pass triggered
  - [ ] **Rapid double-save:** only one `#atomic-wind-css-warm-frame` exists at a time (old one removed)
  - [ ] **Timeout safety net:** if the iframe never reports done, it's still removed after ~20s

  ### Security gates
  - [ ] Visiting `/?atomic_wind_css_warm=bogus&post_id=<id>` directly → **not** served (falls through to normal page)
  - [ ] As Subscriber / logged-out with any nonce → warm page **not** served (requires `edit_post`)
  - [ ] As post author/Admin with valid nonce → stripped warm document renders

  ### Automated tests (optional, for devs)
  - [ ] `npm run test:unit:php:base -- --filter TestAtomicWindBlocks` → green
  - [ ] `npm run lint -- src/atomic-wind` and `npm run lint:php` → clean

  ### Regression sanity
  - [ ] Existing Atomic Wind pages still render correctly on front end
  - [ ] No new console errors or PHP notices during save/view
  ---

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

