### PR TITLE
Release

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b41cfd1bb81a9d4f8ed32b2381a22d65",
+    "content-hash": "556f279ce85f25f708f60329f1f7067c",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.54",
+            "version": "3.3.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "095c2d0f1388af0b0196c492a7f79e2fd092dab1"
+                "reference": "d6807c0b7308e323bd77cced667dee3f2d5e6a82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/095c2d0f1388af0b0196c492a7f79e2fd092dab1",
-                "reference": "095c2d0f1388af0b0196c492a7f79e2fd092dab1",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/d6807c0b7308e323bd77cced667dee3f2d5e6a82",
+                "reference": "d6807c0b7308e323bd77cced667dee3f2d5e6a82",
                 "shasum": ""
             },
             "require-dev": {
@@ -36,16 +36,16 @@
                     "homepage": "https://themeisle.com"
                 }
             ],
-            "description": "Themeisle SDK.",
+            "description": "Themeisle SDK library.",
             "homepage": "https://github.com/Codeinwp/themeisle-sdk",
             "keywords": [
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.54"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.58"
             },
-            "time": "2026-06-23T13:43:47+00:00"
+            "time": "2026-07-29T08:38:52+00:00"
         },
         {
             "name": "enshrined/svg-sanitize",

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -968,7 +968,7 @@ class Registration {
 				);
 			}
 
