### PR TITLE
test: e2e coverage for error rendering on Submission Records

### DIFF
--- a/packages/e2e-tests/mu-plugins/otter-e2e-bootstrap.php
+++ b/packages/e2e-tests/mu-plugins/otter-e2e-bootstrap.php
@@ -48,6 +48,9 @@ const OPTION_WHITELIST = array(
 	'themeisle_blocks_form_fields_option',
 	'themeisle_blocks_settings_patterns_library',
 	'themeisle_blocks_settings_atomic_wind_blocks',
+	// Form webhooks registry; retention specs seed a dead-URL webhook to force
+	// a delivery failure with the 'webhook' action.
+	'themeisle_webhooks_options',
 	'otter_blocks_logger_flag',
 	'otter_blocks_logger_data',
 	'otter_activation_first_save',

--- a/src/blocks/test/e2e/blocks/form-retention.spec.js
+++ b/src/blocks/test/e2e/blocks/form-retention.spec.js
@@ -472,6 +472,37 @@ test.describe( 'Form submission retention', () => {
 		await expect( errorsBox.locator( 'tbody tr' ).first().locator( 'code' ) ).toHaveText( '210' );
 	});
 
+	test( 'form filter is a locked upsell on free and filters records with Pro', async({ page, otterUtils, requestUtils }) => {
+		const formOption = `e2e-filters-${Date.now()}`;
+		const formA = 'wp-block-themeisle-blocks-form-filter-a';
+		const formB = 'wp-block-themeisle-blocks-form-filter-b';
+
+		await otterUtils.upsertFormOption({ form: formOption });
+
+		const nonceValue = await otterUtils.getFormVerificationNonce();
+		await submitFormViaApi( requestUtils, { nonceValue, formOption, formId: formA });
+		await submitFormViaApi( requestUtils, { nonceValue, formOption, formId: formB });
+
+		const records = await otterUtils.getFormRecords();
+		const recordA = records.find( record => record.form === formA );
+		const recordB = records.find( record => record.form === formB );
+
+		// Free: the filters render as disabled selects with the Pro upsell.
+		await page.goto( '/wp-admin/edit.php?post_type=otter_form_record' );
+
+		await expect( page.locator( '.o-filters-locked select' ).first() ).toBeDisabled();
+
+		// Pro: the form dropdown filters the list down to the selected form's records.
+		await otterUtils.activatePro();
+		await page.reload();
+
+		await page.locator( '#filter-by-form' ).selectOption( formA );
+		await page.locator( '#post-query-submit' ).click();
+
+		await expect( page.locator( `#post-${recordA.id}` ) ).toBeVisible();
+		await expect( page.locator( `#post-${recordB.id}` ) ).toBeHidden();
+	});
+
 	test( 'required multiple-choice field stores its label without the asterisk', async({ editor, page, otterUtils }) => {
 		// Regression for the required-field asterisk leaking into the stored/emailed label.
 		// The required sign must render in its own span so the frontend extracts only the

--- a/src/blocks/test/e2e/blocks/form-retention.spec.js
+++ b/src/blocks/test/e2e/blocks/form-retention.spec.js
@@ -82,6 +82,7 @@ test.describe( 'Form submission retention', () => {
 	test.afterEach( async({ otterUtils }) => {
 		await otterUtils.setCaptchaMode( 'off' );
 		await otterUtils.setMailMode( 'ok' );
+		await otterUtils.deactivatePro();
 	});
 
 	test( 'successful submission stores a Record with Complete delivery', async({ editor, page, otterUtils }) => {
@@ -420,6 +421,55 @@ test.describe( 'Form submission retention', () => {
 
 		await expect( page.locator( '#submitpost .metadata' ) ).toContainText( 'Complete' );
 		await expect( page.locator( '#form_record_errors_meta_box' ) ).toBeHidden();
+	});
+
+	test( 'failed webhook marks delivery Failed while the visitor still sees success', async({ page, otterUtils, requestUtils }) => {
+		const formOption = `e2e-webhook-${Date.now()}`;
+		const formId = 'wp-block-themeisle-blocks-form-webhook0';
+
+		// Webhooks are a Pro delivery action; point one at a dead port.
+		await otterUtils.activatePro();
+		await otterUtils.setOptions({
+			themeisle_webhooks_options: [
+				{
+					id: 'e2e-dead-webhook',
+					name: 'E2E dead webhook',
+					url: 'http://127.0.0.1:9/otter-e2e',
+					method: 'POST',
+					headers: []
+				}
+			]
+		});
+		await otterUtils.upsertFormOption({ form: formOption, webhookId: 'e2e-dead-webhook' });
+
+		const response = await submitFormViaApi( requestUtils, {
+			nonceValue: await otterUtils.getFormVerificationNonce(),
+			formOption,
+			formId
+		});
+
+		// The webhook failure is only a warning: the visitor gets a success response.
+		expect( response.success ).toBe( true );
+
+		// ...but the Record is marked failed for the webhook action.
+		const records = ( await otterUtils.getFormRecords() ).filter( record => record.form === formId );
+
+		expect( records ).toHaveLength( 1 );
+		expect( records[0].delivery_status ).toBe( 'failed' );
+		expect( records[0].delivery_errors[0].action ).toBe( 'webhook' );
+
+		const [{ id: recordId }] = records;
+
+		// The record detail page renders the webhook failure in both meta boxes.
+		// The message is the raw transport error, so assert action and code only.
+		await page.goto( `/wp-admin/post.php?post=${recordId}&action=edit` );
+
+		await expect( page.locator( '#submitpost .metadata' ) ).toContainText( 'Failed' );
+		await expect( page.locator( '#submitpost .metadata li' ).first() ).toContainText( 'webhook' );
+
+		const errorsBox = page.locator( '#form_record_errors_meta_box' );
+		await expect( errorsBox ).toBeVisible();
+		await expect( errorsBox.locator( 'tbody tr' ).first().locator( 'code' ) ).toHaveText( '210' );
 	});
 
 	test( 'required multiple-choice field stores its label without the asterisk', async({ editor, page, otterUtils }) => {

--- a/src/blocks/test/e2e/blocks/form-retention.spec.js
+++ b/src/blocks/test/e2e/blocks/form-retention.spec.js
@@ -395,6 +395,31 @@ test.describe( 'Form submission retention', () => {
 		await expect( page.locator( '#submitpost .metadata' ) ).toContainText( 'Delivery' );
 		await expect( page.locator( '#submitpost .metadata' ) ).toContainText( 'Failed' );
 		await expect( page.locator( '#submitpost .metadata li' ).first() ).toContainText( 'email' );
+		await expect( page.locator( '#submitpost .metadata li' ).first() ).toContainText( 'Email could not be sent' );
+
+		// The Errors meta box lists each recorded issue with its code and message.
+		const errorsBox = page.locator( '#form_record_errors_meta_box' );
+		await expect( errorsBox ).toBeVisible();
+		await expect( errorsBox.locator( 'tbody tr' ).first().locator( 'code' ) ).toHaveText( '106' );
+		await expect( errorsBox.locator( 'tbody tr' ).first() ).toContainText( 'Email could not be sent' );
+
+		// A clean record renders Complete delivery and no Errors meta box at all.
+		await otterUtils.setMailMode( 'ok' );
+
+		await submitFormViaApi( requestUtils, {
+			nonceValue: await otterUtils.getFormVerificationNonce(),
+			formOption,
+			formId
+		});
+
+		const cleanRecord = ( await otterUtils.getFormRecords() )
+			.filter( record => record.form === formId )
+			.find( record => record.id !== recordId );
+
+		await page.goto( `/wp-admin/post.php?post=${cleanRecord.id}&action=edit` );
+
+		await expect( page.locator( '#submitpost .metadata' ) ).toContainText( 'Complete' );
+		await expect( page.locator( '#form_record_errors_meta_box' ) ).toBeHidden();
 	});
 
 	test( 'required multiple-choice field stores its label without the asterisk', async({ editor, page, otterUtils }) => {


### PR DESCRIPTION
## Summary

Expands the form-retention e2e suite around how delivery errors surface on Submission Records:

- **Expanded** `failed submissions surface their Delivery Status in the Submissions dashboard`: now asserts the human-readable error message in the Update box, the Errors meta box table (code + message), and that a clean record renders Complete delivery with **no** Errors meta box.
- **New** webhook coverage: a dead-URL webhook (Pro) is warning-only — the visitor still sees success, but the Record is stored delivery-failed with the `webhook` action and code `210` rendered in both record meta boxes. Whitelists `themeisle_webhooks_options` in the e2e bootstrap so specs can seed the webhook registry.
- **New** Submissions filter coverage: the form/post filters render as a disabled upsell on free; with the Pro license stub the form dropdown narrows the list table to the selected form's records.
- `afterEach` now deactivates the Pro license stub so it can't leak between tests/specs.

## Notes

- `legacy save-location value maps to the toggle and is rewritten on save` fails in full-suite runs (editor ErrorBoundary crash) but passes solo — reproduced on a clean tree without this diff, so it's a pre-existing order-dependent flake, not introduced here.

## Test plan

- `npm run test:e2e:playwright -- form-retention` — 11/12 passing (see flake note above); all three new/changed tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)