### PR TITLE
feat: add support for hiding archive title prefix

### DIFF
--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -92,7 +92,7 @@ class Dynamic_Content {
 	 */
 	public static function dynamic_content_regex() {
 		// Todo: Improve this Regex, it can't go on for like this. Soon it will be longer than the available space in the universe!!!
-		return '/<o-dynamic(?:\s+(?:data-type=["\'](?P<type>[^"\'<>]+)["\']|data-id=["\'](?P<id>[^"\'<>]+)["\']|data-before=["\'](?P<before>[^"\'<>]+)["\']|data-after=["\'](?P<after>[^"\'<>]+)["\']|data-length=["\'](?P<length>[^"\'<>]+)["\']|data-date-type=["\'](?P<dateType>[^"\'<>]+)["\']|data-date-format=["\'](?P<dateFormat>[^"\'<>]+)["\']|data-date-custom=["\'](?P<dateCustom>[^"\'<>]+)["\']|data-time-type=["\'](?P<timeType>[^"\'<>]+)["\']|data-time-format=["\'](?P<timeFormat>[^"\'<>]+)["\']|data-time-custom=["\'](?P<timeCustom>[^"\'<>]+)["\']|data-term-type=["\'](?P<termType>[^"\'<>]+)["\']|data-term-separator=["\'](?P<termSeparator>[^"\'<>]+)["\']|data-meta-key=["\'](?P<metaKey>[^"\'<>]+)["\']|data-parameter=["\'](?P<parameter>[^"\'<>]+)["\']|data-format=["\'](?P<format>[^"\'<>]+)["\']|data-context=["\'](?P<context>[^"\'<>]+)["\']|data-taxonomy=["\'](?P<taxonomy>[^"\'<>]+)["\']|[a-zA-Z-]+=["\'][^"\'<>]+["\']))*\s*>(?<default>[^ $].*?)<\s*\/\s*o-dynamic>/';
+		return '/<o-dynamic(?:\s+(?:data-type=["\'](?P<type>[^"\'<>]+)["\']|data-id=["\'](?P<id>[^"\'<>]+)["\']|data-before=["\'](?P<before>[^"\'<>]+)["\']|data-after=["\'](?P<after>[^"\'<>]+)["\']|data-length=["\'](?P<length>[^"\'<>]+)["\']|data-date-type=["\'](?P<dateType>[^"\'<>]+)["\']|data-date-format=["\'](?P<dateFormat>[^"\'<>]+)["\']|data-date-custom=["\'](?P<dateCustom>[^"\'<>]+)["\']|data-time-type=["\'](?P<timeType>[^"\'<>]+)["\']|data-time-format=["\'](?P<timeFormat>[^"\'<>]+)["\']|data-time-custom=["\'](?P<timeCustom>[^"\'<>]+)["\']|data-term-type=["\'](?P<termType>[^"\'<>]+)["\']|data-term-separator=["\'](?P<termSeparator>[^"\'<>]+)["\']|data-meta-key=["\'](?P<metaKey>[^"\'<>]+)["\']|data-parameter=["\'](?P<parameter>[^"\'<>]+)["\']|data-format=["\'](?P<format>[^"\'<>]+)["\']|data-context=["\'](?P<context>[^"\'<>]+)["\']|data-taxonomy=["\'](?P<taxonomy>[^"\'<>]+)["\']|data-hide-prefix=["\'](?P<hidePrefix>[^"\'<>]+)["\']|[a-zA-Z-]+=["\'][^"\'<>]+["\']))*\s*>(?<default>[^ $].*?)<\s*\/\s*o-dynamic>/';
 	}
 
 	/**
@@ -512,7 +512,7 @@ class Dynamic_Content {
 		}
 
 		if ( 'archiveTitle' === $data['type'] ) {
-			return get_the_archive_title();
+			return $this->get_archive_title( $data );
 		}
 
 		if ( 'archiveDescription' === $data['type'] ) {
@@ -642,6 +642,29 @@ class Dynamic_Content {
 		}
 
 		return esc_html( $email );
+	}
+
+	/**
+	 * Get Archive Title.
+	 *
+	 * @param array $data Dynamic Data.
+	 *
+	 * @return string
+	 */
+	public function get_archive_title( $data ) {
+		$hide_prefix = isset( $data['hidePrefix'] ) && in_array( $data['hidePrefix'], array( 'true', '1' ), true );
+
+		if ( $hide_prefix ) {
+			add_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
+		}
+
+		$title = get_the_archive_title();
+
+		if ( $hide_prefix ) {
+			remove_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
+		}
+
+		return $title;
 	}
 
 	/**

--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -647,7 +647,7 @@ class Dynamic_Content {
 	/**
 	 * Get Archive Title.
 	 *
-	 * @param array $data Dynamic Data.
+	 * @param array<string, mixed> $data Dynamic Data.
 	 *
 	 * @return string
 	 */

--- a/src/blocks/plugins/dynamic-content/value/fields.js
+++ b/src/blocks/plugins/dynamic-content/value/fields.js
@@ -17,6 +17,7 @@ import {
 	ExternalLink,
 	SelectControl,
 	TextControl,
+	ToggleControl,
 	PanelBody,
 	Spinner
 } from '@wordpress/components';
@@ -41,7 +42,8 @@ import { getQueryStringFromObject, setUtm } from '../../../helpers/helper-functi
 let hasSettingsPanel = [
 	'postExcerpt',
 	'date',
-	'time'
+	'time',
+	'archiveTitle'
 ];
 
 const dateFormats = {
@@ -240,6 +242,15 @@ const Fields = ({
 								/>
 							) }
 						</Fragment>
+					) }
+
+					{ 'archiveTitle' === attributes.type && (
+						<ToggleControl
+							label={ __( 'Remove Title Prefix', 'otter-blocks' ) }
+							help={ __( 'Display only the term name, removing prefixes such as "Category:", "Tag:", or "Author:".', 'otter-blocks' ) }
+							checked={ Boolean( attributes.hidePrefix ) && 'false' !== attributes.hidePrefix }
+							onChange={ value => changeAttributes({ hidePrefix: value ? '1' : undefined }) }
+						/>
 					) }
 
 					{ applyFilters( 'otter.dynamicContent.text.controls', '', attributes, changeAttributes ) }

