### PR TITLE
Enhanced CSV export

### DIFF
--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -24,6 +24,13 @@ class Form_Records_Export {
 	const EXPORT_BATCH_SIZE = 100;
 
 	/**
+	 * Post statuses.
+	 *
+	 * @var string[]
+	 */
+	const EXPORT_POST_STATUSES = array( 'draft', 'unread', 'read', 'trash', 'publish' );
+
+	/**
 	 * Register hooks.
 	 *
 	 * @return void
@@ -76,12 +83,14 @@ class Form_Records_Export {
 	}
 
 	/**
-	 * Build a CSV export of all submissions.
+	 * Write a CSV export of all submissions to the output.
 	 *
 	 * @return void
 	 */
 	private function export_csv() {
-		$columns = array_merge( $this->get_fixed_columns(), $this->collect_input_columns() );
+		$max_id = (int) $this->get_max_submission_id();
+
+		$columns = array_merge( $this->get_fixed_columns(), $this->collect_input_columns( $max_id ) );
 
 		$stream = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 
@@ -97,8 +106,9 @@ class Form_Records_Export {
 		$column_keys = array_keys( $columns );
 
 		$this->walk_submissions(
-			function ( $meta, $record ) use ( $stream, $column_keys ) {
-				$row  = $this->get_record_row( $record, $meta );
+			$max_id,
+			function ( $meta, $post_id ) use ( $stream, $column_keys ) {
+				$row  = $this->get_record_row( $post_id, $meta );
 				$line = array();
 
 				foreach ( $column_keys as $key ) {
@@ -130,12 +140,14 @@ class Form_Records_Export {
 	/**
 	 * Collect the dynamically generated input columns found across every submission.
 	 *
+	 * @param int $max_id Highest submission ID to export.
 	 * @return array<string, string> Column key => header label, in order of first appearance.
 	 */
-	private function collect_input_columns() {
+	private function collect_input_columns( $max_id ) {
 		$input_columns = array();
 
 		$this->walk_submissions(
+			$max_id,
 			function ( $meta ) use ( &$input_columns ) {
 				foreach ( $this->get_record_inputs( $meta ) as $column_key => $input ) {
 					if ( isset( $input_columns[ $column_key ] ) ) {
@@ -153,22 +165,24 @@ class Form_Records_Export {
 	/**
 	 * Run a callback over every submission, loading them in bounded batches.
 	 *
-	 * @param callable $callback Receives the submission record meta and the submission post.
+	 * @param int      $max_id   Highest submission ID to export.
+	 * @param callable $callback Receives the submission record meta and the submission post ID.
 	 * @return void
 	 */
-	private function walk_submissions( $callback ) {
-		$offset               = 0;
-		$has_more_submissions = false;
+	private function walk_submissions( $max_id, $callback ) {
+		$last_id = 0;
 
 		do {
-			$records = $this->get_submissions_batch( $offset );
-			$count   = count( $records );
+			$records = $this->get_submissions_batch( $last_id, $max_id );
 
-			if ( 0 === $count ) {
+			// The batch is only limited, never offset, so an empty one means the range is done.
+			if ( empty( $records ) ) {
 				return;
 			}
 
-			$ids = wp_list_pluck( $records, 'ID' );
+			$ids     = wp_list_pluck( $records, 'ID' );
+			$last_id = (int) end( $ids );
+
 			update_meta_cache( 'post', $ids );
 
 			foreach ( $records as $record ) {
@@ -178,9 +192,10 @@ class Form_Records_Export {
 					continue;
 				}
 
-				$callback( $meta, $record );
+				$callback( $meta, $record->ID );
 			}
 
+			// Drop the batch from the object cache, otherwise memory grows with every batch.
 			foreach ( $ids as $id ) {
 				wp_cache_delete( $id, 'posts' );
 				wp_cache_delete( $id, 'post_meta' );
@@ -188,42 +203,75 @@ class Form_Records_Export {
 
 			unset( $records, $ids );
 
-			$offset              += $count;
-			$has_more_submissions = self::EXPORT_BATCH_SIZE === $count;
+			$has_more_submissions = $last_id < $max_id;
 		} while ( $has_more_submissions );
 	}
 
 	/**
-	 * Fetch a batch of submissions, oldest first.
+	 * The highest submission ID eligible for export.
 	 *
-	 * @param int $offset How many submissions to skip.
-	 * @return \WP_Post[]
+	 * @return int
 	 */
-	private function get_submissions_batch( $offset ) {
-		return get_posts(
+	private function get_max_submission_id() {
+		$ids = get_posts(
 			array(
 				'post_type'              => Form_Submissions::FORM_RECORD_TYPE,
-				'post_status'            => array( 'draft', 'unread', 'read', 'trash', 'publish' ),
-				'posts_per_page'         => self::EXPORT_BATCH_SIZE,
-				'offset'                 => $offset,
+				'post_status'            => self::EXPORT_POST_STATUSES,
+				'posts_per_page'         => 1,
 				'orderby'                => 'ID',
-				'order'                  => 'ASC',
+				'order'                  => 'DESC',
+				'fields'                 => 'ids',
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
 			)
 		);
+
+		return empty( $ids ) ? 0 : reset( $ids );
+	}
+
+	/**
+	 * Fetch the submissions following the last one handled, oldest first.
+	 *
+	 * @param int $last_id Highest submission ID handled so far.
+	 * @param int $max_id  Highest submission ID to export.
+	 * @return \WP_Post[]
+	 */
+	private function get_submissions_batch( $last_id, $max_id ) {
+		$keyset_clause = static function ( $where ) use ( $last_id, $max_id ) {
+			global $wpdb;
+
+			return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d AND {$wpdb->posts}.ID <= %d", $last_id, $max_id );
+		};
+
+		add_filter( 'posts_where', $keyset_clause );
+
+		$query = new \WP_Query(
+			array(
+				'post_type'              => Form_Submissions::FORM_RECORD_TYPE,
+				'post_status'            => self::EXPORT_POST_STATUSES,
+				'posts_per_page'         => self::EXPORT_BATCH_SIZE,
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'suppress_filters'       => false,
+			)
+		);
+
+		remove_filter( 'posts_where', $keyset_clause );
+
+		return $query->posts;
 	}
 
 	/**
 	 * Build the CSV row of a single submission, keyed by column.
 	 *
-	 * @param \WP_Post             $record Submission post.
-	 * @param array<string, mixed> $meta   Submission record meta.
+	 * @param int                  $post_id Submission post ID.
+	 * @param array<string, mixed> $meta    Submission record meta.
 	 * @return array<string, mixed>
 	 */
-	private function get_record_row( $record, $meta ) {
-		$post_id = $record->ID;
-
+	private function get_record_row( $post_id, $meta ) {
 		$row = array(
 			'id'     => substr( strval( $post_id ), -8 ),
 			'status' => get_post_status( $post_id ),

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -17,6 +17,13 @@ use ThemeIsle\GutenbergBlocks\Pro;
  */
 class Form_Records_Export {
 	/**
+	 * The number of submissions to fetch in each batch when exporting to CSV.
+	 *
+	 * @var int
+	 */
+	const EXPORT_BATCH_SIZE = 100;
+
+	/**
 	 * Register hooks.
 	 *
 	 * @return void
@@ -44,7 +51,12 @@ class Form_Records_Export {
 
 		$format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'xml'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		echo 'csv' === $format ? $this->export_csv() : $this->export_xml(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		if ( 'csv' === $format ) {
+			$this->export_csv();
+		} else {
+			echo $this->export_xml(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+
 		wp_die();
 	}
 
@@ -66,101 +78,206 @@ class Form_Records_Export {
 	/**
 	 * Build a CSV export of all submissions.
 	 *
-	 * @return string
+	 * @return void
 	 */
 	private function export_csv() {
-		$records = get_posts(
-			array(
-				'post_type'      => Form_Submissions::FORM_RECORD_TYPE,
-				'post_status'    => array( 'draft', 'unread', 'read', 'trash', 'publish' ),
-				'posts_per_page' => -1,
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-			)
+		$columns = array_merge( $this->get_fixed_columns(), $this->collect_input_columns() );
+
+		$stream = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+
+		if ( false === $stream ) {
+			return;
+		}
+
+		// Prefix a UTF-8 BOM so Excel detects the encoding instead of mangling accented characters.
+		fwrite( $stream, "\xEF\xBB\xBF" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+
+		fputcsv( $stream, array_map( array( $this, 'sanitize_cell' ), array_values( $columns ) ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+
+		$column_keys = array_keys( $columns );
+
+		$this->walk_submissions(
+			function ( $meta, $record ) use ( $stream, $column_keys ) {
+				$row  = $this->get_record_row( $record, $meta );
+				$line = array();
+
+				foreach ( $column_keys as $key ) {
+					$line[] = $this->sanitize_cell( isset( $row[ $key ] ) ? $row[ $key ] : '' );
+				}
+
+				fputcsv( $stream, $line ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+			}
 		);
 
-		update_meta_cache( 'post', wp_list_pluck( $records, 'ID' ) );
+		fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+	}
 
-		$fixed_columns = array(
+	/**
+	 * Columns present for every submission, in export order.
+	 *
+	 * @return array<string, string> Column key => header label.
+	 */
+	private function get_fixed_columns() {
+		return array(
 			'id'     => __( 'ID', 'otter-blocks' ),
 			'status' => __( 'Status', 'otter-blocks' ),
 			'date'   => __( 'Submission Date', 'otter-blocks' ),
 			'form'   => __( 'Form', 'otter-blocks' ),
 			'post'   => __( 'Post URL', 'otter-blocks' ),
 		);
+	}
 
+	/**
+	 * Collect the dynamically generated input columns found across every submission.
+	 *
+	 * @return array<string, string> Column key => header label, in order of first appearance.
+	 */
+	private function collect_input_columns() {
 		$input_columns = array();
-		$rows          = array();
 
-		foreach ( $records as $record ) {
-			$post_id = $record->ID;
-			$meta    = get_post_meta( $post_id, Form_Submissions::FORM_RECORD_META_KEY, true );
+		$this->walk_submissions(
+			function ( $meta ) use ( &$input_columns ) {
+				foreach ( $this->get_record_inputs( $meta ) as $column_key => $input ) {
+					if ( isset( $input_columns[ $column_key ] ) ) {
+						continue;
+					}
 
-			if ( ! is_array( $meta ) ) {
-				continue;
+					$input_columns[ $column_key ] = $input['label'];
+				}
+			}
+		);
+
+		return $input_columns;
+	}
+
+	/**
+	 * Run a callback over every submission, loading them in bounded batches.
+	 *
+	 * @param callable $callback Receives the submission record meta and the submission post.
+	 * @return void
+	 */
+	private function walk_submissions( $callback ) {
+		$offset               = 0;
+		$has_more_submissions = false;
+
+		do {
+			$records = $this->get_submissions_batch( $offset );
+			$count   = count( $records );
+
+			if ( 0 === $count ) {
+				return;
 			}
 
-			$row = array(
-				'id'     => substr( strval( $post_id ), -8 ),
-				'status' => get_post_status( $post_id ),
-				'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post_id ),
-				'form'   => isset( $meta['form']['value'] ) ? $meta['form']['value'] : '',
-				'post'   => isset( $meta['post_url']['value'] ) ? $meta['post_url']['value'] : '',
-			);
+			$ids = wp_list_pluck( $records, 'ID' );
+			update_meta_cache( 'post', $ids );
 
-			$inputs = isset( $meta['inputs'] ) && is_array( $meta['inputs'] ) ? $meta['inputs'] : array();
+			foreach ( $records as $record ) {
+				$meta = get_post_meta( $record->ID, Form_Submissions::FORM_RECORD_META_KEY, true );
 
-			foreach ( $inputs as $input ) {
-				if ( empty( $input ) || ! isset( $input['type'], $input['label'] ) || 'stripe-field' === $input['type'] ) {
+				if ( ! is_array( $meta ) ) {
 					continue;
 				}
 
-				$label      = $input['label'];
-				$column_key = 'input:' . $label;
-
-				if ( ! isset( $input_columns[ $label ] ) ) {
-					$input_columns[ $column_key ] = $label;
-				}
-
-				$value = isset( $input['value'] ) ? $input['value'] : '';
-
-				if ( 'file' === $input['type'] && isset( $input['metadata']['name'] ) ) {
-					$value = $input['metadata']['name'];
-				}
-
-				$row[ $column_key ] = $value;
+				$callback( $meta, $record );
 			}
 
-			$rows[] = $row;
-		}
-
-		$columns = array_merge( $fixed_columns, $input_columns );
-
-		$stream = fopen( 'php://temp', 'w+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-
-		$sanitize_cell = static function ( $value ) {
-			$value = strval( $value );
-			return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
-		};
-
-		fputcsv( $stream, array_map( $sanitize_cell, array_values( $columns ) ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
-
-		foreach ( $rows as $row ) {
-			$line = array();
-
-			foreach ( array_keys( $columns ) as $key ) {
-				$value  = isset( $row[ $key ] ) ? $row[ $key ] : '';
-				$line[] = $sanitize_cell( $value );
+			foreach ( $ids as $id ) {
+				wp_cache_delete( $id, 'posts' );
+				wp_cache_delete( $id, 'post_meta' );
 			}
 
-			fputcsv( $stream, $line ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+			unset( $records, $ids );
+
+			$offset              += $count;
+			$has_more_submissions = self::EXPORT_BATCH_SIZE === $count;
+		} while ( $has_more_submissions );
+	}
+
+	/**
+	 * Fetch a batch of submissions, oldest first.
+	 *
+	 * @param int $offset How many submissions to skip.
+	 * @return \WP_Post[]
+	 */
+	private function get_submissions_batch( $offset ) {
+		return get_posts(
+			array(
+				'post_type'              => Form_Submissions::FORM_RECORD_TYPE,
+				'post_status'            => array( 'draft', 'unread', 'read', 'trash', 'publish' ),
+				'posts_per_page'         => self::EXPORT_BATCH_SIZE,
+				'offset'                 => $offset,
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+	}
+
+	/**
+	 * Build the CSV row of a single submission, keyed by column.
+	 *
+	 * @param \WP_Post             $record Submission post.
+	 * @param array<string, mixed> $meta   Submission record meta.
+	 * @return array<string, mixed>
+	 */
+	private function get_record_row( $record, $meta ) {
+		$post_id = $record->ID;
+
+		$row = array(
+			'id'     => substr( strval( $post_id ), -8 ),
+			'status' => get_post_status( $post_id ),
+			'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post_id ),
+			'form'   => isset( $meta['form']['value'] ) ? $meta['form']['value'] : '',
+			'post'   => isset( $meta['post_url']['value'] ) ? $meta['post_url']['value'] : '',
+		);
+
+		foreach ( $this->get_record_inputs( $meta ) as $column_key => $input ) {
+			$row[ $column_key ] = $input['value'];
 		}
 
-		rewind( $stream );
-		$csv = stream_get_contents( $stream );
-		fclose( $stream );
+		return $row;
+	}
 
-		// Prefix a UTF-8 BOM so Excel detects the encoding instead of mangling accented characters.
-		return "\xEF\xBB\xBF" . $csv;
+	/**
+	 * Extract the exportable inputs of a submission, keyed by column.
+	 *
+	 * @param array<string, mixed> $meta Submission record meta.
+	 * @return array<string, array<string, mixed>> Column key => array with the `label` and `value` of the input.
+	 */
+	private function get_record_inputs( $meta ) {
+		$inputs = isset( $meta['inputs'] ) && is_array( $meta['inputs'] ) ? $meta['inputs'] : array();
+		$parsed = array();
+
+		foreach ( $inputs as $input ) {
+			if ( empty( $input ) || ! isset( $input['type'], $input['label'] ) || 'stripe-field' === $input['type'] ) {
+				continue;
+			}
+
+			$value = isset( $input['value'] ) ? $input['value'] : '';
+
+			if ( 'file' === $input['type'] && isset( $input['metadata']['name'] ) ) {
+				$value = $input['metadata']['name'];
+			}
+
+			$parsed[ 'input:' . $input['label'] ] = array(
+				'label' => $input['label'],
+				'value' => $value,
+			);
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * Sanitize a cell value for CSV export, prefixing with a single quote if it looks like a formula.
+	 *
+	 * @param mixed $value Cell value.
+	 * @return string
+	 */
+	private function sanitize_cell( $value ) {
+		$value = strval( $value );
+
+		return preg_match( '/^[\x00-\x20]*[=+\-@]/', $value ) ? "'" . $value : $value;
 	}
 }

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -47,7 +47,7 @@ class Form_Records_Export {
 			wp_die( esc_html( __( 'Exporting submissions requires Otter Pro.', 'otter-blocks' ) ) );
 		}
 
-		$nonce = isset( $_POST['_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$nonce = isset( $_POST['_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_nonce'] ) ) : '';
 		if ( ! wp_verify_nonce( $nonce, 'otter_form_export_submissions' ) ) {
 			wp_die( esc_html( __( 'Invalid nonce.', 'otter-blocks' ) ) );
 		}
@@ -56,12 +56,14 @@ class Form_Records_Export {
 			wp_die( esc_html( __( 'You are not allowed to export submissions.', 'otter-blocks' ) ) );
 		}
 
-		$format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'xml'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'xml';
+
+		$output = new \SplFileObject( 'php://output', 'w' );
 
 		if ( 'csv' === $format ) {
-			$this->export_csv();
+			$this->export_csv( $output );
 		} else {
-			echo $this->export_xml(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$this->export_xml( $output );
 		}
 
 		wp_die();
@@ -70,56 +72,50 @@ class Form_Records_Export {
 	/**
 	 * Build the WordPress WXR (XML) export of all submissions.
 	 *
-	 * @return string
+	 * @param \SplFileObject $output Output stream.
+	 * @return void
 	 */
-	private function export_xml() {
+	private function export_xml( $output ) {
 		require_once ABSPATH . 'wp-admin/includes/export.php';
 
 		ob_start();
 		export_wp( array( 'content' => Form_Submissions::FORM_RECORD_TYPE ) );
 		$export = ob_get_clean();
 
-		return ent2ncr( $export );
+		$output->fwrite( ent2ncr( $export ) );
 	}
 
 	/**
 	 * Write a CSV export of all submissions to the output.
 	 *
+	 * @param \SplFileObject $output Output stream.
 	 * @return void
 	 */
-	private function export_csv() {
+	private function export_csv( $output ) {
 		$max_id = (int) $this->get_max_submission_id();
 
 		$columns = array_merge( $this->get_fixed_columns(), $this->collect_input_columns( $max_id ) );
 
-		$stream = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-
-		if ( false === $stream ) {
-			return;
-		}
-
 		// Prefix a UTF-8 BOM so Excel detects the encoding instead of mangling accented characters.
-		fwrite( $stream, "\xEF\xBB\xBF" ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fwrite
+		$output->fwrite( "\xEF\xBB\xBF" );
 
-		fputcsv( $stream, array_map( array( $this, 'sanitize_cell' ), array_values( $columns ) ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+		$output->fputcsv( array_map( array( $this, 'sanitize_cell' ), array_values( $columns ) ) );
 
 		$column_keys = array_keys( $columns );
 
 		$this->walk_submissions(
 			$max_id,
-			function ( $meta, $post_id ) use ( $stream, $column_keys ) {
-				$row  = $this->get_record_row( $post_id, $meta );
+			function ( $meta, $record ) use ( $output, $column_keys ) {
+				$row  = $this->get_record_row( $record, $meta );
 				$line = array();
 
 				foreach ( $column_keys as $key ) {
 					$line[] = $this->sanitize_cell( isset( $row[ $key ] ) ? $row[ $key ] : '' );
 				}
 
-				fputcsv( $stream, $line ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
+				$output->fputcsv( $line );
 			}
 		);
-
-		fclose( $stream ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 	}
 
 	/**
@@ -166,7 +162,7 @@ class Form_Records_Export {
 	 * Run a callback over every submission, loading them in bounded batches.
 	 *
 	 * @param int      $max_id   Highest submission ID to export.
-	 * @param callable $callback Receives the submission record meta and the submission post ID.
+	 * @param callable $callback Receives the submission record meta and the submission post.
 	 * @return void
 	 */
 	private function walk_submissions( $max_id, $callback ) {
@@ -192,12 +188,11 @@ class Form_Records_Export {
 					continue;
 				}
 
-				$callback( $meta, $record->ID );
+				$callback( $meta, $record );
 			}
 
 			// Drop the batch from the object cache, otherwise memory grows with every batch.
 			foreach ( $ids as $id ) {
-				wp_cache_delete( $id, 'posts' );
 				wp_cache_delete( $id, 'post_meta' );
 			}
 
@@ -280,15 +275,15 @@ class Form_Records_Export {
 	/**
 	 * Build the CSV row of a single submission, keyed by column.
 	 *
-	 * @param int                  $post_id Submission post ID.
-	 * @param array<string, mixed> $meta    Submission record meta.
+	 * @param \WP_Post             $record Submission post.
+	 * @param array<string, mixed> $meta   Submission record meta.
 	 * @return array<string, mixed>
 	 */
-	private function get_record_row( $post_id, $meta ) {
+	private function get_record_row( $record, $meta ) {
 		$row = array(
-			'id'     => substr( strval( $post_id ), -8 ),
-			'status' => get_post_status( $post_id ),
-			'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $post_id ),
+			'id'     => substr( strval( $record->ID ), -8 ),
+			'status' => get_post_status( $record ),
+			'date'   => get_the_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $record ),
 			'form'   => isset( $meta['form']['value'] ) ? $meta['form']['value'] : '',
 			'post'   => isset( $meta['post_url']['value'] ) ? $meta['post_url']['value'] : '',
 		);

--- a/inc/plugins/class-form-records-export.php
+++ b/inc/plugins/class-form-records-export.php
@@ -221,6 +221,7 @@ class Form_Records_Export {
 				'orderby'                => 'ID',
 				'order'                  => 'DESC',
 				'fields'                 => 'ids',
+				'cache_results'          => false,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
 			)
@@ -243,7 +244,17 @@ class Form_Records_Export {
 			return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d AND {$wpdb->posts}.ID <= %d", $last_id, $max_id );
 		};
 
+		/*
+		 * A split query fetches the IDs and then primes the post cache with a second query, which
+		 * is wasted work here: the batch is read once and its caches are dropped straight after.
+		 * That priming is not covered by `cache_results`, so it has to be turned off separately.
+		 */
+		$single_query = static function () {
+			return false;
+		};
+
 		add_filter( 'posts_where', $keyset_clause );
+		add_filter( 'split_the_query', $single_query );
 
 		$query = new \WP_Query(
 			array(
@@ -253,12 +264,14 @@ class Form_Records_Export {
 				'orderby'                => 'ID',
 				'order'                  => 'ASC',
 				'no_found_rows'          => true,
+				'cache_results'          => false,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
 				'suppress_filters'       => false,
 			)
 		);
 
+		remove_filter( 'split_the_query', $single_query );
 		remove_filter( 'posts_where', $keyset_clause );
 
 		return $query->posts;

--- a/tests/test-form-submissions.php
+++ b/tests/test-form-submissions.php
@@ -896,6 +896,64 @@ class Test_Form_Submissions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the CSV export walks past the first batch: every submission gets a row, and a field
+	 * that only shows up in a later batch still makes it into the header row.
+	 */
+	public function test_export_csv_paginates_beyond_a_single_batch() {
+		if ( ! \ThemeIsle\GutenbergBlocks\Pro::is_pro_installed() ) {
+			$this->markTestSkipped( 'Otter Pro is not installed in this test environment.' );
+		}
+
+		add_filter( 'product_otter_license_status', array( $this, 'valid_license' ) );
+
+		$total = Form_Records_Export::EXPORT_BATCH_SIZE + 5;
+
+		for ( $index = 0; $index < $total; $index++ ) {
+			// Only the very last submission carries the late field, so it lands in a second batch.
+			$label = $index === $total - 1 ? 'Late Field' : 'Name';
+
+			$this->create_record(
+				'unread',
+				array(
+					'inputs' => array(
+						'input01' => array(
+							'label' => $label,
+							'value' => 'Submission ' . $index,
+							'type'  => 'text',
+						),
+					),
+				)
+			);
+		}
+
+		wp_set_current_user( $this->admin_id );
+		$_POST['_nonce'] = wp_create_nonce( 'otter_form_export_submissions' );
+		$_POST['format'] = 'csv';
+
+		ob_start();
+
+		try {
+			( new Form_Records_Export() )->export_submissions();
+		} catch ( WPDieException $exception ) {
+			// export_submissions() always ends in wp_die(); assertions run on the buffered output below.
+		}
+
+		$output = ob_get_clean();
+
+		$lines = array_filter( explode( "\n", trim( $output ) ) );
+
+		// One header row plus one row per submission.
+		$this->assertCount( $total + 1, $lines );
+
+		// The header is built from a full pass, so a label from a later batch is not missed.
+		$this->assertStringContainsString( 'Late Field', reset( $lines ) );
+
+		$this->assertStringContainsString( 'Submission 0', $output );
+		$this->assertStringContainsString( 'Submission ' . ( Form_Records_Export::EXPORT_BATCH_SIZE - 1 ), $output );
+		$this->assertStringContainsString( 'Submission ' . ( $total - 1 ), $output );
+	}
+
+	/**
 	 * Ensure the list-table bulk actions match the current status view.
 	 */
 	public function test_list_table_bulk_actions_follow_status_view() {


### PR DESCRIPTION
Fixed https://github.com/Codeinwp/otter-blocks/pull/2924#discussion_r3620354141

### Summary
Improved the CSV export functionality by batching the submissions to reduce memory usage and prevent timeouts.

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

