### PR TITLE
Editor performance improvements

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -42,4 +42,5 @@ tsconfig.json
 /plugins
 /docs
 /build/pro/
+*.map
 AGENTS.md

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -761,6 +761,8 @@ class Registration {
 	 * @access  public
 	 */
 	public function enqueue_block_styles( $post ) {
+		$asset_file = null;
+
 		foreach ( self::$blocks as $block ) {
 			if ( in_array( $block, self::$styles_loaded ) || ! has_block( 'themeisle-blocks/' . $block, $post ) ) {
 				continue;
@@ -788,7 +790,11 @@ class Registration {
 				continue;
 			}
 
-			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
+			// Read the shared asset file once, lazily — only when a matching
+			// block is actually present — instead of on every loop iteration.
+			if ( null === $asset_file ) {
+				$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
+			}
 
 			$deps = array();
 
@@ -897,6 +903,10 @@ class Registration {
 			)
 		);
 
+		// All blocks share the same generated asset file (version/deps); read it
+		// once here instead of re-including it on every loop iteration.
+		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
+
 		foreach ( self::$blocks as $block ) {
 			$block_path   = OTTER_BLOCKS_PATH . '/build/blocks/' . $block;
 			$editor_style = OTTER_BLOCKS_URL . 'build/blocks/' . $block . '/editor.css';
@@ -914,8 +924,6 @@ class Registration {
 			if ( false === $metadata ) {
 				continue;
 			}
-
-			$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
 
 			$deps = array();
 

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -241,9 +241,7 @@ class Registration {
 
 		wp_set_script_translations( 'otter-blocks', 'otter-blocks' );
 
-		// The Patterns Library (Design Library) is a separate bundle so it — and
-		// its fuse.js / react-intersection-observer dependencies — only load when
-		// the module is enabled, instead of being parsed on every editor load.
+		// Separate bundle: loads only when the Patterns Library module is on.
 		if ( boolval( get_option( 'themeisle_blocks_settings_patterns_library', true ) ) ) {
 			$patterns_asset = include OTTER_BLOCKS_PATH . '/build/patterns-library/index.asset.php';
 
@@ -790,8 +788,7 @@ class Registration {
 				continue;
 			}
 
-			// Read the shared asset file once, lazily — only when a matching
-			// block is actually present — instead of on every loop iteration.
+			// Read the shared asset file once, only when a matching block exists.
 			if ( null === $asset_file ) {
 				$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
 			}
@@ -903,8 +900,7 @@ class Registration {
 			)
 		);
 
-		// All blocks share the same generated asset file (version/deps); read it
-		// once here instead of re-including it on every loop iteration.
+		// Shared asset file (version/deps) for all blocks — read once, not per block.
 		$asset_file = include OTTER_BLOCKS_PATH . '/build/blocks/blocks.asset.php';
 
 		foreach ( self::$blocks as $block ) {

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -241,6 +241,32 @@ class Registration {
 
 		wp_set_script_translations( 'otter-blocks', 'otter-blocks' );
 
+		// The Patterns Library (Design Library) is a separate bundle so it — and
+		// its fuse.js / react-intersection-observer dependencies — only load when
+		// the module is enabled, instead of being parsed on every editor load.
+		if ( boolval( get_option( 'themeisle_blocks_settings_patterns_library', true ) ) ) {
+			$patterns_asset = include OTTER_BLOCKS_PATH . '/build/patterns-library/index.asset.php';
+
+			wp_enqueue_script(
+				'otter-patterns-library',
+				OTTER_BLOCKS_URL . 'build/patterns-library/index.js',
+				array_merge( $patterns_asset['dependencies'], array( 'otter-blocks' ) ),
+				$patterns_asset['version'],
+				true
+			);
+
+			wp_set_script_translations( 'otter-patterns-library', 'otter-blocks' );
+
+			if ( file_exists( OTTER_BLOCKS_PATH . '/build/patterns-library/index.css' ) ) {
+				wp_enqueue_style(
+					'otter-patterns-library',
+					OTTER_BLOCKS_URL . 'build/patterns-library/index.css',
+					array(),
+					$patterns_asset['version']
+				);
+			}
+		}
+
 		if ( defined( 'THEMEISLE_GUTENBERG_GOOGLE_MAPS_API' ) ) {
 			$api = THEMEISLE_GUTENBERG_GOOGLE_MAPS_API;
 		} else {

--- a/inc/render/class-plugin-card-block.php
+++ b/inc/render/class-plugin-card-block.php
@@ -110,6 +110,16 @@ class Plugin_Card_Block {
 
 		$slug = $request;
 
+		$cache_key = 'otter_plugin_card_' . sanitize_key( $slug );
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached ) {
+			$return['success'] = true;
+			$return['data']    = $cached;
+
+			return $return;
+		}
+
 		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 
 		$request = array(
@@ -139,6 +149,8 @@ class Plugin_Card_Block {
 
 			return $return;
 		}
+
+		set_transient( $cache_key, $results, 12 * HOUR_IN_SECONDS );
 
 		$return['success'] = true;
 

--- a/src/blocks/blocks/accordion/group/edit.js
+++ b/src/blocks/blocks/accordion/group/edit.js
@@ -8,7 +8,7 @@ import googleFontsLoader from '../../../helpers/google-fonts.js';
  * WordPress dependencies.
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
-import { Fragment, useEffect } from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -27,8 +27,7 @@ import {
 
 import { useDarkBackground, useColorResolver } from '../../../helpers/utility-hooks.js';
 
-// @ts-ignore
-import faIcons from '../../../../../assets/fontawesome/fa-icons.json';
+import { loadFontAwesomeIcons } from '../../../helpers/fontawesome-icons.js';
 
 const { attributes: defaultAttributes } = metadata;
 
@@ -99,8 +98,29 @@ const Edit = ({
 		]);
 	}, [ attributes.fontSize, attributes.fontFamily, attributes.fontVariant, attributes.fontStyle, attributes.textTransform, attributes.letterSpacing ]);
 
+	// The Font Awesome icon map is loaded lazily (it is ~143KB); the icon CSS is
+	// (re)generated once it resolves and whenever the selected icons change.
+	const [ faIcons, setFaIcons ] = useState( null );
+	useEffect( () => {
+		let isMounted = true;
+
+		loadFontAwesomeIcons().then( data => {
+			if ( isMounted ) {
+				setFaIcons( data );
+			}
+		});
+
+		return () => {
+			isMounted = false;
+		};
+	}, []);
+
 	const [ iconsCSSNodeName, setIconsNodeCSS ] = useCSSNode();
 	useEffect( () => {
+		if ( ! faIcons ) {
+			return;
+		}
+
 		const icon = getValue( 'icon' );
 		const openIcon = getValue( 'openItemIcon' );
 
@@ -116,7 +136,7 @@ const Edit = ({
 				font-weight: ${ 'fas' !== openIcon.prefix ? '400' : '900' }
 			}` ]  : [])
 		]);
-	}, [ attributes.icon, attributes.openItemIcon ]);
+	}, [ attributes.icon, attributes.openItemIcon, faIcons ]);
 
 	const [ activeCSSNodeName, setActiveNodeCSS ] = useCSSNode();
 	useEffect( () => {

--- a/src/blocks/blocks/accordion/group/edit.js
+++ b/src/blocks/blocks/accordion/group/edit.js
@@ -98,8 +98,7 @@ const Edit = ({
 		]);
 	}, [ attributes.fontSize, attributes.fontFamily, attributes.fontVariant, attributes.fontStyle, attributes.textTransform, attributes.letterSpacing ]);
 
-	// The Font Awesome icon map is loaded lazily (it is ~143KB); the icon CSS is
-	// (re)generated once it resolves and whenever the selected icons change.
+	// Load the ~143KB icon map lazily; regenerate icon CSS once it resolves.
 	const [ faIcons, setFaIcons ] = useState( null );
 	useEffect( () => {
 		let isMounted = true;

--- a/src/blocks/components/icon-picker-control/index.js
+++ b/src/blocks/components/icon-picker-control/index.js
@@ -41,8 +41,7 @@ import './editor.scss';
 
 import AltTextControl from '../alt-text-control/index.js';
 
-// @ts-ignore
-import data from '../../../../assets/fontawesome/fa-icons.json';
+import { loadFontAwesomeIconsList } from '../../helpers/fontawesome-icons.js';
 import themeIsleIcons from './../../helpers/themeisle-icons.js';
 
 const FontAwesomeIconsList = ({
@@ -87,36 +86,17 @@ const IconPickerControl = ({
 	const instanceId = useInstanceId( IconPickerControl );
 
 	useEffect( () => {
-		const icons = [];
+		let isMounted = true;
 
-		Object.keys( data ).forEach( i => {
-			Object.keys( data[i].styles ).forEach( o => {
-				let prefix = '';
-
-				switch ( data[i].styles[o]) {
-				case 'brands':
-					prefix = 'fab';
-					break;
-				case 'solid':
-					prefix = 'fas';
-					break;
-				case 'regular':
-					prefix = 'far';
-					break;
-				default:
-					prefix = 'fas';
-				}
-
-				icons.push({
-					name: i,
-					unicode: data[i].unicode,
-					prefix,
-					label: data[i].label
-				});
-			});
+		loadFontAwesomeIconsList().then( loadedIcons => {
+			if ( isMounted ) {
+				setIcons( loadedIcons );
+			}
 		});
 
-		setIcons( icons );
+		return () => {
+			isMounted = false;
+		};
 	}, []);
 
 	const [ isURL, setIsUrl ] = useState( false );
@@ -294,7 +274,7 @@ const IconPickerControl = ({
 							/>
 
 							<div className="components-popover__items">
-								{ selectedIcons.map( ( i, index ) => {
+								{ ( selectedIcons || [] ).map( ( i, index ) => {
 									if ( 'fontawesome' === library && ( ! search || i.name.match( search.toLowerCase() ) || i.label.toLowerCase().match( search.toLowerCase() ) ) ) {
 										return (
 											<FontAwesomeIconsList
@@ -346,36 +326,13 @@ export const IconPickerToolbarControl = ({
 	setAttributes
 }) => {
 	useEffect( () => {
-		const icons = [];
+		let isMounted = true;
 
-		Object.keys( data ).forEach( i => {
-			Object.keys( data[i].styles ).forEach( o => {
-				let prefix = '';
-
-				switch ( data[i].styles[o]) {
-				case 'brands':
-					prefix = 'fab';
-					break;
-				case 'solid':
-					prefix = 'fas';
-					break;
-				case 'regular':
-					prefix = 'far';
-					break;
-				default:
-					prefix = 'fas';
-				}
-
-				icons.push({
-					name: i,
-					unicode: data[i].unicode,
-					prefix,
-					label: data[i].label
-				});
-			});
+		loadFontAwesomeIconsList().then( loadedIcons => {
+			if ( isMounted ) {
+				setIcons( loadedIcons );
+			}
 		});
-
-		setIcons( icons );
 
 		if ( classes ) {
 			const classList = classes.split( ' ' );
@@ -393,6 +350,10 @@ export const IconPickerToolbarControl = ({
 				setIcon( icon );
 			}
 		}
+
+		return () => {
+			isMounted = false;
+		};
 	}, []);
 
 	const [ search, setSearch ] = useState( '' );
@@ -476,7 +437,7 @@ export const IconPickerToolbarControl = ({
 								</MenuItem>
 							) }
 
-							{ icons.map( (i, index) => {
+							{ ( icons || [] ).map( (i, index) => {
 								if ( ! search || i.name.match( search.toLowerCase() ) || i.label.toLowerCase().match( search.toLowerCase() ) ) {
 									return (
 										<FontAwesomeIconsList

--- a/src/blocks/helpers/fontawesome-icons.js
+++ b/src/blocks/helpers/fontawesome-icons.js
@@ -1,11 +1,7 @@
 /**
- * Font Awesome icon metadata loader.
- *
- * The icon metadata JSON is ~143KB. Importing it statically pulls the whole
- * file into the main editor bundle, where it is downloaded and parsed on every
- * editor load even when no icon is ever inserted. Loading it through a dynamic
- * import keeps it in its own chunk that is fetched once — and only when an icon
- * picker (or an icon-driven block such as the accordion) actually needs it.
+ * Lazy loader for the ~143KB Font Awesome icon metadata. A dynamic import keeps
+ * it out of the editor bundle, in its own chunk fetched only when an icon picker
+ * (or icon-driven block) needs it.
  */
 
 const PREFIX_BY_STYLE = {
@@ -18,9 +14,7 @@ let rawCache = null;
 let rawRequest = null;
 
 /**
- * Lazily load the raw Font Awesome icon map (keyed by icon name).
- *
- * The result is cached so the chunk is fetched and parsed at most once.
+ * Lazily load the raw icon map (keyed by name); cached after first load.
  *
  * @return {Promise<Record<string, { unicode: string, label: string, styles: Record<string, string> }>>}
  */

--- a/src/blocks/helpers/fontawesome-icons.js
+++ b/src/blocks/helpers/fontawesome-icons.js
@@ -1,0 +1,64 @@
+/**
+ * Font Awesome icon metadata loader.
+ *
+ * The icon metadata JSON is ~143KB. Importing it statically pulls the whole
+ * file into the main editor bundle, where it is downloaded and parsed on every
+ * editor load even when no icon is ever inserted. Loading it through a dynamic
+ * import keeps it in its own chunk that is fetched once — and only when an icon
+ * picker (or an icon-driven block such as the accordion) actually needs it.
+ */
+
+const PREFIX_BY_STYLE = {
+	brands: 'fab',
+	solid: 'fas',
+	regular: 'far'
+};
+
+let rawCache = null;
+let rawRequest = null;
+
+/**
+ * Lazily load the raw Font Awesome icon map (keyed by icon name).
+ *
+ * The result is cached so the chunk is fetched and parsed at most once.
+ *
+ * @return {Promise<Record<string, { unicode: string, label: string, styles: Record<string, string> }>>}
+ */
+export function loadFontAwesomeIcons() {
+	if ( rawCache ) {
+		return Promise.resolve( rawCache );
+	}
+
+	if ( ! rawRequest ) {
+		rawRequest = import( /* webpackChunkName: "fontawesome-icons" */ '../../../assets/fontawesome/fa-icons.json' )
+			.then( ({ default: data }) => {
+				rawCache = data;
+				return rawCache;
+			});
+	}
+
+	return rawRequest;
+}
+
+/**
+ * Lazily load the Font Awesome icons as a flat, picker-ready list.
+ *
+ * @return {Promise<Array<{ name: string, unicode: string, prefix: string, label: string }>>}
+ */
+export async function loadFontAwesomeIconsList() {
+	const data = await loadFontAwesomeIcons();
+	const icons = [];
+
+	Object.keys( data ).forEach( name => {
+		Object.keys( data[ name ].styles ).forEach( style => {
+			icons.push({
+				name,
+				unicode: data[ name ].unicode,
+				prefix: PREFIX_BY_STYLE[ data[ name ].styles[ style ] ] ?? 'fas',
+				label: data[ name ].label
+			});
+		});
+	});
+
+	return icons;
+}

--- a/src/blocks/plugins/registerPlugin.tsx
+++ b/src/blocks/plugins/registerPlugin.tsx
@@ -29,13 +29,31 @@ import './keyboard-navigation/index.js';
 // We disable the copy-paste plugin for now.
 // import './copy-paste/index.js';
 import './sticky/index.js';
-import './dynamic-content/index.js';
 import './welcome-guide/index.js';
 import './feedback/index.js';
 import './otter-tools-inspector/index';
 import './live-search/index.js';
 import './upsell-block/index.js';
-import './ai-content/index.tsx';
+
+/**
+ * Optional modules are loaded on demand, gated on their settings toggle, so
+ * their code is only downloaded and parsed when the module is enabled instead
+ * of on every editor load.
+ *
+ * `conditions` is intentionally kept as a static import above: it registers a
+ * `blocks.registerBlockType` attribute filter (`otterConditions`) that must be
+ * in place before core blocks register during editor bootstrap — a timing an
+ * async chunk cannot guarantee, and missing it would strip saved conditions.
+ * The modules below only register late-safe hooks (RichText formats,
+ * `editor.BlockEdit` / `editor.MediaUpload` filters), so deferring them is safe.
+ */
+if ( window.themeisleGutenberg?.hasModule?.dynamicContent ) {
+	import( /* webpackChunkName: "dynamic-content" */ './dynamic-content/index.js' );
+}
+
+if ( window.themeisleGutenberg?.hasModule?.aiToolbar ) {
+	import( /* webpackChunkName: "ai-content" */ './ai-content/index.tsx' );
+}
 
 const icon = <Icon icon={ otterIcon } />;
 

--- a/src/blocks/plugins/registerPlugin.tsx
+++ b/src/blocks/plugins/registerPlugin.tsx
@@ -36,7 +36,6 @@ import './otter-tools-inspector/index';
 import './live-search/index.js';
 import './upsell-block/index.js';
 import './ai-content/index.tsx';
-import './patterns-library/index.js';
 
 const icon = <Icon icon={ otterIcon } />;
 

--- a/src/blocks/plugins/registerPlugin.tsx
+++ b/src/blocks/plugins/registerPlugin.tsx
@@ -36,16 +36,12 @@ import './live-search/index.js';
 import './upsell-block/index.js';
 
 /**
- * Optional modules are loaded on demand, gated on their settings toggle, so
- * their code is only downloaded and parsed when the module is enabled instead
- * of on every editor load.
+ * Load optional modules on demand, gated on their toggle, so they're only
+ * fetched when enabled.
  *
- * `conditions` is intentionally kept as a static import above: it registers a
- * `blocks.registerBlockType` attribute filter (`otterConditions`) that must be
- * in place before core blocks register during editor bootstrap — a timing an
- * async chunk cannot guarantee, and missing it would strip saved conditions.
- * The modules below only register late-safe hooks (RichText formats,
- * `editor.BlockEdit` / `editor.MediaUpload` filters), so deferring them is safe.
+ * `conditions` stays a static import above: its `blocks.registerBlockType`
+ * filter must run before core blocks register, which an async chunk can't
+ * guarantee. The modules below only add late-safe hooks, so deferring is fine.
  */
 if ( window.themeisleGutenberg?.hasModule?.dynamicContent ) {
 	import( /* webpackChunkName: "dynamic-content" */ './dynamic-content/index.js' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -171,6 +171,31 @@ module.exports = [
 	},
 	{
 
+		// PATTERNS LIBRARY (Design Library)
+		//
+		// Split out of the main `blocks` bundle so this tree — plus its
+		// `fuse.js` and `react-intersection-observer` dependencies, which are
+		// used nowhere else — is only downloaded/parsed when the Patterns
+		// Library module is enabled, instead of on every editor load.
+		...defaultConfig,
+		stats: 'minimal',
+		mode: NODE_ENV,
+		entry: {
+			index: './src/blocks/plugins/patterns-library/index.js'
+		},
+		output: {
+			path: path.resolve( __dirname, './build/patterns-library' )
+		},
+		plugins: [
+			...defaultConfig.plugins,
+			new BundleAnalyzerPlugin({
+				analyzerMode: 'disabled',
+				generateStatsFile: ANALYZER
+			})
+		]
+	},
+	{
+
 		// OTTER BLOCKS
 		...defaultConfig,
 		stats: 'minimal',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -172,11 +172,8 @@ module.exports = [
 	{
 
 		// PATTERNS LIBRARY (Design Library)
-		//
-		// Split out of the main `blocks` bundle so this tree — plus its
-		// `fuse.js` and `react-intersection-observer` dependencies, which are
-		// used nowhere else — is only downloaded/parsed when the Patterns
-		// Library module is enabled, instead of on every editor load.
+		// Own bundle so this tree and its fuse.js / react-intersection-observer
+		// deps load only when the module is enabled, not on every editor load.
 		...defaultConfig,
 		stats: 'minimal',
 		mode: NODE_ENV,


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes Codeinwp/otter-internals#250.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
Small performance improvements for the block editor editor 
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

----

### Test instructions
<!-- Describe how this pull request can be tested. -->
- [x] **Plugin Card cache** — Open a post that already contains a Plugin Card block (it's deprecated/hidden from the inserter; or paste `<!-- wp:themeisle-blocks/plugin-cards {"slug":"otter-blocks"} /-->` via the code editor). View on frontend → card renders; reload → (transient `otter_plugin_card_<slug>` is set) - you should see it in the DB.
- [x] **Patterns Library** — With the module ON, the Patterns/Design Library button opens, patterns load, and search works. Turn the module OFF → its script isn't requested and the editor still work (see in the inspector **Network** tab by filtering for `otter` in the search)
- [x] **Font Awesome icons** — `chunk-fontawesome-icons.js` is NOT loaded on editor open; it loads when you insert an icon block, open an icon picker (Button/Icon List/Font Awesome block) — grid populates, search works, selection persists. Accordion open/close icons still render.
- [ ] **Dynamic Content / AI toolbar** — With each module ON, the feature works and its chunk loads; with it OFF, the chunk isn't requested and the editor still works. Posts with existing dynamic values save without losing them.
- [x] **Visibility Conditions (regression)** — Add a condition to a core block and an Otter block, save, reload → it persists and applies. (This module was intentionally left eager; verify it didn't regress.)
- [x] No new console errors in the editor or on the frontend.

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

-  ~[ ]Included E2E or unit tests for the changes in this PR.~
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

