### PR TITLE
fix: find synced patterns at any depth when registering block assets

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -529,16 +529,8 @@ class Registration {
 		$this->enqueue_block_styles( $post );
 
 		if ( has_block( 'core/block', $post ) ) {
-			$blocks = parse_blocks( $content );
-			$blocks = array_filter(
-				$blocks,
-				function ( $block ) {
-					return 'core/block' === $block['blockName'] && isset( $block['attrs']['ref'] );
-				}
-			);
-
-			foreach ( $blocks as $block ) {
-				$this->enqueue_dependencies( $block['attrs']['ref'] );
+			foreach ( self::get_reusable_block_ids( parse_blocks( $content ) ) as $ref ) {
+				$this->enqueue_dependencies( $ref );
 			}
 		}
 
@@ -1228,6 +1220,35 @@ class Registration {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Collect the IDs of every reusable block (synced pattern) in a block tree.
+	 *
+	 * Synced patterns can be nested inside other blocks, so the whole tree is
+	 * walked instead of only its top level. Without this, a pattern placed inside
+	 * a Group block is never found and the blocks it holds get none of their
+	 * assets registered.
+	 *
+	 * @param array<int, array<string, mixed>> $blocks Parsed blocks.
+	 * @return array<int, int> List of reusable block IDs.
+	 * @since   3.2.3
+	 * @access  public
+	 */
+	public static function get_reusable_block_ids( $blocks ) {
+		$ids = array();
+
+		foreach ( $blocks as $block ) {
+			if ( 'core/block' === $block['blockName'] && isset( $block['attrs']['ref'] ) ) {
+				$ids[] = (int) $block['attrs']['ref'];
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$ids = array_merge( $ids, self::get_reusable_block_ids( $block['innerBlocks'] ) );
+			}
+		}
+
+		return array_values( array_unique( $ids ) );
 	}
 
 	/**

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -244,4 +244,38 @@ class Test_Registration extends WP_UnitTestCase {
 		$this->assertFalse( class_exists( $class, false ), 'The renderer class must not have been defined.' );
 		$this->assertCaptchaRegisteredWithoutRenderer();
 	}
+
+	/**
+	 * A synced pattern nested inside another block must still be found: the blocks
+	 * it holds get none of their assets registered otherwise.
+	 */
+	public function test_reusable_block_ids_finds_a_nested_pattern() {
+		$content = '<!-- wp:group --><div class="wp-block-group"><!-- wp:block {"ref":42} /--></div><!-- /wp:group -->';
+
+		$this->assertEquals( array( 42 ), Registration::get_reusable_block_ids( parse_blocks( $content ) ) );
+	}
+
+	/**
+	 * Patterns are collected from every level, each ID only once.
+	 */
+	public function test_reusable_block_ids_collects_every_level_without_duplicates() {
+		$content = '<!-- wp:block {"ref":1} /-->'
+			. '<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column --><div class="wp-block-column"><!-- wp:block {"ref":2} /--></div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->'
+			. '<!-- wp:block {"ref":1} /-->'
+			. '</div><!-- /wp:group -->';
+
+		$this->assertEquals( array( 1, 2 ), Registration::get_reusable_block_ids( parse_blocks( $content ) ) );
+	}
+
+	/**
+	 * Content without patterns yields nothing, and a pattern block without a ref
+	 * attribute is skipped rather than producing a bogus ID.
+	 */
+	public function test_reusable_block_ids_is_empty_without_usable_patterns() {
+		$this->assertEquals( array(), Registration::get_reusable_block_ids( parse_blocks( '<!-- wp:paragraph --><p>Text</p><!-- /wp:paragraph -->' ) ) );
+		$this->assertEquals( array(), Registration::get_reusable_block_ids( parse_blocks( '<!-- wp:block /-->' ) ) );
+	}
 }


### PR DESCRIPTION
Closes #2984.

### Summary

`Registration::enqueue_dependencies()` scanned for reusable blocks (`core/block`) by filtering the flat list returned by `parse_blocks()`, so only patterns sitting at the top level of the content were found. A synced pattern nested inside a Group — the usual way people place one — was never seen, and none of the blocks it holds got their assets registered.

Because the handles are registered conditionally, core's own render-time enqueue then no-ops on an unregistered handle, so the block ends up with neither its stylesheet nor its script. For the Form block that is not just cosmetic: submission happens in JS, so the form cannot be submitted at all.

The collection step now walks the whole tree, gathering each pattern ID once. Extracted as `Registration::get_reusable_block_ids()`, public static like the neighbouring `get_active_widgets_content()`, so the behaviour is unit-testable without a built `build/` directory.

Since patterns can contain patterns, `enqueue_dependencies()` still recurses per ID as before — this only changes which IDs it is handed.

### Test instructions

1. Add a Form block to a page, then create a synced pattern from it.
2. On a page, place that pattern **inside a Group block**.
3. View the page on the frontend.
4. Before this change: `otter-form-style` and `build/blocks/form.js` are both absent, `.otter-form__container` falls back to `display: block`, and submitting does nothing. After: both load and the form submits.
5. Confirm the top-level case still works by placing the same pattern directly in the page root.

Unit tests cover a pattern nested in a Group, patterns collected from several levels without duplicates, and content with no usable pattern (including a `core/block` without a `ref`).

I could not run the PHPUnit suite locally — it needs wp-env, and Docker was unavailable on this machine — so the new tests have not been executed. `composer run lint` (phpcs) passes on both changed files, and phpstan reports the same 22 pre-existing errors in `class-registration.php` before and after, so nothing new was introduced. The behaviour itself is verified in a real WordPress 7.0.4 install: two otherwise identical pages against the same pattern, nested versus top level, before and after the patch.

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

Notes on the checklist: no attributes, markup or visual elements change, so the deprecation and copy/paste items do not apply. Assets are still only registered for blocks the page actually uses — the change is which patterns get scanned, not how much is loaded. The widgets path (`enqueue_dependencies( 'widgets' )`) goes through the same collection step and is fixed along with it.

---

*Created with help of Claude Code.*