--- a/src/blocks/plugins/dynamic-content/value/index.js
+++ b/src/blocks/plugins/dynamic-content/value/index.js
@@ -48,7 +48,8 @@ export const format = {
 		metaKey: 'data-meta-key',
 		parameter: 'data-parameter',
 		format: 'data-format',
-		taxonomy: 'data-taxonomy'
+		taxonomy: 'data-taxonomy',
+		hidePrefix: 'data-hide-prefix'
 	},
 	edit
 };
@@ -82,7 +83,7 @@ const withDynamicConditions = createHigherOrderComponent( BlockEdit => {
 
 			elements.forEach( element => {
 				const context = select( 'core/editor' ).getCurrentPostId();
-				const attrs = pick( Object.assign({ context }, element.dataset ), [ 'type', 'context', 'before', 'after', 'length', 'dateType', 'dateFormat', 'dateCustom', 'timeType', 'timeFormat', 'timeCustom', 'termType', 'termSeparator', 'metaKey', 'taxonomy' ]);
+				const attrs = pick( Object.assign({ context }, element.dataset ), [ 'type', 'context', 'before', 'after', 'length', 'dateType', 'dateFormat', 'dateCustom', 'timeType', 'timeFormat', 'timeCustom', 'termType', 'termSeparator', 'metaKey', 'taxonomy', 'hidePrefix' ]);
 
 				if ( 'postContent' === attrs.type ) {
 					return;

--- a/tests/test-dynamic-content.php
+++ b/tests/test-dynamic-content.php
@@ -413,6 +413,40 @@ class TestDynamicContent extends WP_UnitTestCase
 	}
 
 	/**
+	 * Test the Archive Title query with the prefix removed.
+	 */
+	public function test_archive_title_hide_prefix() {
+		$archive_title_query = '<p><o-dynamic data-type="archiveTitle" data-hide-prefix="1">Archive Title</o-dynamic></p>';
+
+		$result = array();
+		$num    = Dynamic_Content::parse_dynamic_content_query( $archive_title_query, $result );
+		$this->assertTrue( boolval( $num ) );
+		$result = $result[0];
+
+		$this->assertEquals( 'archiveTitle', $result['type'] );
+		$this->assertEquals( '1', $result['hidePrefix'] );
+	}
+
+	/**
+	 * Test the Archive Title evaluation on a category archive.
+	 */
+	public function test_archive_title_evaluation() {
+		$this->go_to( get_term_link( $this->category_id, 'category' ) );
+
+		// Default behaviour keeps the prefix.
+		$with_prefix_query = '<p><o-dynamic data-type="archiveTitle">Archive Title</o-dynamic></p>';
+		$with_prefix       = $this->dynamic_content->apply_dynamic_content( $with_prefix_query );
+		$this->assertStringContainsString( 'Test Category', $with_prefix );
+		$this->assertStringContainsString( 'Category:', $with_prefix );
+
+		// Enabling the toggle strips the prefix and leaves only the term name.
+		$no_prefix_query = '<p><o-dynamic data-type="archiveTitle" data-hide-prefix="1">Archive Title</o-dynamic></p>';
+		$no_prefix       = $this->dynamic_content->apply_dynamic_content( $no_prefix_query );
+		$this->assertEquals( '<p>Test Category</p>', $no_prefix );
+		$this->assertStringNotContainsString( 'Category:', $no_prefix );
+	}
+
+	/**
 	 * Test the Archive Description query.
 	 */
 	public function test_archive_description() {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/otter-internals/issues/266.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
- Adds toggle to hide archive title prefix for dynamic data;
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->
<img width="358" height="457" alt="image" src="https://github.com/user-attachments/assets/4903fc39-6ced-492e-bf43-1b033dcec7cd" />

----

### Test instructions
- Use a default FSE theme (Twenty Twenty-Five should be ok).
- Edit the archive page in the full site editor.
- Editor: select text → Dynamic Value → Archive Title → confirm a "Remove Title Prefix" toggle appears in Settings.
- Frontend: place Archive Title on a category archive with the toggle on → shows term name only, no Category:.
- Regression: toggle off → prefix returns (Category: …); the Before/After fields still apply on top.
- Coming to this version from a previous one without the toggle should still work as expected.
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [ ] ~Included E2E or unit tests for the changes in this PR.~
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

