### PR TITLE
test: close PHPUnit and E2E coverage gaps from the release audit

### DIFF
--- a/bin/e2e-tests.sh
+++ b/bin/e2e-tests.sh
@@ -2,3 +2,4 @@
 
 # Set-up the `wp_env` environment.
 npm run wp-env run cli wp option set themeisle_open_ai_api_key "sk_XXXXXXXXXXXXXXXXXXXXXXXx" # Used by AI tools.
+npm run wp-env run cli wp rewrite structure '/%postname%/' # Pretty permalinks: the e2e global-setup reads /wp-json/.

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -92,7 +92,9 @@ class Registration {
 	 * @return object
 	 */
 	public static function get_editor_global_defaults() {
-		return json_decode( get_option( 'themeisle_blocks_settings_global_defaults', '{}' ) ) ?? new \stdClass();
+		$defaults = json_decode( get_option( 'themeisle_blocks_settings_global_defaults', '{}' ) );
+
+		return is_object( $defaults ) ? $defaults : new \stdClass();
 	}
 
 	/**

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -83,6 +83,19 @@ class Registration {
 	public static $is_fa_loaded = false;
 
 	/**
+	 * Get the decoded global defaults for the editor, always as an object.
+	 *
+	 * The option can exist as an empty string or corrupt JSON, which json_decode
+	 * turns into null — and a null localized value crashes every block's Edit
+	 * component when the editor reads per-block defaults from it.
+	 *
+	 * @return object
+	 */
+	public static function get_editor_global_defaults() {
+		return json_decode( get_option( 'themeisle_blocks_settings_global_defaults', '{}' ) ) ?? new \stdClass();
+	}
+
+	/**
 	 * Initialize the class
 	 */
 	public function init() {
@@ -290,7 +303,7 @@ class Registration {
 				'optionsPath'             => admin_url( 'admin.php?page=otter' ),
 				'mapsAPI'                 => $api,
 				'hasStripeAPI'            => Stripe_API::has_keys(),
-				'globalDefaults'          => json_decode( get_option( 'themeisle_blocks_settings_global_defaults', '{}' ) ),
+				'globalDefaults'          => self::get_editor_global_defaults(),
 				'themeDefaults'           => Main::get_global_defaults(),
 				'imageSizes'              => function_exists( 'is_wpcom_vip' ) ? array( 'thumbnail', 'medium', 'medium_large', 'large' ) : get_intermediate_image_sizes(), // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_intermediate_image_sizes_get_intermediate_image_sizes
 				'isWPVIP'                 => function_exists( 'is_wpcom_vip' ),

--- a/packages/e2e-tests/mu-plugins/otter-e2e-bootstrap.php
+++ b/packages/e2e-tests/mu-plugins/otter-e2e-bootstrap.php
@@ -181,6 +181,7 @@ function stub_wp_mail_for_e2e( $short_circuit, $atts = array() ) {
 	$log[] = array(
 		'to'      => isset( $atts['to'] ) ? $atts['to'] : '',
 		'subject' => isset( $atts['subject'] ) ? $atts['subject'] : '',
+		'headers' => isset( $atts['headers'] ) ? $atts['headers'] : array(),
 	);
 	update_option( MAIL_LOG_OPTION, $log, false );
 

--- a/src/blocks/helpers/block-utility.js
+++ b/src/blocks/helpers/block-utility.js
@@ -44,8 +44,11 @@ window.themeisleGutenberg.blockIDs ??= [];
 export const addGlobalDefaults = ( attributes, setAttributes, name, defaultAttributes ) => {
 
 	// Check if the globals default are available and its values are different from the base values.
-	if ( undefined !== window.themeisleGutenberg?.globalDefaults && ! isEqual( globalDefaultsBlocksAttrs[name], window.themeisleGutenberg.globalDefaults[name]) ) {
-		const defaultGlobalAttrs = { ...window.themeisleGutenberg.globalDefaults[name] };
+	// Optional chaining throughout: a corrupt/empty option localizes globalDefaults as null.
+	const globalDefaults = window.themeisleGutenberg?.globalDefaults?.[ name ];
+
+	if ( globalDefaults && ! isEqual( globalDefaultsBlocksAttrs[name], globalDefaults ) ) {
+		const defaultGlobalAttrs = { ...globalDefaults };
 
 		const attrs = Object.keys( defaultGlobalAttrs )
 			.filter( attr => isEqual( attributes[ attr ], defaultAttributes[ attr ]?.default ) ) // Keep only the properties with the default value.

--- a/src/blocks/test/e2e/blocks/atomic-wind-list-view.spec.js
+++ b/src/blocks/test/e2e/blocks/atomic-wind-list-view.spec.js
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+import { setAtomicWind } from '../helpers/design-library';
+
+/**
+ * List View labels for Atomic Wind blocks: generic wrappers show their semantic
+ * tag, text blocks show their content, and a custom name from the Rename UI wins.
+ */
+test.describe( 'Atomic Wind List View labels', () => {
+	test.beforeEach( async({ otterUtils, admin }) => {
+		await setAtomicWind( otterUtils, true );
+		await admin.createNewPost();
+	});
+
+	test.afterAll( async({ otterUtils }) => {
+		await setAtomicWind( otterUtils, false );
+	});
+
+	test( 'shows semantic and content-based names instead of generic titles', async({ editor, page }) => {
+		// Top-level blocks only: List View collapses inner blocks by default.
+		await editor.insertBlock({
+			name: 'atomic-wind/box',
+			attributes: { tagName: 'section' }
+		});
+
+		await editor.insertBlock({
+			name: 'atomic-wind/text',
+			attributes: { content: 'Hello labels' }
+		});
+
+		await editor.insertBlock({
+			name: 'atomic-wind/box',
+			attributes: {
+				tagName: 'header',
+				metadata: { name: 'Hero Wrapper' }
+			}
+		});
+
+		await page.getByLabel( 'Document Overview' ).click();
+
+		// The box labels resolve from the semantic tag, the text label from its content.
+		await expect( page.getByRole( 'link', { name: 'Section', exact: true }) ).toBeVisible();
+		await expect( page.getByRole( 'link', { name: 'Hello labels' }) ).toBeVisible();
+
+		// A custom name set through the core Rename UI must win over the tag label.
+		await expect( page.getByRole( 'link', { name: 'Hero Wrapper' }) ).toBeVisible();
+		await expect( page.getByRole( 'link', { name: 'Header', exact: true }) ).toBeHidden();
+	});
+});

--- a/src/blocks/test/e2e/blocks/block-conditions.spec.js
+++ b/src/blocks/test/e2e/blocks/block-conditions.spec.js
@@ -52,4 +52,63 @@ test.describe( 'Block Conditions', () => {
 		await page.goto( `/?p=${postId}` );
 		await expect( page.locator( 'main .wp-block-image img, .entry-content .wp-block-image img' ).first() ).toBeHidden();
 	});
+
+	test( 'build visibility conditions through the inspector rule builder', async({ editor, page }) => {
+		await waitForEditorReady( page );
+
+		await editor.insertBlock({
+			name: 'core/paragraph',
+			attributes: { content: 'Members only content' }
+		});
+
+		await editor.openDocumentSettingsSidebar();
+
+		// The panel is collapsed by default.
+		await page.getByRole( 'button', { name: 'Visibility Conditions' }).click();
+
+		// First rule group: pick a condition through the searchable picker.
+		await page.getByRole( 'button', { name: 'Add Rule Group' }).click();
+		await page.getByRole( 'button', { name: 'Add condition' }).click();
+
+		await page.getByPlaceholder( 'Search conditions…' ).fill( 'logged in' );
+		await page.locator( '.o-conditions-picker__item' ).filter({ hasText: 'Logged In Users' }).click();
+
+		await expect( page.locator( '.o-conditions__row-title' ) ).toHaveText( 'Logged In Users' );
+
+		// A second condition in the same group is combined with AND.
+		await page.getByRole( 'button', { name: 'Add condition' }).click();
+		await page.locator( '.o-conditions-picker__item' ).filter({ hasText: 'Logged Out Users' }).click();
+
+		await expect( page.locator( '.o-conditions__separator-label' ).filter({ hasText: 'AND' }) ).toBeVisible();
+
+		// A second rule group is combined with OR.
+		await page.getByRole( 'button', { name: 'Add Rule Group' }).click();
+		await expect( page.locator( '.o-conditions__separator-label' ).filter({ hasText: 'OR' }) ).toBeVisible();
+
+		// Deleting the extra group and condition trims the attribute back down.
+		await page.getByRole( 'button', { name: 'Delete rule group' }).nth( 1 ).click();
+		await expect( page.locator( '.o-conditions__separator-label' ).filter({ hasText: 'OR' }) ).toBeHidden();
+
+		await page.getByRole( 'button', { name: 'Remove condition' }).nth( 1 ).click();
+		await expect( page.locator( '.o-conditions__separator-label' ).filter({ hasText: 'AND' }) ).toBeHidden();
+
+		const conditions = await page.evaluate(
+			() => window.wp.data.select( 'core/block-editor' ).getSelectedBlock()?.attributes?.otterConditions
+		);
+
+		expect( conditions ).toHaveLength( 1 );
+		expect( conditions[0]).toHaveLength( 1 );
+		expect( conditions[0][0].type ).toBe( 'loggedInUser' );
+
+		// The built condition drives the frontend: visible logged in, hidden logged out.
+		const postId = await publishAndViewPost({ editor, page });
+		await expect( page.getByText( 'Members only content' ) ).toBeVisible();
+
+		await page.getByRole( 'menuitem', { name: 'Howdy, admin' }).hover();
+		await page.waitForTimeout( 200 );
+		await page.getByRole( 'menuitem', { name: 'Log Out' }).click();
+
+		await page.goto( `/?p=${postId}` );
+		await expect( page.getByText( 'Members only content' ) ).toBeHidden();
+	});
 });

--- a/src/blocks/test/e2e/blocks/button-group.spec.js
+++ b/src/blocks/test/e2e/blocks/button-group.spec.js
@@ -108,9 +108,36 @@ test.describe( 'Button Group', () => {
 		await expect( btn ).toHaveCSS( 'text-transform', 'uppercase' );
 	});
 
+	test( 'editor survives an empty global defaults option', async({ admin, editor, page, requestUtils }) => {
+		// Regression: an empty-string option json_decode()s to null server-side and
+		// used to crash every newly inserted Otter block's Edit component.
+		await requestUtils.rest({
+			method: 'POST',
+			path: '/wp/v2/settings',
+			data: { themeisle_blocks_settings_global_defaults: '' }
+		});
+
+		// A fresh editor load so the poisoned option gets localized.
+		await admin.createNewPost();
+
+		await editor.insertBlock({
+			name: 'themeisle-blocks/button-group',
+			innerBlocks: [
+				{
+					name: 'themeisle-blocks/button',
+					attributes: { text: 'Still alive' }
+				}
+			]
+		});
+
+		// The block renders instead of falling into the block crash boundary.
+		await expect( editor.canvas.getByText( 'Still alive' ) ).toBeVisible();
+		await expect( editor.canvas.locator( '.block-editor-warning' ) ).toHaveCount( 0 );
+	});
+
 	// Global defaults persist site-wide; reset them so other specs are unaffected.
-	// Must be '{}', not '': the editor bootstrap json_decode()s the raw option and
-	// a null result crashes every Otter block's Edit component.
+	// Must be '{}', not '': on unfixed builds the editor bootstrap json_decode()s
+	// the raw option and a null result crashes every Otter block's Edit component.
 	test.afterEach( async({ requestUtils }) => {
 		await requestUtils.rest({
 			method: 'POST',

--- a/src/blocks/test/e2e/blocks/button-group.spec.js
+++ b/src/blocks/test/e2e/blocks/button-group.spec.js
@@ -45,4 +45,77 @@ test.describe( 'Button Group', () => {
 		await expect( btn ).toHaveCSS( 'font-style', attributes.fontStyle );
 		await expect( btn ).toHaveCSS( 'line-height', `${parseInt( attributes.fontSize ) * parseFloat( attributes.lineHeight )}px` ); // Playwright use computed line-height based on font-size.
 	});
+
+	test( 'global defaults typography saves the right attributes and new blocks inherit them', async({ admin, editor, page, requestUtils }) => {
+		const getSavedDefaults = async() => {
+			const settings = await requestUtils.rest({ path: '/wp/v2/settings' });
+			return JSON.parse( settings.themeisle_blocks_settings_global_defaults || '{}' )['themeisle-blocks/button-group'] ?? {};
+		};
+
+		// Build the defaults through the Otter Options global-defaults UI.
+		await page.getByRole( 'button', { name: 'Otter Options' }).click();
+		await page.getByRole( 'button', { name: 'Block Settings' }).click();
+
+		const row = page.locator( '.o-options-block-item' ).filter({
+			has: page.getByText( 'Button Group', { exact: true })
+		});
+		await row.getByRole( 'button', { name: 'Open Settings' }).click();
+
+		// Appearance and Letter Case are hidden until enabled from the view-options menu.
+		await page.getByRole( 'button', { name: 'View options' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Appearance' }).click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Letter Case' }).click();
+		await page.keyboard.press( 'Escape' );
+
+		await page.getByLabel( 'Appearance' ).selectOption( 'italic' );
+		await page.getByRole( 'button', { name: 'Uppercase' }).click();
+
+		await page.getByRole( 'button', { name: 'Save', exact: true }).click();
+
+		// Regression: Appearance/Letter Case used to be written to the wrong keys
+		// (fontVariant/fontStyle) instead of fontStyle/textTransform.
+		await expect.poll( getSavedDefaults ).toMatchObject({
+			fontStyle: 'italic',
+			textTransform: 'uppercase'
+		});
+		expect( ( await getSavedDefaults() ).fontVariant ).toBeUndefined();
+
+		// A Button Group inserted on a fresh editor load inherits the defaults.
+		await admin.createNewPost();
+		await editor.insertBlock({
+			name: 'themeisle-blocks/button-group',
+			innerBlocks: [
+				{
+					name: 'themeisle-blocks/button',
+					attributes: { text: 'Inherit me' }
+				}
+			]
+		});
+
+		await expect.poll( async() => {
+			const blocks = await editor.getBlocks();
+			const group = blocks.find( block => 'themeisle-blocks/button-group' === block.name );
+			return {
+				fontStyle: group?.attributes?.fontStyle,
+				textTransform: group?.attributes?.textTransform
+			};
+		}).toEqual({ fontStyle: 'italic', textTransform: 'uppercase' });
+
+		await publishAndViewPost({ editor, page });
+
+		const btn = page.locator( 'a' ).filter({ hasText: 'Inherit me' });
+		await expect( btn ).toHaveCSS( 'font-style', 'italic' );
+		await expect( btn ).toHaveCSS( 'text-transform', 'uppercase' );
+	});
+
+	// Global defaults persist site-wide; reset them so other specs are unaffected.
+	// Must be '{}', not '': the editor bootstrap json_decode()s the raw option and
+	// a null result crashes every Otter block's Edit component.
+	test.afterEach( async({ requestUtils }) => {
+		await requestUtils.rest({
+			method: 'POST',
+			path: '/wp/v2/settings',
+			data: { themeisle_blocks_settings_global_defaults: '{}' }
+		});
+	});
 });

--- a/src/blocks/test/e2e/blocks/form-retention.spec.js
+++ b/src/blocks/test/e2e/blocks/form-retention.spec.js
@@ -3,7 +3,7 @@
  */
 import { test, expect } from '../fixtures';
 import { expectBlockByName, publishPostReliable } from '../helpers/editor';
-import { expectFormOptionSavedNotice, findSavedFormEmail, getEmailNotificationToggle, getSavedFormEmails, insertContactForm, prepareFormOptionsInspector } from '../helpers/forms';
+import { expectFormOptionSavedNotice, findSavedFormEmail, getEmailNotificationToggle, getSavedFormEmails, insertContactForm, prepareFormOptionsInspector, showFormOption } from '../helpers/forms';
 import { expectSuccessMessage } from '../helpers/frontend';
 
 /**
@@ -487,5 +487,56 @@ test.describe( 'Form submission retention', () => {
 
 		// No field label (the required Name/Email included) may carry the required marker.
 		records[0].inputs.forEach( input => expect( input.label ).not.toContain( '*' ) );
+	});
+
+	test( 'notification email Reply-To defaults to the submitter and honors the Reply-To Email option', async({ admin, editor, page, otterUtils }) => {
+		const joinHeaders = ( headers ) => [].concat( headers ?? [] ).join( '\n' );
+
+		await insertContactForm({ editor, page });
+		const postId = await publishPostReliable( editor, page );
+		await expectFormOptionSavedNotice( page );
+
+		// Clear the mail log of anything the publish flow may have attempted.
+		await otterUtils.setMailMode( 'ok' );
+
+		await page.goto( `/?p=${postId}` );
+		await fillAndSubmitContactForm( page );
+		await expectSuccessMessage( page );
+
+		// Without an explicit option, replies go to the address the visitor entered.
+		let mailLog = await otterUtils.getMailLog();
+		expect( mailLog ).toHaveLength( 1 );
+		expect( joinHeaders( mailLog[0].headers ) ).toContain( 'Reply-To: ada@example.com' );
+
+		// Set an explicit Reply-To through the inspector control.
+		await admin.editPost( postId );
+
+		await page.waitForFunction( () => 0 < window.wp?.data?.select( 'core/block-editor' )?.getBlocks()?.length );
+		await page.evaluate( () => {
+			const blocks = window.wp.data.select( 'core/block-editor' ).getBlocks();
+			const form = blocks.find( block => 'themeisle-blocks/form' === block.name );
+			window.wp.data.dispatch( 'core/block-editor' ).selectBlock( form.clientId );
+		});
+		await editor.openDocumentSettingsSidebar();
+
+		// Wait until the Form Options panel is ready, then reveal the hidden-by-default control.
+		await getEmailNotificationToggle( page );
+		await showFormOption( page, 'Reply-To Email' );
+		await page.getByLabel( 'Reply-To Email' ).fill( 'owner-replies@example.com' );
+
+		const saveBtn = page.locator( '.editor-post-publish-button__button' );
+		await expect( saveBtn ).toBeEnabled({ timeout: 10_000 });
+		await saveBtn.click();
+		await expectFormOptionSavedNotice( page );
+
+		await otterUtils.setMailMode( 'ok' );
+
+		await page.goto( `/?p=${postId}` );
+		await fillAndSubmitContactForm( page );
+		await expectSuccessMessage( page );
+
+		mailLog = await otterUtils.getMailLog();
+		expect( mailLog ).toHaveLength( 1 );
+		expect( joinHeaders( mailLog[0].headers ) ).toContain( 'Reply-To: owner-replies@example.com' );
 	});
 });

--- a/src/blocks/test/e2e/blocks/live-search.spec.js
+++ b/src/blocks/test/e2e/blocks/live-search.spec.js
@@ -51,4 +51,38 @@ test.describe( 'Live Search Block', () => {
 		const width = await container.evaluate( node => node.offsetWidth );
 		expect( width ).toBeGreaterThan( 0 );
 	});
+
+	test( 'post-only search query without a category renders cleanly', async({ editor, page }) => {
+		const errors = [];
+		page.on( 'pageerror', error => errors.push( error.message ) );
+		page.on( 'console', message => {
+			if ( 'error' === message.type() ) {
+				errors.push( message.text() );
+			}
+		});
+
+		// Regression: a post-only query with no 'cat' key used to raise an
+		// undefined-array-key PHP warning while rendering the block.
+		await editor.insertBlock({
+			name: 'core/search',
+			attributes: {
+				otterIsLive: true,
+				otterSearchQuery: {
+					'post_type': [ 'post' ]
+				}
+			}
+		});
+
+		await publishAndViewPost({ editor, page });
+
+		await expect( page.locator( 'body' ) ).not.toContainText( 'Undefined array key' );
+
+		const input = page.locator( '.o-live-search input[type="search"]' );
+		await expect( input ).toBeVisible();
+
+		await input.fill( 'u' );
+		await expect( page.locator( '.o-live-search .container-wrap' ) ).toBeVisible();
+
+		expect( errors ).toEqual([]);
+	});
 });

--- a/src/blocks/test/e2e/fixtures.ts
+++ b/src/blocks/test/e2e/fixtures.ts
@@ -6,6 +6,7 @@ import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
 export type MailLogEntry = {
 	to: string | string[];
 	subject: string;
+	headers: string | string[];
 };
 
 export type FormRecord = {

--- a/src/blocks/test/e2e/global-setup.ts
+++ b/src/blocks/test/e2e/global-setup.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { execSync } from 'child_process';
-import { mkdirSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
 import path from 'path';
 import { request } from '@playwright/test';
 import type { FullConfig } from '@playwright/test';
@@ -36,7 +36,36 @@ async function assertWpEnvReady( requestContext: { get: ( url: string ) => Promi
 	}
 }
 
+/**
+ * The free and pro bundles load on the same editor page. If both compilations
+ * use the same webpack chunk-loading global, their runtimes resolve each
+ * other's numeric module IDs and the editor crashes with
+ * "Cannot read properties of undefined (reading 'call')" — but only on builds
+ * whose module IDs happen to mismatch, so specs alone can't catch a regression
+ * deterministically. Assert the runtime globals are distinct instead.
+ */
+function assertDistinctWebpackRuntimes() {
+	const bundles = [ 'build/blocks/blocks.js', 'build/pro/blocks.js' ].map(
+		( bundle ) => path.join( process.cwd(), bundle )
+	);
+
+	if ( ! bundles.every( ( bundle ) => existsSync( bundle ) ) ) {
+		return;
+	}
+
+	const [ free, pro ] = bundles.map(
+		( bundle ) => readFileSync( bundle, 'utf8' ).match( /webpackChunk[a-zA-Z_$][\w$]*/ )?.[ 0 ]
+	);
+
+	if ( free && free === pro ) {
+		throw new Error(
+			`[Otter E2E] The free and pro bundles share the webpack runtime global "${ free }" — set a distinct output.uniqueName in webpack.config.pro.js or the editor can crash when both load.`
+		);
+	}
+}
+
 async function globalSetup( config: FullConfig ) {
+	assertDistinctWebpackRuntimes();
 	const { storageState, baseURL } = config.projects[ 0 ].use;
 	const storageStatePath =
 		'string' === typeof storageState ? storageState : undefined;

--- a/src/blocks/test/e2e/global-setup.ts
+++ b/src/blocks/test/e2e/global-setup.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { execSync } from 'child_process';
 import { mkdirSync } from 'fs';
 import path from 'path';
 import { request } from '@playwright/test';
@@ -11,8 +12,18 @@ import type { FullConfig } from '@playwright/test';
  */
 import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
 
-async function assertWpEnvReady( requestContext: { get: ( url: string ) => Promise<{ ok: () => boolean; json: () => Promise<{ namespaces?: string[] }> }> }, baseURL: string ) {
-	const indexResponse = await requestContext.get( `${ baseURL }/wp-json/` );
+async function assertWpEnvReady( requestContext: { get: ( url: string ) => Promise<{ ok: () => boolean; headers: () => Record<string, string>; json: () => Promise<{ namespaces?: string[] }> }> }, baseURL: string ) {
+	let indexResponse = await requestContext.get( `${ baseURL }/wp-json/` );
+
+	/*
+	 * The single-environment PHPUnit suite reinstalls WordPress over the shared
+	 * wp-env site, which drops the permalink structure and makes /wp-json/ serve
+	 * the homepage HTML. Restore it once and retry before failing.
+	 */
+	if ( indexResponse.ok() && ! ( indexResponse.headers()['content-type'] ?? '' ).includes( 'application/json' ) ) {
+		execSync( 'npx wp-env run cli -- wp rewrite structure /%postname%/', { stdio: 'ignore' });
+		indexResponse = await requestContext.get( `${ baseURL }/wp-json/` );
+	}
 
 	if ( ! indexResponse.ok() ) {
 		throw new Error( `[Otter E2E] wp-env is not reachable at ${ baseURL }` );

--- a/src/blocks/test/e2e/playwright.config.js
+++ b/src/blocks/test/e2e/playwright.config.js
@@ -51,7 +51,10 @@ const SERIAL_SPECS = [
 	'**/blocks/form-retention.spec.js',
 	'**/blocks/form-turnstile.spec.js',
 	'**/blocks/onboarding.spec.js',
-	'**/blocks/design-library.spec.js'
+	'**/blocks/design-library.spec.js',
+
+	// Flips the site-wide atomic-wind blocks option.
+	'**/blocks/atomic-wind-list-view.spec.js'
 ];
 
 const config = defineConfig({

--- a/src/blocks/test/unit/block-utility-lightweight.test.ts
+++ b/src/blocks/test/unit/block-utility-lightweight.test.ts
@@ -37,6 +37,7 @@ jest.mock( '@wordpress/data', () => ({
 }) );
 
 import {
+	addGlobalDefaults,
 	buildGetSyncValue,
 	getDefaultValue,
 	getDefaultValueByField,
@@ -51,6 +52,54 @@ describe( 'block utility lightweight helpers', () => {
 			blockIDs: [],
 			globalDefaults: {}
 		};
+	});
+
+	describe( 'addGlobalDefaults', () => {
+		it( 'is a no-op when globalDefaults is null (empty or corrupt option)', () => {
+			( window as any ).themeisleGutenberg.globalDefaults = null;
+			const setAttributes = jest.fn();
+
+			expect( () =>
+				addGlobalDefaults({}, setAttributes, 'themeisle-blocks/button-group', {})
+			).not.toThrow();
+			expect( setAttributes ).not.toHaveBeenCalled();
+		});
+
+		it( 'applies global defaults to attributes still at their block defaults', () => {
+			( window as any ).themeisleGutenberg.globalDefaults = {
+				'themeisle-blocks/button-group': {
+					fontSize: '20px'
+				}
+			};
+			const setAttributes = jest.fn();
+
+			addGlobalDefaults(
+				{ fontSize: undefined },
+				setAttributes,
+				'themeisle-blocks/button-group',
+				{ fontSize: { default: undefined } }
+			);
+
+			expect( setAttributes ).toHaveBeenCalledWith({ fontSize: '20px' });
+		});
+
+		it( 'does not override attributes the user already changed', () => {
+			( window as any ).themeisleGutenberg.globalDefaults = {
+				'themeisle-blocks/button-group': {
+					fontSize: '20px'
+				}
+			};
+			const setAttributes = jest.fn();
+
+			addGlobalDefaults(
+				{ fontSize: '36px' },
+				setAttributes,
+				'themeisle-blocks/button-group',
+				{ fontSize: { default: undefined } }
+			);
+
+			expect( setAttributes ).toHaveBeenCalledWith({});
+		});
 	});
 
 	describe( 'getDefaultValue', () => {

--- a/tests/test-ai-usage.php
+++ b/tests/test-ai-usage.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Class Test_AI_Usage
+ *
+ * @package gutenberg-blocks
+ */
+
+use ThemeIsle\GutenbergBlocks\Server\AI_Usage;
+
+/**
+ * Tests for the AI usage tracker: per-action counters, the distinct-action cap and
+ * the last-N prompt trimming that keep the autoloaded option bounded.
+ */
+class Test_AI_Usage extends WP_UnitTestCase {
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tear_down() {
+		delete_option( AI_Usage::OPTION_NAME );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Read the stored usage count for an action.
+	 *
+	 * @param string $action The action key.
+	 * @return int|null
+	 */
+	private function get_usage_count( $action ) {
+		$usage = get_option( AI_Usage::OPTION_NAME );
+
+		foreach ( isset( $usage['usage_count'] ) ? $usage['usage_count'] : array() as $entry ) {
+			if ( $entry['key'] === $action ) {
+				return $entry['value'];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Read the stored prompts for an action.
+	 *
+	 * @param string $action The action key.
+	 * @return string[]
+	 */
+	private function get_prompts( $action ) {
+		$usage = get_option( AI_Usage::OPTION_NAME );
+
+		foreach ( isset( $usage['prompts'] ) ? $usage['prompts'] : array() as $entry ) {
+			if ( $entry['key'] === $action ) {
+				return $entry['values'];
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Ensure recording creates a new entry and increments an existing one.
+	 */
+	public function test_record_creates_and_increments_action_count() {
+		AI_Usage::record( 'formAutoresponder::generate', 'first prompt' );
+
+		$this->assertSame( 1, $this->get_usage_count( 'formAutoresponder::generate' ) );
+		$this->assertSame( array( 'first prompt' ), $this->get_prompts( 'formAutoresponder::generate' ) );
+
+		AI_Usage::record( 'formAutoresponder::generate', 'second prompt' );
+
+		$this->assertSame( 2, $this->get_usage_count( 'formAutoresponder::generate' ) );
+		$this->assertSame( array( 'first prompt', 'second prompt' ), $this->get_prompts( 'formAutoresponder::generate' ) );
+	}
+
+	/**
+	 * Ensure a new action is dropped once 50 distinct actions exist, while existing
+	 * actions keep incrementing (the option is autoloaded and must stay bounded).
+	 */
+	public function test_record_caps_distinct_actions_at_fifty() {
+		for ( $i = 1; $i <= 50; $i++ ) {
+			AI_Usage::record( 'action-' . $i, 'prompt' );
+		}
+
+		AI_Usage::record( 'action-51', 'prompt' );
+
+		$this->assertNull( $this->get_usage_count( 'action-51' ) );
+		$this->assertEmpty( $this->get_prompts( 'action-51' ) );
+
+		AI_Usage::record( 'action-1', 'prompt' );
+
+		$this->assertSame( 2, $this->get_usage_count( 'action-1' ) );
+	}
+
+	/**
+	 * Ensure only the last 10 prompts per action are kept (FIFO).
+	 */
+	public function test_record_keeps_only_last_ten_prompts() {
+		for ( $i = 1; $i <= 12; $i++ ) {
+			AI_Usage::record( 'textTransformation', 'prompt ' . $i );
+		}
+
+		$prompts = $this->get_prompts( 'textTransformation' );
+
+		$this->assertCount( 10, $prompts );
+		$this->assertSame( 'prompt 3', $prompts[0] );
+		$this->assertSame( 'prompt 12', $prompts[9] );
+		$this->assertSame( 12, $this->get_usage_count( 'textTransformation' ) );
+	}
+
+	/**
+	 * Ensure an action that sanitizes to an empty string is a no-op.
+	 */
+	public function test_record_ignores_empty_action() {
+		AI_Usage::record( '', 'prompt' );
+		AI_Usage::record( "\n\t ", 'prompt' );
+
+		// The option is registered with a default, so check no entries were recorded.
+		$usage = get_option( AI_Usage::OPTION_NAME );
+		$this->assertEmpty( isset( $usage['usage_count'] ) ? $usage['usage_count'] : array() );
+		$this->assertEmpty( isset( $usage['prompts'] ) ? $usage['prompts'] : array() );
+	}
+
+	/**
+	 * Ensure legacy stored data with a non-numeric count is coerced instead of fataling.
+	 */
+	public function test_record_coerces_legacy_non_numeric_count() {
+		update_option(
+			AI_Usage::OPTION_NAME,
+			array(
+				'usage_count' => array(
+					array(
+						'key'   => 'legacy',
+						'value' => 'not-a-number',
+					),
+				),
+				'prompts'     => array(),
+			)
+		);
+
+		AI_Usage::record( 'legacy', 'prompt' );
+
+		$this->assertSame( 1, $this->get_usage_count( 'legacy' ) );
+	}
+}

--- a/tests/test-form-captcha-block.php
+++ b/tests/test-form-captcha-block.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Class Test_Form_Captcha_Block
+ *
+ * @package gutenberg-blocks
+ */
+
+use ThemeIsle\GutenbergBlocks\Render\Form_Captcha_Block;
+
+/**
+ * Form captcha block render tests: provider fallback and the missing-keys editor warning.
+ */
+class Test_Form_Captcha_Block extends WP_UnitTestCase {
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tear_down() {
+		delete_option( 'themeisle_google_captcha_api_site_key' );
+		delete_option( 'themeisle_google_captcha_api_secret_key' );
+		delete_option( 'themeisle_cloudflare_turnstile_site_key' );
+		delete_option( 'themeisle_cloudflare_turnstile_secret_key' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Ensure an unknown provider falls back to recaptcha and known providers pass through.
+	 */
+	public function test_render_provider_attribute() {
+		$block = new Form_Captcha_Block();
+
+		$this->assertStringContainsString( 'data-captcha-provider="recaptcha"', $block->render( array() ) );
+		$this->assertStringContainsString( 'data-captcha-provider="recaptcha"', $block->render( array( 'provider' => 'not-a-provider' ) ) );
+		$this->assertStringContainsString( 'data-captcha-provider="turnstile"', $block->render( array( 'provider' => 'turnstile' ) ) );
+	}
+
+	/**
+	 * Ensure the missing-keys warning shows only to users who can edit posts.
+	 */
+	public function test_render_warning_requires_edit_posts_capability() {
+		$block = new Form_Captcha_Block();
+
+		wp_set_current_user( 0 );
+		$this->assertStringNotContainsString( 'o-form-captcha-warning', $block->render( array() ) );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+		$this->assertStringContainsString( 'o-form-captcha-warning', $block->render( array() ) );
+	}
+
+	/**
+	 * Ensure the warning checks the keys of the selected provider, not just any provider.
+	 */
+	public function test_render_warning_uses_provider_specific_keys() {
+		$block = new Form_Captcha_Block();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		update_option( 'themeisle_google_captcha_api_site_key', 'site' );
+		update_option( 'themeisle_google_captcha_api_secret_key', 'secret' );
+
+		// reCAPTCHA keys satisfy the recaptcha provider but not turnstile.
+		$this->assertStringNotContainsString( 'o-form-captcha-warning', $block->render( array( 'provider' => 'recaptcha' ) ) );
+		$this->assertStringContainsString( 'o-form-captcha-warning', $block->render( array( 'provider' => 'turnstile' ) ) );
+
+		update_option( 'themeisle_cloudflare_turnstile_site_key', 'site' );
+		update_option( 'themeisle_cloudflare_turnstile_secret_key', 'secret' );
+
+		$this->assertStringNotContainsString( 'o-form-captcha-warning', $block->render( array( 'provider' => 'turnstile' ) ) );
+	}
+}

--- a/tests/test-form-submissions.php
+++ b/tests/test-form-submissions.php
@@ -9,6 +9,7 @@ use ThemeIsle\GutenbergBlocks\Integration\Form_Data_Request;
 use ThemeIsle\GutenbergBlocks\Integration\Form_Data_Response;
 use ThemeIsle\GutenbergBlocks\Integration\Form_Settings_Data;
 use ThemeIsle\GutenbergBlocks\Plugins\Form_Records_Export;
+use ThemeIsle\GutenbergBlocks\Plugins\Form_Records_Filters;
 use ThemeIsle\GutenbergBlocks\Plugins\Form_Records_Post_Type;
 use ThemeIsle\GutenbergBlocks\Plugins\Form_Submissions;
 use ThemeIsle\GutenbergBlocks\Tests\StripeHttpClientMock;
@@ -57,6 +58,8 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		unset( $_REQUEST[ Form_Submissions::FORM_RECORD_TYPE ], $_REQUEST['_wpnonce'], $_REQUEST['post'] );
+		unset( $_POST['action'], $_POST['_wpnonce'], $_POST['_nonce'] );
+		unset( $_GET['post_type'], $_GET['filter_action'], $_GET['filters_nonce'], $_GET['otter_form_filter'], $_REQUEST['otter_form_filter'] );
 		unset( $GLOBALS['otter_test_stripe_record_id'] );
 		unset( $GLOBALS['otter_legacy_store_called'] );
 
@@ -608,5 +611,209 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'Failed', $output );
+	}
+
+	/**
+	 * Ensure record deletion never deletes files outside the uploads directory,
+	 * even when the stored path uses traversal to point there.
+	 */
+	public function test_permanent_delete_never_touches_files_outside_uploads() {
+		$uploads      = wp_upload_dir();
+		$outside_path = dirname( $uploads['basedir'] ) . '/otter-outside-uploads.txt';
+		file_put_contents( $outside_path, 'must survive' );
+
+		wp_mkdir_p( $uploads['basedir'] . '/otter-tests' );
+		$traversal = $uploads['basedir'] . '/otter-tests/../../' . basename( $outside_path );
+		$record_id = $this->create_record( 'unread', $this->get_file_record_meta( $traversal ) );
+
+		try {
+			wp_delete_post( $record_id, true );
+			$this->assertFileExists( $outside_path );
+		} finally {
+			@unlink( $outside_path );
+		}
+	}
+
+	/**
+	 * Ensure the record edit-screen save handler dies on an invalid nonce.
+	 */
+	public function test_meta_box_save_rejects_invalid_nonce() {
+		wp_set_current_user( $this->admin_id );
+		$record_id = $this->create_record();
+
+		$_POST['action']   = 'editpost';
+		$_POST['_wpnonce'] = 'invalid-nonce';
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'Nonce not verified.' );
+
+		do_action( 'save_post', $record_id, get_post( $record_id ) );
+	}
+
+	/**
+	 * Ensure a valid nonce is not enough: the user must be able to edit the record.
+	 */
+	public function test_meta_box_save_requires_edit_capability() {
+		wp_set_current_user( $this->editor_id );
+		$record_id = $this->create_record();
+
+		$_POST['action']   = 'editpost';
+		$_POST['_wpnonce'] = wp_create_nonce( 'update-post_' . $record_id );
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'User cannot edit this post.' );
+
+		do_action( 'save_post', $record_id, get_post( $record_id ) );
+	}
+
+	/**
+	 * Ensure backslashes in an edited field value survive the save round-trip
+	 * (the handler wp_slash()es the meta because update_post_meta unslashes it).
+	 */
+	public function test_meta_box_save_preserves_backslashes() {
+		wp_set_current_user( $this->admin_id );
+
+		$record_id = $this->create_record(
+			'unread',
+			array(
+				'inputs' => array(
+					'slash123' => array(
+						'label'    => 'Path',
+						'value'    => 'old',
+						'type'     => 'text',
+						'metadata' => array(),
+					),
+				),
+			)
+		);
+
+		$value = 'C:\Users\test\file.txt';
+
+		$_POST['action']              = 'editpost';
+		$_POST['_wpnonce']            = wp_create_nonce( 'update-post_' . $record_id );
+		$_POST['otter_meta_slash123'] = wp_slash( $value );
+
+		do_action( 'save_post', $record_id, get_post( $record_id ) );
+
+		$meta = get_post_meta( $record_id, Form_Submissions::FORM_RECORD_META_KEY, true );
+
+		unset( $_POST['otter_meta_slash123'] );
+
+		$this->assertSame( $value, $meta['inputs']['slash123']['value'] );
+	}
+
+	/**
+	 * Ensure the list-table filter leaves the query untouched when Pro is not active,
+	 * even with otherwise valid filter parameters.
+	 */
+	public function test_filter_query_untouched_without_pro() {
+		$this->assertFalse( \ThemeIsle\GutenbergBlocks\Pro::is_pro_active() );
+
+		set_current_screen( 'edit-' . Form_Submissions::FORM_RECORD_TYPE );
+
+		global $pagenow;
+		$previous_pagenow = $pagenow;
+		$pagenow          = 'edit.php';
+
+		$_GET['post_type']             = Form_Submissions::FORM_RECORD_TYPE;
+		$_GET['filter_action']         = 'Filter';
+		$_GET['filters_nonce']         = wp_create_nonce( 'filter' );
+		$_GET['otter_form_filter']     = 'guard-form';
+		$_REQUEST['otter_form_filter'] = 'guard-form';
+
+		$query        = new WP_Query();
+		$query->query = array( 'post_type' => Form_Submissions::FORM_RECORD_TYPE );
+
+		// Called directly: `parse_query` is fired as an action by core, so other
+		// void-returning callbacks would break an apply_filters() chain.
+		$result = ( new Form_Records_Filters() )->form_record_filter_query( $query );
+
+		$pagenow = $previous_pagenow;
+
+		$this->assertArrayNotHasKey( 'meta_query', $result->query_vars );
+	}
+
+	/**
+	 * Ensure the list-table filter leaves the query untouched when the nonce is invalid,
+	 * even with Pro active.
+	 */
+	public function test_filter_query_untouched_with_invalid_nonce() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		$license = function () {
+			return 'valid';
+		};
+		add_filter( 'product_otter_license_status', $license );
+
+		set_current_screen( 'edit-' . Form_Submissions::FORM_RECORD_TYPE );
+
+		global $pagenow;
+		$previous_pagenow = $pagenow;
+		$pagenow          = 'edit.php';
+
+		$_GET['post_type']             = Form_Submissions::FORM_RECORD_TYPE;
+		$_GET['filter_action']         = 'Filter';
+		$_GET['filters_nonce']         = 'invalid-nonce';
+		$_GET['otter_form_filter']     = 'guard-form';
+		$_REQUEST['otter_form_filter'] = 'guard-form';
+
+		$query        = new WP_Query();
+		$query->query = array( 'post_type' => Form_Submissions::FORM_RECORD_TYPE );
+
+		$result = ( new Form_Records_Filters() )->form_record_filter_query( $query );
+
+		remove_filter( 'product_otter_license_status', $license );
+		$pagenow = $previous_pagenow;
+
+		$this->assertArrayNotHasKey( 'meta_query', $result->query_vars );
+	}
+
+	/**
+	 * Ensure bulk export dies on an invalid nonce even with Pro active and an admin user.
+	 */
+	public function test_export_rejects_invalid_nonce() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		add_filter( 'product_otter_license_status', array( $this, 'valid_license' ) );
+
+		wp_set_current_user( $this->admin_id );
+		$_POST['_nonce'] = 'invalid-nonce';
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'Invalid nonce.' );
+
+		( new Form_Records_Export() )->export_submissions();
+	}
+
+	/**
+	 * Ensure bulk export requires manage_options, even with Pro active and a valid nonce.
+	 */
+	public function test_export_requires_manage_options() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		add_filter( 'product_otter_license_status', array( $this, 'valid_license' ) );
+
+		wp_set_current_user( $this->editor_id );
+		$_POST['_nonce'] = wp_create_nonce( 'otter_form_export_submissions' );
+
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'You are not allowed to export submissions.' );
+
+		( new Form_Records_Export() )->export_submissions();
+	}
+
+	/**
+	 * License filter callback (a method so tear_down survives wp_die tests; WP resets filters between tests).
+	 *
+	 * @return string
+	 */
+	public function valid_license() {
+		return 'valid';
 	}
 }

--- a/tests/test-form-submissions.php
+++ b/tests/test-form-submissions.php
@@ -809,6 +809,77 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the list-table bulk actions match the current status view.
+	 */
+	public function test_list_table_bulk_actions_follow_status_view() {
+		$hook = 'bulk_actions-edit-' . Form_Submissions::FORM_RECORD_TYPE;
+
+		$this->assertSame( array( 'trash', 'unread', 'read' ), array_keys( apply_filters( $hook, array() ) ) );
+
+		$_GET['post_status'] = 'unread';
+		$this->assertSame( array( 'trash', 'read' ), array_keys( apply_filters( $hook, array() ) ) );
+
+		$_GET['post_status'] = 'read';
+		$this->assertSame( array( 'trash', 'unread' ), array_keys( apply_filters( $hook, array() ) ) );
+
+		$_GET['post_status'] = 'trash';
+		$this->assertSame( array( 'untrash', 'delete' ), array_keys( apply_filters( $hook, array() ) ) );
+
+		unset( $_GET['post_status'] );
+	}
+
+	/**
+	 * Ensure the row actions swap read/unread based on the record status and
+	 * carry the nonce the row-action handler verifies.
+	 */
+	public function test_list_table_row_actions_follow_record_status() {
+		$defaults = array(
+			'edit'                => 'Edit',
+			'inline hide-if-no-js' => 'Quick Edit',
+		);
+
+		// Non-record posts keep their actions untouched.
+		$post_id = self::factory()->post->create();
+		$this->assertSame( $defaults, apply_filters( 'post_row_actions', $defaults, get_post( $post_id ) ) );
+
+		$unread  = $this->create_record( 'unread' );
+		$actions = apply_filters( 'post_row_actions', $defaults, get_post( $unread ) );
+
+		$this->assertArrayNotHasKey( 'edit', $actions );
+		$this->assertArrayNotHasKey( 'inline hide-if-no-js', $actions );
+		$this->assertArrayHasKey( 'view', $actions );
+		$this->assertArrayHasKey( 'read', $actions );
+		$this->assertArrayNotHasKey( 'unread', $actions );
+		$this->assertStringContainsString(
+			wp_create_nonce( 'read-' . Form_Submissions::FORM_RECORD_TYPE . '_' . $unread ),
+			$actions['read']
+		);
+
+		$read    = $this->create_record( 'read' );
+		$actions = apply_filters( 'post_row_actions', $defaults, get_post( $read ) );
+
+		$this->assertArrayHasKey( 'unread', $actions );
+		$this->assertArrayNotHasKey( 'read', $actions );
+	}
+
+	/**
+	 * Ensure the form column links to the source page anchor when Pro is not active.
+	 */
+	public function test_list_table_form_column_links_to_post_anchor_without_pro() {
+		$this->assertFalse( \ThemeIsle\GutenbergBlocks\Pro::is_pro_active() );
+
+		$record_id = $this->create_record();
+
+		ob_start();
+		do_action( 'manage_' . Form_Submissions::FORM_RECORD_TYPE . '_posts_custom_column', 'form', $record_id );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'https://example.com/cap#cap-form', $output );
+		// Unread rows render bold.
+		$this->assertStringContainsString( '<strong>', $output );
+	}
+
+	/**
 	 * License filter callback (a method so tear_down survives wp_die tests; WP resets filters between tests).
 	 *
 	 * @return string

--- a/tests/test-plugin-card-block.php
+++ b/tests/test-plugin-card-block.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Class Test_Plugin_Card_Block
+ *
+ * @package gutenberg-blocks
+ */
+
+use ThemeIsle\GutenbergBlocks\Render\Plugin_Card_Block;
+
+/**
+ * Plugin Card block tests: the plugins_api transient cache.
+ */
+class Test_Plugin_Card_Block extends WP_UnitTestCase {
+
+	/**
+	 * Number of plugins_api calls observed.
+	 *
+	 * @var int
+	 */
+	private $api_calls = 0;
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tear_down() {
+		delete_transient( 'otter_plugin_card_otter-blocks' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Short-circuit plugins_api with a stub result and count the calls.
+	 *
+	 * @return object
+	 */
+	public function stub_plugins_api() {
+		$this->api_calls++;
+
+		return (object) array(
+			'name' => 'Otter Blocks',
+			'slug' => 'otter-blocks',
+		);
+	}
+
+	/**
+	 * Expose the protected search() method.
+	 *
+	 * @return Plugin_Card_Block
+	 */
+	private function get_block() {
+		return new class() extends Plugin_Card_Block {
+			public function search_public( $slug ) {
+				return $this->search( $slug );
+			}
+		};
+	}
+
+	/**
+	 * Ensure a second lookup for the same slug is served from the transient
+	 * without a second plugins_api call.
+	 */
+	public function test_search_caches_plugins_api_result() {
+		add_filter( 'plugins_api', array( $this, 'stub_plugins_api' ) );
+
+		$block = $this->get_block();
+
+		$first = $block->search_public( 'otter-blocks' );
+
+		$this->assertSame( 1, $this->api_calls );
+		$this->assertTrue( $first['success'] );
+		$this->assertSame( 'Otter Blocks', $first['data']->name );
+		$this->assertNotFalse( get_transient( 'otter_plugin_card_otter-blocks' ) );
+
+		$second = $block->search_public( 'otter-blocks' );
+
+		$this->assertSame( 1, $this->api_calls, 'The cached result must be used instead of a second plugins_api call.' );
+		$this->assertSame( 'Otter Blocks', $second['data']->name );
+	}
+
+	/**
+	 * Ensure a failed lookup is not cached, so a later retry can succeed.
+	 */
+	public function test_search_does_not_cache_errors() {
+		add_filter(
+			'plugins_api',
+			function () {
+				$this->api_calls++;
+				return new WP_Error( 'plugins_api_failed', 'down' );
+			}
+		);
+
+		$block  = $this->get_block();
+		$result = $block->search_public( 'otter-blocks' );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertFalse( get_transient( 'otter_plugin_card_otter-blocks' ) );
+	}
+}

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Class Test_Registration
+ *
+ * @package gutenberg-blocks
+ */
+
+use ThemeIsle\GutenbergBlocks\Registration;
+
+/**
+ * Editor localization tests: the global defaults handed to the editor must
+ * always be an object, or every block's Edit component crashes on null.
+ */
+class Test_Registration extends WP_UnitTestCase {
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tear_down() {
+		delete_option( 'themeisle_blocks_settings_global_defaults' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Ensure an option stored as an empty string localizes as an object, not null.
+	 */
+	public function test_editor_global_defaults_is_object_when_option_is_empty_string() {
+		update_option( 'themeisle_blocks_settings_global_defaults', '' );
+
+		$this->assertEquals( new stdClass(), Registration::get_editor_global_defaults() );
+	}
+
+	/**
+	 * Ensure corrupt JSON localizes as an object, not null.
+	 */
+	public function test_editor_global_defaults_is_object_when_option_is_corrupt() {
+		update_option( 'themeisle_blocks_settings_global_defaults', '{"themeisle-blocks/button-group":' );
+		$this->assertEquals( new stdClass(), Registration::get_editor_global_defaults() );
+
+		update_option( 'themeisle_blocks_settings_global_defaults', 'null' );
+		$this->assertEquals( new stdClass(), Registration::get_editor_global_defaults() );
+	}
+
+	/**
+	 * Ensure valid stored defaults still come through decoded.
+	 */
+	public function test_editor_global_defaults_decodes_valid_json() {
+		update_option( 'themeisle_blocks_settings_global_defaults', '{"themeisle-blocks/button-group":{"fontSize":"20px"}}' );
+
+		$defaults = Registration::get_editor_global_defaults();
+
+		$this->assertSame( '20px', $defaults->{'themeisle-blocks/button-group'}->fontSize );
+	}
+
+	/**
+	 * Ensure a missing option localizes as an object.
+	 */
+	public function test_editor_global_defaults_is_object_when_option_is_missing() {
+		delete_option( 'themeisle_blocks_settings_global_defaults' );
+
+		$this->assertEquals( new stdClass(), Registration::get_editor_global_defaults() );
+	}
+}

--- a/webpack.config.pro.js
+++ b/webpack.config.pro.js
@@ -66,7 +66,12 @@ module.exports = [
 		output: {
 			path: path.resolve( __dirname, './build/pro' ),
 			filename: '[name].js',
-			chunkFilename: 'chunk-[name].js'
+			chunkFilename: 'chunk-[name].js',
+
+			// Isolate the chunk-loading global from the free build: both default to
+			// webpackChunkotter_blocks, and colliding runtimes resolve each other's
+			// numeric module IDs, crashing the editor when free + pro load together.
+			uniqueName: 'otterProBlocks'
 		},
 		module: {
 			rules: [


### PR DESCRIPTION
## Summary

Follow-up to a coverage-gap analysis of the upcoming release (`development` vs `master`). Adds the missing tests around the new Form Records admin classes, the AI usage tracker, the form Reply-To feature (#2858), the reworked visibility conditions UI (#2857), the Form Records list table, the captcha block render, the Plugin Card cache, Atomic Wind List View labels, the Live Search 'cat' regression and the Button Group global-defaults fix.

### PHPUnit
- **Form Records admin gates** (`tests/test-form-submissions.php`): path-traversal safety on record file deletion, nonce + capability `wp_die` gates on the meta-box save handler, backslash round-trip through the `wp_slash` fix, list-table filter query untouched without Pro / with an invalid nonce, and export nonce + `manage_options` gates (Pro-gated tests skip where Pro isn't installed).
- **Form Records list table** (`tests/test-form-submissions.php`): bulk actions per status view, read/unread row-action swap with the verified nonce, no-Pro form column URL.
- **AI Usage tracker** (`tests/test-ai-usage.php`, new): counter create/increment, the 50-distinct-action cap, the last-10-prompts FIFO trim, empty-action no-op, legacy non-numeric count coercion.
- **Form Captcha block** (`tests/test-form-captcha-block.php`, new): provider fallback, warning gated on `edit_posts`, provider-specific key checks.
- **Plugin Card block** (`tests/test-plugin-card-block.php`, new): the 12h `plugins_api` transient cache; errors are not cached.

### E2E
- **Form Reply-To** (`form-retention.spec.js`): default `Reply-To` header is the submitter's email; the *Reply-To Email* inspector option overrides it. The e2e mail mock now logs `wp_mail` headers.
- **Visibility conditions rule builder** (`block-conditions.spec.js`): rule groups, searchable condition picker, AND/OR separators, removal, and frontend show/hide.
- **Atomic Wind List View labels** (`atomic-wind-list-view.spec.js`, new, serial): semantic tag labels, content labels, custom Rename-UI name wins.
- **Live Search** (`live-search.spec.js`): post-only query without a category renders with no PHP warnings or console errors (regression for the undefined `cat` key).
- **Button Group global defaults** (`button-group.spec.js`): Appearance/Letter Case save to `fontStyle`/`textTransform` (regression for the wrong-key mapping), and a freshly inserted Button Group inherits them down to the frontend CSS.

### Dev environment
- `bin/e2e-tests.sh` sets pretty permalinks on wp-env start, and `global-setup.ts` self-heals them — the PHPUnit suite reinstalls WordPress over the shared wp-env site and drops the permalink structure, breaking REST discovery at `/wp-json/`.

### Bug found and fixed
If `themeisle_blocks_settings_global_defaults` ever holds an empty string, `class-registration.php` localizes `json_decode('') === null` and `addGlobalDefaults` in `block-utility.js` throws on `null[name]`, crashing every Otter block's Edit component. Fixed in this PR (TDD): the editor localization now always hands out an object, addGlobalDefaults reads the per-block entry with optional chaining, and both sides are covered by unit tests (tests/test-registration.php, block-utility-lightweight.test.ts). Verified end-to-end by recreating the poison state and inserting a Button Group, plus a dedicated e2e regression test in `button-group.spec.js`.

### Second bug found and fixed: colliding webpack runtimes
Fresh production builds crashed the whole editor (`Cannot read properties of undefined (reading 'call')` in `vendor.js`): the free and pro compilations both defaulted to the `webpackChunkotter_blocks` chunk-loading global, so their runtimes resolved each other's numeric module IDs. Whether it manifests depends on how module IDs land per build, which made it look intermittent. Fixed with `output.uniqueName` in `webpack.config.pro.js`, and `global-setup.ts` now fails fast if the two bundles ever share a runtime global again.

## Testing
- PHPUnit: full suite green locally (only pre-existing Pro/license skips).
- Playwright: all touched specs green — `block-conditions`, `form-retention`, `atomic-wind-list-view`, `live-search`, `button-group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

