### PR TITLE
fix: Post Content dynamic value reads the loop globals instead of its context post

### DIFF
--- a/inc/plugins/class-dynamic-content.php
+++ b/inc/plugins/class-dynamic-content.php
@@ -545,7 +545,7 @@ class Dynamic_Content {
 			return '';
 		}
 
-		$content = get_the_content( $data['context'] );
+		$content = get_the_content( null, false, $data['context'] );
 		$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
 		return wp_kses_post( $content );
 	}
@@ -902,7 +902,7 @@ class Dynamic_Content {
 				if ( ! $post instanceof \WP_Post ) {
 					return $data;
 				}
-				$content = get_the_content( $data['context'] );
+				$content = get_the_content( null, false, $data['context'] );
 				if ( strpos( $content, 'data-type="postContent"' ) ) {
 					$key = $this->get_exception_key( $data, $post->ID );
 					if ( $key ) {

--- a/packages/e2e-tests/mu-plugins/otter-e2e-bootstrap.php
+++ b/packages/e2e-tests/mu-plugins/otter-e2e-bootstrap.php
@@ -754,6 +754,54 @@ function stub_openai_http_for_e2e( $preempt, $parsed_args, $url ) {
 	return stub_openai_http_response( $content );
 }
 
+/**
+ * Issue #2929 rig: with ?otter_e2e_corrupt_pages=1, mimic a theme/plugin that
+ * clobbers the $pages loop global (main templates are included at global scope,
+ * so any template-level $pages variable overwrites it) while Otter evaluates a
+ * dynamic tag, and surface PHP notices in the output so the spec can assert
+ * none are emitted.
+ *
+ * The corruption is scoped to blocks carrying an <o-dynamic> tag and restored
+ * straight after Otter's filter (priority 10): leaving it in place for every
+ * block would make core's own the_content() warn too, which is core behavior
+ * rather than the bug under test.
+ */
+function corrupt_pages_around_dynamic_tags() {
+	if ( is_admin() || ! isset( $_GET['otter_e2e_corrupt_pages'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
+	ini_set( 'display_errors', '1' ); // phpcs:ignore WordPress.PHP.IniSet.display_errors_Disallowed
+
+	$saved = null;
+
+	add_filter(
+		'render_block',
+		function ( $block_content ) use ( &$saved ) {
+			if ( false !== strpos( $block_content, '<o-dynamic' ) ) {
+				$saved            = isset( $GLOBALS['pages'] ) ? $GLOBALS['pages'] : null;
+				$GLOBALS['pages'] = array();
+			}
+			return $block_content;
+		},
+		9
+	);
+
+	add_filter(
+		'render_block',
+		function ( $block_content ) use ( &$saved ) {
+			if ( null !== $saved ) {
+				$GLOBALS['pages'] = $saved;
+				$saved            = null;
+			}
+			return $block_content;
+		},
+		11
+	);
+}
+
+add_action( 'wp', __NAMESPACE__ . '\\corrupt_pages_around_dynamic_tags' );
+
 add_filter( 'pre_wp_mail', __NAMESPACE__ . '\\stub_wp_mail_for_e2e', 10, 2 );
 add_filter( 'pre_http_request', __NAMESPACE__ . '\\stub_openai_http_for_e2e', 10, 3 );
 

--- a/src/blocks/test/e2e/blocks/dynamic-content-frontend.spec.js
+++ b/src/blocks/test/e2e/blocks/dynamic-content-frontend.spec.js
@@ -12,24 +12,38 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
  * rendered empty.
  */
 test.describe( 'Dynamic Content postContent tag', () => {
-	const TARGET_CONTENT = 'Otter dynamic target content 2929';
+
+	// wp-env is persistent, so the fixtures are namespaced per run and torn down
+	// in afterAll: a fixed token would let leftovers from an earlier run (or a
+	// retry) win the Query Loop and make the assertions state-dependent.
+	let token;
+	let targetContent;
 	let pageId;
 
+	// Every record created by this spec, so a retried beforeAll cleans up both
+	// attempts instead of leaking the first one.
+	const created = [];
+
 	test.beforeAll( async({ requestUtils }) => {
+		token         = `frontier2929${ Date.now() }`;
+		targetContent = `Otter dynamic target content ${ token }`;
+
 		// The Query Loop block has no include/post__in arg, so the loop is
-		// scoped to the target post via a unique search token in its title.
-		await requestUtils.createPost({
-			title: 'Dynamic content target frontier2929',
-			content: `<!-- wp:paragraph --><p>${ TARGET_CONTENT }</p><!-- /wp:paragraph -->`,
+		// scoped to the target post via the run's search token in its title.
+		const target = await requestUtils.createPost({
+			title: `Dynamic content target ${ token }`,
+			content: `<!-- wp:paragraph --><p>${ targetContent }</p><!-- /wp:paragraph -->`,
 			status: 'publish'
 		});
 
+		created.push({ type: 'posts', id: target.id });
+
 		const holder = await requestUtils.createPage({
-			title: 'Dynamic content holder 2929',
+			title: `Dynamic content holder ${ token }`,
 			// The tag is wrapped in a group: postContent runs the_content, which
 			// wraps its output in <p>, and a nested <p> would be auto-closed by
 			// the browser parser and land outside the marker element.
-			content: `<!-- wp:query {"query":{"perPage":1,"postType":"post","search":"frontier2929","inherit":false}} -->
+			content: `<!-- wp:query {"query":{"perPage":1,"postType":"post","search":"${ token }","inherit":false}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:group {"className":"o-dyn-2929"} --><div class="wp-block-group o-dyn-2929"><!-- wp:paragraph --><p><o-dynamic data-type="postContent" data-context="query">Post Content</o-dynamic></p><!-- /wp:paragraph --></div><!-- /wp:group -->
 <!-- /wp:post-template --></div>
@@ -37,13 +51,32 @@ test.describe( 'Dynamic Content postContent tag', () => {
 			status: 'publish'
 		});
 
+		created.push({ type: 'pages', id: holder.id });
+
 		pageId = holder.id;
+	});
+
+	test.afterAll( async({ requestUtils }) => {
+		// Only this spec's own records - other specs run against the same site.
+		// Best-effort per record: one failed request must not orphan the rest.
+		while ( created.length ) {
+			const record = created.pop();
+			try {
+				await requestUtils.rest({
+					method: 'DELETE',
+					path: `/wp/v2/${ record.type }/${ record.id }`,
+					params: { force: true }
+				});
+			} catch ( error ) {
+				console.warn( `Could not delete ${ record.type }/${ record.id }:`, error.message );
+			}
+		}
 	});
 
 	test( 'renders the target post content on the frontend', async({ page }) => {
 		await page.goto( `/?page_id=${ pageId }` );
 
-		await expect( page.locator( '.o-dyn-2929' ) ).toContainText( TARGET_CONTENT );
+		await expect( page.locator( '.o-dyn-2929' ) ).toContainText( targetContent );
 	});
 
 	test( 'survives a corrupted $pages loop global without PHP warnings', async({ page }) => {
@@ -55,6 +88,6 @@ test.describe( 'Dynamic Content postContent tag', () => {
 		await expect( page.locator( 'body' ) ).not.toContainText( 'preg_match' );
 
 		// The tag must still resolve the context post's content.
-		await expect( page.locator( '.o-dyn-2929' ) ).toContainText( TARGET_CONTENT );
+		await expect( page.locator( '.o-dyn-2929' ) ).toContainText( targetContent );
 	});
 });

--- a/src/blocks/test/e2e/blocks/dynamic-content-frontend.spec.js
+++ b/src/blocks/test/e2e/blocks/dynamic-content-frontend.spec.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Frontend rendering of the postContent dynamic tag (issue #2929).
+ *
+ * The tag's context post ID used to be passed to get_the_content() as
+ * $more_link_text, so core fell back to the loop globals: a clobbered $pages
+ * global surfaced "Undefined array key -1" from post-template.php and the tag
+ * rendered empty.
+ */
+test.describe( 'Dynamic Content postContent tag', () => {
+	const TARGET_CONTENT = 'Otter dynamic target content 2929';
+	let pageId;
+
+	test.beforeAll( async({ requestUtils }) => {
+		// The Query Loop block has no include/post__in arg, so the loop is
+		// scoped to the target post via a unique search token in its title.
+		await requestUtils.createPost({
+			title: 'Dynamic content target frontier2929',
+			content: `<!-- wp:paragraph --><p>${ TARGET_CONTENT }</p><!-- /wp:paragraph -->`,
+			status: 'publish'
+		});
+
+		const holder = await requestUtils.createPage({
+			title: 'Dynamic content holder 2929',
+			// The tag is wrapped in a group: postContent runs the_content, which
+			// wraps its output in <p>, and a nested <p> would be auto-closed by
+			// the browser parser and land outside the marker element.
+			content: `<!-- wp:query {"query":{"perPage":1,"postType":"post","search":"frontier2929","inherit":false}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:group {"className":"o-dyn-2929"} --><div class="wp-block-group o-dyn-2929"><!-- wp:paragraph --><p><o-dynamic data-type="postContent" data-context="query">Post Content</o-dynamic></p><!-- /wp:paragraph --></div><!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->`,
+			status: 'publish'
+		});
+
+		pageId = holder.id;
+	});
+
+	test( 'renders the target post content on the frontend', async({ page }) => {
+		await page.goto( `/?page_id=${ pageId }` );
+
+		await expect( page.locator( '.o-dyn-2929' ) ).toContainText( TARGET_CONTENT );
+	});
+
+	test( 'survives a corrupted $pages loop global without PHP warnings', async({ page }) => {
+		await page.goto( `/?page_id=${ pageId }&otter_e2e_corrupt_pages=1` );
+
+		// Regression #2929: "Warning: Undefined array key -1 in .../post-template.php"
+		// (PHP 7.4 words it "Undefined offset: -1") plus a preg_match() deprecation.
+		await expect( page.locator( 'body' ) ).not.toContainText( /Undefined (array key|offset)/ );
+		await expect( page.locator( 'body' ) ).not.toContainText( 'preg_match' );
+
+		// The tag must still resolve the context post's content.
+		await expect( page.locator( '.o-dyn-2929' ) ).toContainText( TARGET_CONTENT );
+	});
+});

--- a/tests/test-dynamic-content.php
+++ b/tests/test-dynamic-content.php
@@ -1095,4 +1095,75 @@ class TestDynamicContent extends WP_UnitTestCase
 		$this->assertTrue( \ThemeIsle\OtterPro\Plugins\Dynamic_Content::is_protected_meta_key( 'USER_PASS' ) );
 		$this->assertFalse( \ThemeIsle\OtterPro\Plugins\Dynamic_Content::is_protected_meta_key( 'test_meta' ) );
 	}
+
+	/**
+	 * postContent must render the context post, not whatever post the loop
+	 * globals happen to point at (issue #2929: the context ID was passed to
+	 * get_the_content() as $more_link_text, so the post argument stayed null).
+	 */
+	public function test_post_content_uses_context_not_loop_globals() {
+		$other_id = $this->factory()->post->create(
+			array(
+				'post_title'   => 'Other',
+				'post_content' => 'Other post content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$this->go_to( get_permalink( $this->post_id ) );
+
+		// A secondary loop (page builder, related-posts widget) that forgot wp_reset_postdata().
+		$query = new WP_Query( array( 'p' => $other_id ) );
+		while ( $query->have_posts() ) {
+			$query->the_post();
+		}
+
+		$result = $this->dynamic_content->apply_dynamic_content( '<p><o-dynamic data-type="postContent">Post Content</o-dynamic></p>' );
+
+		wp_reset_postdata();
+		wp_delete_post( $other_id, true );
+
+		$this->assertStringNotContainsString( 'Other post content', $result );
+		$this->assertStringContainsString( 'Test', $result );
+	}
+
+	/**
+	 * A clobbered $pages loop global (theme templates are included at global
+	 * scope, so any template-level $pages variable overwrites it) must not
+	 * surface "Undefined array key -1" from post-template.php nor swallow the
+	 * content (issue #2929).
+	 */
+	public function test_post_content_survives_corrupted_pages_global() {
+		$this->go_to( get_permalink( $this->post_id ) );
+
+		// Fire the loop so did_action( 'the_post' ) is truthy, then corrupt the global.
+		$query = new WP_Query( array( 'p' => $this->post_id ) );
+		while ( $query->have_posts() ) {
+			$query->the_post();
+		}
+		$GLOBALS['pages'] = array();
+
+		$captured = array();
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$captured ) {
+				$captured[] = $errstr;
+				return true;
+			}
+		);
+
+		$result = $this->dynamic_content->apply_dynamic_content( '<p><o-dynamic data-type="postContent">Post Content</o-dynamic></p>' );
+
+		restore_error_handler();
+		wp_reset_postdata();
+
+		$page_warnings = array_filter(
+			$captured,
+			function ( $message ) {
+				return false !== strpos( $message, 'Undefined' ) || false !== strpos( $message, 'preg_match' );
+			}
+		);
+
+		$this->assertSame( array(), array_values( $page_warnings ) );
+		$this->assertStringContainsString( 'Test', $result );
+	}
 }

--- a/tests/test-dynamic-content.php
+++ b/tests/test-dynamic-content.php
@@ -1166,4 +1166,97 @@ class TestDynamicContent extends WP_UnitTestCase
 		$this->assertSame( array(), array_values( $page_warnings ) );
 		$this->assertStringContainsString( 'Test', $result );
 	}
+
+	/**
+	 * The infinite-loop guard in mark_exceptions() must inspect the context
+	 * post. When the context post nests a postContent tag the guard has to fire
+	 * even though the loop-global post is clean (issue #2929: the guard read the
+	 * loop global, so the nested tag went undetected and recursed).
+	 */
+	public function test_post_content_guard_detects_nested_tag_in_context_post() {
+		$nested_id = $this->factory()->post->create(
+			array(
+				'post_title'   => 'Nested',
+				'post_content' => 'Before <o-dynamic data-type="postContent">Post Content</o-dynamic> after',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$clean_id = $this->factory()->post->create(
+			array(
+				'post_title'   => 'Clean loop global',
+				'post_content' => 'Clean loop global content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Context = the nested post, loop global = the clean post.
+		$this->go_to( get_permalink( $nested_id ) );
+
+		$query = new WP_Query( array( 'p' => $clean_id ) );
+		while ( $query->have_posts() ) {
+			$query->the_post();
+		}
+
+		$data      = array(
+			'type'    => 'postContent',
+			'context' => $nested_id,
+		);
+		$marked    = $this->dynamic_content->mark_exceptions( $data );
+		$guard_key = $this->dynamic_content->get_exception_key( $data, $nested_id );
+
+		// Asserted before rendering on purpose: an unfired guard makes
+		// apply_dynamic_content() recurse until the process dies, so this has to
+		// fail fast rather than hang.
+		$this->assertArrayHasKey( $guard_key, $marked );
+
+		$result = $this->dynamic_content->apply_dynamic_content( '<p><o-dynamic data-type="postContent">Post Content</o-dynamic></p>' );
+
+		wp_reset_postdata();
+		wp_delete_post( $nested_id, true );
+		wp_delete_post( $clean_id, true );
+
+		// Guard fired: the tag resolves to an empty string instead of recursing.
+		$this->assertSame( '<p></p>', $result );
+		$this->assertStringNotContainsString( 'Clean loop global content', $result );
+	}
+
+	/**
+	 * The mirror case: a nested postContent tag in the loop-global post must not
+	 * blank out a clean context post (issue #2929).
+	 */
+	public function test_post_content_guard_ignores_nested_tag_in_loop_global() {
+		$nested_id = $this->factory()->post->create(
+			array(
+				'post_title'   => 'Nested loop global',
+				'post_content' => 'Before <o-dynamic data-type="postContent">Post Content</o-dynamic> after',
+				'post_status'  => 'publish',
+			)
+		);
+
+		// Context = the clean post from set_up(), loop global = the nested post.
+		$this->go_to( get_permalink( $this->post_id ) );
+
+		$query = new WP_Query( array( 'p' => $nested_id ) );
+		while ( $query->have_posts() ) {
+			$query->the_post();
+		}
+
+		$data      = array(
+			'type'    => 'postContent',
+			'context' => $this->post_id,
+		);
+		$marked    = $this->dynamic_content->mark_exceptions( $data );
+		$guard_key = $this->dynamic_content->get_exception_key( $data, $this->post_id );
+
+		$this->assertArrayNotHasKey( $guard_key, $marked );
+
+		$result = $this->dynamic_content->apply_dynamic_content( '<p><o-dynamic data-type="postContent">Post Content</o-dynamic></p>' );
+
+		wp_reset_postdata();
+		wp_delete_post( $nested_id, true );
+
+		// Guard did not fire: the context post's own content is still rendered.
+		$this->assertStringContainsString( 'Test', $result );
+	}
 }


### PR DESCRIPTION
Closes #2929.

### Summary

The **Post Content** dynamic value read the loop globals instead of the post it was bound to. When a theme or plugin left those globals clobbered, WordPress logged `Undefined array key -1 in wp-includes/post-template.php on line 330` plus a `preg_match()` deprecation, and the tag rendered nothing.

`get_the_content()` takes the post as its **third** argument. Otter passed the context post ID as the **first** one, which is `$more_link_text`, so the post argument stayed `null` and core fell back to `$pages`, `$page` and the other loop globals.

- **Post Content dynamic value** — resolves from its own context post. The output no longer depends on the state of the loop globals.

- **`mark_exceptions()`** — the infinite-loop guard reads the same context post. Before, it inspected whichever post the globals pointed at, so it could miss a nested `postContent` tag or flag one that was not there.

> [!NOTE]
> Both call sites had the same argument mistake, so a page could emit the warning twice per dynamic tag. The other `get_the_content()` callers in the plugin already pass the post correctly and are untouched.

#### Render flow

```mermaid
flowchart LR
    A[Block with<br/>Post Content tag] --> B[Resolve the<br/>context post ID]
    B --> C[Changed:<br/>pass the post as<br/>the 3rd argument]:::changed
    C --> D{Loop globals<br/>clobbered?}
    D -- Yes --> E[Post content renders]
    D -- No --> E

    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

----

### Test instructions

1. Open `wp-config.php`. Set `WP_DEBUG` to `true`, set `WP_DEBUG_LOG` to `true`, and set `WP_DEBUG_DISPLAY` to `false`. Delete `wp-content/debug.log` if the file exists.

2. Go to `WP Admin → Posts → Add New`. Add a paragraph with the text `Target body copy`. Give the post the title `Dynamic target`. Publish the post.

3. Go to `WP Admin → Pages → Add New`. Open the editor options menu (three dots, top right) and select **Code editor**. Paste this markup, then switch back to the visual editor and publish:

   ```html
   <!-- wp:query {"query":{"perPage":1,"postType":"post","search":"Dynamic target","inherit":false}} -->
   <div class="wp-block-query"><!-- wp:post-template -->
   <!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph --><p><o-dynamic data-type="postContent" data-context="query">Post Content</o-dynamic></p><!-- /wp:paragraph --></div><!-- /wp:group -->
   <!-- /wp:post-template --></div>
   <!-- /wp:query -->
   ```

   **Expect:** the editor shows a Query Loop that contains one **Dynamic Value** placeholder.

4. Select **View Page** to open the page on the front end.

   **Expect:** the page shows `Target body copy`. No PHP notice appears on the page.

5. Open `wp-content/debug.log`.

   **Expect:** the file has no `Undefined array key -1` entry and no `preg_match(): Passing null` entry for `post-template.php`.

6. Build the same page through the interface instead of markup, to check the editor path: add a **Query Loop** block, insert a paragraph inside it, select **Dynamic Value** in the block toolbar, choose **Post Content** in the **Dynamic Value by Otter** modal, and publish.

   **Expect:** the front end shows the looped post's content, and `debug.log` stays clean.

----

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()
