### PR TITLE
fix: translation label issues found via make-pot audit

### DIFF
--- a/src/blocks/blocks/button-group/button/inspector.js
+++ b/src/blocks/blocks/button-group/button/inspector.js
@@ -513,9 +513,9 @@ const Inspector = ({
 
 											</AutoDisableSyncAttr>
 
-											<AutoDisableSyncAttr attr='boxShadowVertical' attributes={attributes}>
+											<AutoDisableSyncAttr attr='hoverBoxShadowSpread' attributes={attributes}>
 												<RangeControl
-													label={ __( 'hoverBoxShadowSpread', 'otter-blocks' ) }
+													label={ __( 'Spread', 'otter-blocks' ) }
 													value={ attributes.hoverBoxShadowSpread }
 													onChange={ e => setAttributes({ hoverBoxShadowSpread: e }) }
 													min={ -100 }

--- a/src/blocks/blocks/slider/inspector.js
+++ b/src/blocks/blocks/slider/inspector.js
@@ -169,9 +169,12 @@ const Inspector = ({
 								/>
 
 								<AltTextControl
+									label={ sprintf(
 
-									// translators: %d: the position of the image in the slider.
-									label={ sprintf( __( 'Image %d alt text (alternative text)', 'otter-blocks' ), index + 1 ) }
+										/* translators: %d: the position of the image in the slider. */
+										__( 'Image %d alt text (alternative text)', 'otter-blocks' ),
+										index + 1
+									) }
 									value={ image.alt }
 									onChange={ alt => setAttributes({
 										images: attributes.images.map( ( img, i ) => index === i ? { ...img, alt } : img )

--- a/src/blocks/plugins/conditions/utils.js
+++ b/src/blocks/plugins/conditions/utils.js
@@ -198,9 +198,13 @@ export const getConditionSummary = condition => {
 		} else if ( 1 === params.length ) {
 			summary = params[0];
 		} else {
+			summary = sprintf(
 
-			/* translators: %1$s: the first URL parameter, %2$d: the number of remaining parameters */
-			summary = sprintf( __( '%1$s + %2$d more', 'otter-blocks' ), params[0], params.length - 1 );
+				/* translators: %1$s: the first URL parameter, %2$d: the number of remaining parameters */
+				__( '%1$s + %2$d more', 'otter-blocks' ),
+				params[0],
+				params.length - 1
+			);
 		}
 		break;
 	}


### PR DESCRIPTION
## Summary

Audited the generated `.pot` files (`wp i18n make-pot`) for both `otter-blocks` and `otter-pro` domains and fixed the issues found:

- **Translator comments dropped by minification**: the `translators:` comments for `%1$s + %2$d more` (visibility conditions) and `Image %d alt text (alternative text)` (slider) existed in source but terser dropped them when merging the surrounding statements into ternary chains, so `make-pot` warned about placeholder strings with no comment. Moving the comments inside the `sprintf()` call, directly above the `__()` argument, makes them survive into the production bundle.
- **Leaked attribute name as UI label**: the hover box-shadow *Spread* control in the Button block showed the raw attribute name `hoverBoxShadowSpread` as its label (and sent it to translators). It also wrapped the control in `AutoDisableSyncAttr` with the wrong attribute (`boxShadowVertical`). Both now match the non-hover section.

## Verification

- Rebuilt production bundles and re-ran `wp i18n make-pot` for both domains: zero warnings, both strings now carry their `#. translators:` comment in the pot, `hoverBoxShadowSpread` no longer appears as a msgid.
- `msgfmt --check` passes on both generated pots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)