### PR TITLE
Feat/atomic wind styles on dynamic pages

### DIFF
--- a/inc/plugins/class-atomic-wind-blocks.php
+++ b/inc/plugins/class-atomic-wind-blocks.php
@@ -23,6 +23,27 @@ class Atomic_Wind_Blocks {
 	private static $in_query = false;
 
 	/**
+	 * Expected Atomic Wind blocks by post ID.
+	 *
+	 * @var array<int, int>
+	 */
+	private $expected = array();
+
+	/**
+	 * Rendered Atomic Wind blocks by post ID. ID 0 is unknown.
+	 *
+	 * @var array<int, int>
+	 */
+	private $rendered = array();
+
+	/**
+	 * Hashes of inlined CSS.
+	 *
+	 * @var array<string, bool>
+	 */
+	private $inlined = array();
+
+	/**
 	 * Initialize the module.
 	 *
 	 * @return void
@@ -55,6 +76,8 @@ class Atomic_Wind_Blocks {
 		add_filter( 'render_block', array( $this, 'render_post_fields' ), 20, 2 );
 		add_filter( 'render_block', array( $this, 'render_animation_attrs' ), 10, 2 );
 		add_filter( 'render_block', array( $this, 'render_state_attrs' ), 10, 2 );
+		add_filter( 'render_block', array( $this, 'track_rendered_blocks' ), 10, 2 );
+		add_action( 'wp_footer', array( $this, 'output_late_css' ), 19 );
 		add_action( 'template_redirect', array( $this, 'maybe_render_css_warm_page' ), 0 );
 		add_action( 'save_post', array( $this, 'clear_cached_css' ) );
 		add_filter( 'block_categories_all', array( $this, 'register_category' ) );
@@ -161,18 +184,25 @@ class Atomic_Wind_Blocks {
 	 * @return void
 	 */
 	public function enqueue_base_css() {
+		$css = '[class*="wp-block-atomic-wind-"]{margin:0;max-width:unset;}[class*="wp-block-atomic-wind-"] p{margin:0;}';
+
+		// Always reset frontend blocks, including those outside the main query.
+		if ( ! is_admin() ) {
+			wp_register_style( 'atomic-wind-base', false, [], OTTER_BLOCKS_VERSION );
+			wp_enqueue_style( 'atomic-wind-base' );
+			wp_add_inline_style( 'atomic-wind-base', $css );
+			return;
+		}
+
 		global $post;
-	
+
 		if ( ! $post || ! $this->post_has_atomic_wind_blocks( $post ) ) {
 			return;
 		}
-	
+
 		wp_register_style( 'atomic-wind-base', false, [], OTTER_BLOCKS_VERSION );
 		wp_enqueue_style( 'atomic-wind-base' );
-		$css = '[class*="wp-block-atomic-wind-"]{margin:0;max-width:unset;}[class*="wp-block-atomic-wind-"] p{margin:0;}';
-		if ( is_admin() ) {
-			$css .= '.editor-styles-wrapper .wp-block[class*="wp-block-atomic-wind-"]{margin:0;max-width:unset;}.editor-styles-wrapper [class*="wp-block-atomic-wind-"] p{margin:0;}';
-		}
+		$css .= '.editor-styles-wrapper .wp-block[class*="wp-block-atomic-wind-"]{margin:0;max-width:unset;}.editor-styles-wrapper [class*="wp-block-atomic-wind-"] p{margin:0;}';
 		wp_add_inline_style( 'atomic-wind-base', $css );
 	}
 
@@ -252,30 +282,11 @@ class Atomic_Wind_Blocks {
 	}
 
 	/**
-	 * Output cached Tailwind CSS or enqueue the generator + style-builder.
+	 * Enqueue the frontend Tailwind fallback.
 	 *
 	 * @return void
 	 */
-	public function output_cached_css() {
-		global $post;
-
-		if ( ! $post ) {
-			return;
-		}
-
-		if ( ! $this->post_has_atomic_wind_blocks( $post ) ) {
-			return;
-		}
-
-		$cached_css = get_post_meta( $post->ID, '_atomic_wind_css', true );
-
-		if ( $cached_css ) {
-			wp_register_style( 'atomic-wind-tailwind', false, [], OTTER_BLOCKS_VERSION );
-			wp_enqueue_style( 'atomic-wind-tailwind' );
-			wp_add_inline_style( 'atomic-wind-tailwind', $cached_css );
-			return;
-		}
-
+	private function enqueue_generator() {
 		$generator_asset = $this->build_path() . '/tailwind-generator-frontend.asset.php';
 
 		if ( ! file_exists( $generator_asset ) ) {
@@ -290,30 +301,185 @@ class Atomic_Wind_Blocks {
 			$gen['version'],
 			true
 		);
+	}
 
-		if ( is_user_logged_in() && current_user_can( 'edit_post', $post->ID ) ) {
-			$builder_asset = $this->build_path() . '/style-builder.asset.php';
+	/**
+	 * Load cached CSS for main-query posts.
+	 *
+	 * Missing CSS uses the generator. Footer rendering is handled separately.
+	 *
+	 * @return void
+	 */
+	public function output_cached_css() {
+		$candidates = array();
 
-			if ( file_exists( $builder_asset ) ) {
-				$sb = include $builder_asset;
-				wp_enqueue_script(
-					'atomic-wind-style-builder',
-					$this->plugin_url( 'build/atomic-wind/style-builder.js' ),
-					$sb['dependencies'],
-					$sb['version'],
-					true
-				);
-
-				wp_localize_script(
-					'atomic-wind-style-builder',
-					'atomicWindStyleBuilder',
-					array(
-						'postId'  => $post->ID,
-						'restUrl' => rest_url( 'otter/v1/atomic-wind' ),
-						'nonce'   => wp_create_nonce( 'wp_rest' ),
-					) 
-				);
+		if ( isset( $GLOBALS['wp_query'] ) && ! empty( $GLOBALS['wp_query']->posts ) ) {
+			foreach ( $GLOBALS['wp_query']->posts as $candidate ) {
+				if ( $candidate instanceof \WP_Post ) {
+					$candidates[ $candidate->ID ] = $candidate;
+				}
 			}
+		}
+
+		$blobs           = array();
+		$needs_generator = false;
+
+		foreach ( $candidates as $candidate ) {
+			if ( ! $this->post_has_atomic_wind_blocks( $candidate ) ) {
+				continue;
+			}
+
+			$this->expected[ $candidate->ID ] = substr_count( $candidate->post_content, '<!-- wp:atomic-wind/' );
+
+			$cached_css = get_post_meta( $candidate->ID, '_atomic_wind_css', true );
+
+			if ( $cached_css ) {
+				$hash = md5( $cached_css );
+				if ( ! isset( $this->inlined[ $hash ] ) ) {
+					$this->inlined[ $hash ] = true;
+					$blobs[]                = $cached_css;
+				}
+			} else {
+				$needs_generator = true;
+			}
+		}
+
+		if ( ! empty( $blobs ) ) {
+			wp_register_style( 'atomic-wind-tailwind', false, [], OTTER_BLOCKS_VERSION );
+			wp_enqueue_style( 'atomic-wind-tailwind' );
+			wp_add_inline_style( 'atomic-wind-tailwind', implode( "\n", $blobs ) );
+		}
+
+		if ( $needs_generator ) {
+			$this->enqueue_generator();
+		}
+
+		$this->maybe_enqueue_style_builder();
+	}
+
+	/**
+	 * Enqueue the style builder for editable singular posts without cached CSS.
+	 *
+	 * @return void
+	 */
+	private function maybe_enqueue_style_builder() {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		$queried = get_queried_object();
+
+		if ( ! $queried instanceof \WP_Post
+			|| ! $this->post_has_atomic_wind_blocks( $queried )
+			|| get_post_meta( $queried->ID, '_atomic_wind_css', true )
+			|| ! current_user_can( 'edit_post', $queried->ID ) ) {
+			return;
+		}
+
+		$builder_asset = $this->build_path() . '/style-builder.asset.php';
+
+		if ( ! file_exists( $builder_asset ) ) {
+			return;
+		}
+
+		$sb = include $builder_asset;
+		wp_enqueue_script(
+			'atomic-wind-style-builder',
+			$this->plugin_url( 'build/atomic-wind/style-builder.js' ),
+			$sb['dependencies'],
+			$sb['version'],
+			true
+		);
+
+		wp_localize_script(
+			'atomic-wind-style-builder',
+			'atomicWindStyleBuilder',
+			array(
+				'postId'  => $queried->ID,
+				'restUrl' => rest_url( 'otter/v1/atomic-wind' ),
+				'nonce'   => wp_create_nonce( 'wp_rest' ),
+			)
+		);
+	}
+
+	/**
+	 * Track frontend Atomic Wind blocks by current post.
+	 *
+	 * Query re-renders are skipped to avoid duplicate counts.
+	 *
+	 * @param string               $block_content Block content.
+	 * @param array<string, mixed> $block         Block data.
+	 * @return string
+	 */
+	public function track_rendered_blocks( $block_content, $block ) {
+		if ( is_admin() || self::$in_query ) {
+			return $block_content;
+		}
+
+		$block_name = isset( $block['blockName'] ) ? $block['blockName'] : '';
+		if ( 0 !== strpos( $block_name, 'atomic-wind/' ) ) {
+			return $block_content;
+		}
+
+		$id  = get_the_ID();
+		$key = $id ? $id : 0;
+
+		if ( isset( $this->rendered[ $key ] ) ) {
+			$this->rendered[ $key ]++;
+		} else {
+			$this->rendered[ $key ] = 1;
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Load CSS for blocks rendered after the head.
+	 *
+	 * Missing or unattributed CSS uses the generator.
+	 *
+	 * @return void
+	 */
+	public function output_late_css() {
+		$blobs           = array();
+		$needs_generator = false;
+
+		foreach ( $this->rendered as $id => $count ) {
+			if ( ! isset( $this->expected[ $id ] ) ) {
+				$post = $id ? get_post( $id ) : null;
+
+				if ( $post instanceof \WP_Post && $this->post_has_atomic_wind_blocks( $post ) ) {
+					$this->expected[ $id ] = substr_count( $post->post_content, '<!-- wp:atomic-wind/' );
+
+					$cached_css = get_post_meta( $id, '_atomic_wind_css', true );
+
+					if ( $cached_css ) {
+						$hash = md5( $cached_css );
+						if ( ! isset( $this->inlined[ $hash ] ) ) {
+							$this->inlined[ $hash ] = true;
+							$blobs[]                = $cached_css;
+						}
+					} else {
+						$needs_generator = true;
+					}
+				} else {
+					$this->expected[ $id ] = 0;
+				}
+			}
+
+			if ( $count > $this->expected[ $id ] ) {
+				$needs_generator = true;
+			}
+		}
+
+		if ( ! empty( $blobs ) ) {
+			wp_register_style( 'atomic-wind-tailwind-late', false, [], OTTER_BLOCKS_VERSION );
+			wp_enqueue_style( 'atomic-wind-tailwind-late' );
+			wp_add_inline_style( 'atomic-wind-tailwind-late', implode( "\n", $blobs ) );
+		}
+
+		if ( $needs_generator ) {
+			$this->enqueue_generator();
 		}
 	}
 

--- a/inc/plugins/class-atomic-wind-blocks.php
+++ b/inc/plugins/class-atomic-wind-blocks.php
@@ -68,7 +68,7 @@ class Atomic_Wind_Blocks {
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_base_css' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_icons_data' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'output_cached_css' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_style_builder' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_frontend_animations' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_frontend_states' ) );
@@ -189,7 +189,6 @@ class Atomic_Wind_Blocks {
 		// Always reset frontend blocks, including those outside the main query.
 		if ( ! is_admin() ) {
 			wp_register_style( 'atomic-wind-base', false, [], OTTER_BLOCKS_VERSION );
-			wp_enqueue_style( 'atomic-wind-base' );
 			wp_add_inline_style( 'atomic-wind-base', $css );
 			return;
 		}
@@ -304,65 +303,11 @@ class Atomic_Wind_Blocks {
 	}
 
 	/**
-	 * Load cached CSS for main-query posts.
-	 *
-	 * Missing CSS uses the generator. Footer rendering is handled separately.
-	 *
-	 * @return void
-	 */
-	public function output_cached_css() {
-		$candidates = array();
-
-		if ( isset( $GLOBALS['wp_query'] ) && ! empty( $GLOBALS['wp_query']->posts ) ) {
-			foreach ( $GLOBALS['wp_query']->posts as $candidate ) {
-				if ( $candidate instanceof \WP_Post ) {
-					$candidates[ $candidate->ID ] = $candidate;
-				}
-			}
-		}
-
-		$blobs           = array();
-		$needs_generator = false;
-
-		foreach ( $candidates as $candidate ) {
-			if ( ! $this->post_has_atomic_wind_blocks( $candidate ) ) {
-				continue;
-			}
-
-			$this->expected[ $candidate->ID ] = substr_count( $candidate->post_content, '<!-- wp:atomic-wind/' );
-
-			$cached_css = get_post_meta( $candidate->ID, '_atomic_wind_css', true );
-
-			if ( $cached_css ) {
-				$hash = md5( $cached_css );
-				if ( ! isset( $this->inlined[ $hash ] ) ) {
-					$this->inlined[ $hash ] = true;
-					$blobs[]                = $cached_css;
-				}
-			} else {
-				$needs_generator = true;
-			}
-		}
-
-		if ( ! empty( $blobs ) ) {
-			wp_register_style( 'atomic-wind-tailwind', false, [], OTTER_BLOCKS_VERSION );
-			wp_enqueue_style( 'atomic-wind-tailwind' );
-			wp_add_inline_style( 'atomic-wind-tailwind', implode( "\n", $blobs ) );
-		}
-
-		if ( $needs_generator ) {
-			$this->enqueue_generator();
-		}
-
-		$this->maybe_enqueue_style_builder();
-	}
-
-	/**
 	 * Enqueue the style builder for editable singular posts without cached CSS.
 	 *
 	 * @return void
 	 */
-	private function maybe_enqueue_style_builder() {
+	public function maybe_enqueue_style_builder() {
 		if ( ! is_singular() ) {
 			return;
 		}
@@ -421,11 +366,13 @@ class Atomic_Wind_Blocks {
 			return $block_content;
 		}
 
+		wp_enqueue_style( 'atomic-wind-base' );
+
 		$id  = get_the_ID();
 		$key = $id ? $id : 0;
 
 		if ( isset( $this->rendered[ $key ] ) ) {
-			$this->rendered[ $key ]++;
+			++$this->rendered[ $key ];
 		} else {
 			$this->rendered[ $key ] = 1;
 		}

--- a/inc/plugins/class-atomic-wind-blocks.php
+++ b/inc/plugins/class-atomic-wind-blocks.php
@@ -68,6 +68,7 @@ class Atomic_Wind_Blocks {
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_base_css' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_icons_data' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'output_singular_css' ), 11 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_style_builder' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_frontend_animations' ) );
@@ -300,6 +301,42 @@ class Atomic_Wind_Blocks {
 			$gen['version'],
 			true
 		);
+	}
+
+	/**
+	 * Load the queried post's CSS in the head on singular views.
+	 *
+	 * The post is guaranteed to render, so inlining its cached CSS early avoids
+	 * a flash of unstyled content for the main content. Everything else (hooked
+	 * layouts, embeds) stays on the render-tracked footer path.
+	 *
+	 * @return void
+	 */
+	public function output_singular_css() {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		$queried = get_queried_object();
+
+		if ( ! $queried instanceof \WP_Post || ! $this->post_has_atomic_wind_blocks( $queried ) ) {
+			return;
+		}
+
+		$this->expected[ $queried->ID ] = substr_count( $queried->post_content, '<!-- wp:atomic-wind/' );
+		wp_enqueue_style( 'atomic-wind-base' );
+
+		$cached_css = get_post_meta( $queried->ID, '_atomic_wind_css', true );
+
+		if ( ! $cached_css ) {
+			$this->enqueue_generator();
+			return;
+		}
+
+		$this->inlined[ md5( $cached_css ) ] = true;
+		wp_register_style( 'atomic-wind-tailwind', false, [], OTTER_BLOCKS_VERSION );
+		wp_enqueue_style( 'atomic-wind-tailwind' );
+		wp_add_inline_style( 'atomic-wind-tailwind', $cached_css );
 	}
 
 	/**

--- a/tests/test-atomic-wind-blocks.php
+++ b/tests/test-atomic-wind-blocks.php
@@ -1212,4 +1212,200 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 
 		$this->assertSame( $sentinel, $post, 'The global $post must be restored after rendering the warm page.' );
 	}
+
+	// -------------------------------------------------------
+	// Frontend CSS loading.
+	// -------------------------------------------------------
+
+	/**
+	 * Read a private property.
+	 *
+	 * @param string $name Property name.
+	 * @return mixed
+	 */
+	private function get_private_prop( $name ) {
+		$ref = new ReflectionProperty( Atomic_Wind_Blocks::class, $name );
+		$ref->setAccessible( true );
+		return $ref->getValue( $this->instance );
+	}
+
+	/**
+	 * Reset style and script queues.
+	 */
+	private function reset_style_globals() {
+		$GLOBALS['wp_styles']  = new WP_Styles();
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
+	}
+
+	/**
+	 * Get inline CSS for a style.
+	 *
+	 * @param string $handle Style handle.
+	 * @return string
+	 */
+	private function inline_style_for( $handle ) {
+		$data = wp_styles()->get_data( $handle, 'after' );
+		return is_array( $data ) ? implode( '', $data ) : (string) $data;
+	}
+
+	public function test_track_rendered_blocks_increments_per_current_post() {
+		$this->reset_in_query( false );
+
+		global $post;
+		$post = get_post( $this->post_id );
+		setup_postdata( $post );
+
+		$block = $this->make_block( 'atomic-wind/box' );
+		$this->instance->track_rendered_blocks( '<div></div>', $block );
+		$this->instance->track_rendered_blocks( '<div></div>', $block );
+
+		$rendered = $this->get_private_prop( 'rendered' );
+
+		wp_reset_postdata();
+
+		$this->assertSame( 2, $rendered[ $this->post_id ] );
+	}
+
+	public function test_track_rendered_blocks_skips_non_atomic() {
+		$this->reset_in_query( false );
+
+		$this->instance->track_rendered_blocks( '<p></p>', $this->make_block( 'core/paragraph' ) );
+
+		$this->assertSame( array(), $this->get_private_prop( 'rendered' ) );
+	}
+
+	public function test_track_rendered_blocks_skips_inside_query_loop() {
+		$this->reset_in_query( true );
+
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
+
+		$this->assertSame( array(), $this->get_private_prop( 'rendered' ) );
+	}
+
+	public function test_output_cached_css_inlines_multiple_main_query_posts() {
+		$this->reset_style_globals();
+
+		$a = $this->make_atomic_wind_post( 'flex' );
+		$b = $this->make_atomic_wind_post( 'grid' );
+		update_post_meta( $a, '_atomic_wind_css', '.flex{display:flex}' );
+		update_post_meta( $b, '_atomic_wind_css', '.grid{display:grid}' );
+
+		$GLOBALS['wp_query']->posts = array( get_post( $a ), get_post( $b ) );
+
+		$this->instance->output_cached_css();
+
+		$inline = $this->inline_style_for( 'atomic-wind-tailwind' );
+
+		$this->assertStringContainsString( '.flex{display:flex}', $inline );
+		$this->assertStringContainsString( '.grid{display:grid}', $inline );
+	}
+
+	public function test_output_cached_css_dedupes_identical_blobs() {
+		$this->reset_style_globals();
+
+		$a = $this->make_atomic_wind_post( 'flex' );
+		$b = $this->make_atomic_wind_post( 'flex' );
+		update_post_meta( $a, '_atomic_wind_css', '.flex{display:flex}' );
+		update_post_meta( $b, '_atomic_wind_css', '.flex{display:flex}' );
+
+		$GLOBALS['wp_query']->posts = array( get_post( $a ), get_post( $b ) );
+
+		$this->instance->output_cached_css();
+
+		$inline = $this->inline_style_for( 'atomic-wind-tailwind' );
+
+		$this->assertSame( 1, substr_count( $inline, '.flex{display:flex}' ) );
+	}
+
+	public function test_output_late_css_inlines_tracked_post_and_skips_generator() {
+		$this->reset_style_globals();
+		$this->reset_in_query( false );
+
+		$late = $this->make_atomic_wind_post( 'flex' );
+		update_post_meta( $late, '_atomic_wind_css', '.late{color:blue}' );
+
+		global $post;
+		$post = get_post( $late );
+		setup_postdata( $post );
+
+		// Render the post's single Atomic Wind block.
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
+
+		$this->instance->output_late_css();
+
+		$inline = $this->inline_style_for( 'atomic-wind-tailwind-late' );
+
+		wp_reset_postdata();
+
+		$this->assertStringContainsString( '.late{color:blue}', $inline );
+		$this->assertFalse( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
+	}
+
+	public function test_output_late_css_collects_blocks_rendered_by_normal_footer_callbacks() {
+		$this->reset_style_globals();
+		$this->reset_in_query( false );
+		update_option( 'themeisle_blocks_settings_atomic_wind_blocks', true );
+
+		$late = $this->make_atomic_wind_post( 'flex' );
+		update_post_meta( $late, '_atomic_wind_css', '.footer-callback{color:purple}' );
+
+		global $post;
+		$post = get_post( $late );
+		setup_postdata( $post );
+
+		$render_footer_block = function () {
+			$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
+		};
+
+		// Avoid unrelated core footer output.
+		remove_all_actions( 'wp_footer' );
+		add_action( 'wp_footer', $render_footer_block, 10 );
+		$this->instance->run();
+		do_action( 'wp_footer' );
+		remove_action( 'wp_footer', $render_footer_block, 10 );
+		remove_action( 'wp_footer', array( $this->instance, 'output_late_css' ), 19 );
+
+		$inline = $this->inline_style_for( 'atomic-wind-tailwind-late' );
+
+		wp_reset_postdata();
+
+		$this->assertStringContainsString( '.footer-callback{color:purple}', $inline );
+	}
+
+	public function test_output_late_css_falls_back_to_generator_when_counts_exceed() {
+		$this->reset_style_globals();
+		$this->reset_in_query( false );
+
+		$late = $this->make_atomic_wind_post( 'flex' );
+		update_post_meta( $late, '_atomic_wind_css', '.late{color:blue}' );
+
+		global $post;
+		$post = get_post( $late );
+		setup_postdata( $post );
+
+		// Render one block more than the post declares.
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
+
+		$this->instance->output_late_css();
+
+		wp_reset_postdata();
+
+		$this->assertTrue( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
+	}
+
+	public function test_enqueue_base_css_on_frontend_without_global_post() {
+		$this->reset_style_globals();
+
+		global $post;
+		$post = null;
+
+		$this->instance->enqueue_base_css();
+
+		$this->assertTrue( wp_style_is( 'atomic-wind-base', 'enqueued' ) );
+		$this->assertStringContainsString(
+			'wp-block-atomic-wind-',
+			$this->inline_style_for( 'atomic-wind-base' )
+		);
+	}
 }

--- a/tests/test-atomic-wind-blocks.php
+++ b/tests/test-atomic-wind-blocks.php
@@ -1431,6 +1431,69 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->assertTrue( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
 	}
 
+	public function test_output_singular_css_inlines_queried_post_in_head() {
+		$this->reset_style_globals();
+
+		$singular = $this->make_atomic_wind_post( 'flex' );
+		update_post_meta( $singular, '_atomic_wind_css', '.flex{display:flex}' );
+
+		$this->go_to( get_permalink( $singular ) );
+		$this->instance->enqueue_base_css();
+		$this->instance->output_singular_css();
+
+		$this->assertStringContainsString( '.flex{display:flex}', $this->inline_style_for( 'atomic-wind-tailwind' ) );
+		$this->assertTrue( wp_style_is( 'atomic-wind-base', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
+	}
+
+	public function test_output_singular_css_enqueues_generator_without_cache() {
+		$this->reset_style_globals();
+
+		$singular = $this->make_atomic_wind_post( 'flex' );
+
+		$this->go_to( get_permalink( $singular ) );
+		$this->instance->output_singular_css();
+
+		$this->assertSame( '', $this->inline_style_for( 'atomic-wind-tailwind' ) );
+		$this->assertTrue( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
+	}
+
+	public function test_output_singular_css_noop_on_non_singular_views() {
+		$this->reset_style_globals();
+
+		$listed = $this->make_atomic_wind_post( 'flex' );
+		update_post_meta( $listed, '_atomic_wind_css', '.flex{display:flex}' );
+
+		$this->go_to( home_url( '/' ) );
+		$this->instance->output_singular_css();
+
+		$this->assertSame( '', $this->inline_style_for( 'atomic-wind-tailwind' ) );
+		$this->assertFalse( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
+	}
+
+	public function test_output_late_css_skips_post_already_inlined_at_head() {
+		$this->reset_style_globals();
+		$this->reset_in_query( false );
+
+		$singular = $this->make_atomic_wind_post( 'flex' );
+		update_post_meta( $singular, '_atomic_wind_css', '.flex{display:flex}' );
+
+		$this->go_to( get_permalink( $singular ) );
+		$this->instance->output_singular_css();
+
+		// The post's single block renders and is tracked, as during a real request.
+		global $post;
+		$post = get_post( $singular );
+		setup_postdata( $post );
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
+		wp_reset_postdata();
+
+		$this->instance->output_late_css();
+
+		$this->assertSame( '', $this->inline_style_for( 'atomic-wind-tailwind-late' ) );
+		$this->assertFalse( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
+	}
+
 	public function test_enqueue_base_css_registers_frontend_style_without_enqueuing_it() {
 		$this->reset_style_globals();
 

--- a/tests/test-atomic-wind-blocks.php
+++ b/tests/test-atomic-wind-blocks.php
@@ -992,7 +992,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------
-	// Security: output_cached_css uses wp_add_inline_style
+	// Security: cached CSS uses wp_add_inline_style.
 	// -------------------------------------------------------
 
 	public function test_cached_css_uses_inline_style_api() {
@@ -1001,12 +1001,12 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 
 		$this->assertNotFalse(
 			strpos( $source, 'wp_add_inline_style' ),
-			'output_cached_css should use wp_add_inline_style instead of raw echo'
+			'Cached CSS should use wp_add_inline_style instead of raw echo'
 		);
 
 		$this->assertFalse(
 			(bool) preg_match( '/echo.*\$cached_css/', $source ),
-			'output_cached_css should not echo $cached_css directly'
+			'Cached CSS should not be echoed directly'
 		);
 	}
 
@@ -1282,44 +1282,80 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->assertSame( array(), $this->get_private_prop( 'rendered' ) );
 	}
 
-	public function test_output_cached_css_inlines_multiple_main_query_posts() {
+	public function test_output_late_css_inlines_multiple_rendered_posts() {
 		$this->reset_style_globals();
+		$this->reset_in_query( false );
 
 		$a = $this->make_atomic_wind_post( 'flex' );
 		$b = $this->make_atomic_wind_post( 'grid' );
 		update_post_meta( $a, '_atomic_wind_css', '.flex{display:flex}' );
 		update_post_meta( $b, '_atomic_wind_css', '.grid{display:grid}' );
 
-		$GLOBALS['wp_query']->posts = array( get_post( $a ), get_post( $b ) );
+		global $post;
+		$post = get_post( $a );
+		setup_postdata( $post );
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
 
-		$this->instance->output_cached_css();
+		$post = get_post( $b );
+		setup_postdata( $post );
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
 
-		$inline = $this->inline_style_for( 'atomic-wind-tailwind' );
+		$this->instance->output_late_css();
+
+		$inline = $this->inline_style_for( 'atomic-wind-tailwind-late' );
+
+		wp_reset_postdata();
 
 		$this->assertStringContainsString( '.flex{display:flex}', $inline );
 		$this->assertStringContainsString( '.grid{display:grid}', $inline );
 	}
 
-	public function test_output_cached_css_dedupes_identical_blobs() {
+	public function test_output_late_css_dedupes_identical_blobs() {
 		$this->reset_style_globals();
+		$this->reset_in_query( false );
 
 		$a = $this->make_atomic_wind_post( 'flex' );
 		$b = $this->make_atomic_wind_post( 'flex' );
 		update_post_meta( $a, '_atomic_wind_css', '.flex{display:flex}' );
 		update_post_meta( $b, '_atomic_wind_css', '.flex{display:flex}' );
 
-		$GLOBALS['wp_query']->posts = array( get_post( $a ), get_post( $b ) );
+		global $post;
+		$post = get_post( $a );
+		setup_postdata( $post );
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
 
-		$this->instance->output_cached_css();
+		$post = get_post( $b );
+		setup_postdata( $post );
+		$this->instance->track_rendered_blocks( '<div></div>', $this->make_block( 'atomic-wind/box' ) );
 
-		$inline = $this->inline_style_for( 'atomic-wind-tailwind' );
+		$this->instance->output_late_css();
+
+		$inline = $this->inline_style_for( 'atomic-wind-tailwind-late' );
+
+		wp_reset_postdata();
 
 		$this->assertSame( 1, substr_count( $inline, '.flex{display:flex}' ) );
+	}
+
+	public function test_frontend_css_is_not_enqueued_until_a_block_renders() {
+		$this->reset_style_globals();
+
+		$post_id = $this->make_atomic_wind_post( 'flex' );
+		update_post_meta( $post_id, '_atomic_wind_css', '.flex{display:flex}' );
+
+		$GLOBALS['wp_query']->posts = array( get_post( $post_id ) );
+
+		$this->instance->enqueue_base_css();
+		$this->instance->maybe_enqueue_style_builder();
+
+		$this->assertFalse( wp_style_is( 'atomic-wind-base', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'atomic-wind-tailwind', 'enqueued' ) );
 	}
 
 	public function test_output_late_css_inlines_tracked_post_and_skips_generator() {
 		$this->reset_style_globals();
 		$this->reset_in_query( false );
+		$this->instance->enqueue_base_css();
 
 		$late = $this->make_atomic_wind_post( 'flex' );
 		update_post_meta( $late, '_atomic_wind_css', '.late{color:blue}' );
@@ -1337,6 +1373,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 
 		wp_reset_postdata();
 
+		$this->assertTrue( wp_style_is( 'atomic-wind-base', 'enqueued' ) );
 		$this->assertStringContainsString( '.late{color:blue}', $inline );
 		$this->assertFalse( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
 	}
@@ -1394,7 +1431,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->assertTrue( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
 	}
 
-	public function test_enqueue_base_css_on_frontend_without_global_post() {
+	public function test_enqueue_base_css_registers_frontend_style_without_enqueuing_it() {
 		$this->reset_style_globals();
 
 		global $post;
@@ -1402,7 +1439,8 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 
 		$this->instance->enqueue_base_css();
 
-		$this->assertTrue( wp_style_is( 'atomic-wind-base', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'atomic-wind-base', 'registered' ) );
+		$this->assertFalse( wp_style_is( 'atomic-wind-base', 'enqueued' ) );
 		$this->assertStringContainsString(
 			'wp-block-atomic-wind-',
 			$this->inline_style_for( 'atomic-wind-base' )


### PR DESCRIPTION
<!-- Issues that this pull request closes. -->
<!-- Should look like this: `Closes #1, #2, #3.` . -->

### Summary
Atomic Wind block styles now load wherever a post is displayed: single views, archives and search listings, and content attached via theme hooks (e.g. Neve Pro Custom Layouts on private post types). Previously they only loaded on singular pages via `global $post`. The queried post's CSS loads in the head on singular views; everything else is gathered at render time, with an in-browser Tailwind generator as the correctness fallback.

## Changes

- **Render-time attribution**: a `render_block` tracker counts rendered `atomic-wind/*` blocks per current post ID (skipping query-loop re-renders so counts stay aligned with raw content). At `wp_footer` priority 19, before WordPress prints footer assets at 20, `output_late_css` inlines each tracked post's cached `_atomic_wind_css` meta into a single style tag, md5-deduped across posts.
- **Generator fallback**: the DOM-scanning frontend Tailwind generator is enqueued only when a tracked post has no cached CSS, or when more blocks rendered than the post's content declares (markup that can't be attributed to a post, e.g. embedders that don't set up postdata or blocks inside reusable-block refs). The page always ends up styled; the cost is a brief flash on this last-resort path only.
- **Base margin-reset CSS unconditional on the frontend**: the ~130-byte reset is registered on every frontend page and enqueued lazily when the first Atomic Wind block renders. Gating it on `global $post` had the same structural hole as the old loader. Editor path unchanged.
- **Style builder extraction**: the editor-facing regeneration path is its own gated method (`maybe_enqueue_style_builder`): singular views only, queried post has Atomic Wind blocks, no cached CSS, current user can edit it. It regenerates and persists CSS via the existing REST route.
- **Head inline for singular views**: on singular pages the queried post is guaranteed to render, so its cached CSS is inlined in the head (and the generator enqueued early when uncached), eliminating the unstyled flash for the main content. The head pass records the post in the expected/inlined maps so the footer collector neither duplicates the blob nor re-fetches the meta. Hooked layouts and embeds stay on the footer path.
- **Tests**: new coverage for the tracker (per-post counts, non-atomic blocks skipped, query-loop renders skipped), late inline (tracked posts, dedupe, blocks rendered by ordinary footer callbacks at priority 10), generator-on-count-mismatch, the singular head path (head inline, generator when uncached, no-op on non-singular views, no double-inline in the footer), and base CSS registration without a global post.

----

### Test instructions

Setup: enable **Atomic Wind Blocks** in Otter settings. You need one regular post with Atomic Wind blocks, and (for hook coverage) a Neve Pro Custom Layout containing Atomic Wind blocks, hooked to display on single posts.

- [ ] **Singular, cached**: edit and save the post with Atomic Wind blocks (the save warms its CSS cache), then view it logged out. Blocks are styled with no flash; the post's CSS is in a head inline `<style id="atomic-wind-tailwind-inline-css">` and the page does **not** load `tailwind-generator-frontend.js`.
- [ ] **Hooked private content**: with the Custom Layout active, view a single post. The layout's Tailwind classes are styled (check something layout-specific, e.g. a background/backdrop utility that isn't used by the post itself), served from the footer inline `<style id="atomic-wind-tailwind-late-inline-css">`. The post's own CSS is not duplicated there.
- [ ] **Archive/search**: view the blog home or a search result listing full content of at least two Atomic Wind posts. All listed posts are styled; the footer inline style appears once, without duplicated CSS blobs.
- [ ] **Generator fallback**: delete a displayed post's cache (`wp post meta delete <id> _atomic_wind_css`) and reload logged out. `tailwind-generator-frontend.js` loads and the blocks are styled after page load (brief flash is expected).
- [ ] **Editor re-cache**: visit that same post logged in as someone who can edit it (singular view). `style-builder.js` loads and the `_atomic_wind_css` meta is re-created (verify with `wp post meta get <id> _atomic_wind_css`); subsequent logged-out loads use the head inline style again, no generator.
- [ ] **Regression, no Atomic Wind content**: a page without Atomic Wind blocks anywhere outputs no atomic-wind styles or scripts (base reset style is registered but not printed).
- [ ] **Regression, editor**: blocks still render styled in the block editor, and saving a post still warms the cache (the hidden-iframe warm request fires on save).

> [!NOTE]
>  - The queried post's CSS loads in the head on singular views; everything else (hooked layouts, archive listings) is emitted at the bottom of the HTML (`wp_footer` 19). For above-the-fold hooked content (header layouts) a brief unstyled flash during progressive rendering is possible on slow connections. This is a deliberate trade-off: beyond the guaranteed-to-render singular post, CSS is gathered only for posts that actually display, with no speculative site-wide preloading and no extra queries or options.
> - `save_post` still clears a post's cached CSS on any update (including programmatic ones); pages self-heal via the generator until the next editor save re-warms the cache.

---- 

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

