### PR TITLE
Fix memory issue with devtools opened

### DIFF
--- a/src/atomic-wind/tailwind/generator.js
+++ b/src/atomic-wind/tailwind/generator.js
@@ -25,6 +25,17 @@ const stylesheetMap = {
 	'./utilities.css': { path: 'virtual:tailwindcss/utilities.css', content: assets.utilities },
 };
 
+// One compiler per frame would exhaust the renderer (the editor injects this
+// script into the canvas and every preview iframe). Run the full pipeline only
+// in the top frame; it already styles the canvas via resolveEditorContext().
+function isTopFrame() {
+	try {
+		return window.self === window.top;
+	} catch ( error ) {
+		return false;
+	}
+}
+
 let compiler;
 const classes = new Set();
 let buildQueue = Promise.resolve();
@@ -395,7 +406,7 @@ function rebuild( kind ) {
 		.catch( console.error );
 }
 
-document.addEventListener( 'DOMContentLoaded', () => {
+function bootstrap() {
 	let retries = 0;
 	const maxRetries = 20;
 
@@ -423,4 +434,84 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	};
 
 	waitForEditorContext();
-} );
+}
+
+// Style a preview iframe by borrowing the top frame's shared compiler instead
+// of building a local one. The canvas iframe is excluded (top frame styles it).
+function bootstrapPreviewFrame() {
+	if ( ( window.name || '' ).startsWith( 'editor-canvas' ) ) {
+		return;
+	}
+
+	let queue = Promise.resolve();
+	let pending = false;
+
+	const apply = () => {
+		pending = false;
+
+		let generate;
+		try {
+			generate = window.top && window.top.atomicWindGenerateCss;
+		} catch ( error ) {
+			// Cross-origin parent.
+			return;
+		}
+
+		if ( 'function' !== typeof generate ) {
+			return;
+		}
+
+		const found = new Set();
+		for ( const el of document.querySelectorAll( '[class]' ) ) {
+			for ( const c of el.classList ) {
+				found.add( c );
+			}
+		}
+
+		if ( 0 === found.size ) {
+			return;
+		}
+
+		queue = queue
+			.then( () => generate( Array.from( found ) ) )
+			.then( ( css ) => {
+				ensureStyleTag( document );
+				sheet.textContent = css;
+			} )
+			.catch( () => {} );
+	};
+
+	const schedule = () => {
+		if ( pending ) {
+			return;
+		}
+		pending = true;
+		( window.requestAnimationFrame || window.setTimeout )( apply );
+	};
+
+	schedule();
+
+	// Parent injects markup after load; regenerate when it arrives. Body only,
+	// so our own <head> style writes can't retrigger this.
+	const observer = new MutationObserver( schedule );
+	observer.observe( document.body, {
+		attributes: true,
+		attributeFilter: [ 'class' ],
+		childList: true,
+		subtree: true,
+	} );
+}
+
+function start() {
+	if ( isTopFrame() ) {
+		bootstrap();
+	} else {
+		bootstrapPreviewFrame();
+	}
+}
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', start );
+} else {
+	start();
+}

--- a/src/blocks/blocks/form/captcha/block.json
+++ b/src/blocks/blocks/form/captcha/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "themeisle-blocks/form-captcha",
 	"title": "Captcha",
 	"category": "themeisle-blocks",

--- a/src/blocks/plugins/patterns-library/editor.scss
+++ b/src/blocks/plugins/patterns-library/editor.scss
@@ -1282,6 +1282,7 @@ select.o-library__sort {
 }
 
 .o-library__similar-thumb {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/src/blocks/plugins/patterns-library/library.js
+++ b/src/blocks/plugins/patterns-library/library.js
@@ -147,9 +147,7 @@ const Library = ({ onClose }) => {
 		return {
 			clientID: getSelectedBlockClientId(),
 			favorites: get('themeisle/otter-blocks', 'patterns-favorites') || [],
-			// Clamp to the menu's range: 5 columns used to be offered, so the
-			// stored preference may exceed the current maximum.
-			columns: Math.min(get('themeisle/otter-blocks', 'patterns-columns') || 3, 4),
+			columns: get('themeisle/otter-blocks', 'patterns-columns') || 3,
 			accent: get('themeisle/otter-blocks', 'patterns-accent') || null,
 		};
 	}, []);

