### PR TITLE
Fix: Design Library inserts lock as patterns instead of editable blocks in WP 7.0

### DIFF
--- a/packages/e2e-tests/mu-plugins/otter-e2e-pattern-fixtures.php
+++ b/packages/e2e-tests/mu-plugins/otter-e2e-pattern-fixtures.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Plugin Name: Otter E2E Pattern Fixtures
+ * Description: Registers Design Library test patterns containing wp:pattern references (issue #2854).
+ */
+
+// Late priority: mu-plugins load before Otter, and the library's "Featured"
+// sort is registration order — registering late keeps the fixtures out of the
+// grid's first cards, which other tests insert blindly.
+add_action(
+	'init',
+	function () {
+		register_block_pattern(
+			'otter-e2e/referenced-inner',
+			array(
+				'title'   => 'E2E Referenced Inner Pattern',
+				'content' => '<!-- wp:paragraph --><p>E2E inner pattern content</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		// One registered reference, one unresolvable reference — a single insert
+		// exercises both paths of the Design Library's pattern expansion.
+		register_block_pattern(
+			'otter-e2e/pattern-reference-fixture',
+			array(
+				'title'      => 'E2E Pattern Reference Fixture',
+				'categories' => array( 'otter-blocks' ),
+				'content'    => '<!-- wp:heading --><h2>E2E reference fixture heading</h2><!-- /wp:heading --><!-- wp:pattern {"slug":"otter-e2e/referenced-inner"} /--><!-- wp:pattern {"slug":"otter-e2e/slug-that-is-not-registered"} /-->',
+			)
+		);
+	},
+	100
+);

--- a/packages/e2e-tests/mu-plugins/otter-e2e-pattern-fixtures.php
+++ b/packages/e2e-tests/mu-plugins/otter-e2e-pattern-fixtures.php
@@ -4,9 +4,8 @@
  * Description: Registers Design Library test patterns containing wp:pattern references (issue #2854).
  */
 
-// Late priority: mu-plugins load before Otter, and the library's "Featured"
-// sort is registration order — registering late keeps the fixtures out of the
-// grid's first cards, which other tests insert blindly.
+// Register after Otter's patterns: "Featured" sort is registration order and
+// other tests insert the grid's first card blindly.
 add_action(
 	'init',
 	function () {
@@ -18,8 +17,7 @@ add_action(
 			)
 		);
 
-		// One registered reference, one unresolvable reference — a single insert
-		// exercises both paths of the Design Library's pattern expansion.
+		// One registered and one unresolvable reference — one insert covers both paths.
 		register_block_pattern(
 			'otter-e2e/pattern-reference-fixture',
 			array(

--- a/src/blocks/plugins/patterns-library/library.js
+++ b/src/blocks/plugins/patterns-library/library.js
@@ -38,6 +38,28 @@ import {
 
 import { accentContent } from './accent';
 
+import { resolvePatternBlocks } from '../../../onboarding/utils.js';
+
+// WordPress 7.0 inlines nested wp:pattern references server-side and stamps
+// each inlined block with metadata.patternName, which its editor then locks
+// into content-only mode ("A block pattern" / "Edit pattern"). Library inserts
+// are unsynced copies, so shed the attribution; every other metadata key
+// (bindings, custom labels) is kept.
+const stripPatternAttribution = (blocks) =>
+	blocks.map((block) => {
+		const metadata = { ...(block.attributes?.metadata || {}) };
+		delete metadata.patternName;
+
+		return {
+			...block,
+			attributes: {
+				...block.attributes,
+				metadata: Object.keys(metadata).length ? metadata : undefined,
+			},
+			innerBlocks: stripPatternAttribution(block.innerBlocks || []),
+		};
+	});
+
 const CLOUD_EMPTY_CATEGORY = 'cloud-empty';
 
 // Section categories bucketed into meaningful sidebar groups. Mirrors the
@@ -574,8 +596,13 @@ const Library = ({ onClose }) => {
 			}
 
 			// With Pro active the upsell banner removes itself right after
-			// insertion anyway — skip it up front.
-			const blocks = parse(accentContent(pattern, accent)).filter(
+			// insertion anyway — skip it up front. Inline wp:pattern references
+			// while parsing: inserted literally they render as locked "Edit
+			// pattern" wrappers (or nothing, for unregistered slugs) instead of
+			// editable blocks.
+			const blocks = stripPatternAttribution(
+				resolvePatternBlocks(parse(accentContent(pattern, accent)), allPatterns),
+			).filter(
 				(block) =>
 					UPSELL_BLOCK !== block.name ||
           !Boolean(window.themeisleGutenberg?.hasPro),
@@ -660,7 +687,7 @@ const Library = ({ onClose }) => {
 
 			onClose();
 		},
-		[ clientID, accent ],
+		[ clientID, accent, allPatterns ],
 	);
 
 	const resetFilters = () => {

--- a/src/blocks/plugins/patterns-library/library.js
+++ b/src/blocks/plugins/patterns-library/library.js
@@ -40,11 +40,9 @@ import { accentContent } from './accent';
 
 import { resolvePatternBlocks } from '../../../onboarding/utils.js';
 
-// WordPress 7.0 inlines nested wp:pattern references server-side and stamps
-// each inlined block with metadata.patternName, which its editor then locks
-// into content-only mode ("A block pattern" / "Edit pattern"). Library inserts
-// are unsynced copies, so shed the attribution; every other metadata key
-// (bindings, custom labels) is kept.
+// WP 7.0 stamps blocks inlined from wp:pattern refs with metadata.patternName
+// and locks them into content-only mode. Inserts are unsynced copies — drop
+// the stamp, keep the rest of metadata (bindings, labels).
 const stripPatternAttribution = (blocks) =>
 	blocks.map((block) => {
 		const metadata = { ...(block.attributes?.metadata || {}) };
@@ -596,10 +594,9 @@ const Library = ({ onClose }) => {
 			}
 
 			// With Pro active the upsell banner removes itself right after
-			// insertion anyway — skip it up front. Inline wp:pattern references
-			// while parsing: inserted literally they render as locked "Edit
-			// pattern" wrappers (or nothing, for unregistered slugs) instead of
-			// editable blocks.
+			// insertion anyway — skip it up front. Inline wp:pattern refs while
+			// parsing: inserted raw they render locked, or not at all for
+			// unregistered slugs.
 			const blocks = stripPatternAttribution(
 				resolvePatternBlocks(parse(accentContent(pattern, accent)), allPatterns),
 			).filter(

--- a/src/blocks/test/e2e/blocks/design-library.spec.js
+++ b/src/blocks/test/e2e/blocks/design-library.spec.js
@@ -244,6 +244,44 @@ test.describe( 'Design Library', () => {
 				page.locator( '.components-snackbar', { hasText: title })
 			).toBeVisible();
 		});
+
+		test( 'expands wp:pattern references into editable blocks on insert', async({ page, editor }) => {
+
+			// The fixture pattern (registered by otter-e2e-pattern-fixtures.php)
+			// contains a heading, a reference to a registered pattern and a
+			// reference to a missing slug. Inserted content must arrive as plain
+			// editable blocks: registered references inlined, missing ones dropped —
+			// never a core/pattern block, which the editor renders as a locked
+			// "Edit pattern" wrapper (or nothing at all for missing slugs).
+			// See https://github.com/Codeinwp/otter-blocks/issues/2854
+			const modal = await openLibrary( page );
+			await waitForGrid( modal );
+
+			await modal.locator( '.o-library__search' ).fill( 'E2E Pattern Reference Fixture' );
+
+			const card = firstCard( modal );
+			await card.hover();
+			await card.getByRole( 'button', { name: 'Insert', exact: true }).click();
+
+			await expect( modal ).toHaveCount( 0 );
+			await waitForEditorReady( page );
+
+			const blocks = await editor.getBlocks();
+			const names = blocks.map( ( block ) => block.name );
+
+			expect( names ).toContain( 'core/heading' );
+			expect( names ).toContain( 'core/paragraph' );
+			expect( names ).not.toContain( 'core/pattern' );
+
+			// WordPress 7.0 inlines registered references server-side and stamps
+			// the inlined blocks with metadata.patternName, which its editor then
+			// locks into content-only mode ("A block pattern" / "Edit pattern").
+			// Unsynced inserts must shed the attribution to stay editable.
+			const stamped = blocks
+				.filter( ( block ) => block.attributes?.metadata?.patternName )
+				.map( ( block ) => block.name );
+			expect( stamped ).toEqual( [] );
+		});
 	});
 
 	test.describe( 'Pro upsells', () => {

--- a/src/blocks/test/e2e/blocks/design-library.spec.js
+++ b/src/blocks/test/e2e/blocks/design-library.spec.js
@@ -247,13 +247,10 @@ test.describe( 'Design Library', () => {
 
 		test( 'expands wp:pattern references into editable blocks on insert', async({ page, editor }) => {
 
-			// The fixture pattern (registered by otter-e2e-pattern-fixtures.php)
-			// contains a heading, a reference to a registered pattern and a
-			// reference to a missing slug. Inserted content must arrive as plain
-			// editable blocks: registered references inlined, missing ones dropped —
-			// never a core/pattern block, which the editor renders as a locked
-			// "Edit pattern" wrapper (or nothing at all for missing slugs).
-			// See https://github.com/Codeinwp/otter-blocks/issues/2854
+			// Fixture (otter-e2e-pattern-fixtures.php): a heading plus one
+			// registered and one missing wp:pattern reference. Inserts must
+			// arrive as plain editable blocks — refs inlined, missing ones
+			// dropped, never a locked core/pattern wrapper. See #2854.
 			const modal = await openLibrary( page );
 			await waitForGrid( modal );
 
@@ -273,10 +270,8 @@ test.describe( 'Design Library', () => {
 			expect( names ).toContain( 'core/paragraph' );
 			expect( names ).not.toContain( 'core/pattern' );
 
-			// WordPress 7.0 inlines registered references server-side and stamps
-			// the inlined blocks with metadata.patternName, which its editor then
-			// locks into content-only mode ("A block pattern" / "Edit pattern").
-			// Unsynced inserts must shed the attribution to stay editable.
+			// WP 7.0 stamps inlined blocks with metadata.patternName and locks
+			// them into content-only mode — inserts must shed it.
 			const stamped = blocks
 				.filter( ( block ) => block.attributes?.metadata?.patternName )
 				.map( ( block ) => block.name );


### PR DESCRIPTION
Closes #2854

## Summary

Design Library content containing `wp:pattern` references broke in two ways. Registered references: WordPress 7.0 inlines them server-side but stamps the blocks with `metadata.patternName`, which the 7.0 editor locks into content-only mode — the inspector shows only "A block pattern" / "Edit pattern", no style controls. Missing references (e.g. templates saved on another site/theme): the raw `core/pattern` block reaches the canvas as an invisible, uneditable placeholder.

`insertPattern()` now expands references at insert time (reusing onboarding's `resolvePatternBlocks`, which also covers pre-7.0 WordPress where references arrive raw) and strips `metadata.patternName` from inserted blocks. Unsynced inserts arrive as plain editable blocks; `metadata.bindings` and custom labels are preserved. Scope: new inserts only — content already stamped in existing pages is unchanged.

## How to test manually

1. On WP 7.0, register a test pattern whose content includes a nested reference, e.g. add to a mu-plugin:
   `register_block_pattern( 'test/outer', [ 'title' => 'Ref Test', 'categories' => [ 'otter-blocks' ], 'content' => '<!-- wp:heading --><h2>Hi</h2><!-- /wp:heading --><!-- wp:pattern {"slug":"core/query-standard-posts"} /--><!-- wp:pattern {"slug":"not/registered"} /--' . '>' ] );`
   (or use the fixtures in `packages/e2e-tests/mu-plugins/otter-e2e-pattern-fixtures.php`).
2. New page → **Design Library** in the editor toolbar → search the pattern title → **Insert**.
3. Click each inserted block. **Before:** the referenced content selects as "A block pattern" with an **Edit pattern** button and no color/typography controls; the missing reference is an invisible "Pattern placeholder" in List View. **After:** every block is a plain editable block with full inspector controls, and the missing reference simply inserts nothing.
4. Optional console check after inserting: `wp.data.select('core/block-editor').getBlocks().some(b => b.name === 'core/pattern' || b.attributes?.metadata?.patternName)` → must be `false`.

Covered by a new e2e test in `design-library.spec.js` 
