### PR TITLE
feat: support XML and CSV exports for form submissions

### DIFF
--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -635,6 +635,54 @@ class Dashboard {
 				max-height: 35px;
 			}
 
+			.o-export-split {
+				position: relative;
+				display: inline-flex;
+			}
+
+			.o-export-split #export-submissions {
+				border-top-right-radius: 0;
+				border-bottom-right-radius: 0;
+			}
+
+			.o-export-split__toggle {
+				border-top-left-radius: 0 !important;
+				border-bottom-left-radius: 0 !important;
+				border-left: none !important;
+				padding: 0 6px !important;
+			}
+
+			.o-export-split__menu {
+				position: absolute;
+				top: 100%;
+				right: 0;
+				z-index: 10;
+				margin: 4px 0 0;
+				padding: 4px 0;
+				list-style: none;
+				background: #fff;
+				border: 1px solid #c3c4c7;
+				border-radius: 4px;
+				box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+				min-width: 220px;
+			}
+
+			.o-export-split__item {
+				display: block;
+				width: 100%;
+				padding: 8px 12px;
+				background: none;
+				border: none;
+				text-align: left;
+				cursor: pointer;
+				font-size: 13px;
+			}
+
+			.o-export-split__item:hover,
+			.o-export-split__item:focus {
+				background: #f0f0f1;
+			}
+
 			.wp-core-ui .button.o-locked-action,
 			.wp-core-ui .button.o-locked-action:focus {
 				display: inline-flex;
@@ -683,9 +731,25 @@ class Dashboard {
 				<h1 class="otter-banner__title" style="line-height: normal;"><?php esc_html_e( 'Form Submissions', 'otter-blocks' ); ?></h1>
 
 				<?php if ( Pro::is_pro_active() ) : ?>
-				<button id="export-submissions" class="button">
-					<?php esc_html_e( 'Export', 'otter-blocks' ); ?>
-				</button>
+				<div class="o-export-split">
+					<button id="export-submissions" class="button" data-format="xml">
+						<?php esc_html_e( 'Export', 'otter-blocks' ); ?>
+					</button>
+					<button
+						id="export-submissions-toggle"
+						type="button"
+						class="button o-export-split__toggle"
+						aria-haspopup="true"
+						aria-expanded="false"
+						aria-label="<?php esc_attr_e( 'Choose file format', 'otter-blocks' ); ?>"
+					>
+						<span class="dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
+					</button>
+					<ul id="export-submissions-menu" class="o-export-split__menu" hidden>
+						<li><button type="button" class="o-export-split__item" data-format="xml"><?php esc_html_e( 'Export as WordPress XML (WXR)', 'otter-blocks' ); ?></button></li>
+						<li><button type="button" class="o-export-split__item" data-format="csv"><?php esc_html_e( 'Export as CSV', 'otter-blocks' ); ?></button></li>
+					</ul>
+				</div>
 				<?php else : ?>
 				<span class="otter-banner__actions">
 					<span class="o-pro-notice"><?php esc_html_e( 'Filter and export form submissions with Otter Pro.', 'otter-blocks' ); ?></span>
@@ -706,7 +770,20 @@ class Dashboard {
 		</div>
 		<script>
 			window.document.addEventListener('DOMContentLoaded', () => {
-				document.querySelector('#export-submissions')?.addEventListener('click', () => {
+				const exportBtn = document.querySelector('#export-submissions');
+				const toggleBtn = document.querySelector('#export-submissions-toggle');
+				const menu = document.querySelector('#export-submissions-menu');
+
+				const closeMenu = () => {
+					if (!menu || !toggleBtn) {
+						return;
+					}
+
+					menu.setAttribute('hidden', '');
+					toggleBtn.setAttribute('aria-expanded', 'false');
+				};
+
+				const runExport = (format) => {
 					fetch('<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>', {
 						method: 'POST',
 						headers: {
@@ -714,6 +791,7 @@ class Dashboard {
 						},
 						body: new URLSearchParams({
 							action: 'otter_form_submissions',
+							format: format,
 							_nonce: '<?php echo esc_attr( wp_create_nonce( 'otter_form_export_submissions' ) ); ?>'
 						})
 					})
@@ -724,17 +802,43 @@ class Dashboard {
 							const month = String(currentDate.getMonth() + 1).padStart(2, '0');
 							const day = String(currentDate.getDate()).padStart(2, '0');
 
-							const blob = new Blob([response], {type: 'text/xml'});
+							const isCsv = 'csv' === format;
+							const blob = new Blob([response], {type: isCsv ? 'text/csv;charset=utf-8' : 'text/xml'});
 							const url = window.URL.createObjectURL(blob);
 							const a = document.createElement('a');
 							a.href = url;
-							a.download = `otter_form_submissions__${year}-${month}-${day}.xml`;
+							a.download = `otter_form_submissions__${year}-${month}-${day}.${isCsv ? 'csv' : 'xml'}`;
 							document.body.appendChild(a);
 							a.click();
 						})
 						.catch(error => console.error('Error:', error));
+				};
+
+				exportBtn?.addEventListener('click', () => runExport(exportBtn.dataset.format || 'xml'));
+
+				toggleBtn?.addEventListener('click', (event) => {
+					event.stopPropagation();
+
+					if (menu.hasAttribute('hidden')) {
+						menu.removeAttribute('hidden');
+						toggleBtn.setAttribute('aria-expanded', 'true');
+					} else {
+						closeMenu();
+					}
 				});
 
+				menu?.querySelectorAll('.o-export-split__item').forEach((item) => {
+					item.addEventListener('click', () => {
+						runExport(item.dataset.format);
+						closeMenu();
+					});
+				});
+
+				document.addEventListener('click', (event) => {
+					if (menu && !menu.hasAttribute('hidden') && !menu.contains(event.target) && event.target !== toggleBtn) {
+						closeMenu();
+					}
+				});
 			})
 		</script>
 		<?php

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -739,7 +739,7 @@ class Dashboard {
 						id="export-submissions-toggle"
 						type="button"
 						class="button o-export-split__toggle"
-						aria-haspopup="true"
+						aria-controls="export-submissions-menu"
 						aria-expanded="false"
 						aria-label="<?php esc_attr_e( 'Choose file format', 'otter-blocks' ); ?>"
 					>

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -42,13 +42,118 @@ class Form_Records_Export {
 			wp_die( esc_html( __( 'You are not allowed to export submissions.', 'otter-blocks' ) ) );
 		}
 
-		// Export submissions.
+		$format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'xml'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		echo 'csv' === $format ? $this->export_csv() : $this->export_xml(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		wp_die();
+	}
+
+	/**
+	 * Build the WordPress WXR (XML) export of all submissions.
+	 *
+	 * @return string
+	 */
+	private function export_xml() {
 		require_once ABSPATH . 'wp-admin/includes/export.php';
+
 		ob_start();
 		export_wp( array( 'content' => Form_Submissions::FORM_RECORD_TYPE ) );
 		$export = ob_get_clean();
 
-		echo ent2ncr( $export ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		wp_die();
+		return ent2ncr( $export );
+	}
+
+	/**
+	 * Build a CSV export of all submissions.
+	 *
+	 * @return string
+	 */
+	private function export_csv() {
+		$records = get_posts(
+			array(
+				'post_type'      => Form_Submissions::FORM_RECORD_TYPE,
+				'post_status'    => array( 'draft', 'unread', 'read', 'trash' ),
+				'posts_per_page' => -1,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		update_meta_cache( 'post', wp_list_pluck( $records, 'ID' ) );
+
+		$fixed_columns = array(
+			'id'     => __( 'ID', 'otter-blocks' ),
+			'status' => __( 'Status', 'otter-blocks' ),
+			'date'   => __( 'Submission Date', 'otter-blocks' ),
+			'form'   => __( 'Form', 'otter-blocks' ),
+			'post'   => __( 'Post URL', 'otter-blocks' ),
+		);
+
+		$input_columns = array();
+		$rows          = array();
+
+		foreach ( $records as $record ) {
+			$post_id = $record->ID;
+			$meta    = get_post_meta( $post_id, Form_Submissions::FORM_RECORD_META_KEY, true );
+
+			if ( ! is_array( $meta ) ) {
+				continue;
+			}
+
+			$row = array(
+				'id'     => substr( strval( $post_id ), -8 ),
+				'status' => get_post_status( $post_id ),
+				'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post_id ),
+				'form'   => isset( $meta['form']['value'] ) ? $meta['form']['value'] : '',
+				'post'   => isset( $meta['post_url']['value'] ) ? $meta['post_url']['value'] : '',
+			);
+
+			$inputs = isset( $meta['inputs'] ) && is_array( $meta['inputs'] ) ? $meta['inputs'] : array();
+
+			foreach ( $inputs as $input ) {
+				if ( empty( $input ) || ! isset( $input['type'], $input['label'] ) || 'stripe-field' === $input['type'] ) {
+					continue;
+				}
+
+				$label = $input['label'];
+
+				if ( ! isset( $input_columns[ $label ] ) ) {
+					$input_columns[ $label ] = $label;
+				}
+
+				$value = isset( $input['value'] ) ? $input['value'] : '';
+
+				if ( 'file' === $input['type'] && isset( $input['metadata']['name'] ) ) {
+					$value = $input['metadata']['name'];
+				}
+
+				$row[ $label ] = $value;
+			}
+
+			$rows[] = $row;
+		}
+
+		$columns = array_merge( $fixed_columns, $input_columns );
+
+		$stream = fopen( 'php://temp', 'w+' );
+
+		fputcsv( $stream, array_values( $columns ) );
+
+		foreach ( $rows as $row ) {
+			$line = array();
+
+			foreach ( array_keys( $columns ) as $key ) {
+				$line[] = isset( $row[ $key ] ) ? $row[ $key ] : '';
+			}
+
+			fputcsv( $stream, $line );
+		}
+
+		rewind( $stream );
+		$csv = stream_get_contents( $stream );
+		fclose( $stream );
+
+		// Prefix a UTF-8 BOM so Excel detects the encoding instead of mangling accented characters.
+		return "\xEF\xBB\xBF" . $csv;
 	}
 }

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -72,7 +72,7 @@ class Form_Records_Export {
 		$records = get_posts(
 			array(
 				'post_type'      => Form_Submissions::FORM_RECORD_TYPE,
-				'post_status'    => array( 'draft', 'unread', 'read', 'trash' ),
+				'post_status'    => array( 'draft', 'unread', 'read', 'trash', 'publish' ),
 				'posts_per_page' => -1,
 				'orderby'        => 'ID',
 				'order'          => 'ASC',
@@ -115,10 +115,11 @@ class Form_Records_Export {
 					continue;
 				}
 
-				$label = $input['label'];
+				$label      = $input['label'];
+ 				$column_key = 'input:' . $label;
 
 				if ( ! isset( $input_columns[ $label ] ) ) {
-					$input_columns[ $label ] = $label;
+					$input_columns[ $column_key ] = $label;
 				}
 
 				$value = isset( $input['value'] ) ? $input['value'] : '';
@@ -127,7 +128,7 @@ class Form_Records_Export {
 					$value = $input['metadata']['name'];
 				}
 
-				$row[ $label ] = $value;
+				$row[ $column_key ] = $value;
 			}
 
 			$rows[] = $row;
@@ -137,13 +138,19 @@ class Form_Records_Export {
 
 		$stream = fopen( 'php://temp', 'w+' );
 
-		fputcsv( $stream, array_values( $columns ) );
+		$sanitize_cell = static function ( $value ) {
+ 			$value = strval( $value );
+ 			return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
+ 		};
+
+ 		fputcsv( $stream, array_map( $sanitize_cell, array_values( $columns ) ) );
 
 		foreach ( $rows as $row ) {
 			$line = array();
 
 			foreach ( array_keys( $columns ) as $key ) {
-				$line[] = isset( $row[ $key ] ) ? $row[ $key ] : '';
+				$value  = isset( $row[ $key ] ) ? $row[ $key ] : '';
+ 				$line[] = $sanitize_cell( $value );
 			}
 
 			fputcsv( $stream, $line );

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -116,7 +116,7 @@ class Form_Records_Export {
 				}
 
 				$label      = $input['label'];
- 				$column_key = 'input:' . $label;
+				$column_key = 'input:' . $label;
 
 				if ( ! isset( $input_columns[ $label ] ) ) {
 					$input_columns[ $column_key ] = $label;
@@ -136,24 +136,24 @@ class Form_Records_Export {
 
 		$columns = array_merge( $fixed_columns, $input_columns );
 
-		$stream = fopen( 'php://temp', 'w+' );
+		$stream = fopen( 'php://temp', 'w+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
 		$sanitize_cell = static function ( $value ) {
- 			$value = strval( $value );
- 			return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
- 		};
+			$value = strval( $value );
+			return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
+		};
 
- 		fputcsv( $stream, array_map( $sanitize_cell, array_values( $columns ) ) );
+		fputcsv( $stream, array_map( $sanitize_cell, array_values( $columns ) ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
 
 		foreach ( $rows as $row ) {
 			$line = array();
 
 			foreach ( array_keys( $columns ) as $key ) {
 				$value  = isset( $row[ $key ] ) ? $row[ $key ] : '';
- 				$line[] = $sanitize_cell( $value );
+				$line[] = $sanitize_cell( $value );
 			}
 
-			fputcsv( $stream, $line );
+			fputcsv( $stream, $line ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
 		}
 
 		rewind( $stream );

--- a/src/blocks/test/e2e/blocks/form.spec.js
+++ b/src/blocks/test/e2e/blocks/form.spec.js
@@ -412,10 +412,10 @@ test.describe( 'Form Block', () => {
 		await expect( page.locator( '.otter-form-input[type="hidden"]' ) ).toHaveValue( '123' );
 	});
 
-	test( 'can export form data', async({ page }) => {
+	test( 'can export form data as WordPress XML (WXR)', async({ page }) => {
 		await page.goto( '/wp-admin/edit.php?post_type=otter_form_record' );
 
-		const exportBtn = page.getByRole( 'button', { name: 'Export' });
+		const exportBtn = page.getByRole( 'button', { name: 'Export', exact: true });
 
 		await expect( exportBtn ).toBeVisible();
 
@@ -425,5 +425,20 @@ test.describe( 'Form Block', () => {
 
 		await download.path(); // Wait for download to complete.
 		expect( download.suggestedFilename().startsWith( 'otter_form_submissions' ) ).toBeTruthy();
+		expect( download.suggestedFilename().endsWith( '.xml' ) ).toBeTruthy();
+	});
+
+	test( 'can export form data as CSV', async({ page }) => {
+		await page.goto( '/wp-admin/edit.php?post_type=otter_form_record' );
+
+		await page.locator( '#export-submissions-toggle' ).click();
+
+		const downloadPromise = page.waitForEvent( 'download' );
+		await page.getByRole( 'button', { name: 'Export as CSV' }).click();
+		const download = await downloadPromise;
+
+		await download.path(); // Wait for download to complete.
+		expect( download.suggestedFilename().startsWith( 'otter_form_submissions' ) ).toBeTruthy();
+		expect( download.suggestedFilename().endsWith( '.csv' ) ).toBeTruthy();
 	});
 });

--- a/tests/test-form-submissions.php
+++ b/tests/test-form-submissions.php
@@ -58,7 +58,7 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		unset( $_REQUEST[ Form_Submissions::FORM_RECORD_TYPE ], $_REQUEST['_wpnonce'], $_REQUEST['post'] );
-		unset( $_POST['action'], $_POST['_wpnonce'], $_POST['_nonce'] );
+		unset( $_POST['action'], $_POST['_wpnonce'], $_POST['_nonce'], $_POST['format'] );
 		unset( $_GET['post_type'], $_GET['filter_action'], $_GET['filters_nonce'], $_GET['otter_form_filter'], $_REQUEST['otter_form_filter'] );
 		unset( $_GET['otter_post_filter'], $_REQUEST['otter_post_filter'] );
 		unset( $GLOBALS['otter_test_stripe_record_id'] );
@@ -807,6 +807,92 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 		$this->expectExceptionMessage( 'You are not allowed to export submissions.' );
 
 		( new Form_Records_Export() )->export_submissions();
+	}
+
+	/**
+	 * Ensure the export defaults to the WordPress XML (WXR) format when no format is
+	 * posted, preserving the pre-existing endpoint contract.
+	 */
+	public function test_export_defaults_to_xml_format() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		add_filter( 'product_otter_license_status', array( $this, 'valid_license' ) );
+
+		$this->create_record();
+
+		wp_set_current_user( $this->admin_id );
+		$_POST['_nonce'] = wp_create_nonce( 'otter_form_export_submissions' );
+
+		ob_start();
+
+		try {
+			( new Form_Records_Export() )->export_submissions();
+		} catch ( WPDieException $exception ) {
+			// export_submissions() always ends in wp_die(); assertions run on the buffered output below.
+		}
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<?xml version="1.0"', $output );
+	}
+
+	/**
+	 * Ensure the CSV export contains a header row and one line per submission, with columns
+	 * covering every input label found across submissions from different forms.
+	 */
+	public function test_export_csv_contains_submission_data() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		add_filter( 'product_otter_license_status', array( $this, 'valid_license' ) );
+
+		$this->create_record(
+			'unread',
+			array(
+				'inputs' => array(
+					'input01' => array(
+						'label' => 'Name',
+						'value' => 'Ada Lovelace',
+						'type'  => 'text',
+					),
+				),
+			)
+		);
+
+		$this->create_record(
+			'read',
+			array(
+				'inputs' => array(
+					'input02' => array(
+						'label' => 'Company',
+						'value' => 'Analytical Engines Ltd',
+						'type'  => 'text',
+					),
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$_POST['_nonce'] = wp_create_nonce( 'otter_form_export_submissions' );
+		$_POST['format'] = 'csv';
+
+		ob_start();
+
+		try {
+			( new Form_Records_Export() )->export_submissions();
+		} catch ( WPDieException $exception ) {
+			// export_submissions() always ends in wp_die(); assertions run on the buffered output below.
+		}
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Name', $output );
+		$this->assertStringContainsString( 'Company', $output );
+		$this->assertStringContainsString( 'Ada Lovelace', $output );
+		$this->assertStringContainsString( 'Analytical Engines Ltd', $output );
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2884

### Summary
Added the ability to export form submissions as CSV. The export button is now a dropdown that allows users to choose between exporting as CSV or WordPress XML (WXR).

### Screenshots
<img width="1676" height="248" alt="image" src="https://github.com/user-attachments/assets/ff9e3d07-4cff-45bd-9f09-624786bad1ea" />


### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

