### PR TITLE
Enhanced dynamic content handling for archive titles

### DIFF
--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -658,9 +658,9 @@ class Dynamic_Content {
 			return get_the_archive_title();
 		}
 
-		$custom_prefix = isset( $data['archiveTitlePrefix'] ) ? (string) $data['archiveTitlePrefix'] : '';
+		$custom_prefix = isset( $data['archiveTitlePrefix'] ) ? sanitize_text_field( (string) $data['archiveTitlePrefix'] ) : '';
 
-		$filter = function () use ( $custom_prefix ) {
+		$filter = function ( $prefix ) use ( $custom_prefix ) {
 			return $custom_prefix;
 		};
 

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -92,7 +92,7 @@ class Dynamic_Content {
 	 */
 	public static function dynamic_content_regex() {
 		// Todo: Improve this Regex, it can't go on for like this. Soon it will be longer than the available space in the universe!!!
-		return '/<o-dynamic(?:\s+(?:data-type=["\'](?P<type>[^"\'<>]+)["\']|data-id=["\'](?P<id>[^"\'<>]+)["\']|data-before=["\'](?P<before>[^"\'<>]+)["\']|data-after=["\'](?P<after>[^"\'<>]+)["\']|data-length=["\'](?P<length>[^"\'<>]+)["\']|data-date-type=["\'](?P<dateType>[^"\'<>]+)["\']|data-date-format=["\'](?P<dateFormat>[^"\'<>]+)["\']|data-date-custom=["\'](?P<dateCustom>[^"\'<>]+)["\']|data-time-type=["\'](?P<timeType>[^"\'<>]+)["\']|data-time-format=["\'](?P<timeFormat>[^"\'<>]+)["\']|data-time-custom=["\'](?P<timeCustom>[^"\'<>]+)["\']|data-term-type=["\'](?P<termType>[^"\'<>]+)["\']|data-term-separator=["\'](?P<termSeparator>[^"\'<>]+)["\']|data-meta-key=["\'](?P<metaKey>[^"\'<>]+)["\']|data-parameter=["\'](?P<parameter>[^"\'<>]+)["\']|data-format=["\'](?P<format>[^"\'<>]+)["\']|data-context=["\'](?P<context>[^"\'<>]+)["\']|data-taxonomy=["\'](?P<taxonomy>[^"\'<>]+)["\']|[a-zA-Z-]+=["\'][^"\'<>]+["\']))*\s*>(?<default>[^ $].*?)<\s*\/\s*o-dynamic>/';
+		return '/<o-dynamic(?:\s+(?:data-type=["\'](?P<type>[^"\'<>]+)["\']|data-id=["\'](?P<id>[^"\'<>]+)["\']|data-before=["\'](?P<before>[^"\'<>]+)["\']|data-after=["\'](?P<after>[^"\'<>]+)["\']|data-length=["\'](?P<length>[^"\'<>]+)["\']|data-date-type=["\'](?P<dateType>[^"\'<>]+)["\']|data-date-format=["\'](?P<dateFormat>[^"\'<>]+)["\']|data-date-custom=["\'](?P<dateCustom>[^"\'<>]+)["\']|data-time-type=["\'](?P<timeType>[^"\'<>]+)["\']|data-time-format=["\'](?P<timeFormat>[^"\'<>]+)["\']|data-time-custom=["\'](?P<timeCustom>[^"\'<>]+)["\']|data-term-type=["\'](?P<termType>[^"\'<>]+)["\']|data-term-separator=["\'](?P<termSeparator>[^"\'<>]+)["\']|data-meta-key=["\'](?P<metaKey>[^"\'<>]+)["\']|data-parameter=["\'](?P<parameter>[^"\'<>]+)["\']|data-format=["\'](?P<format>[^"\'<>]+)["\']|data-context=["\'](?P<context>[^"\'<>]+)["\']|data-taxonomy=["\'](?P<taxonomy>[^"\'<>]+)["\']|data-archive-title-override-prefix=["\'](?P<archiveTitleOverridePrefix>[^"\'<>]+)["\']|data-archive-title-prefix=["\'](?P<archiveTitlePrefix>[^"\'<>]*)["\']|[a-zA-Z-]+=["\'][^"\'<>]+["\']))*\s*>(?<default>[^ $].*?)<\s*\/\s*o-dynamic>/';
 	}
 
 	/**
@@ -512,7 +512,7 @@ class Dynamic_Content {
 		}
 
 		if ( 'archiveTitle' === $data['type'] ) {
-			return get_the_archive_title();
+			return $this->get_archive_title( $data );
 		}
 
 		if ( 'archiveDescription' === $data['type'] ) {
@@ -642,6 +642,33 @@ class Dynamic_Content {
 		}
 
 		return esc_html( $email );
+	}
+
+	/**
+	 * Get Archive Title.
+	 *
+	 * @param array< string, mixed > $data Dynamic Data.
+	 *
+	 * @return string
+	 */
+	public function get_archive_title( $data ) {
+		$override = isset( $data['archiveTitleOverridePrefix'] ) ? $data['archiveTitleOverridePrefix'] : '';
+
+		if ( 'true' !== $override && true !== $override && '1' !== $override ) {
+			return get_the_archive_title();
+		}
+
+		$custom_prefix = isset( $data['archiveTitlePrefix'] ) ? (string) $data['archiveTitlePrefix'] : '';
+
+		$filter = function () use ( $custom_prefix ) {
+			return $custom_prefix;
+		};
+
+		add_filter( 'get_the_archive_title_prefix', $filter );
+		$title = get_the_archive_title();
+		remove_filter( 'get_the_archive_title_prefix', $filter );
+
+		return $title;
 	}
 
 	/**

--- a/src/blocks/plugins/dynamic-content/value/fields.js
+++ b/src/blocks/plugins/dynamic-content/value/fields.js
@@ -17,6 +17,7 @@ import {
 	ExternalLink,
 	SelectControl,
 	TextControl,
+	ToggleControl,
 	PanelBody,
 	Spinner
 } from '@wordpress/components';
@@ -41,7 +42,8 @@ import { getQueryStringFromObject, setUtm } from '../../../helpers/helper-functi
 let hasSettingsPanel = [
 	'postExcerpt',
 	'date',
-	'time'
+	'time',
+	'archiveTitle'
 ];
 
 const dateFormats = {
@@ -237,6 +239,29 @@ const Fields = ({
 									type="text"
 									value={ attributes.timeCustom || '' }
 									onChange={ timeCustom => changeAttributes({ timeCustom }) }
+								/>
+							) }
+						</Fragment>
+					) }
+
+					{ 'archiveTitle' === attributes.type && (
+						<Fragment>
+							<ToggleControl
+								label={ __( 'Override Archive Title Prefix', 'otter-blocks' ) }
+								help={ __( 'Replace the default WordPress archive title prefix (e.g. "Category:") with a custom value, or leave the field empty to remove the prefix entirely.', 'otter-blocks' ) }
+								checked={ 'true' === attributes.archiveTitleOverridePrefix }
+								onChange={ () => changeAttributes({
+									archiveTitleOverridePrefix: 'true' === attributes.archiveTitleOverridePrefix ? undefined : 'true',
+									archiveTitlePrefix: 'true' === attributes.archiveTitleOverridePrefix ? undefined : attributes.archiveTitlePrefix
+								}) }
+							/>
+
+							{ 'true' === attributes.archiveTitleOverridePrefix && (
+								<TextControl
+									label={ __( 'Archive Title Prefix', 'otter-blocks' ) }
+									type="text"
+									value={ attributes.archiveTitlePrefix || '' }
+									onChange={ archiveTitlePrefix => changeAttributes({ archiveTitlePrefix }) }
 								/>
 							) }
 						</Fragment>

--- a/src/blocks/plugins/dynamic-content/value/index.js
+++ b/src/blocks/plugins/dynamic-content/value/index.js
@@ -48,7 +48,9 @@ export const format = {
 		metaKey: 'data-meta-key',
 		parameter: 'data-parameter',
 		format: 'data-format',
-		taxonomy: 'data-taxonomy'
+		taxonomy: 'data-taxonomy',
+		archiveTitleOverridePrefix: 'data-archive-title-override-prefix',
+		archiveTitlePrefix: 'data-archive-title-prefix'
 	},
 	edit
 };
@@ -82,7 +84,7 @@ const withDynamicConditions = createHigherOrderComponent( BlockEdit => {
 
 			elements.forEach( element => {
 				const context = select( 'core/editor' ).getCurrentPostId();
-				const attrs = pick( Object.assign({ context }, element.dataset ), [ 'type', 'context', 'before', 'after', 'length', 'dateType', 'dateFormat', 'dateCustom', 'timeType', 'timeFormat', 'timeCustom', 'termType', 'termSeparator', 'metaKey', 'taxonomy' ]);
+				const attrs = pick( Object.assign({ context }, element.dataset ), [ 'type', 'context', 'before', 'after', 'length', 'dateType', 'dateFormat', 'dateCustom', 'timeType', 'timeFormat', 'timeCustom', 'termType', 'termSeparator', 'metaKey', 'taxonomy', 'archiveTitleOverridePrefix', 'archiveTitlePrefix' ]);
 
 				if ( 'postContent' === attrs.type ) {
 					return;

--- a/tests/test-dynamic-content.php
+++ b/tests/test-dynamic-content.php
@@ -44,6 +44,20 @@ class TestDynamicContent extends WP_UnitTestCase
 	protected $post_id;
 
 	/**
+	 * The test category ID.
+	 *
+	 * @var int
+	 */
+	protected $category_id;
+
+	/**
+	 * The test category slug.
+	 *
+	 * @var string
+	 */
+	protected $category_slug;
+
+	/**
 	 * Set up the test.
 	 */
 	public function set_up() {
@@ -413,6 +427,38 @@ class TestDynamicContent extends WP_UnitTestCase
 	}
 
 	/**
+	 * Test the Archive Title query with the prefix override attributes.
+	 */
+	public function test_archive_title_with_prefix_override() {
+		$archive_title_query = '<p><o-dynamic data-type="archiveTitle" data-archive-title-override-prefix="true" data-archive-title-prefix="Topic:">Archive Title</o-dynamic></p>';
+
+		$result = array();
+		$num    = Dynamic_Content::parse_dynamic_content_query( $archive_title_query, $result );
+		$this->assertTrue( boolval( $num ) );
+		$result = $result[0];
+
+		$this->assertEquals( 'archiveTitle', $result['type'] );
+		$this->assertEquals( 'true', $result['archiveTitleOverridePrefix'] );
+		$this->assertEquals( 'Topic:', $result['archiveTitlePrefix'] );
+	}
+
+	/**
+	 * Test the Archive Title query with the override flag enabled and an empty prefix.
+	 */
+	public function test_archive_title_with_empty_prefix_override() {
+		$archive_title_query = '<p><o-dynamic data-type="archiveTitle" data-archive-title-override-prefix="true" data-archive-title-prefix="">Archive Title</o-dynamic></p>';
+
+		$result = array();
+		$num    = Dynamic_Content::parse_dynamic_content_query( $archive_title_query, $result );
+		$this->assertTrue( boolval( $num ) );
+		$result = $result[0];
+
+		$this->assertEquals( 'archiveTitle', $result['type'] );
+		$this->assertEquals( 'true', $result['archiveTitleOverridePrefix'] );
+		$this->assertSame( '', $result['archiveTitlePrefix'] );
+	}
+
+	/**
 	 * Test the Archive Description query.
 	 */
 	public function test_archive_description() {
@@ -655,6 +701,82 @@ class TestDynamicContent extends WP_UnitTestCase
 		$result                   = $this->dynamic_content->apply_dynamic_content( $author_description_query );
 
 		$this->assertEquals( '<p></p>', $result );
+	}
+
+	/**
+	 * Test the Archive Title evaluation with the default WordPress prefix.
+	 */
+	public function test_archive_title_evaluation_default_prefix() {
+		// Navigate to the category archive so get_the_archive_title() resolves.
+		$this->go_to( get_category_link( $this->category_id ) );
+
+		$archive_title_query = '<p><o-dynamic data-type="archiveTitle">Archive Title</o-dynamic></p>';
+		$result              = $this->dynamic_content->apply_dynamic_content( $archive_title_query );
+
+		// Default WordPress prefix for category archives must be preserved.
+		$this->assertStringContainsString( 'Category:', $result );
+		$this->assertStringContainsString( 'Test Category', $result );
+	}
+
+	/**
+	 * Test the Archive Title evaluation when the override flag is enabled with a custom prefix.
+	 */
+	public function test_archive_title_evaluation_with_custom_prefix() {
+		// Navigate to the category archive so get_the_archive_title() resolves.
+		$this->go_to( get_category_link( $this->category_id ) );
+
+		$archive_title_query = '<p><o-dynamic data-type="archiveTitle" data-archive-title-override-prefix="true" data-archive-title-prefix="Topic:">Archive Title</o-dynamic></p>';
+		$result              = $this->dynamic_content->apply_dynamic_content( $archive_title_query );
+
+		// Custom prefix should replace the default "Category:" prefix.
+		$this->assertStringContainsString( 'Topic:', $result );
+		$this->assertStringNotContainsString( 'Category:', $result );
+		$this->assertStringContainsString( 'Test Category', $result );
+	}
+
+	/**
+	 * Test the Archive Title evaluation when the override flag is enabled with an empty prefix.
+	 */
+	public function test_archive_title_evaluation_with_empty_prefix() {
+		// Navigate to the category archive so get_the_archive_title() resolves.
+		$this->go_to( get_category_link( $this->category_id ) );
+
+		$archive_title_query = '<p><o-dynamic data-type="archiveTitle" data-archive-title-override-prefix="true" data-archive-title-prefix="">Archive Title</o-dynamic></p>';
+		$result              = $this->dynamic_content->apply_dynamic_content( $archive_title_query );
+
+		// Empty prefix should strip the default WordPress prefix entirely.
+		$this->assertStringNotContainsString( 'Category:', $result );
+		$this->assertStringContainsString( 'Test Category', $result );
+	}
+
+	/**
+	 * Test that the Archive Title prefix filter is removed after the dynamic value is rendered.
+	 */
+	public function test_archive_title_evaluation_does_not_leak_filter() {
+		// Navigate to the category archive so get_the_archive_title() resolves.
+		$this->go_to( get_category_link( $this->category_id ) );
+
+		$archive_title_query = '<p><o-dynamic data-type="archiveTitle" data-archive-title-override-prefix="true" data-archive-title-prefix="Topic:">Archive Title</o-dynamic></p>';
+		$this->dynamic_content->apply_dynamic_content( $archive_title_query );
+
+		// After rendering, a subsequent call to get_the_archive_title() must return
+		// the default WordPress prefix (proving the temporary filter was removed).
+		$this->assertStringContainsString( 'Category:', get_the_archive_title() );
+	}
+
+	/**
+	 * Test that the Archive Title is unchanged when the override flag is not "true".
+	 */
+	public function test_archive_title_evaluation_override_flag_off() {
+		// Navigate to the category archive so get_the_archive_title() resolves.
+		$this->go_to( get_category_link( $this->category_id ) );
+
+		// The override flag is missing here, so the custom prefix must be ignored.
+		$archive_title_query = '<p><o-dynamic data-type="archiveTitle" data-archive-title-prefix="Topic:">Archive Title</o-dynamic></p>';
+		$result              = $this->dynamic_content->apply_dynamic_content( $archive_title_query );
+
+		$this->assertStringContainsString( 'Category:', $result );
+		$this->assertStringNotContainsString( 'Topic:', $result );
 	}
 	
 	/**


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-internals/issues/266

### Summary
Added toggle and input field for the archive title dynamic content.

### Screenshots
<img width="549" height="717" alt="Screenshot from 2026-06-24 15-36-03" src="https://github.com/user-attachments/assets/086bb29a-e9bc-44f4-8c68-01e38d1a0128" />

### Test instructions
- Create a category.
- Open the Site Editor to add dynamic content > archive title to the archive template.
- Check if the dynamic content is displayed correctly on the frontend.
- Change the settings of the dynamic content block and check if the changes are reflected on the frontend.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()