### PR TITLE
fix: translate the form response defaults on the frontend

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -633,6 +633,7 @@ class Registration {
 					'nonce'              => wp_create_nonce( 'wp_rest' ),
 					'messages'           => array(
 						'submission'           => __( 'Form submission from', 'otter-blocks' ),
+						'success'              => __( 'Success', 'otter-blocks' ),
 						'captcha-not-loaded'   => __( 'Captcha is not loaded. Please check your browser plugins to allow it.', 'otter-blocks' ),
 						'check-captcha'        => __( 'Please check the captcha.', 'otter-blocks' ),
 						'invalid-email'        => __( 'The email address is invalid!', 'otter-blocks' ),

--- a/inc/integrations/api/form-response-data.php
+++ b/inc/integrations/api/form-response-data.php
@@ -105,8 +105,8 @@ class Form_Data_Response {
 		$this->response['success']       = false;
 		$this->response['reasons']       = array();
 		$this->response['code']          = self::SUCCESS_EMAIL_SEND;
-		$this->response['displayError']  = 'Error. Please try again.';
-		$this->response['submitMessage'] = 'Success';
+		$this->response['displayError']  = __( 'Error. Please try again.', 'otter-blocks' );
+		$this->response['submitMessage'] = __( 'Success', 'otter-blocks' );
 	}
 
 	/**

--- a/src/blocks/frontend/form/index.js
+++ b/src/blocks/frontend/form/index.js
@@ -59,7 +59,7 @@ const extractFormFields = async( form ) => {
 
 
 	/** @type {Array.<import('./types').FormFieldData>} */
-	const formFieldsData = [{ label: window?.themeisleGutenbergForm?.messages['form-submission'] || 'Form submission from', value: window.location.href, metadata: { position: 0 }}];
+	const formFieldsData = [{ label: window?.themeisleGutenbergForm?.messages?.submission || 'Form submission from', value: window.location.href, metadata: { position: 0 }}];
 
 	/**
 	 * All input fields that belong to the current form. Fields from inner forms are removed.
@@ -488,7 +488,7 @@ const collectAndSendInputFormData = async( form, btn, displayMsg ) => {
 						return;
 					}
 
-					const msg = res?.submitMessage ? res.submitMessage :  'Success';
+					const msg = res?.submitMessage ? res.submitMessage : ( window?.themeisleGutenbergForm?.messages?.success || 'Success' );
 					displayMsg.setMsg( msg ).show();
 
 					form?.querySelector( 'form' )?.reset();
@@ -573,7 +573,7 @@ domReady( () => {
 			spinner.show();
 
 			handleAfterSubmit( confirmRecord(), displayMsg, ( res, displayMsg ) => {
-				const msg = res?.submitMessage ? res.submitMessage :  'Success';
+				const msg = res?.submitMessage ? res.submitMessage : ( window?.themeisleGutenbergForm?.messages?.success || 'Success' );
 				displayMsg.setMsg( msg ).show();
 
 				if ( 0 < res?.redirectLink?.length ) {


### PR DESCRIPTION
Closes #2985.

### Summary

`Form_Response_Data::__construct()` set its two defaults as raw strings:

```php
$this->response['displayError']  = 'Error. Please try again.';
$this->response['submitMessage'] = 'Success';
```

That value is what the frontend renders, so a site in any other locale showed "Success" after submitting — even though the string is already translated in the language packs. The editor preview uses `__( 'Success', 'otter-blocks' )` for the same message, which is why the block looked correctly localized while editing and only the live form was in English. Both defaults now go through `__()`. No new strings: existing translations start working immediately.

Two related fixes in the frontend script, same symptom:

- The fallback for the same message was hardcoded. It now reads the localized string, following the pattern already used elsewhere in the file, with the English string kept as a last resort. A `success` key was added to the localized `messages` array to back it.
- `extractFormFields()` read `messages['form-submission']`, but PHP sends that string under the key `submission`. The lookup never matched, so the submission label always fell back to English. It now reads `submission`.

### Test instructions

1. Run a site in a non-English locale — `sv_SE` translates "Success" as "Lyckades".
2. Add a Form block, leave the submit message empty in Form Options, and submit it on the frontend.
3. Before: "Success". After: the locale's translation.
4. Trigger a server-side error (for example an invalid recipient) to check `displayError` the same way.
5. Submit successfully and check the notification email: the first line's label ("Form submission from") is now translated as well.

The PHP side is straightforward to verify. I could not run the PHPUnit or E2E suites locally — they need wp-env and Docker was unavailable on this machine — and I have not built the JS bundle, so the two frontend changes are reviewed by reading rather than executed. `composer run lint` passes on both PHP files. The `submission` key mismatch is verifiable without running anything: the key PHP registers and the key JS reads are simply different strings.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

No tests are included: the changed lines are string plumbing, and testing them meaningfully would mean asserting against a loaded translation catalog in the response class. Happy to add such a test if you would like one. Nothing else on the list is touched — no attributes, markup or assets change, one extra key is added to an array that is already localized.

---

*Created with help of Claude Code.*