### PR TITLE
Fix: popup Inside close button unclickable under positioned content

### DIFF
--- a/src/blocks/blocks/popup/style.scss
+++ b/src/blocks/blocks/popup/style.scss
@@ -122,6 +122,9 @@ $base-index: 99999 !default;
 		position: absolute;
 		right: var( --padding );
 
+		// Keep the close button above positioned popup content, e.g. Section columns.
+		z-index: 2;
+
 		@media (max-width: 600px) {
 			padding-bottom: 0px;
 		}
@@ -135,7 +138,6 @@ $base-index: 99999 !default;
 			padding: 0 !important;
 			border: none;
 			cursor: pointer;
-			z-index: 2;
 
 			&:hover {
 				opacity: .75;

--- a/src/blocks/test/e2e/blocks/popup.spec.js
+++ b/src/blocks/test/e2e/blocks/popup.spec.js
@@ -115,4 +115,60 @@ test.describe( 'Popup', () => {
 		await page.keyboard.press( 'Enter' );
 		await expect( page.getByText( 'Popup Content Test' ) ).toBeHidden();
 	});
+
+	test( 'inside close button receives clicks when content has positioned columns', async({ editor, page }) => {
+
+		// Section columns are position:relative on desktop; without a z-index on
+		// the header they paint over the close button and swallow its clicks.
+		// See https://github.com/Codeinwp/otter-blocks/issues/2863
+		await page.setViewportSize({ width: 1280, height: 800 });
+
+		await editor.insertBlock({
+			name: 'themeisle-blocks/popup',
+			attributes: {},
+			innerBlocks: [
+				{
+					name: 'themeisle-blocks/advanced-columns',
+					attributes: {
+						columns: 2,
+						layout: 'equal'
+					},
+					innerBlocks: [
+						{
+							name: 'themeisle-blocks/advanced-column',
+							innerBlocks: [
+								{
+									name: 'core/paragraph',
+									attributes: {
+										content: 'Popup Content Test'
+									}
+								}
+							]
+						},
+						{
+							name: 'themeisle-blocks/advanced-column',
+							innerBlocks: [
+								{
+									name: 'core/paragraph',
+									attributes: {
+										content: 'Second Column'
+									}
+								}
+							]
+						}
+					]
+				}
+			]
+		});
+
+		await publishAndViewPost({ editor, page });
+
+		await expect( page.getByText( 'Popup Content Test' ) ).toBeVisible();
+
+		// Playwright refuses to click covered elements, so this fails if the
+		// columns overlay the button.
+		await page.getByRole( 'button', { name: 'Close' }).click();
+
+		await expect( page.getByText( 'Popup Content Test' ) ).toBeHidden();
+	});
 });


### PR DESCRIPTION
Closes #2863

## Summary

The `Inside` close button's header wrapper (`.otter-popup__modal_header`) is `position: absolute` with no z-index, so positioned popup content — e.g. Section columns, which are `position: relative` on desktop — paints over it and swallows clicks. The existing `z-index: 2` on the inner button was inert (the button is `position: static`), so it was moved to the wrapper where it takes effect. The rule is shared with the Modal block, so this fixes both.

The `Outside` variant is unaffected (its button keeps its own `position: absolute; z-index: 9`).

## Test

Added an e2e regression test that opens a popup containing Section columns at desktop width and clicks Close — Playwright's actionability check fails it when the button is covered. Verified red without the fix, green with it; full popup suite passes.

Note: `modal.spec.js` currently fails on `development` (modal doesn't open on its trigger) — pre-existing, reproduced with this fix stripped, unrelated to this change.