--- a/src/blocks/plugins/patterns-library/library.js
+++ b/src/blocks/plugins/patterns-library/library.js
@@ -119,6 +119,10 @@ const isPackCategory = (name) => name.endsWith('-pack');
 
 const isCloudCategory = (name) => name.startsWith('ti-tc-');
 
+// A pattern's stable identity: the slug stays constant when it switches from an
+// upsell (`otter-blocks/<slug>`) to the real Pro version (`otter-pro/<slug>`).
+const slugOf = (name) => (name || '').split('/').pop();
+
 const isPagePattern = (pattern) =>
 	pattern.categories.some(
 		(category) => isPackCategory(category) || 'pages' === category,
@@ -166,21 +170,31 @@ const Library = ({ onClose }) => {
 	const setAccent = (value) =>
 		set('themeisle/otter-blocks', 'patterns-accent', value);
 
+	// Match by slug so a pattern favorited as an upsell stays favorited once Pro
+	// registers it; the stored value keeps its original full name.
 	const toggleFavorite = useCallback(
-		(pattern) => {
-			if (favorites.includes(pattern)) {
+		(name) => {
+			const slug = slugOf(name);
+
+			if (favorites.some((favorite) => slugOf(favorite) === slug)) {
 				set(
 					'themeisle/otter-blocks',
 					'patterns-favorites',
-					favorites.filter((name) => name !== pattern),
+					favorites.filter((favorite) => slugOf(favorite) !== slug),
 				);
 			} else {
 				set('themeisle/otter-blocks', 'patterns-favorites', [
 					...favorites,
-					pattern,
+					name,
 				]);
 			}
 		},
+		[ favorites ],
+	);
+
+	// Slug set for favorite membership checks across the library.
+	const favoriteSlugs = useMemo(
+		() => new Set(favorites.map(slugOf)),
 		[ favorites ],
 	);
 
@@ -232,8 +246,6 @@ const Library = ({ onClose }) => {
 		[],
 	);
 
-	const slugOf = (name) => (name || '').split('/').pop();
-
 	const patterns = useMemo(() => {
 		const registeredSlugs = new Set(
 			registeredPatterns.map((pattern) => slugOf(pattern.name)),
@@ -246,6 +258,22 @@ const Library = ({ onClose }) => {
 			),
 		];
 	}, [ registeredPatterns, proUpsells ]);
+
+	// A stored favorite can point at a pattern that's neither registered nor an
+	// upsell anymore; it can't render when filtered, so count only favorites
+	// (by slug) that still resolve to a known pattern.
+	const favCount = useMemo(() => {
+		const known = new Set(patterns.map((pattern) => slugOf(pattern.name)));
+		let count = 0;
+
+		favoriteSlugs.forEach((slug) => {
+			if (known.has(slug)) {
+				count++;
+			}
+		});
+
+		return count;
+	}, [ patterns, favoriteSlugs ]);
 
 	const { sectionGroups, collections, tcCategories, categoryLabels } =
     useMemo(() => {
@@ -420,7 +448,7 @@ const Library = ({ onClose }) => {
 
 		// Everything except the tag facets: these always constrain the counts.
 		const base = scope
-			.filter((pattern) => !favOnly || favorites.includes(pattern.name))
+			.filter((pattern) => !favOnly || favoriteSlugs.has(slugOf(pattern.name)))
 			.filter((pattern) =>
 				parsed.tokens.every((token) => matchToken(pattern, token)),
 			)
@@ -444,7 +472,7 @@ const Library = ({ onClose }) => {
 
 			return { ...tag, count, disabled: 0 === count };
 		});
-	}, [ scope, favOnly, favorites, parsed, textMatches, activeTags ]);
+	}, [ scope, favOnly, favoriteSlugs, parsed, textMatches, activeTags ]);
 
 	// Clear tag selections when the scope changes.
 	useEffect(() => {
@@ -491,7 +519,7 @@ const Library = ({ onClose }) => {
 
 	const filteredPatterns = useMemo(() => {
 		let result = scope
-			.filter((pattern) => !favOnly || favorites.includes(pattern.name))
+			.filter((pattern) => !favOnly || favoriteSlugs.has(slugOf(pattern.name)))
 			.filter((pattern) =>
 				parsed.tokens.every((token) => matchToken(pattern, token)),
 			)
@@ -511,7 +539,7 @@ const Library = ({ onClose }) => {
 		}
 
 		return result;
-	}, [ scope, parsed, activeTags, favOnly, favorites, sort, textMatches ]);
+	}, [ scope, parsed, activeTags, favOnly, favoriteSlugs, sort, textMatches ]);
 
 	// "More like this" suggestions for the preview overlay.
 	const similarPatterns = useMemo(() => {
@@ -739,7 +767,7 @@ const Library = ({ onClose }) => {
 										query={query}
 										setQuery={setQuery}
 										count={filteredPatterns.length}
-										favCount={favorites.length}
+										favCount={favCount}
 										favOnly={favOnly}
 										setFavOnly={setFavOnly}
 										sort={sort}
@@ -787,7 +815,7 @@ const Library = ({ onClose }) => {
 													pattern={pattern}
 													categoryLabel={primaryCategoryLabel(pattern)}
 													isPage={isPage}
-													isFavorite={favorites.includes(pattern.name)}
+													isFavorite={favoriteSlugs.has(slugOf(pattern.name))}
 													accent={accent}
 													onInsert={insertPattern}
 													onPreview={setPreview}
@@ -808,7 +836,7 @@ const Library = ({ onClose }) => {
 					pattern={preview}
 					categoryLabel={primaryCategoryLabel(preview)}
 					isPage={isPagePattern(preview)}
-					isFavorite={favorites.includes(preview.name)}
+					isFavorite={favoriteSlugs.has(slugOf(preview.name))}
 					accent={accent}
 					similar={similarPatterns}
 					onFavorite={() => toggleFavorite(preview.name)}

--- a/src/blocks/plugins/patterns-library/preview.js
+++ b/src/blocks/plugins/patterns-library/preview.js
@@ -3,6 +3,8 @@
  */
 import classnames from 'classnames';
 
+import { useInView } from 'react-intersection-observer';
+
 /**
  * WordPress dependencies.
  */
@@ -32,7 +34,8 @@ import {
 	AsyncPreview,
 	ParsedPreview,
 	ProThumb,
-	QueuedPreview
+	QueuedPreview,
+	Skeleton
 } from './template';
 
 import { previewAccent } from './accent';
@@ -44,12 +47,22 @@ const SimilarCard = ({
 	accent,
 	onClick
 }) => {
+	// Defer each card's BlockPreview until it nears the viewport, so opening the
+	// dialog doesn't mount every preview at once and stall the first paint.
+	const { ref, inView } = useInView({
+		threshold: 0,
+		rootMargin: '200px',
+		triggerOnce: true
+	});
+
+	const thumb = pattern.isPro
+		? <ProThumb pattern={ pattern } />
+		: <QueuedPreview pattern={ pattern } accent={ accent } />;
+
 	return (
-		<button className="o-library__similar-card" onClick={ onClick }>
+		<button className="o-library__similar-card" onClick={ onClick } ref={ ref }>
 			<span className="o-library__similar-thumb">
-				{ pattern.isPro
-					? <ProThumb pattern={ pattern } />
-					: <QueuedPreview pattern={ pattern } accent={ accent } /> }
+				{ inView ? thumb : <Skeleton /> }
 			</span>
 
 			<span className="o-library__similar-name">{ pattern.title }</span>

--- a/src/blocks/plugins/patterns-library/template.js
+++ b/src/blocks/plugins/patterns-library/template.js
@@ -49,7 +49,7 @@ export const AsyncPreview = BlockPreview.Async || ( ({ children }) => children )
 // the modal when it mounts inside a BlockPreview — never preview it.
 export const UPSELL_BLOCK = 'themeisle-blocks/patterns-upsell';
 
-const Skeleton = () => <div className="o-library__thumb-skeleton" />;
+export const Skeleton = () => <div className="o-library__thumb-skeleton" />;
 
 // A stable hue per pattern name, for the screenshot placeholder gradient.
 const hueFromName = ( name = '' ) => {


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
- Moves captcha block to apiVersion 3.
- Fixes memory issue when displaying block previews.
- Fixes issue with favorite patterns not translating well between free/pro.
- Fixes visual issue with skeleton flashing on the whole library modal when previewing a pattern.
<!-- Please describe the changes you made. -->

----

### Test instructions
- With devtools opened, add a new page;
- There should appear a modal that prompts you to insert patterns;
- When closing the modal, the page should still work and NOT throw an error with code 11;
<!-- Describe how this pull request can be tested. -->

<!--
#### Query
```javascript
new QueryQA().select('blocks').run()
```
-->

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