-			if ( isset( $dynamic_blocks[ $block ] ) ) {
+			if ( isset( $dynamic_blocks[ $block ] ) && class_exists( $dynamic_blocks[ $block ] ) ) {
 				$classname = $dynamic_blocks[ $block ];
 				$renderer  = new $classname();
 

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -635,6 +635,54 @@ class Dashboard {
 				max-height: 35px;
 			}
 
+			.o-export-split {
+				position: relative;
+				display: inline-flex;
+			}
+
+			.o-export-split #export-submissions {
+				border-top-right-radius: 0;
+				border-bottom-right-radius: 0;
+			}
+
+			.o-export-split__toggle {
+				border-top-left-radius: 0 !important;
+				border-bottom-left-radius: 0 !important;
+				border-left: none !important;
+				padding: 0 6px !important;
+			}
+
+			.o-export-split__menu {
+				position: absolute;
+				top: 100%;
+				right: 0;
+				z-index: 10;
+				margin: 4px 0 0;
+				padding: 4px 0;
+				list-style: none;
+				background: #fff;
+				border: 1px solid #c3c4c7;
+				border-radius: 4px;
+				box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+				min-width: 220px;
+			}
+
+			.o-export-split__item {
+				display: block;
+				width: 100%;
+				padding: 8px 12px;
+				background: none;
+				border: none;
+				text-align: left;
+				cursor: pointer;
+				font-size: 13px;
+			}
+
+			.o-export-split__item:hover,
+			.o-export-split__item:focus {
+				background: #f0f0f1;
+			}
+
 			.wp-core-ui .button.o-locked-action,
 			.wp-core-ui .button.o-locked-action:focus {
 				display: inline-flex;
@@ -683,9 +731,25 @@ class Dashboard {
 				<h1 class="otter-banner__title" style="line-height: normal;"><?php esc_html_e( 'Form Submissions', 'otter-blocks' ); ?></h1>
 
 				<?php if ( Pro::is_pro_active() ) : ?>
-				<button id="export-submissions" class="button">
-					<?php esc_html_e( 'Export', 'otter-blocks' ); ?>
-				</button>
+				<div class="o-export-split">
+					<button id="export-submissions" class="button" data-format="xml">
+						<?php esc_html_e( 'Export', 'otter-blocks' ); ?>
+					</button>
+					<button
+						id="export-submissions-toggle"
+						type="button"
+						class="button o-export-split__toggle"
+						aria-haspopup="true"
+						aria-expanded="false"
+						aria-label="<?php esc_attr_e( 'Choose file format', 'otter-blocks' ); ?>"
+					>
+						<span class="dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
+					</button>
+					<ul id="export-submissions-menu" class="o-export-split__menu" hidden>
+						<li><button type="button" class="o-export-split__item" data-format="xml"><?php esc_html_e( 'Export as WordPress XML (WXR)', 'otter-blocks' ); ?></button></li>
+						<li><button type="button" class="o-export-split__item" data-format="csv"><?php esc_html_e( 'Export as CSV', 'otter-blocks' ); ?></button></li>
+					</ul>
+				</div>
 				<?php else : ?>
 				<span class="otter-banner__actions">
 					<span class="o-pro-notice"><?php esc_html_e( 'Filter and export form submissions with Otter Pro.', 'otter-blocks' ); ?></span>
@@ -706,7 +770,20 @@ class Dashboard {
 		</div>
 		<script>
 			window.document.addEventListener('DOMContentLoaded', () => {
-				document.querySelector('#export-submissions')?.addEventListener('click', () => {
+				const exportBtn = document.querySelector('#export-submissions');
+				const toggleBtn = document.querySelector('#export-submissions-toggle');
+				const menu = document.querySelector('#export-submissions-menu');
+
+				const closeMenu = () => {
+					if (!menu || !toggleBtn) {
+						return;
+					}
+
+					menu.setAttribute('hidden', '');
+					toggleBtn.setAttribute('aria-expanded', 'false');
+				};
+
+				const runExport = (format) => {
 					fetch('<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>', {
 						method: 'POST',
 						headers: {
@@ -714,6 +791,7 @@ class Dashboard {
 						},
 						body: new URLSearchParams({
 							action: 'otter_form_submissions',
+							format: format,
 							_nonce: '<?php echo esc_attr( wp_create_nonce( 'otter_form_export_submissions' ) ); ?>'
 						})
 					})
@@ -724,17 +802,43 @@ class Dashboard {
 							const month = String(currentDate.getMonth() + 1).padStart(2, '0');
 							const day = String(currentDate.getDate()).padStart(2, '0');
 
-							const blob = new Blob([response], {type: 'text/xml'});
+							const isCsv = 'csv' === format;
+							const blob = new Blob([response], {type: isCsv ? 'text/csv;charset=utf-8' : 'text/xml'});
 							const url = window.URL.createObjectURL(blob);
 							const a = document.createElement('a');
 							a.href = url;
-							a.download = `otter_form_submissions__${year}-${month}-${day}.xml`;
+							a.download = `otter_form_submissions__${year}-${month}-${day}.${isCsv ? 'csv' : 'xml'}`;
 							document.body.appendChild(a);
 							a.click();
 						})
 						.catch(error => console.error('Error:', error));
+				};
+
+				exportBtn?.addEventListener('click', () => runExport(exportBtn.dataset.format || 'xml'));
+
+				toggleBtn?.addEventListener('click', (event) => {
+					event.stopPropagation();
+
+					if (menu.hasAttribute('hidden')) {
+						menu.removeAttribute('hidden');
+						toggleBtn.setAttribute('aria-expanded', 'true');
+					} else {
+						closeMenu();
+					}
 				});
 
+				menu?.querySelectorAll('.o-export-split__item').forEach((item) => {
+					item.addEventListener('click', () => {
+						runExport(item.dataset.format);
+						closeMenu();
+					});
+				});
+
+				document.addEventListener('click', (event) => {
+					if (menu && !menu.hasAttribute('hidden') && !menu.contains(event.target) && event.target !== toggleBtn) {
+						closeMenu();
+					}
+				});
 			})
 		</script>
 		<?php

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -739,7 +739,7 @@ class Dashboard {
 						id="export-submissions-toggle"
 						type="button"
 						class="button o-export-split__toggle"
-						aria-haspopup="true"
+						aria-controls="export-submissions-menu"
 						aria-expanded="false"
 						aria-label="<?php esc_attr_e( 'Choose file format', 'otter-blocks' ); ?>"
 					>

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -42,13 +42,118 @@ class Form_Records_Export {
 			wp_die( esc_html( __( 'You are not allowed to export submissions.', 'otter-blocks' ) ) );
 		}
 
-		// Export submissions.
+		$format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'xml'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		echo 'csv' === $format ? $this->export_csv() : $this->export_xml(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		wp_die();
+	}
+
+	/**
+	 * Build the WordPress WXR (XML) export of all submissions.
+	 *
+	 * @return string
+	 */
+	private function export_xml() {
 		require_once ABSPATH . 'wp-admin/includes/export.php';
+
 		ob_start();
 		export_wp( array( 'content' => Form_Submissions::FORM_RECORD_TYPE ) );
 		$export = ob_get_clean();
 
-		echo ent2ncr( $export ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		wp_die();
+		return ent2ncr( $export );
+	}
+
+	/**
+	 * Build a CSV export of all submissions.
+	 *
+	 * @return string
+	 */
+	private function export_csv() {
+		$records = get_posts(
+			array(
+				'post_type'      => Form_Submissions::FORM_RECORD_TYPE,
+				'post_status'    => array( 'draft', 'unread', 'read', 'trash' ),
+				'posts_per_page' => -1,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		update_meta_cache( 'post', wp_list_pluck( $records, 'ID' ) );
+
+		$fixed_columns = array(
+			'id'     => __( 'ID', 'otter-blocks' ),
+			'status' => __( 'Status', 'otter-blocks' ),
+			'date'   => __( 'Submission Date', 'otter-blocks' ),
+			'form'   => __( 'Form', 'otter-blocks' ),
+			'post'   => __( 'Post URL', 'otter-blocks' ),
+		);
+
+		$input_columns = array();
+		$rows          = array();
+
+		foreach ( $records as $record ) {
+			$post_id = $record->ID;
+			$meta    = get_post_meta( $post_id, Form_Submissions::FORM_RECORD_META_KEY, true );
+
+			if ( ! is_array( $meta ) ) {
+				continue;
+			}
+
+			$row = array(
+				'id'     => substr( strval( $post_id ), -8 ),
+				'status' => get_post_status( $post_id ),
+				'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post_id ),
+				'form'   => isset( $meta['form']['value'] ) ? $meta['form']['value'] : '',
+				'post'   => isset( $meta['post_url']['value'] ) ? $meta['post_url']['value'] : '',
+			);
+
+			$inputs = isset( $meta['inputs'] ) && is_array( $meta['inputs'] ) ? $meta['inputs'] : array();
+
+			foreach ( $inputs as $input ) {
+				if ( empty( $input ) || ! isset( $input['type'], $input['label'] ) || 'stripe-field' === $input['type'] ) {
+					continue;
+				}
+
+				$label = $input['label'];
+
+				if ( ! isset( $input_columns[ $label ] ) ) {
+					$input_columns[ $label ] = $label;
+				}
+
+				$value = isset( $input['value'] ) ? $input['value'] : '';
+
+				if ( 'file' === $input['type'] && isset( $input['metadata']['name'] ) ) {
+					$value = $input['metadata']['name'];
+				}
+
+				$row[ $label ] = $value;
+			}
+
+			$rows[] = $row;
+		}
+
+		$columns = array_merge( $fixed_columns, $input_columns );
+
+		$stream = fopen( 'php://temp', 'w+' );
+
+		fputcsv( $stream, array_values( $columns ) );
+
+		foreach ( $rows as $row ) {
+			$line = array();
+
+			foreach ( array_keys( $columns ) as $key ) {
+				$line[] = isset( $row[ $key ] ) ? $row[ $key ] : '';
+			}
+
+			fputcsv( $stream, $line );
+		}
+
+		rewind( $stream );
+		$csv = stream_get_contents( $stream );
+		fclose( $stream );
+
+		// Prefix a UTF-8 BOM so Excel detects the encoding instead of mangling accented characters.
+		return "\xEF\xBB\xBF" . $csv;
 	}
 }

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -72,7 +72,7 @@ class Form_Records_Export {
 		$records = get_posts(
 			array(
 				'post_type'      => Form_Submissions::FORM_RECORD_TYPE,
-				'post_status'    => array( 'draft', 'unread', 'read', 'trash' ),
+				'post_status'    => array( 'draft', 'unread', 'read', 'trash', 'publish' ),
 				'posts_per_page' => -1,
 				'orderby'        => 'ID',
 				'order'          => 'ASC',
@@ -115,10 +115,11 @@ class Form_Records_Export {
 					continue;
 				}
 
-				$label = $input['label'];
+				$label      = $input['label'];
+ 				$column_key = 'input:' . $label;
 
 				if ( ! isset( $input_columns[ $label ] ) ) {
-					$input_columns[ $label ] = $label;
+					$input_columns[ $column_key ] = $label;
 				}
 
 				$value = isset( $input['value'] ) ? $input['value'] : '';
@@ -127,7 +128,7 @@ class Form_Records_Export {
 					$value = $input['metadata']['name'];
 				}
 
-				$row[ $label ] = $value;
+				$row[ $column_key ] = $value;
 			}
 
 			$rows[] = $row;
@@ -137,13 +138,19 @@ class Form_Records_Export {
 
 		$stream = fopen( 'php://temp', 'w+' );
 
-		fputcsv( $stream, array_values( $columns ) );
+		$sanitize_cell = static function ( $value ) {
+ 			$value = strval( $value );
+ 			return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
+ 		};
+
+ 		fputcsv( $stream, array_map( $sanitize_cell, array_values( $columns ) ) );
 
 		foreach ( $rows as $row ) {
 			$line = array();
 
 			foreach ( array_keys( $columns ) as $key ) {
-				$line[] = isset( $row[ $key ] ) ? $row[ $key ] : '';
+				$value  = isset( $row[ $key ] ) ? $row[ $key ] : '';
+ 				$line[] = $sanitize_cell( $value );
 			}
 
 			fputcsv( $stream, $line );

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -24,6 +24,13 @@ class Form_Records_Export {
 	const EXPORT_BATCH_SIZE = 100;
 
 	/**
+	 * Post statuses.
+	 *
+	 * @var string[]
+	 */
+	const EXPORT_POST_STATUSES = array( 'draft', 'unread', 'read', 'trash', 'publish' );
+
+	/**
 	 * Register hooks.
 	 *
 	 * @return void
@@ -76,12 +83,14 @@ class Form_Records_Export {
 	}
 
 	/**
-	 * Build a CSV export of all submissions.
+	 * Write a CSV export of all submissions to the output.
 	 *
 	 * @return void
 	 */
 	private function export_csv() {
-		$columns = array_merge( $this->get_fixed_columns(), $this->collect_input_columns() );
+		$max_id = (int) $this->get_max_submission_id();
+
+		$columns = array_merge( $this->get_fixed_columns(), $this->collect_input_columns( $max_id ) );
 
 		$stream = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
@@ -97,8 +106,9 @@ class Form_Records_Export {
 		$column_keys = array_keys( $columns );
 
 		$this->walk_submissions(
-			function ( $meta, $record ) use ( $stream, $column_keys ) {
-				$row  = $this->get_record_row( $record, $meta );
+			$max_id,
+			function ( $meta, $post_id ) use ( $stream, $column_keys ) {
+				$row  = $this->get_record_row( $post_id, $meta );
 				$line = array();
 
 				foreach ( $column_keys as $key ) {
@@ -130,12 +140,14 @@ class Form_Records_Export {
 	/**
 	 * Collect the dynamically generated input columns found across every submission.
 	 *
+	 * @param int $max_id Highest submission ID to export.
 	 * @return array<string, string> Column key => header label, in order of first appearance.
 	 */
-	private function collect_input_columns() {
+	private function collect_input_columns( $max_id ) {
 		$input_columns = array();
 
 		$this->walk_submissions(
+			$max_id,
 			function ( $meta ) use ( &$input_columns ) {
 				foreach ( $this->get_record_inputs( $meta ) as $column_key => $input ) {
 					if ( isset( $input_columns[ $column_key ] ) ) {
@@ -153,22 +165,24 @@ class Form_Records_Export {
 	/**
 	 * Run a callback over every submission, loading them in bounded batches.
 	 *
-	 * @param callable $callback Receives the submission record meta and the submission post.
+	 * @param int      $max_id   Highest submission ID to export.
+	 * @param callable $callback Receives the submission record meta and the submission post ID.
 	 * @return void
 	 */
-	private function walk_submissions( $callback ) {
-		$offset               = 0;
-		$has_more_submissions = false;
+	private function walk_submissions( $max_id, $callback ) {
+		$last_id = 0;
 
 		do {
-			$records = $this->get_submissions_batch( $offset );
-			$count   = count( $records );
+			$records = $this->get_submissions_batch( $last_id, $max_id );
 
-			if ( 0 === $count ) {
+			// The batch is only limited, never offset, so an empty one means the range is done.
+			if ( empty( $records ) ) {
 				return;
 			}
 
-			$ids = wp_list_pluck( $records, 'ID' );
+			$ids     = wp_list_pluck( $records, 'ID' );
+			$last_id = (int) end( $ids );
+
 			update_meta_cache( 'post', $ids );
 
 			foreach ( $records as $record ) {
@@ -178,9 +192,10 @@ class Form_Records_Export {
 					continue;
 				}
 
-				$callback( $meta, $record );
+				$callback( $meta, $record->ID );
 			}
 
+			// Drop the batch from the object cache, otherwise memory grows with every batch.
 			foreach ( $ids as $id ) {
 				wp_cache_delete( $id, 'posts' );
 				wp_cache_delete( $id, 'post_meta' );
@@ -188,42 +203,75 @@ class Form_Records_Export {
 
 			unset( $records, $ids );
 
-			$offset              += $count;
-			$has_more_submissions = self::EXPORT_BATCH_SIZE === $count;
+			$has_more_submissions = $last_id < $max_id;
 		} while ( $has_more_submissions );
 	}
 
 	/**
-	 * Fetch a batch of submissions, oldest first.
+	 * The highest submission ID eligible for export.
 	 *
-	 * @param int $offset How many submissions to skip.
-	 * @return \WP_Post[]
+	 * @return int
 	 */
-	private function get_submissions_batch( $offset ) {
-		return get_posts(
+	private function get_max_submission_id() {
+		$ids = get_posts(
 			array(
 				'post_type'              => Form_Submissions::FORM_RECORD_TYPE,
-				'post_status'            => array( 'draft', 'unread', 'read', 'trash', 'publish' ),
-				'posts_per_page'         => self::EXPORT_BATCH_SIZE,
-				'offset'                 => $offset,
+				'post_status'            => self::EXPORT_POST_STATUSES,
+				'posts_per_page'         => 1,
 				'orderby'                => 'ID',
-				'order'                  => 'ASC',
+				'order'                  => 'DESC',
+				'fields'                 => 'ids',
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
 			)
 		);
+
+		return empty( $ids ) ? 0 : reset( $ids );
+	}
+
+	/**
+	 * Fetch the submissions following the last one handled, oldest first.
+	 *
+	 * @param int $last_id Highest submission ID handled so far.
+	 * @param int $max_id  Highest submission ID to export.
+	 * @return \WP_Post[]
+	 */
+	private function get_submissions_batch( $last_id, $max_id ) {
+		$keyset_clause = static function ( $where ) use ( $last_id, $max_id ) {
+			global $wpdb;
+
+			return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d AND {$wpdb->posts}.ID <= %d", $last_id, $max_id );
+		};
+
+		add_filter( 'posts_where', $keyset_clause );
+
+		$query = new \WP_Query(
+			array(
+				'post_type'              => Form_Submissions::FORM_RECORD_TYPE,
+				'post_status'            => self::EXPORT_POST_STATUSES,
+				'posts_per_page'         => self::EXPORT_BATCH_SIZE,
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'suppress_filters'       => false,
+			)
+		);
+
+		remove_filter( 'posts_where', $keyset_clause );
+
+		return $query->posts;
 	}
 
 	/**
 	 * Build the CSV row of a single submission, keyed by column.
 	 *
-	 * @param \WP_Post             $record Submission post.
-	 * @param array<string, mixed> $meta   Submission record meta.
+	 * @param int                  $post_id Submission post ID.
+	 * @param array<string, mixed> $meta    Submission record meta.
 	 * @return array<string, mixed>
 	 */
-	private function get_record_row( $record, $meta ) {
-		$post_id = $record->ID;
-
+	private function get_record_row( $post_id, $meta ) {
 		$row = array(
 			'id'     => substr( strval( $post_id ), -8 ),
 			'status' => get_post_status( $post_id ),

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -17,6 +17,13 @@ use ThemeIsle\GutenbergBlocks\Pro;
  */
 class Form_Records_Export {
 	/**
+	 * The number of submissions to fetch in each batch when exporting to CSV.
+	 *
+	 * @var int
+	 */
+	const EXPORT_BATCH_SIZE = 100;
+
+	/**
 	 * Register hooks.
 	 *
 	 * @return void
@@ -44,7 +51,12 @@ class Form_Records_Export {
 
 		$format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'xml'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		echo 'csv' === $format ? $this->export_csv() : $this->export_xml(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		if ( 'csv' === $format ) {
+			$this->export_csv();
+		} else {
+			echo $this->export_xml(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+
 		wp_die();
 	}
 
@@ -66,101 +78,206 @@ class Form_Records_Export {
 	/**
 	 * Build a CSV export of all submissions.
 	 *
-	 * @return string
+	 * @return void
 	 */
 	private function export_csv() {
-		$records = get_posts(
-			array(
-				'post_type'      => Form_Submissions::FORM_RECORD_TYPE,
-				'post_status'    => array( 'draft', 'unread', 'read', 'trash', 'publish' ),
-				'posts_per_page' => -1,
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-			)
+		$columns = array_merge( $this->get_fixed_columns(), $this->collect_input_columns() );
+
+		$stream = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+
+		if ( false === $stream ) {
+			return;
+		}
+
+		// Prefix a UTF-8 BOM so Excel detects the encoding instead of mangling accented characters.
+		fwrite( $stream, "\xEF\xBB\xBF" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+
+		fputcsv( $stream, array_map( array( $this, 'sanitize_cell' ), array_values( $columns ) ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+
+		$column_keys = array_keys( $columns );
+
+		$this->walk_submissions(
+			function ( $meta, $record ) use ( $stream, $column_keys ) {
+				$row  = $this->get_record_row( $record, $meta );
+				$line = array();
+
+				foreach ( $column_keys as $key ) {
+					$line[] = $this->sanitize_cell( isset( $row[ $key ] ) ? $row[ $key ] : '' );
+				}
+
+				fputcsv( $stream, $line ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+			}
 		);
 
-		update_meta_cache( 'post', wp_list_pluck( $records, 'ID' ) );
+		fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+	}
 
-		$fixed_columns = array(
+	/**
+	 * Columns present for every submission, in export order.
+	 *
+	 * @return array<string, string> Column key => header label.
+	 */
+	private function get_fixed_columns() {
+		return array(
 			'id'     => __( 'ID', 'otter-blocks' ),
 			'status' => __( 'Status', 'otter-blocks' ),
 			'date'   => __( 'Submission Date', 'otter-blocks' ),
 			'form'   => __( 'Form', 'otter-blocks' ),
 			'post'   => __( 'Post URL', 'otter-blocks' ),
 		);
+	}
 
+	/**
+	 * Collect the dynamically generated input columns found across every submission.
+	 *
+	 * @return array<string, string> Column key => header label, in order of first appearance.
+	 */
+	private function collect_input_columns() {
 		$input_columns = array();
-		$rows          = array();
 
-		foreach ( $records as $record ) {
-			$post_id = $record->ID;
-			$meta    = get_post_meta( $post_id, Form_Submissions::FORM_RECORD_META_KEY, true );
+		$this->walk_submissions(
+			function ( $meta ) use ( &$input_columns ) {
+				foreach ( $this->get_record_inputs( $meta ) as $column_key => $input ) {
+					if ( isset( $input_columns[ $column_key ] ) ) {
+						continue;
+					}
 
-			if ( ! is_array( $meta ) ) {
-				continue;
+					$input_columns[ $column_key ] = $input['label'];
+				}
+			}
+		);
+
+		return $input_columns;
+	}
+
+	/**
+	 * Run a callback over every submission, loading them in bounded batches.
+	 *
+	 * @param callable $callback Receives the submission record meta and the submission post.
+	 * @return void
+	 */
+	private function walk_submissions( $callback ) {
+		$offset               = 0;
+		$has_more_submissions = false;
+
+		do {
+			$records = $this->get_submissions_batch( $offset );
+			$count   = count( $records );
+
+			if ( 0 === $count ) {
+				return;
 			}
 
-			$row = array(
-				'id'     => substr( strval( $post_id ), -8 ),
-				'status' => get_post_status( $post_id ),
-				'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post_id ),
-				'form'   => isset( $meta['form']['value'] ) ? $meta['form']['value'] : '',
-				'post'   => isset( $meta['post_url']['value'] ) ? $meta['post_url']['value'] : '',
-			);
+			$ids = wp_list_pluck( $records, 'ID' );
+			update_meta_cache( 'post', $ids );
 
-			$inputs = isset( $meta['inputs'] ) && is_array( $meta['inputs'] ) ? $meta['inputs'] : array();
+			foreach ( $records as $record ) {
+				$meta = get_post_meta( $record->ID, Form_Submissions::FORM_RECORD_META_KEY, true );
 
-			foreach ( $inputs as $input ) {
-				if ( empty( $input ) || ! isset( $input['type'], $input['label'] ) || 'stripe-field' === $input['type'] ) {
+				if ( ! is_array( $meta ) ) {
 					continue;
 				}
 
-				$label      = $input['label'];
-				$column_key = 'input:' . $label;
-
-				if ( ! isset( $input_columns[ $label ] ) ) {
-					$input_columns[ $column_key ] = $label;
-				}
-
-				$value = isset( $input['value'] ) ? $input['value'] : '';
-
-				if ( 'file' === $input['type'] && isset( $input['metadata']['name'] ) ) {
-					$value = $input['metadata']['name'];
-				}
-
-				$row[ $column_key ] = $value;
+				$callback( $meta, $record );
 			}
 
-			$rows[] = $row;
-		}
-
-		$columns = array_merge( $fixed_columns, $input_columns );
-
-		$stream = fopen( 'php://temp', 'w+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-
-		$sanitize_cell = static function ( $value ) {
-			$value = strval( $value );
-			return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
-		};
-
-		fputcsv( $stream, array_map( $sanitize_cell, array_values( $columns ) ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
-
-		foreach ( $rows as $row ) {
-			$line = array();
-
-			foreach ( array_keys( $columns ) as $key ) {
-				$value  = isset( $row[ $key ] ) ? $row[ $key ] : '';
-				$line[] = $sanitize_cell( $value );
+			foreach ( $ids as $id ) {
+				wp_cache_delete( $id, 'posts' );
+				wp_cache_delete( $id, 'post_meta' );
 			}
 
-			fputcsv( $stream, $line ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+			unset( $records, $ids );
+
+			$offset              += $count;
+			$has_more_submissions = self::EXPORT_BATCH_SIZE === $count;
+		} while ( $has_more_submissions );
+	}
+
+	/**
+	 * Fetch a batch of submissions, oldest first.
+	 *
+	 * @param int $offset How many submissions to skip.
+	 * @return \WP_Post[]
+	 */
+	private function get_submissions_batch( $offset ) {
+		return get_posts(
+			array(
+				'post_type'              => Form_Submissions::FORM_RECORD_TYPE,
+				'post_status'            => array( 'draft', 'unread', 'read', 'trash', 'publish' ),
+				'posts_per_page'         => self::EXPORT_BATCH_SIZE,
+				'offset'                 => $offset,
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+	}
+
+	/**
+	 * Build the CSV row of a single submission, keyed by column.
+	 *
+	 * @param \WP_Post             $record Submission post.
+	 * @param array<string, mixed> $meta   Submission record meta.
+	 * @return array<string, mixed>
+	 */
+	private function get_record_row( $record, $meta ) {
+		$post_id = $record->ID;
+
+		$row = array(
+			'id'     => substr( strval( $post_id ), -8 ),
+			'status' => get_post_status( $post_id ),
+			'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post_id ),
+			'form'   => isset( $meta['form']['value'] ) ? $meta['form']['value'] : '',
+			'post'   => isset( $meta['post_url']['value'] ) ? $meta['post_url']['value'] : '',
+		);
+
+		foreach ( $this->get_record_inputs( $meta ) as $column_key => $input ) {
+			$row[ $column_key ] = $input['value'];
 		}
 
-		rewind( $stream );
-		$csv = stream_get_contents( $stream );
-		fclose( $stream );
+		return $row;
+	}
 
-		// Prefix a UTF-8 BOM so Excel detects the encoding instead of mangling accented characters.
-		return "\xEF\xBB\xBF" . $csv;
+	/**
+	 * Extract the exportable inputs of a submission, keyed by column.
+	 *
+	 * @param array<string, mixed> $meta Submission record meta.
+	 * @return array<string, array<string, mixed>> Column key => array with the `label` and `value` of the input.
+	 */
+	private function get_record_inputs( $meta ) {
+		$inputs = isset( $meta['inputs'] ) && is_array( $meta['inputs'] ) ? $meta['inputs'] : array();
+		$parsed = array();
+
+		foreach ( $inputs as $input ) {
+			if ( empty( $input ) || ! isset( $input['type'], $input['label'] ) || 'stripe-field' === $input['type'] ) {
+				continue;
+			}
+
+			$value = isset( $input['value'] ) ? $input['value'] : '';
+
+			if ( 'file' === $input['type'] && isset( $input['metadata']['name'] ) ) {
+				$value = $input['metadata']['name'];
+			}
+
+			$parsed[ 'input:' . $input['label'] ] = array(
+				'label' => $input['label'],
+				'value' => $value,
+			);
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * Sanitize a cell value for CSV export, prefixing with a single quote if it looks like a formula.
+	 *
+	 * @param mixed $value Cell value.
+	 * @return string
+	 */
+	private function sanitize_cell( $value ) {
+		$value = strval( $value );
+
+		return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
 	}
 }

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -47,7 +47,7 @@ class Form_Records_Export {
 			wp_die( esc_html( __( 'Exporting submissions requires Otter Pro.', 'otter-blocks' ) ) );
 		}
 
-		$nonce = isset( $_POST['_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$nonce = isset( $_POST['_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce'] ) ) : '';
 		if ( ! wp_verify_nonce( $nonce, 'otter_form_export_submissions' ) ) {
 			wp_die( esc_html( __( 'Invalid nonce.', 'otter-blocks' ) ) );
 		}
@@ -56,12 +56,14 @@ class Form_Records_Export {
 			wp_die( esc_html( __( 'You are not allowed to export submissions.', 'otter-blocks' ) ) );
 		}
 
-		$format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'xml'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'xml';
+
+		$output = new \SplFileObject( 'php://output', 'w' );
 
 		if ( 'csv' === $format ) {
-			$this->export_csv();
+			$this->export_csv( $output );
 		} else {
-			echo $this->export_xml(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$this->export_xml( $output );
 		}
 
 		wp_die();
@@ -70,56 +72,50 @@ class Form_Records_Export {
 	/**
 	 * Build the WordPress WXR (XML) export of all submissions.
 	 *
-	 * @return string
+	 * @param \SplFileObject $output Output stream.
+	 * @return void
 	 */
-	private function export_xml() {
+	private function export_xml( $output ) {
 		require_once ABSPATH . 'wp-admin/includes/export.php';
 
 		ob_start();
 		export_wp( array( 'content' => Form_Submissions::FORM_RECORD_TYPE ) );
 		$export = ob_get_clean();
 
-		return ent2ncr( $export );
+		$output->fwrite( ent2ncr( $export ) );
 	}
 
 	/**
 	 * Write a CSV export of all submissions to the output.
 	 *
+	 * @param \SplFileObject $output Output stream.
 	 * @return void
 	 */
-	private function export_csv() {
+	private function export_csv( $output ) {
 		$max_id = (int) $this->get_max_submission_id();
 
 		$columns = array_merge( $this->get_fixed_columns(), $this->collect_input_columns( $max_id ) );
 
-		$stream = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-
-		if ( false === $stream ) {
-			return;
-		}
-
 		// Prefix a UTF-8 BOM so Excel detects the encoding instead of mangling accented characters.
-		fwrite( $stream, "\xEF\xBB\xBF" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+		$output->fwrite( "\xEF\xBB\xBF" );
 
-		fputcsv( $stream, array_map( array( $this, 'sanitize_cell' ), array_values( $columns ) ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+		$output->fputcsv( array_map( array( $this, 'sanitize_cell' ), array_values( $columns ) ) );
 
 		$column_keys = array_keys( $columns );
 
 		$this->walk_submissions(
 			$max_id,
-			function ( $meta, $post_id ) use ( $stream, $column_keys ) {
-				$row  = $this->get_record_row( $post_id, $meta );
+			function ( $meta, $record ) use ( $output, $column_keys ) {
+				$row  = $this->get_record_row( $record, $meta );
 				$line = array();
 
 				foreach ( $column_keys as $key ) {
 					$line[] = $this->sanitize_cell( isset( $row[ $key ] ) ? $row[ $key ] : '' );
 				}
 
-				fputcsv( $stream, $line ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+				$output->fputcsv( $line );
 			}
 		);
-
-		fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 	}
 
 	/**
@@ -166,7 +162,7 @@ class Form_Records_Export {
 	 * Run a callback over every submission, loading them in bounded batches.
 	 *
 	 * @param int      $max_id   Highest submission ID to export.
-	 * @param callable $callback Receives the submission record meta and the submission post ID.
+	 * @param callable $callback Receives the submission record meta and the submission post.
 	 * @return void
 	 */
 	private function walk_submissions( $max_id, $callback ) {
@@ -192,12 +188,11 @@ class Form_Records_Export {
 					continue;
 				}
 
-				$callback( $meta, $record->ID );
+				$callback( $meta, $record );
 			}
 
 			// Drop the batch from the object cache, otherwise memory grows with every batch.
 			foreach ( $ids as $id ) {
-				wp_cache_delete( $id, 'posts' );
 				wp_cache_delete( $id, 'post_meta' );
 			}
 
@@ -280,15 +275,15 @@ class Form_Records_Export {
 	/**
 	 * Build the CSV row of a single submission, keyed by column.
 	 *
-	 * @param int                  $post_id Submission post ID.
-	 * @param array<string, mixed> $meta    Submission record meta.
+	 * @param \WP_Post             $record Submission post.
+	 * @param array<string, mixed> $meta   Submission record meta.
 	 * @return array<string, mixed>
 	 */
-	private function get_record_row( $post_id, $meta ) {
+	private function get_record_row( $record, $meta ) {
 		$row = array(
-			'id'     => substr( strval( $post_id ), -8 ),
-			'status' => get_post_status( $post_id ),
-			'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post_id ),
+			'id'     => substr( strval( $record->ID ), -8 ),
+			'status' => get_post_status( $record ),
+			'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $record ),
 			'form'   => isset( $meta['form']['value'] ) ? $meta['form']['value'] : '',
 			'post'   => isset( $meta['post_url']['value'] ) ? $meta['post_url']['value'] : '',
 		);

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -116,7 +116,7 @@ class Form_Records_Export {
 				}
 
 				$label      = $input['label'];
- 				$column_key = 'input:' . $label;
+				$column_key = 'input:' . $label;
 
 				if ( ! isset( $input_columns[ $label ] ) ) {
 					$input_columns[ $column_key ] = $label;
@@ -136,24 +136,24 @@ class Form_Records_Export {
 
 		$columns = array_merge( $fixed_columns, $input_columns );
 
-		$stream = fopen( 'php://temp', 'w+' );
+		$stream = fopen( 'php://temp', 'w+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
 		$sanitize_cell = static function ( $value ) {
- 			$value = strval( $value );
- 			return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
- 		};
+			$value = strval( $value );
+			return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
+		};
 
- 		fputcsv( $stream, array_map( $sanitize_cell, array_values( $columns ) ) );
+		fputcsv( $stream, array_map( $sanitize_cell, array_values( $columns ) ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
 
 		foreach ( $rows as $row ) {
 			$line = array();
 
 			foreach ( array_keys( $columns ) as $key ) {
 				$value  = isset( $row[ $key ] ) ? $row[ $key ] : '';
- 				$line[] = $sanitize_cell( $value );
+				$line[] = $sanitize_cell( $value );
 			}
 
-			fputcsv( $stream, $line );
+			fputcsv( $stream, $line ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
 		}
 
 		rewind( $stream );

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -221,6 +221,7 @@ class Form_Records_Export {
 				'orderby'                => 'ID',
 				'order'                  => 'DESC',
 				'fields'                 => 'ids',
+				'cache_results'          => false,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
 			)
@@ -243,7 +244,17 @@ class Form_Records_Export {
 			return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d AND {$wpdb->posts}.ID <= %d", $last_id, $max_id );
 		};
 
+		/*
+		 * A split query fetches the IDs and then primes the post cache with a second query, which
+		 * is wasted work here: the batch is read once and its caches are dropped straight after.
+		 * That priming is not covered by `cache_results`, so it has to be turned off separately.
+		 */
+		$single_query = static function () {
+			return false;
+		};
+
 		add_filter( 'posts_where', $keyset_clause );
+		add_filter( 'split_the_query', $single_query );
 
 		$query = new \WP_Query(
 			array(
@@ -253,12 +264,14 @@ class Form_Records_Export {
 				'orderby'                => 'ID',
 				'order'                  => 'ASC',
 				'no_found_rows'          => true,
+				'cache_results'          => false,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
 				'suppress_filters'       => false,
 			)
 		);
 
+		remove_filter( 'split_the_query', $single_query );
 		remove_filter( 'posts_where', $keyset_clause );
 
 		return $query->posts;

--- a/plugins/blocks-animation/composer.lock
+++ b/plugins/blocks-animation/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.54",
+            "version": "3.3.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "095c2d0f1388af0b0196c492a7f79e2fd092dab1"
+                "reference": "d6807c0b7308e323bd77cced667dee3f2d5e6a82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/095c2d0f1388af0b0196c492a7f79e2fd092dab1",
-                "reference": "095c2d0f1388af0b0196c492a7f79e2fd092dab1",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/d6807c0b7308e323bd77cced667dee3f2d5e6a82",
+                "reference": "d6807c0b7308e323bd77cced667dee3f2d5e6a82",
                 "shasum": ""
             },
             "require-dev": {
@@ -36,16 +36,16 @@
                     "homepage": "https://themeisle.com"
                 }
             ],
-            "description": "Themeisle SDK.",
+            "description": "Themeisle SDK library.",
             "homepage": "https://github.com/Codeinwp/themeisle-sdk",
             "keywords": [
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.54"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.58"
             },
-            "time": "2026-06-23T13:43:47+00:00"
+            "time": "2026-07-29T08:38:52+00:00"
         }
     ],
     "packages-dev": [],

--- a/plugins/blocks-css/composer.lock
+++ b/plugins/blocks-css/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.54",
+            "version": "3.3.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "095c2d0f1388af0b0196c492a7f79e2fd092dab1"
+                "reference": "d6807c0b7308e323bd77cced667dee3f2d5e6a82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/095c2d0f1388af0b0196c492a7f79e2fd092dab1",
-                "reference": "095c2d0f1388af0b0196c492a7f79e2fd092dab1",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/d6807c0b7308e323bd77cced667dee3f2d5e6a82",
+                "reference": "d6807c0b7308e323bd77cced667dee3f2d5e6a82",
                 "shasum": ""
             },
             "require-dev": {
@@ -36,16 +36,16 @@
                     "homepage": "https://themeisle.com"
                 }
             ],
-            "description": "Themeisle SDK.",
+            "description": "Themeisle SDK library.",
             "homepage": "https://github.com/Codeinwp/themeisle-sdk",
             "keywords": [
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.54"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.58"
             },
-            "time": "2026-06-23T13:43:47+00:00"
+            "time": "2026-07-29T08:38:52+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/blocks/test/e2e/blocks/form.spec.js
+++ b/src/blocks/test/e2e/blocks/form.spec.js
@@ -412,10 +412,10 @@ test.describe( 'Form Block', () => {
 		await expect( page.locator( '.otter-form-input[type="hidden"]' ) ).toHaveValue( '123' );
 	});
 
-	test( 'can export form data', async({ page }) => {
+	test( 'can export form data as WordPress XML (WXR)', async({ page }) => {
 		await page.goto( '/wp-admin/edit.php?post_type=otter_form_record' );
 
-		const exportBtn = page.getByRole( 'button', { name: 'Export' });
+		const exportBtn = page.getByRole( 'button', { name: 'Export', exact: true });
 
 		await expect( exportBtn ).toBeVisible();
 
@@ -425,5 +425,20 @@ test.describe( 'Form Block', () => {
 
 		await download.path(); // Wait for download to complete.
 		expect( download.suggestedFilename().startsWith( 'otter_form_submissions' ) ).toBeTruthy();
+		expect( download.suggestedFilename().endsWith( '.xml' ) ).toBeTruthy();
+	});
+
+	test( 'can export form data as CSV', async({ page }) => {
+		await page.goto( '/wp-admin/edit.php?post_type=otter_form_record' );
+
+		await page.locator( '#export-submissions-toggle' ).click();
+
+		const downloadPromise = page.waitForEvent( 'download' );
+		await page.getByRole( 'button', { name: 'Export as CSV' }).click();
+		const download = await downloadPromise;
+
+		await download.path(); // Wait for download to complete.
+		expect( download.suggestedFilename().startsWith( 'otter_form_submissions' ) ).toBeTruthy();
+		expect( download.suggestedFilename().endsWith( '.csv' ) ).toBeTruthy();
 	});
 });

--- a/tests/test-form-submissions.php
+++ b/tests/test-form-submissions.php
@@ -896,6 +896,64 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the CSV export walks past the first batch: every submission gets a row, and a field
+	 * that only shows up in a later batch still makes it into the header row.
+	 */
+	public function test_export_csv_paginates_beyond_a_single_batch() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		add_filter( 'product_otter_license_status', array( $this, 'valid_license' ) );
+
+		$total = Form_Records_Export::EXPORT_BATCH_SIZE + 5;
+
+		for ( $index = 0; $index < $total; $index++ ) {
+			// Only the very last submission carries the late field, so it lands in a second batch.
+			$label = $index === $total - 1 ? 'Late Field' : 'Name';
+
+			$this->create_record(
+				'unread',
+				array(
+					'inputs' => array(
+						'input01' => array(
+							'label' => $label,
+							'value' => 'Submission ' . $index,
+							'type'  => 'text',
+						),
+					),
+				)
+			);
+		}
+
+		wp_set_current_user( $this->admin_id );
+		$_POST['_nonce'] = wp_create_nonce( 'otter_form_export_submissions' );
+		$_POST['format'] = 'csv';
+
+		ob_start();
+
+		try {
+			( new Form_Records_Export() )->export_submissions();
+		} catch ( WPDieException $exception ) {
+			// export_submissions() always ends in wp_die(); assertions run on the buffered output below.
+		}
+
+		$output = ob_get_clean();
+
+		$lines = array_filter( explode( "\n", trim( $output ) ) );
+
+		// One header row plus one row per submission.
+		$this->assertCount( $total + 1, $lines );
+
+		// The header is built from a full pass, so a label from a later batch is not missed.
+		$this->assertStringContainsString( 'Late Field', reset( $lines ) );
+
+		$this->assertStringContainsString( 'Submission 0', $output );
+		$this->assertStringContainsString( 'Submission ' . ( Form_Records_Export::EXPORT_BATCH_SIZE - 1 ), $output );
+		$this->assertStringContainsString( 'Submission ' . ( $total - 1 ), $output );
+	}
+
+	/**
 	 * Ensure the list-table bulk actions match the current status view.
 	 */
 	public function test_list_table_bulk_actions_follow_status_view() {

--- a/tests/test-form-submissions.php
+++ b/tests/test-form-submissions.php
@@ -58,7 +58,7 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		unset( $_REQUEST[ Form_Submissions::FORM_RECORD_TYPE ], $_REQUEST['_wpnonce'], $_REQUEST['post'] );
-		unset( $_POST['action'], $_POST['_wpnonce'], $_POST['_nonce'] );
+		unset( $_POST['action'], $_POST['_wpnonce'], $_POST['_nonce'], $_POST['format'] );
 		unset( $_GET['post_type'], $_GET['filter_action'], $_GET['filters_nonce'], $_GET['otter_form_filter'], $_REQUEST['otter_form_filter'] );
 		unset( $_GET['otter_post_filter'], $_REQUEST['otter_post_filter'] );
 		unset( $GLOBALS['otter_test_stripe_record_id'] );
@@ -807,6 +807,92 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 		$this->expectExceptionMessage( 'You are not allowed to export submissions.' );
 
 		( new Form_Records_Export() )->export_submissions();
+	}
+
+	/**
+	 * Ensure the export defaults to the WordPress XML (WXR) format when no format is
+	 * posted, preserving the pre-existing endpoint contract.
+	 */
+	public function test_export_defaults_to_xml_format() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		add_filter( 'product_otter_license_status', array( $this, 'valid_license' ) );
+
+		$this->create_record();
+
+		wp_set_current_user( $this->admin_id );
+		$_POST['_nonce'] = wp_create_nonce( 'otter_form_export_submissions' );
+
+		ob_start();
+
+		try {
+			( new Form_Records_Export() )->export_submissions();
+		} catch ( WPDieException $exception ) {
+			// export_submissions() always ends in wp_die(); assertions run on the buffered output below.
+		}
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<?xml version="1.0"', $output );
+	}
+
+	/**
+	 * Ensure the CSV export contains a header row and one line per submission, with columns
+	 * covering every input label found across submissions from different forms.
+	 */
+	public function test_export_csv_contains_submission_data() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		add_filter( 'product_otter_license_status', array( $this, 'valid_license' ) );
+
+		$this->create_record(
+			'unread',
+			array(
+				'inputs' => array(
+					'input01' => array(
+						'label' => 'Name',
+						'value' => 'Ada Lovelace',
+						'type'  => 'text',
+					),
+				),
+			)
+		);
+
+		$this->create_record(
+			'read',
+			array(
+				'inputs' => array(
+					'input02' => array(
+						'label' => 'Company',
+						'value' => 'Analytical Engines Ltd',
+						'type'  => 'text',
+					),
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$_POST['_nonce'] = wp_create_nonce( 'otter_form_export_submissions' );
+		$_POST['format'] = 'csv';
+
+		ob_start();
+
+		try {
+			( new Form_Records_Export() )->export_submissions();
+		} catch ( WPDieException $exception ) {
+			// export_submissions() always ends in wp_die(); assertions run on the buffered output below.
+		}
+
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Name', $output );
+		$this->assertStringContainsString( 'Company', $output );
+		$this->assertStringContainsString( 'Ada Lovelace', $output );
+		$this->assertStringContainsString( 'Analytical Engines Ltd', $output );
 	}
 
 	/**

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -110,17 +110,18 @@ class Test_Registration extends WP_UnitTestCase {
 		// WordPress does not convert PHP warnings into exceptions the way this
 		// suite is configured to; swallow the failed-include warning so the
 		// production code path is what gets exercised.
-		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_handler
-			function () {
-				return true;
-			}
+		set_error_handler(
+			function ( $error_level, $message ) {
+ 				return E_WARNING === $error_level && false !== strpos( $message, 'renderer.php' );
+ 			}
 		);
 
-		( new Registration() )->register_blocks();
-
-		restore_error_handler();
-
-		remove_filter( 'otter_blocks_register_dynamic_blocks', $filter );
+		try {
+ 			( new Registration() )->register_blocks();
+ 		} finally {
+ 			restore_error_handler();
+ 			remove_filter( 'otter_blocks_register_dynamic_blocks', $filter );
+ 		}
 	}
 
 	/**
@@ -135,13 +136,27 @@ class Test_Registration extends WP_UnitTestCase {
 	private function register_composer_like_loader( $class, $file ) {
 		$loader = function ( $requested ) use ( $class, $file ) {
 			if ( ltrim( $class, '\\' ) === $requested ) {
-				include $file; // phpcs:ignore
+				include $file;
 			}
 		};
 
 		spl_autoload_register( $loader );
 
 		return $loader;
+	}
+
+	/**
+	 * Positive control: a loadable renderer must register the block *with* a
+	 * render_callback. Without this, the null-callback assertions below would
+	 * pass even if registration silently stopped wiring renderers altogether.
+	 */
+	public function test_register_blocks_uses_the_renderer_when_the_class_is_loadable() {
+		$this->register_blocks_with_captcha_renderer( '\ThemeIsle\GutenbergBlocks\Render\Form_Captcha_Block' );
+
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'themeisle-blocks/form-captcha' );
+
+		$this->assertNotNull( $block_type, 'The block must be registered.' );
+		$this->assertIsCallable( $block_type->render_callback, 'A loadable renderer must be wired as the render callback.' );
 	}
 
 	/**
@@ -152,7 +167,21 @@ class Test_Registration extends WP_UnitTestCase {
 	public function test_register_blocks_survives_dynamic_renderer_class_with_no_autoload_entry() {
 		$this->register_blocks_with_captcha_renderer( '\ThemeIsle\GutenbergBlocks\Render\Nonexistent_Form_Captcha_Block' );
 
-		$this->assertTrue( \WP_Block_Type_Registry::get_instance()->is_registered( 'themeisle-blocks/form-captcha' ) );
+		$this->assertCaptchaRegisteredWithoutRenderer();
+	}
+
+	/**
+	 * Assert the captcha block came through the fallback branch: still registered,
+	 * but with no render_callback. `is_registered()` alone would also pass on the
+	 * dynamic path, so the null callback is what pins the fallback down.
+	 *
+	 * @return void
+	 */
+	private function assertCaptchaRegisteredWithoutRenderer() {
+		$block_type = \WP_Block_Type_Registry::get_instance()->get_registered( 'themeisle-blocks/form-captcha' );
+
+		$this->assertNotNull( $block_type, 'The block must still be registered.' );
+		$this->assertNull( $block_type->render_callback, 'The block must fall back to registration without a renderer.' );
 	}
 
 	/**
@@ -165,12 +194,15 @@ class Test_Registration extends WP_UnitTestCase {
 		$class  = 'ThemeIsle\GutenbergBlocks\Render\Missing_File_Captcha_Block';
 		$loader = $this->register_composer_like_loader( $class, get_temp_dir() . 'otter-absent-renderer.php' );
 
-		$this->register_blocks_with_captcha_renderer( $class );
+		try {
+ 			$this->register_blocks_with_captcha_renderer( $class );
+ 		} finally {
+ 			spl_autoload_unregister( $loader );
+ 		}
 
-		spl_autoload_unregister( $loader );
 
 		$this->assertFalse( class_exists( $class, false ), 'The renderer class must not have been defined.' );
-		$this->assertTrue( \WP_Block_Type_Registry::get_instance()->is_registered( 'themeisle-blocks/form-captcha' ) );
+		$this->assertCaptchaRegisteredWithoutRenderer();
 	}
 
 	/**
@@ -184,7 +216,7 @@ class Test_Registration extends WP_UnitTestCase {
 
 		$this->temp_renderer_files[] = $file;
 
-		file_put_contents( $file, '<?php namespace ThemeIsle\GutenbergBlocks\Render; class Unreadable_File_Captcha_Block { public function render( $attributes ) { return ""; } }' ); // phpcs:ignore
+		file_put_contents( $file, '<?php namespace ThemeIsle\GutenbergBlocks\Render; class Unreadable_File_Captcha_Block { public function render( $attributes ) { return ""; } }' );
 		chmod( $file, 0000 );
 
 		if ( is_readable( $file ) ) {
@@ -193,11 +225,14 @@ class Test_Registration extends WP_UnitTestCase {
 
 		$loader = $this->register_composer_like_loader( $class, $file );
 
-		$this->register_blocks_with_captcha_renderer( $class );
+		try {
+ 			$this->register_blocks_with_captcha_renderer( $class );
+ 		} finally {
+ 			spl_autoload_unregister( $loader );
+ 		}
 
-		spl_autoload_unregister( $loader );
 
 		$this->assertFalse( class_exists( $class, false ), 'The renderer class must not have been defined.' );
-		$this->assertTrue( \WP_Block_Type_Registry::get_instance()->is_registered( 'themeisle-blocks/form-captcha' ) );
+		$this->assertCaptchaRegisteredWithoutRenderer();
 	}
 }

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -87,10 +87,11 @@ class Test_Registration extends WP_UnitTestCase {
 	 * bootstrap, so the plugin's blocks are unregistered first to keep this a
 	 * clean registration instead of "already registered" notices.
 	 *
-	 * @param string $classname Renderer class to map form-captcha to.
+	 * @param string $classname                Renderer class to map form-captcha to.
+	 * @param string $expected_include_failure Path whose failed include is expected, or empty if no include failure is expected.
 	 * @return void
 	 */
-	private function register_blocks_with_captcha_renderer( $classname ) {
+	private function register_blocks_with_captcha_renderer( $classname, $expected_include_failure = '' ) {
 		$filter = function ( $dynamic_blocks ) use ( $classname ) {
 			$dynamic_blocks['form-captcha'] = $classname;
 
@@ -107,21 +108,30 @@ class Test_Registration extends WP_UnitTestCase {
 			}
 		}
 
-		// WordPress does not convert PHP warnings into exceptions the way this
-		// suite is configured to; swallow the failed-include warning so the
-		// production code path is what gets exercised.
-		set_error_handler(
-			function ( $error_level, $message ) {
- 				return E_WARNING === $error_level && false !== strpos( $message, 'renderer.php' );
- 			}
+		$previous = set_error_handler(
+			function ( $level, $message, $file = '', $line = 0 ) use ( &$previous, $expected_include_failure ) {
+				if (
+					'' !== $expected_include_failure &&
+					E_WARNING === $level &&
+					false !== strpos( $message, $expected_include_failure )
+				) {
+					return true;
+				}
+
+				if ( null === $previous ) {
+					return false;
+				}
+
+				return call_user_func( $previous, $level, $message, $file, $line );
+			}
 		);
 
 		try {
- 			( new Registration() )->register_blocks();
- 		} finally {
- 			restore_error_handler();
- 			remove_filter( 'otter_blocks_register_dynamic_blocks', $filter );
- 		}
+			( new Registration() )->register_blocks();
+		} finally {
+			restore_error_handler();
+			remove_filter( 'otter_blocks_register_dynamic_blocks', $filter );
+		}
 	}
 
 	/**
@@ -192,14 +202,14 @@ class Test_Registration extends WP_UnitTestCase {
 	 */
 	public function test_register_blocks_survives_dynamic_renderer_class_whose_file_is_missing() {
 		$class  = 'ThemeIsle\GutenbergBlocks\Render\Missing_File_Captcha_Block';
-		$loader = $this->register_composer_like_loader( $class, get_temp_dir() . 'otter-absent-renderer.php' );
+		$file   = get_temp_dir() . 'otter-absent-renderer.php';
+		$loader = $this->register_composer_like_loader( $class, $file );
 
 		try {
- 			$this->register_blocks_with_captcha_renderer( $class );
- 		} finally {
- 			spl_autoload_unregister( $loader );
- 		}
-
+			$this->register_blocks_with_captcha_renderer( $class, $file );
+		} finally {
+			spl_autoload_unregister( $loader );
+		}
 
 		$this->assertFalse( class_exists( $class, false ), 'The renderer class must not have been defined.' );
 		$this->assertCaptchaRegisteredWithoutRenderer();
@@ -226,11 +236,10 @@ class Test_Registration extends WP_UnitTestCase {
 		$loader = $this->register_composer_like_loader( $class, $file );
 
 		try {
- 			$this->register_blocks_with_captcha_renderer( $class );
- 		} finally {
- 			spl_autoload_unregister( $loader );
- 		}
-
+			$this->register_blocks_with_captcha_renderer( $class, $file );
+		} finally {
+			spl_autoload_unregister( $loader );
+		}
 
 		$this->assertFalse( class_exists( $class, false ), 'The renderer class must not have been defined.' );
 		$this->assertCaptchaRegisteredWithoutRenderer();

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -14,10 +14,28 @@ use ThemeIsle\GutenbergBlocks\Registration;
 class Test_Registration extends WP_UnitTestCase {
 
 	/**
+	 * Temp renderer files to remove after the test, even if it failed part way.
+	 *
+	 * @var array<string>
+	 */
+	private $temp_renderer_files = array();
+
+	/**
 	 * Tear down test environment.
 	 */
 	public function tear_down() {
 		delete_option( 'themeisle_blocks_settings_global_defaults' );
+
+		// Restore permissions before unlinking: a test that fails mid-way would
+		// otherwise leave an unreadable file behind and poison later runs.
+		foreach ( $this->temp_renderer_files as $file ) {
+			if ( file_exists( $file ) ) {
+				chmod( $file, 0644 );
+				unlink( $file );
+			}
+		}
+
+		$this->temp_renderer_files = array();
 
 		parent::tear_down();
 	}
@@ -60,5 +78,126 @@ class Test_Registration extends WP_UnitTestCase {
 		delete_option( 'themeisle_blocks_settings_global_defaults' );
 
 		$this->assertEquals( new stdClass(), Registration::get_editor_global_defaults() );
+	}
+
+	/**
+	 * Run register_blocks() with `form-captcha` mapped to $classname.
+	 *
+	 * register_blocks() already ran once via the `init` hook fired during
+	 * bootstrap, so the plugin's blocks are unregistered first to keep this a
+	 * clean registration instead of "already registered" notices.
+	 *
+	 * @param string $classname Renderer class to map form-captcha to.
+	 * @return void
+	 */
+	private function register_blocks_with_captcha_renderer( $classname ) {
+		$filter = function ( $dynamic_blocks ) use ( $classname ) {
+			$dynamic_blocks['form-captcha'] = $classname;
+
+			return $dynamic_blocks;
+		};
+
+		add_filter( 'otter_blocks_register_dynamic_blocks', $filter );
+
+		$registry = \WP_Block_Type_Registry::get_instance();
+
+		foreach ( array_keys( $registry->get_all_registered() ) as $name ) {
+			if ( 0 === strpos( $name, 'themeisle-blocks/' ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		// WordPress does not convert PHP warnings into exceptions the way this
+		// suite is configured to; swallow the failed-include warning so the
+		// production code path is what gets exercised.
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_error_handler
+			function () {
+				return true;
+			}
+		);
+
+		( new Registration() )->register_blocks();
+
+		restore_error_handler();
+
+		remove_filter( 'otter_blocks_register_dynamic_blocks', $filter );
+	}
+
+	/**
+	 * Register a throwaway autoloader that resolves $class from $file the same
+	 * way Composer's classmap loader does: an unsuppressed `include` of the
+	 * mapped path, with no prior existence check.
+	 *
+	 * @param string $class Class to map.
+	 * @param string $file  Path to include for it.
+	 * @return callable The loader, for spl_autoload_unregister.
+	 */
+	private function register_composer_like_loader( $class, $file ) {
+		$loader = function ( $requested ) use ( $class, $file ) {
+			if ( ltrim( $class, '\\' ) === $requested ) {
+				include $file; // phpcs:ignore
+			}
+		};
+
+		spl_autoload_register( $loader );
+
+		return $loader;
+	}
+
+	/**
+	 * A dynamic block whose mapped renderer class has no autoload entry at all
+	 * must not fatal registration for every other block; it should fall back to
+	 * plain metadata registration.
+	 */
+	public function test_register_blocks_survives_dynamic_renderer_class_with_no_autoload_entry() {
+		$this->register_blocks_with_captcha_renderer( '\ThemeIsle\GutenbergBlocks\Render\Nonexistent_Form_Captcha_Block' );
+
+		$this->assertTrue( \WP_Block_Type_Registry::get_instance()->is_registered( 'themeisle-blocks/form-captcha' ) );
+	}
+
+	/**
+	 * A renderer class that is mapped by the autoloader but whose file is absent
+	 * from the deployed artifact must degrade the same way. Composer's classmap
+	 * returns the path without checking it exists, so the include only warns and
+	 * the class stays undefined.
+	 */
+	public function test_register_blocks_survives_dynamic_renderer_class_whose_file_is_missing() {
+		$class  = 'ThemeIsle\GutenbergBlocks\Render\Missing_File_Captcha_Block';
+		$loader = $this->register_composer_like_loader( $class, get_temp_dir() . 'otter-absent-renderer.php' );
+
+		$this->register_blocks_with_captcha_renderer( $class );
+
+		spl_autoload_unregister( $loader );
+
+		$this->assertFalse( class_exists( $class, false ), 'The renderer class must not have been defined.' );
+		$this->assertTrue( \WP_Block_Type_Registry::get_instance()->is_registered( 'themeisle-blocks/form-captcha' ) );
+	}
+
+	/**
+	 * Same degradation when the renderer file is present but not readable — a
+	 * permissions mishap during deploy. `include` needs read permission, so the
+	 * class again stays undefined.
+	 */
+	public function test_register_blocks_survives_dynamic_renderer_class_whose_file_is_unreadable() {
+		$class = 'ThemeIsle\GutenbergBlocks\Render\Unreadable_File_Captcha_Block';
+		$file  = get_temp_dir() . 'otter-unreadable-renderer.php';
+
+		$this->temp_renderer_files[] = $file;
+
+		file_put_contents( $file, '<?php namespace ThemeIsle\GutenbergBlocks\Render; class Unreadable_File_Captcha_Block { public function render( $attributes ) { return ""; } }' ); // phpcs:ignore
+		chmod( $file, 0000 );
+
+		if ( is_readable( $file ) ) {
+			$this->markTestSkipped( 'Cannot make a file unreadable as this user (likely running as root).' );
+		}
+
+		$loader = $this->register_composer_like_loader( $class, $file );
+
+		$this->register_blocks_with_captcha_renderer( $class );
+
+		spl_autoload_unregister( $loader );
+
+		$this->assertFalse( class_exists( $class, false ), 'The renderer class must not have been defined.' );
+		$this->assertTrue( \WP_Block_Type_Registry::get_instance()->is_registered( 'themeisle-blocks/form-captcha' ) );
 	}
 }


### PR DESCRIPTION
### Linked issues
<!-- linked-issues:start -->
This release will close the following issues once merged:

- Closes #2884 — [Experimental] Form Submissions "Export" outputs WordPress WXR XML, not the CSV stated in the changelog
- Closes #2943 — Otter 3.2.0 crashes when registering Form Captcha block
<!-- linked-issues:end -->

### Public changelog
<!-- public-changelog:start -->
- Form submissions can now be exported as a CSV file, with the export button offering a choice between CSV and XML formats.
- Fixed a fatal error when a dynamic block class was not available during block registration.
- Updated dependencies
<!-- public-changelog:end -->
