### PR TITLE
fix: declare captchaProvider in form emails REST schema

### DIFF
--- a/inc/plugins/class-options-settings.php
+++ b/inc/plugins/class-options-settings.php
@@ -412,6 +412,9 @@ class Options_Settings {
 							if ( isset( $item['redirectLink'] ) ) {
 								$item['redirectLink'] = sanitize_text_field( $item['redirectLink'] );
 							}
+							if ( isset( $item['captchaProvider'] ) ) {
+								$item['captchaProvider'] = sanitize_text_field( $item['captchaProvider'] );
+							}
 							if ( isset( $item['titleSubject'] ) ) {
 								$item['titleSubject'] = sanitize_text_field( $item['titleSubject'] );
 							}
@@ -492,6 +495,9 @@ class Options_Settings {
 								),
 								'hasCaptcha'              => array(
 									'type' => array( 'boolean', 'number', 'string' ),
+								),
+								'captchaProvider'         => array(
+									'type' => 'string',
 								),
 								'email'                   => array(
 									'type' => 'string',

--- a/src/blocks/test/e2e/blocks/form-turnstile.spec.js
+++ b/src/blocks/test/e2e/blocks/form-turnstile.spec.js
@@ -2,8 +2,8 @@
  * Internal dependencies
  */
 import { test, expect } from '../fixtures';
-import { getBlockByName, expectBlockByName, publishAndViewPost } from '../helpers/editor';
-import { getFormClientId, insertContactForm, insertFormCaptchaBlock } from '../helpers/forms';
+import { getBlockByName, expectBlockByName, publishAndViewPost, publishPostReliable } from '../helpers/editor';
+import { expectFormOptionSavedNotice, findSavedFormEmail, getFormClientId, getSavedFormEmails, insertContactForm, insertFormCaptchaBlock, showFormOption } from '../helpers/forms';
 
 const CAPTCHA_BLOCK = 'themeisle-blocks/form-captcha';
 
@@ -12,7 +12,11 @@ test.describe( 'Form Block - Captcha block', () => {
 	test.beforeEach( async({ admin, otterUtils }) => {
 		await otterUtils.setOptions({
 			themeisle_cloudflare_turnstile_site_key: 'turnstile-sitekey',
-			themeisle_cloudflare_turnstile_secret_key: 'turnstile-secret'
+			themeisle_cloudflare_turnstile_secret_key: 'turnstile-secret',
+
+			// Start from a clean form-options state (see form.spec.js).
+			themeisle_blocks_form_emails: [],
+			themeisle_blocks_form_fields_option: []
 		});
 
 		await admin.createNewPost();
@@ -78,6 +82,47 @@ test.describe( 'Form Block - Captcha block', () => {
 		await page.getByRole( 'button', { name: 'Submit' }).click();
 
 		await expect( page.locator( `#${formId} .o-form-server-response.o-success` ) ).toBeVisible({ timeout: 15000 });
+	});
+
+	// Regression for #2919: `captchaProvider` was missing from the
+	// `themeisle_blocks_form_emails` REST schema, so the settings endpoint
+	// (which forces `additionalProperties: false`) rejected the entire
+	// form-options save whenever a captcha was present.
+	test( 'saves form options when a Turnstile captcha is present', async({ editor, page }) => {
+		const ccValue = 'otter@turnstile-form.com';
+
+		await insertContactForm({ editor, page });
+
+		const formClientId = await getFormClientId( page );
+		expect( formClientId ).toBeTruthy();
+
+		await insertFormCaptchaBlock( page, formClientId, 'turnstile' );
+
+		await expect.poll( async() => {
+			const form = await getBlockByName( editor, 'themeisle-blocks/form' );
+			return form?.innerBlocks?.filter( ({ name }) => CAPTCHA_BLOCK === name )?.length;
+		}).toBe( 1 );
+
+		await showFormOption( page, 'Show CC' );
+
+		const cc = page.getByPlaceholder( 'Send copies to' );
+		await cc.fill( ccValue );
+
+		await publishPostReliable( editor, page );
+
+		// Without the schema fix the settings request fails with
+		// `rest_additional_properties_forbidden` and this notice never shows.
+		await expectFormOptionSavedNotice( page );
+
+		const formBlock = await expectBlockByName( editor, 'themeisle-blocks/form' );
+		expect( formBlock.attributes.optionName ).toBeTruthy();
+
+		const databaseEmails = await getSavedFormEmails( page );
+		const savedEmail = findSavedFormEmail( databaseEmails, formBlock.attributes.optionName );
+
+		expect( savedEmail ).toBeTruthy();
+		expect( savedEmail?.cc ).toBe( ccValue );
+		expect( savedEmail?.captchaProvider ).toBe( 'turnstile' );
 	});
 
 	test( 'keeps a single Captcha block per form', async({ editor, page }) => {

--- a/src/blocks/test/e2e/blocks/form-turnstile.spec.js
+++ b/src/blocks/test/e2e/blocks/form-turnstile.spec.js
@@ -3,7 +3,7 @@
  */
 import { test, expect } from '../fixtures';
 import { getBlockByName, expectBlockByName, publishAndViewPost, publishPostReliable } from '../helpers/editor';
-import { expectFormOptionSavedNotice, findSavedFormEmail, getFormClientId, getSavedFormEmails, insertContactForm, insertFormCaptchaBlock, showFormOption } from '../helpers/forms';
+import { expectFormOptionSavedNotice, findSavedFormEmail, getFormClientId, getSavedFormEmails, insertContactForm, insertFormCaptchaBlock, prepareFormOptionsInspector, showFormOption } from '../helpers/forms';
 
 const CAPTCHA_BLOCK = 'themeisle-blocks/form-captcha';
 
@@ -102,6 +102,14 @@ test.describe( 'Form Block - Captcha block', () => {
 			const form = await getBlockByName( editor, 'themeisle-blocks/form' );
 			return form?.innerBlocks?.filter( ({ name }) => CAPTCHA_BLOCK === name )?.length;
 		}).toBe( 1 );
+
+		// Inserting the captcha selects it; the Form Options panel only shows
+		// in the Form block's own inspector.
+		await page.evaluate( ( clientId ) => {
+			window.wp.data.dispatch( 'core/block-editor' ).selectBlock( clientId );
+		}, formClientId );
+
+		await prepareFormOptionsInspector( editor, page );
 
 		await showFormOption( page, 'Show CC' );
 

--- a/tests/test-options-settings.php
+++ b/tests/test-options-settings.php
@@ -61,6 +61,7 @@ class Test_Options_Settings extends WP_UnitTestCase {
 			array(
 				array(
 					'form'          => ' form-id<script> ',
+					'captchaProvider' => ' turnstile<script> ',
 					'fromEmail'     => 'bad-email',
 					'replyTo'       => "sales@example.com\r\nBcc: evil@attacker.com",
 					'requiredFields' => 'invalid-type',
@@ -76,6 +77,7 @@ class Test_Options_Settings extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 'form-id', $sanitized[0]['form'] );
+		$this->assertSame( 'turnstile', $sanitized[0]['captchaProvider'] );
 		$this->assertSame( '', $sanitized[0]['fromEmail'] );
 		$this->assertStringNotContainsString( "\r", $sanitized[0]['replyTo'] );
 		$this->assertStringNotContainsString( "\n", $sanitized[0]['replyTo'] );
@@ -84,6 +86,18 @@ class Test_Options_Settings extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<strong>ok</strong>', $sanitized[0]['autoresponder']['body'] );
 		$this->assertStringNotContainsString( '<form>', $sanitized[0]['autoresponder']['body'] );
 		$this->assertStringNotContainsString( '<input', $sanitized[0]['autoresponder']['body'] );
+	}
+
+	/**
+	 * Every property the form editor writes must be declared in the REST schema:
+	 * the settings endpoint forces additionalProperties to false, so a missing
+	 * property rejects the whole save (see #2919).
+	 */
+	public function test_form_emails_rest_schema_declares_captcha_provider() {
+		$registered_settings = get_registered_settings();
+		$schema              = $registered_settings['themeisle_blocks_form_emails']['show_in_rest']['schema'];
+
+		$this->assertArrayHasKey( 'captchaProvider', $schema['items']['properties'] );
 	}
 
 	/**


### PR DESCRIPTION
Closes #2919.

### Summary

Since v3.2.0, saving any Otter Form settings fails when the form contains a captcha, and none of the form customizations (recipient email, subject, success/error messages) persist.

**Root cause:** the form editor writes `captchaProvider` into the `themeisle_blocks_form_emails` option payload (`src/blocks/blocks/form/edit.js`), and the backend consumes it (`Form_Settings_Data::set_captcha_provider()`), but the option's `show_in_rest` schema in `inc/plugins/class-options-settings.php` never declared the property. WordPress forces `additionalProperties: false` on settings schemas (since WP 4.9), so the whole settings update is rejected:

```json
{
  "code": "rest_invalid_param",
  "data": { "details": { "themeisle_blocks_form_emails": {
    "code": "rest_additional_properties_forbidden",
    "message": "captchaProvider is not a valid property of Object."
  } } }
}
```

**Changes:**

- Declare `captchaProvider` (string) in the `themeisle_blocks_form_emails` REST schema.
- Sanitize it with `sanitize_text_field()` in the option's sanitize callback. Kept as a plain string rather than an enum — `set_captcha_provider()` already whitelists values at read time, and an enum would recreate this save-blocking failure when a new provider is added.

----

### Test instructions

1. On WP 7.0.1 with Otter 3.2.0, insert a Form block, add the Captcha block inside it and select Cloudflare Turnstile.
2. Change a form option (e.g. recipient email) and update the post.
3. Without this fix the deferred `wp/v2/settings` request returns 400 (`rest_additional_properties_forbidden: captchaProvider`) and the values revert on reload; with the fix the "Form options have been saved." notice appears and values persist.

Automated coverage:

- Unit: `test_form_emails_sanitize_callback_sanitizes_nested_data` (extended) and `test_form_emails_rest_schema_declares_captcha_provider` (new) in `tests/test-options-settings.php`.
- E2E: `saves form options when a Turnstile captcha is present` in `src/blocks/test/e2e/blocks/form-turnstile.spec.js`.

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

🤖 Generated with [Claude Code](https://claude.com/claude-code)
