### PR TITLE
fix: keep the submit button from growing while the form is submitting

### DIFF
--- a/src/blocks/blocks/form/style.scss
+++ b/src/blocks/blocks/form/style.scss
@@ -452,7 +452,8 @@
 
 	.spinner {
 		position: relative;
-		padding: 2rem;
+		width: 20px;
+		height: 20px;
 		&:before {
 			content: "";
 			box-sizing: border-box;
@@ -464,7 +465,7 @@
 			margin-top: -10px;
 			margin-left: -10px;
 			border-radius: 50%;
-			border-top: 2px solid var(--submit-color, white);
+			border-top: 2px solid var(--submit-color, currentColor);
 			border-right: 2px solid transparent;
 			animation: spinner 0.6s linear infinite;
 		}


### PR DESCRIPTION
Closes #2986.

### Summary

The loading spinner is appended as a `<span class="spinner">` inside the submit button, and it carried `padding: 2rem`. The button therefore grew — mostly in height — for as long as the submission was in flight, then shrank back. On a centered button the surrounding layout moves with it.

The ring itself is drawn by `:before` with `position: absolute`, its own `width`/`height` and negative margins for centering, so the span never needed a box of its own. It is now sized to the ring instead.

Second change on the same element: the ring's colour defaulted to `white`, which assumes a dark button. `--submit-color` is only set when the user picks a submit text colour in the block, so out of the box the spinner is white — invisible on any light or brightly coloured button. Since the span sits inside the button, `currentColor` inherits the button's own text colour and works on both light and dark.

### Screenshots

Measured on a 46px-tall button with a lime background and dark text:

| | Button height, idle | Button height, submitting | Spinner visible |
|---|---|---|---|
| Before | 46px | grows | no (white on lime) |
| After | 46px | 46px | yes |

### Test instructions

1. Add a Form block to a page and give the submit button a visible padding and a light background colour.
2. Submit the form on the frontend and watch the button while the request is pending.
3. Before: the button grows and the spinner cannot be seen. After: the button keeps its height and the spinner is drawn in the button's text colour.
4. Check a dark button too, where the ring previously showed: it still does, now inheriting the text colour rather than being hard-coded white.

The change is two declarations in `style.scss`. I verified the compiled output and the resulting geometry in a browser against a real form, but I could not run the E2E suite locally — it needs wp-env and Docker was unavailable on this machine.

If you would rather keep `white` as the fallback for backwards compatibility, dropping the padding alone still fixes the reported bug — happy to trim the PR to that.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.

This is a visual change by definition — the spinner is the visual element in question, and the button around it stops moving. No tests included: asserting "the button does not change height mid-request" needs an intercepted, held-open submission in E2E. I can write that if you want it.

---

*Created with help of Claude Code.*