### PR TITLE
Fix: nested animated block stays hidden until scroll inside a transform-animated parent

### DIFF
--- a/src/animation/frontend.js
+++ b/src/animation/frontend.js
@@ -160,7 +160,7 @@ const speed = [ 'none', 'slow', 'slower', 'fast', 'faster' ];
 const elementsScroll = [];
 let scrollListenerAttached = false;
 
-const processElement = ( element ) => {
+const processElement = ( element, visible = isElementInViewport( element ) ) => {
 	// Skip if already processed
 	if ( element.classList.contains( 'o-anim-ready' ) ) {
 		return;
@@ -169,7 +169,7 @@ const processElement = ( element ) => {
 	const classes = element.classList;
 	element.animationClasses = [];
 
-	if ( ! isElementInViewport( element ) ) {
+	if ( ! visible ) {
 		const animationClass = animations.find( ( i ) => {
 			return Array.from( classes ).find( ( o ) => o === i );
 		});
@@ -283,8 +283,14 @@ const animateElements = () => {
 
 	createCustomAnimationNode( elements );
 
+	// Measure every element before processing marks any of them o-anim-ready:
+	const inViewport = new Map();
 	for ( const element of elements ) {
-		processElement( element );
+		inViewport.set( element, isElementInViewport( element ) );
+	}
+
+	for ( const element of elements ) {
+		processElement( element, inViewport.get( element ) );
 	}
 
 	attachScrollListener();

--- a/src/blocks/test/e2e/blocks/animations.spec.js
+++ b/src/blocks/test/e2e/blocks/animations.spec.js
@@ -3,9 +3,44 @@
  */
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
+/**
+ * Internal dependencies
+ */
+import { publishAndViewPost } from '../helpers/editor';
+
 test.describe( 'Animations', () => {
 	test.beforeEach( async({ admin }) => {
 		await admin.createNewPost();
+	});
+
+	test( 'nested animated block plays on load inside a transform-animated parent', async({ editor, page }) => {
+		
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		await editor.insertBlock({
+			name: 'core/cover',
+			attributes: {
+				overlayColor: 'black',
+				dimRatio: 100,
+				minHeight: 800,
+				contentPosition: 'top center',
+				className: 'animated slideInDown'
+			},
+			innerBlocks: [
+				{
+					name: 'core/heading',
+					attributes: {
+						content: 'Nested Animated Heading',
+						className: 'animated fadeInLeft delay-1s'
+					}
+				}
+			]
+		});
+
+		await publishAndViewPost({ editor, page });
+
+		// Without any scrolling, the nested heading must animate in after its delay.
+		await expect( page.getByText( 'Nested Animated Heading' ) ).toBeVisible({ timeout: 10000 });
 	});
 
 	test( 'can add a typing animation"', async({ editor, page }) => {


### PR DESCRIPTION
Closes #2883

## Summary

On `window.load`, `animateElements()` measured each element's viewport position interleaved with processing. Processing marks an element `o-anim-ready`, which unblocks its CSS animation — and with `animation-fill-mode: both` the first keyframe transform (e.g. `slideInDown`'s `translateY(-100%)`) applies to computed style immediately. A nested child measured after its parent was therefore seen displaced by the parent's full height; if that pushed it outside the viewport, its animation classes were stripped and it was parked for scroll-triggered replay — invisible until the first scroll.

The fix measures all elements **before** processing any of them, so every element is classified at its natural position. `processElement()` takes the precomputed result via a defaulted parameter, leaving the lightbox path (`refreshLightboxAnimations`) unchanged. Reads are no longer interleaved with class writes, which also collapses N forced layouts into one.

This only reproduces when the parent is tall enough that its height displacement pushes the child fully above the viewport (roughly viewport-height covers — typical heroes), which is why it looked intermittent. The standalone Blocks Animation plugin builds from the same source and gets the fix too.

## How to test manually

1. Add a **Cover** block near the top of a page, give it an overlay color and a **min-height of ~800px** (height matters: short covers don't trigger the bug).
2. In the Cover's **Animations** panel, pick **Slide In Down**.
3. Inside the Cover, add a **Heading** positioned near the top of the cover, with animation **Fade In Left** (any delay, or none).
4. Publish and open the page on the frontend at a desktop viewport. Hard-refresh (Ctrl/Cmd+Shift+R) and **don't scroll** — keep hands off the mouse wheel; one scroll tick masks the bug.
5. **Before this fix:** the cover slides in but the heading never appears (it has `hidden-animated` and `visibility: hidden` in DevTools); scrolling even 1px makes it fade in.
6. **With this fix:** the heading animates in on load, no scrolling needed.
