### PR TITLE
Improved Atomic Wind Blocks CSS scoping

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -27,3 +27,7 @@ jobs:
           npm run lint
         env:
           CI: true
+      - name: Run unit tests
+        run: npm run test:unit
+        env:
+          CI: true

--- a/inc/plugins/class-atomic-wind-blocks.php
+++ b/inc/plugins/class-atomic-wind-blocks.php
@@ -16,6 +16,13 @@ namespace ThemeIsle\GutenbergBlocks\Plugins;
 class Atomic_Wind_Blocks {
 
 	/**
+	 * CSS version for the Atomic Wind blocks.
+	 *
+	 * @var string
+	 */
+	const ATOMIC_WIND_CSS_VERSION = '1.0.0';
+
+	/**
 	 * Whether we are currently inside a query loop render.
 	 *
 	 * @var bool
@@ -326,7 +333,7 @@ class Atomic_Wind_Blocks {
 		$this->expected[ $queried->ID ] = substr_count( $queried->post_content, '<!-- wp:atomic-wind/' );
 		wp_enqueue_style( 'atomic-wind-base' );
 
-		$cached_css = get_post_meta( $queried->ID, '_atomic_wind_css', true );
+		$cached_css = $this->get_cached_css( $queried->ID );
 
 		if ( ! $cached_css ) {
 			$this->enqueue_generator();
@@ -353,7 +360,7 @@ class Atomic_Wind_Blocks {
 
 		if ( ! $queried instanceof \WP_Post
 			|| ! $this->post_has_atomic_wind_blocks( $queried )
-			|| get_post_meta( $queried->ID, '_atomic_wind_css', true )
+			|| $this->get_cached_css( $queried->ID )
 			|| ! current_user_can( 'edit_post', $queried->ID ) ) {
 			return;
 		}
@@ -435,7 +442,7 @@ class Atomic_Wind_Blocks {
 				if ( $post instanceof \WP_Post && $this->post_has_atomic_wind_blocks( $post ) ) {
 					$this->expected[ $id ] = substr_count( $post->post_content, '<!-- wp:atomic-wind/' );
 
-					$cached_css = get_post_meta( $id, '_atomic_wind_css', true );
+					$cached_css = $this->get_cached_css( $id );
 
 					if ( $cached_css ) {
 						$hash = md5( $cached_css );
@@ -507,8 +514,25 @@ class Atomic_Wind_Blocks {
 		$css     = $request->get_param( 'css' );
 
 		$success = update_post_meta( $post_id, '_atomic_wind_css', wp_slash( $css ) );
+		update_post_meta( $post_id, '_atomic_wind_css_version', self::ATOMIC_WIND_CSS_VERSION );
 
 		return new \WP_REST_Response( array( 'success' => $success ), 200 );
+	}
+
+	/**
+	 * Read cached CSS, ignoring stylesheets built by an older generator.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string
+	 */
+	private function get_cached_css( $post_id ) {
+		if ( self::ATOMIC_WIND_CSS_VERSION !== get_post_meta( $post_id, '_atomic_wind_css_version', true ) ) {
+			return '';
+		}
+
+		$css = get_post_meta( $post_id, '_atomic_wind_css', true );
+
+		return is_string( $css ) ? $css : '';
 	}
 
 	/**
@@ -534,6 +558,7 @@ class Atomic_Wind_Blocks {
 	 */
 	public function clear_cached_css( $post_id ) {
 		delete_post_meta( $post_id, '_atomic_wind_css' );
+		delete_post_meta( $post_id, '_atomic_wind_css_version' );
 	}
 
 	/**

--- a/src/atomic-wind/tailwind/generator-frontend.js
+++ b/src/atomic-wind/tailwind/generator-frontend.js
@@ -4,6 +4,7 @@ import indexCSS from 'tailwindcss/index.css';
 import preflightCSS from 'tailwindcss/preflight.css';
 import themeCSS from 'tailwindcss/theme.css';
 import utilitiesCSS from 'tailwindcss/utilities.css';
+import { scopeToAtomicWind } from './scope-css';
 
 const assets = {
 	index: indexCSS,
@@ -71,7 +72,7 @@ async function build( kind ) {
 		return;
 	}
 
-	sheet.textContent = compiler.build( Array.from( newClasses ) );
+	sheet.textContent = scopeToAtomicWind( compiler.build( Array.from( newClasses ) ) );
 }
 
 function rebuild( kind ) {

--- a/src/atomic-wind/tailwind/generator.js
+++ b/src/atomic-wind/tailwind/generator.js
@@ -4,6 +4,7 @@ import indexCSS from 'tailwindcss/index.css';
 import preflightCSS from 'tailwindcss/preflight.css';
 import themeCSS from 'tailwindcss/theme.css';
 import utilitiesCSS from 'tailwindcss/utilities.css';
+import { prefixCss, scopeToAtomicWind } from './scope-css';
 
 const assets = {
 	index: indexCSS,
@@ -85,157 +86,6 @@ function resolveEditorContext() {
 	}
 
 	return null;
-}
-
-function splitSelectorList( selectorText ) {
-	const selectors = [];
-	let current = '';
-	let parenDepth = 0;
-	let bracketDepth = 0;
-	let braceDepth = 0;
-	let inSingleQuote = false;
-	let inDoubleQuote = false;
-	let escaped = false;
-
-	for ( const char of selectorText ) {
-		if ( escaped ) {
-			current += char;
-			escaped = false;
-			continue;
-		}
-
-		if ( '\\' === char ) {
-			current += char;
-			escaped = true;
-			continue;
-		}
-
-		if ( '\'' === char && ! inDoubleQuote ) {
-			inSingleQuote = ! inSingleQuote;
-			current += char;
-			continue;
-		}
-
-		if ( '"' === char && ! inSingleQuote ) {
-			inDoubleQuote = ! inDoubleQuote;
-			current += char;
-			continue;
-		}
-
-		if ( inSingleQuote || inDoubleQuote ) {
-			current += char;
-			continue;
-		}
-
-		if ( '(' === char ) {
-			parenDepth++;
-			current += char;
-			continue;
-		}
-		if ( ')' === char ) {
-			parenDepth = Math.max( 0, parenDepth - 1 );
-			current += char;
-			continue;
-		}
-
-		if ( '[' === char ) {
-			bracketDepth++;
-			current += char;
-			continue;
-		}
-		if ( ']' === char ) {
-			bracketDepth = Math.max( 0, bracketDepth - 1 );
-			current += char;
-			continue;
-		}
-
-		if ( '{' === char ) {
-			braceDepth++;
-			current += char;
-			continue;
-		}
-		if ( '}' === char ) {
-			braceDepth = Math.max( 0, braceDepth - 1 );
-			current += char;
-			continue;
-		}
-
-		if ( ',' === char && 0 === parenDepth && 0 === bracketDepth && 0 === braceDepth ) {
-			selectors.push( current.trim() );
-			current = '';
-			continue;
-		}
-
-		current += char;
-	}
-
-	if ( current.trim() ) {
-		selectors.push( current.trim() );
-	}
-
-	return selectors;
-}
-
-function prefixSelectorList( selectorText, scopeSelector ) {
-	return splitSelectorList( selectorText )
-		.map( ( selector ) => {
-			if ( /^(:root|:host|html|body)(\b|$|:|\.|#|\[)/.test( selector ) ) {
-				return scopeSelector;
-			}
-
-			return `${scopeSelector} ${selector}`;
-		} )
-		.join( ', ' );
-}
-
-function scopeRuleCss( rule, scopeSelector ) {
-	if ( CSSRule.STYLE_RULE === rule.type ) {
-		const open = rule.cssText.indexOf( '{' );
-		if ( -1 === open ) {
-			return rule.cssText;
-		}
-
-		const prefixedSelector = prefixSelectorList( rule.selectorText, scopeSelector );
-		const body = rule.cssText.slice( open );
-		return `${prefixedSelector}${body}`;
-	}
-
-	if (
-		CSSRule.FONT_FACE_RULE === rule.type ||
-		CSSRule.KEYFRAMES_RULE === rule.type ||
-		( 'PROPERTY_RULE' in CSSRule && CSSRule.PROPERTY_RULE === rule.type )
-	) {
-		return rule.cssText;
-	}
-
-	if ( rule.cssRules && rule.cssRules.length > 0 ) {
-		const open = rule.cssText.indexOf( '{' );
-		const close = rule.cssText.lastIndexOf( '}' );
-		if ( -1 !== open && -1 !== close ) {
-			return `${rule.cssText.slice( 0, open + 1 )}${scopeCssRules( rule.cssRules, scopeSelector )}}`;
-		}
-	}
-
-	return rule.cssText;
-}
-
-function scopeCssRules( rules, scopeSelector ) {
-	return Array.from( rules ).map( ( rule ) => scopeRuleCss( rule, scopeSelector ) ).join( '' );
-}
-
-function scopeGeneratedCss( css, scopeSelector ) {
-	if ( ! css || ! scopeSelector ) {
-		return css;
-	}
-
-	try {
-		const parsed = new CSSStyleSheet();
-		parsed.replaceSync( css );
-		return scopeCssRules( parsed.cssRules, scopeSelector );
-	} catch ( error ) {
-		console.error( error );
-		return css;
-	}
 }
 
 function attachObserver( root ) {
@@ -369,14 +219,14 @@ async function build( kind ) {
 		return;
 	}
 
-	const generated = compiler.build( Array.from( newClasses ) );
-	const scopedCss = activeScopeSelector ? scopeGeneratedCss( generated, activeScopeSelector ) : generated;
+	const generated = scopeToAtomicWind( compiler.build( Array.from( newClasses ) ) );
+	const scopedCss = activeScopeSelector ? prefixCss( generated, activeScopeSelector ) : generated;
 	ensureStyleTag( activeDocument );
 	sheet.textContent = scopedCss;
 }
 
 // Lets other editor features (the Design Library pattern previews) generate
-// unscoped Tailwind CSS for an arbitrary class list. Kept separate from the
+// Tailwind CSS for an arbitrary class list. Kept separate from the
 // canvas compiler: it must not pollute the canvas sheet, and canvas full
 // rebuilds reset that compiler, which would drop classes fed in here. The
 // compiler is cumulative — each call returns the full stylesheet for every
@@ -392,7 +242,7 @@ window.atomicWindGenerateCss = async ( classNames ) => {
 	}
 
 	const instance = await apiCompiler;
-	return instance.build( Array.from( new Set( classNames ) ) );
+	return scopeToAtomicWind( instance.build( Array.from( new Set( classNames ) ) ) );
 };
 
 function rebuild( kind ) {

--- a/src/atomic-wind/tailwind/scope-css.js
+++ b/src/atomic-wind/tailwind/scope-css.js
@@ -1,0 +1,390 @@
+/**
+ * Selector rewriting for the generated Tailwind stylesheet.
+ *
+ * Tailwind ships preflight, whose rules target bare HTML elements (`h1`,
+ * `button`, `img`, `*`). Injected as-is they reset the whole document and win
+ * over the theme's own element styles, so every element-anchored rule is
+ * confined to the Atomic Wind block subtree. Class-anchored rules (the
+ * utilities) stay global — they only match our generated markup anyway.
+ */
+
+const ATOMIC_ROOT = '[class*="wp-block-atomic-wind-"]';
+const ATOMIC_MATCH = `:where(${ ATOMIC_ROOT }, ${ ATOMIC_ROOT } *)`;
+// Zero specificity, so a theme rule aimed at the block wrapper still wins.
+const ATOMIC_SELF = `:where(${ ATOMIC_ROOT })`;
+
+// At-rules whose bodies are not selector lists and must be emitted verbatim.
+const OPAQUE_AT_RULE = /^@(-[a-z]+-)?(keyframes|font-face|property|counter-style|font-feature-values|font-palette-values|page|viewport|charset|import|namespace)\b/i;
+
+// Document-level selectors: they carry inherited defaults, not element resets.
+const ROOT_SELECTOR = /^(:root|:host|html|body)($|[\s:.#[(,>+~])/;
+
+const LEGACY_PSEUDO_ELEMENT = /^:(before|after|first-line|first-letter)\b/i;
+
+const COMBINATOR = /[\s>+~]/;
+
+/**
+ * Mark every character that sits outside brackets, parentheses and strings.
+ *
+ * @param {string} text Selector or prelude text.
+ * @return {boolean[]} Per-character top-level flags.
+ */
+function topLevelMask( text ) {
+	const mask = new Array( text.length ).fill( false );
+	let depth = 0;
+	let quote = '';
+	let escaped = false;
+
+	for ( let i = 0; i < text.length; i++ ) {
+		const char = text[ i ];
+
+		if ( escaped ) {
+			escaped = false;
+			continue;
+		}
+
+		if ( '\\' === char ) {
+			escaped = true;
+			continue;
+		}
+
+		if ( quote ) {
+			if ( char === quote ) {
+				quote = '';
+			}
+			continue;
+		}
+
+		if ( '"' === char || '\'' === char ) {
+			quote = char;
+			continue;
+		}
+
+		if ( '(' === char || '[' === char || '{' === char ) {
+			mask[ i ] = 0 === depth;
+			depth++;
+			continue;
+		}
+
+		if ( ')' === char || ']' === char || '}' === char ) {
+			depth = Math.max( 0, depth - 1 );
+			mask[ i ] = 0 === depth;
+			continue;
+		}
+
+		mask[ i ] = 0 === depth;
+	}
+
+	return mask;
+}
+
+/**
+ * Split a comma-separated selector list, ignoring commas nested in `:is()` & co.
+ *
+ * @param {string} selectorText Selector list.
+ * @return {string[]} Individual selectors.
+ */
+export function splitSelectorList( selectorText ) {
+	const mask = topLevelMask( selectorText );
+	const selectors = [];
+	let start = 0;
+
+	for ( let i = 0; i < selectorText.length; i++ ) {
+		if ( ',' === selectorText[ i ] && mask[ i ] ) {
+			selectors.push( selectorText.slice( start, i ).trim() );
+			start = i + 1;
+		}
+	}
+
+	selectors.push( selectorText.slice( start ).trim() );
+
+	return selectors.filter( Boolean );
+}
+
+/**
+ * Locate the start of the subject compound (everything after the last combinator).
+ *
+ * @param {string} selector Single selector.
+ * @return {number} Index the subject compound starts at.
+ */
+function subjectStart( selector ) {
+	const mask = topLevelMask( selector );
+	let start = 0;
+
+	for ( let i = 0; i < selector.length; i++ ) {
+		if ( mask[ i ] && COMBINATOR.test( selector[ i ] ) ) {
+			start = i + 1;
+		}
+	}
+
+	return start;
+}
+
+/**
+ * Find where the subject's pseudo-element suffix begins.
+ *
+ * @param {string} subject Subject compound.
+ * @return {number} Index of the pseudo-element, or -1.
+ */
+function pseudoElementStart( subject ) {
+	const mask = topLevelMask( subject );
+
+	for ( let i = 0; i < subject.length; i++ ) {
+		if ( ! mask[ i ] || ':' !== subject[ i ] ) {
+			continue;
+		}
+
+		if ( ':' === subject[ i + 1 ] || LEGACY_PSEUDO_ELEMENT.test( subject.slice( i ) ) ) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+/**
+ * Whether the subject is already anchored to a class or id.
+ *
+ * Those are the generated utilities; attribute-only subjects (`[hidden]`) still
+ * match theme markup, so they get scoped like bare elements do.
+ *
+ * @param {string} subject Subject compound.
+ * @return {boolean} True when the rule cannot leak onto theme markup.
+ */
+function isAnchored( subject ) {
+	const mask = topLevelMask( subject );
+
+	for ( let i = 0; i < subject.length; i++ ) {
+		if ( mask[ i ] && ( '.' === subject[ i ] || '#' === subject[ i ] ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Confine one selector to the Atomic Wind subtree when it targets bare elements.
+ *
+ * @param {string} selector Single selector.
+ * @return {string} Scoped selector.
+ */
+function scopeSelectorToBlocks( selector ) {
+	if ( ROOT_SELECTOR.test( selector ) ) {
+		return ATOMIC_SELF;
+	}
+
+	const start = subjectStart( selector );
+	const subject = selector.slice( start );
+
+	if ( isAnchored( subject ) ) {
+		return selector;
+	}
+
+	const prefix = selector.slice( 0, start );
+	const pseudo = pseudoElementStart( subject );
+	const base = -1 === pseudo ? subject : subject.slice( 0, pseudo );
+	const suffix = -1 === pseudo ? '' : subject.slice( pseudo );
+
+	return `${ prefix }${ base || '*' }${ ATOMIC_MATCH }${ suffix }`;
+}
+
+/**
+ * Whether a declaration block only defines custom properties.
+ *
+ * Those rules feed `var()` lookups instead of styling anything, so they are
+ * safe to leave at their original scope.
+ *
+ * @param {string} body Declaration block, without the braces.
+ * @return {boolean} True for custom-property-only blocks.
+ */
+function isCustomPropertyOnly( body ) {
+	if ( body.includes( '{' ) ) {
+		return false;
+	}
+
+	const declarations = body.split( ';' ).map( ( declaration ) => declaration.trim() ).filter( Boolean );
+
+	return 0 < declarations.length && declarations.every( ( declaration ) => declaration.startsWith( '--' ) );
+}
+
+/**
+ * Index of the `}` closing the block opened at `open`.
+ *
+ * @param {string} css  Stylesheet text.
+ * @param {number} open Index of the opening brace.
+ * @return {number} Index of the matching brace, or -1 when unterminated.
+ */
+function blockEnd( css, open ) {
+	let depth = 0;
+	let quote = '';
+	let escaped = false;
+
+	for ( let i = open; i < css.length; i++ ) {
+		const char = css[ i ];
+
+		if ( escaped ) {
+			escaped = false;
+			continue;
+		}
+
+		if ( '\\' === char ) {
+			escaped = true;
+			continue;
+		}
+
+		if ( quote ) {
+			if ( char === quote ) {
+				quote = '';
+			}
+			continue;
+		}
+
+		if ( '/' === char && '*' === css[ i + 1 ] ) {
+			const end = css.indexOf( '*/', i + 2 );
+			i = -1 === end ? css.length : end + 1;
+			continue;
+		}
+
+		if ( '"' === char || '\'' === char ) {
+			quote = char;
+			continue;
+		}
+
+		if ( '{' === char ) {
+			depth++;
+			continue;
+		}
+
+		if ( '}' === char ) {
+			depth--;
+			if ( 0 === depth ) {
+				return i;
+			}
+		}
+	}
+
+	return -1;
+}
+
+/**
+ * Rewrite every style-rule selector in a stylesheet.
+ *
+ * A falsy return from `transform` drops the rule.
+ *
+ * @param {string}   css       Stylesheet text.
+ * @param {Function} transform Receives the selector list and the declaration block.
+ * @return {string} Rewritten stylesheet.
+ */
+export function transformCssSelectors( css, transform ) {
+	let out = '';
+	let prelude = '';
+	let i = 0;
+
+	while ( i < css.length ) {
+		const char = css[ i ];
+
+		if ( '/' === char && '*' === css[ i + 1 ] ) {
+			const end = css.indexOf( '*/', i + 2 );
+			i = -1 === end ? css.length : end + 2;
+			continue;
+		}
+
+		if ( '"' === char || '\'' === char ) {
+			let end = i + 1;
+			while ( end < css.length ) {
+				if ( '\\' === css[ end ] ) {
+					end += 2;
+					continue;
+				}
+				if ( css[ end ] === char ) {
+					end++;
+					break;
+				}
+				end++;
+			}
+			prelude += css.slice( i, end );
+			i = end;
+			continue;
+		}
+
+		if ( '{' === char ) {
+			const end = blockEnd( css, i );
+			const close = -1 === end ? css.length : end;
+			const body = css.slice( i + 1, close );
+			const trimmed = prelude.trim();
+
+			if ( trimmed.startsWith( '@' ) ) {
+				const inner = OPAQUE_AT_RULE.test( trimmed ) ? body : transformCssSelectors( body, transform );
+				out += `${ trimmed }{${ inner }}`;
+			} else {
+				const selector = transform( trimmed, body );
+				if ( selector ) {
+					out += `${ selector }{${ body }}`;
+				}
+			}
+
+			prelude = '';
+			i = close + 1;
+			continue;
+		}
+
+		if ( ';' === char ) {
+			out += `${ prelude.trim() };`;
+			prelude = '';
+			i++;
+			continue;
+		}
+
+		if ( '}' === char ) {
+			i++;
+			continue;
+		}
+
+		prelude += char;
+		i++;
+	}
+
+	return out + prelude.trim();
+}
+
+/**
+ * Keep Tailwind's element resets inside Atomic Wind blocks.
+ *
+ * @param {string} css Generated stylesheet.
+ * @return {string} Scoped stylesheet.
+ */
+export function scopeToAtomicWind( css ) {
+	if ( ! css ) {
+		return css;
+	}
+
+	return transformCssSelectors( css, ( selectorText, body ) => {
+		if ( isCustomPropertyOnly( body ) ) {
+			return selectorText;
+		}
+
+		const scoped = splitSelectorList( selectorText ).map( scopeSelectorToBlocks );
+
+		return Array.from( new Set( scoped ) ).join( ', ' );
+	} );
+}
+
+/**
+ * Prefix every selector with a container scope (used for the editor canvas).
+ *
+ * @param {string} css           Generated stylesheet.
+ * @param {string} scopeSelector Container selector.
+ * @return {string} Prefixed stylesheet.
+ */
+export function prefixCss( css, scopeSelector ) {
+	if ( ! css || ! scopeSelector ) {
+		return css;
+	}
+
+	return transformCssSelectors( css, ( selectorText ) =>
+		splitSelectorList( selectorText )
+			.map( ( selector ) => ( ROOT_SELECTOR.test( selector ) ? scopeSelector : `${ scopeSelector } ${ selector }` ) )
+			.join( ', ' )
+	);
+}

--- a/src/atomic-wind/tailwind/scope-css.js
+++ b/src/atomic-wind/tailwind/scope-css.js
@@ -290,6 +290,12 @@ export function transformCssSelectors( css, transform ) {
 			continue;
 		}
 
+		if ( '\\' === char ) {
+			prelude += css.slice( i, i + 2 );
+			i += 2;
+			continue;
+		}
+
 		if ( '"' === char || '\'' === char ) {
 			let end = i + 1;
 			while ( end < css.length ) {

--- a/src/atomic-wind/tailwind/scope-css.js
+++ b/src/atomic-wind/tailwind/scope-css.js
@@ -16,8 +16,8 @@ const ATOMIC_SELF = `:where(${ ATOMIC_ROOT })`;
 // At-rules whose bodies are not selector lists and must be emitted verbatim.
 const OPAQUE_AT_RULE = /^@(-[a-z]+-)?(keyframes|font-face|property|counter-style|font-feature-values|font-palette-values|page|viewport|charset|import|namespace)\b/i;
 
-// Document-level selectors: they carry inherited defaults, not element resets.
-const ROOT_SELECTOR = /^(:root|:host|html|body)($|[\s:.#[(,>+~])/;
+// Document-level subjects: they carry inherited defaults, not element resets.
+const ROOT_SELECTOR = /^(:root|:host|html|body)$/;
 
 const LEGACY_PSEUDO_ELEMENT = /^:(before|after|first-line|first-letter)\b/i;
 
@@ -170,12 +170,12 @@ function isAnchored( subject ) {
  * @return {string} Scoped selector.
  */
 function scopeSelectorToBlocks( selector ) {
-	if ( ROOT_SELECTOR.test( selector ) ) {
-		return ATOMIC_SELF;
-	}
-
 	const start = subjectStart( selector );
 	const subject = selector.slice( start );
+
+	if ( 0 === start && ROOT_SELECTOR.test( subject ) ) {
+		return ATOMIC_SELF;
+	}
 
 	if ( isAnchored( subject ) ) {
 		return selector;
@@ -187,25 +187,6 @@ function scopeSelectorToBlocks( selector ) {
 	const suffix = -1 === pseudo ? '' : subject.slice( pseudo );
 
 	return `${ prefix }${ base || '*' }${ ATOMIC_MATCH }${ suffix }`;
-}
-
-/**
- * Whether a declaration block only defines custom properties.
- *
- * Those rules feed `var()` lookups instead of styling anything, so they are
- * safe to leave at their original scope.
- *
- * @param {string} body Declaration block, without the braces.
- * @return {boolean} True for custom-property-only blocks.
- */
-function isCustomPropertyOnly( body ) {
-	if ( body.includes( '{' ) ) {
-		return false;
-	}
-
-	const declarations = body.split( ';' ).map( ( declaration ) => declaration.trim() ).filter( Boolean );
-
-	return 0 < declarations.length && declarations.every( ( declaration ) => declaration.startsWith( '--' ) );
 }
 
 /**
@@ -355,7 +336,7 @@ export function transformCssSelectors( css, transform ) {
 }
 
 /**
- * Keep Tailwind's element resets inside Atomic Wind blocks.
+ * Keep Tailwind's element resets and variables inside Atomic Wind blocks.
  *
  * @param {string} css Generated stylesheet.
  * @return {string} Scoped stylesheet.
@@ -365,11 +346,7 @@ export function scopeToAtomicWind( css ) {
 		return css;
 	}
 
-	return transformCssSelectors( css, ( selectorText, body ) => {
-		if ( isCustomPropertyOnly( body ) ) {
-			return selectorText;
-		}
-
+	return transformCssSelectors( css, ( selectorText ) => {
 		const scoped = splitSelectorList( selectorText ).map( scopeSelectorToBlocks );
 
 		return Array.from( new Set( scoped ) ).join( ', ' );
@@ -390,7 +367,13 @@ export function prefixCss( css, scopeSelector ) {
 
 	return transformCssSelectors( css, ( selectorText ) =>
 		splitSelectorList( selectorText )
-			.map( ( selector ) => ( ROOT_SELECTOR.test( selector ) ? scopeSelector : `${ scopeSelector } ${ selector }` ) )
+			.map( ( selector ) => {
+				if ( ROOT_SELECTOR.test( selector ) ) {
+					return scopeSelector;
+				}
+
+				return `${ scopeSelector } ${ selector }`;
+			} )
 			.join( ', ' )
 	);
 }

--- a/src/atomic-wind/tailwind/scope-css.js
+++ b/src/atomic-wind/tailwind/scope-css.js
@@ -19,6 +19,8 @@ const OPAQUE_AT_RULE = /^@(-[a-z]+-)?(keyframes|font-face|property|counter-style
 // Document-level subjects: they carry inherited defaults, not element resets.
 const ROOT_SELECTOR = /^(:root|:host|html|body)$/;
 
+const ROOT_PREFIX = /^(:root|:host|html|body)(?=$|[\s>+~])/;
+
 const LEGACY_PSEUDO_ELEMENT = /^:(before|after|first-line|first-letter)\b/i;
 
 const COMBINATOR = /[\s>+~]/;
@@ -368,8 +370,12 @@ export function prefixCss( css, scopeSelector ) {
 	return transformCssSelectors( css, ( selectorText ) =>
 		splitSelectorList( selectorText )
 			.map( ( selector ) => {
-				if ( ROOT_SELECTOR.test( selector ) ) {
-					return scopeSelector;
+				// The container stands in for the document root, so substitute it
+				// for a leading root compound rather than prepending.
+				const rooted = selector.match( ROOT_PREFIX );
+
+				if ( rooted ) {
+					return `${ scopeSelector }${ selector.slice( rooted[ 0 ].length ) }`;
 				}
 
 				return `${ scopeSelector } ${ selector }`;

--- a/src/atomic-wind/tailwind/test/scope-css.test.js
+++ b/src/atomic-wind/tailwind/test/scope-css.test.js
@@ -49,9 +49,29 @@ describe( 'scopeToAtomicWind', () => {
 		);
 	} );
 
-	it( 'leaves custom-property-only rules at their original scope', () => {
-		const css = ':root, :host{--spacing:0.25rem;--text-lg:1.125rem}';
-		expect( scopeToAtomicWind( css ) ).toBe( css );
+	it( 'moves theme variables onto the block wrapper so they cannot shadow theme ones', () => {
+		expect( scopeToAtomicWind( ':root, :host{--spacing:0.25rem;--text-lg:1.125rem}' ) ).toBe(
+			`${ SELF }{--spacing:0.25rem;--text-lg:1.125rem}`
+		);
+	} );
+
+	it( 'scopes the universal custom-property initializers', () => {
+		expect( scopeToAtomicWind( '*, ::before, ::backdrop{--tw-content:""}' ) ).toBe(
+			`*${ MATCH }, *${ MATCH }::before, *${ MATCH }::backdrop{--tw-content:""}`
+		);
+	} );
+
+	it( 'keeps a document root used as an ancestor, scoping its subject instead', () => {
+		// `[body_&]:text-red-500` and friends put a root in front of the real
+		// subject; collapsing the whole selector would drop that subject and
+		// apply the declarations to every block wrapper.
+		expect( scopeToAtomicWind( 'body .\\[body_\\&\\]\\:text-red-500{color:red}' ) ).toBe(
+			'body .\\[body_\\&\\]\\:text-red-500{color:red}'
+		);
+
+		expect( scopeToAtomicWind( 'html figure{margin:0}' ) ).toBe(
+			`html figure${ MATCH }{margin:0}`
+		);
 	} );
 
 	it( 'recurses into conditional at-rules', () => {
@@ -106,7 +126,7 @@ describe( 'scopeToAtomicWind', () => {
 
 		// Layer statements, theme variables, utilities and @property pass through.
 		expect( out ).toContain( '@layer properties;@layer theme, base, components, utilities;' );
-		expect( out ).toContain( '@layer theme{:root, :host{--spacing:0.25rem}}' );
+		expect( out ).toContain( `@layer theme{${ SELF }{--spacing:0.25rem}}` );
 		expect( out ).toContain( '.flex{display:flex !important}' );
 		expect( out ).toContain( '.hover\\:underline{&:hover{@media (hover: hover){text-decoration:underline !important}}}' );
 		expect( out ).toContain( '@property --tw-content{syntax:"*";initial-value:"";inherits:false}' );
@@ -130,6 +150,12 @@ describe( 'prefixCss', () => {
 	it( 'prefixes selectors and collapses document-level ones onto the scope', () => {
 		expect( prefixCss( 'h1{color:red}html{tab-size:4}', ':where(.editor-styles-wrapper)' ) ).toBe(
 			':where(.editor-styles-wrapper) h1{color:red}:where(.editor-styles-wrapper){tab-size:4}'
+		);
+	} );
+
+	it( 'prefixes a root-prefixed descendant instead of collapsing it', () => {
+		expect( prefixCss( 'body .utility{color:red}', ':where(.editor-styles-wrapper)' ) ).toBe(
+			':where(.editor-styles-wrapper) body .utility{color:red}'
 		);
 	} );
 

--- a/src/atomic-wind/tailwind/test/scope-css.test.js
+++ b/src/atomic-wind/tailwind/test/scope-css.test.js
@@ -1,0 +1,147 @@
+import { prefixCss, scopeToAtomicWind, splitSelectorList } from '../scope-css';
+
+const MATCH = ':where([class*="wp-block-atomic-wind-"], [class*="wp-block-atomic-wind-"] *)';
+const SELF = ':where([class*="wp-block-atomic-wind-"])';
+
+describe( 'splitSelectorList', () => {
+	it( 'ignores commas nested in functional pseudo-classes and strings', () => {
+		expect( splitSelectorList( 'a:is(b, c), d[title="x, y"], e' ) ).toEqual( [
+			'a:is(b, c)',
+			'd[title="x, y"]',
+			'e',
+		] );
+	} );
+} );
+
+describe( 'scopeToAtomicWind', () => {
+	it( 'confines element resets to the block subtree', () => {
+		expect( scopeToAtomicWind( 'h1, h2 { font-size: inherit; }' ) ).toBe(
+			`h1${ MATCH }, h2${ MATCH }{ font-size: inherit; }`
+		);
+	} );
+
+	it( 'leaves utility rules global', () => {
+		const css = '.flex{display:flex}#id{color:red}';
+		expect( scopeToAtomicWind( css ) ).toBe( css );
+	} );
+
+	it( 'scopes the subject compound only, keeping ancestors intact', () => {
+		expect( scopeToAtomicWind( ':where(select:is([multiple])) optgroup{font-weight:bolder}' ) ).toBe(
+			`:where(select:is([multiple])) optgroup${ MATCH }{font-weight:bolder}`
+		);
+	} );
+
+	it( 'keeps the pseudo-element last and qualifies bare ones with a universal', () => {
+		expect( scopeToAtomicWind( '::placeholder, h1::before, p:first-line{opacity:1}' ) ).toBe(
+			`*${ MATCH }::placeholder, h1${ MATCH }::before, p${ MATCH }:first-line{opacity:1}`
+		);
+	} );
+
+	it( 'scopes attribute-anchored rules, which still match theme markup', () => {
+		expect( scopeToAtomicWind( '[hidden]{display:none !important}' ) ).toBe(
+			`[hidden]${ MATCH }{display:none !important}`
+		);
+	} );
+
+	it( 'moves document-level styling onto the block wrapper', () => {
+		expect( scopeToAtomicWind( 'html, :host{line-height:1.5;tab-size:4}' ) ).toBe(
+			`${ SELF }{line-height:1.5;tab-size:4}`
+		);
+	} );
+
+	it( 'leaves custom-property-only rules at their original scope', () => {
+		const css = ':root, :host{--spacing:0.25rem;--text-lg:1.125rem}';
+		expect( scopeToAtomicWind( css ) ).toBe( css );
+	} );
+
+	it( 'recurses into conditional at-rules', () => {
+		expect( scopeToAtomicWind( '@layer base{@media (width >= 48rem){img{display:block}}}' ) ).toBe(
+			`@layer base{@media (width >= 48rem){img${ MATCH }{display:block}}}`
+		);
+	} );
+
+	it( 'emits keyframes, @property and @import verbatim', () => {
+		const css = '@import "x.css";@property --tw-x{syntax:"*";inherits:false}@keyframes spin{from{transform:rotate(0)}to{transform:rotate(1turn)}}';
+		expect( scopeToAtomicWind( css ) ).toBe( css );
+	} );
+
+	it( 'leaves nested selectors inside a utility rule untouched', () => {
+		const css = '.space-y-4{:where(& > :not(:last-child)){margin-block-start:0}}.hover\\:underline{&:hover{text-decoration:underline}}';
+		expect( scopeToAtomicWind( css ) ).toBe( css );
+	} );
+
+	it( 'keeps escaped arbitrary-value selectors intact and keeps scoping after them', () => {
+		// Tailwind escapes the quotes in `after:content-["it's"]`, leaving a lone
+		// apostrophe. Reading it as a string opener used to swallow the rest of
+		// the stylesheet, silently leaking every element rule that followed.
+		const utility = '.after\\:content-\\[\\"it\\\'s\\"\\]';
+		const css = `${ utility }{--tw-content:"it's"}h1{font-size:inherit}`;
+
+		expect( scopeToAtomicWind( css ) ).toBe(
+			`${ utility }{--tw-content:"it's"}h1${ MATCH }{font-size:inherit}`
+		);
+	} );
+
+	it( 'does not split selectors on escaped commas', () => {
+		const utility = '.grid-cols-\\[repeat\\(2\\,minmax\\(0\\,1fr\\)\\)\\]';
+		const css = `${ utility }{grid-template-columns:repeat(2,minmax(0,1fr))}`;
+
+		expect( scopeToAtomicWind( css ) ).toBe( css );
+	} );
+
+	it( 'handles a Tailwind-shaped stylesheet layer by layer', () => {
+		const css = [
+			'@layer properties;@layer theme, base, components, utilities;',
+			'@layer theme{:root, :host{--spacing:0.25rem}}',
+			'@layer base{*, ::before{box-sizing:border-box;margin:0}',
+			'html, :host{line-height:1.5}',
+			'ul, menu{list-style:none}',
+			'input:where([type="button"])::file-selector-button{appearance:button}}',
+			'@layer utilities{.flex{display:flex !important}',
+			'.hover\\:underline{&:hover{@media (hover: hover){text-decoration:underline !important}}}}',
+			'@property --tw-content{syntax:"*";initial-value:"";inherits:false}',
+		].join( '' );
+
+		const out = scopeToAtomicWind( css );
+
+		// Layer statements, theme variables, utilities and @property pass through.
+		expect( out ).toContain( '@layer properties;@layer theme, base, components, utilities;' );
+		expect( out ).toContain( '@layer theme{:root, :host{--spacing:0.25rem}}' );
+		expect( out ).toContain( '.flex{display:flex !important}' );
+		expect( out ).toContain( '.hover\\:underline{&:hover{@media (hover: hover){text-decoration:underline !important}}}' );
+		expect( out ).toContain( '@property --tw-content{syntax:"*";initial-value:"";inherits:false}' );
+
+		// Every base-layer rule is confined to the blocks.
+		expect( out ).toContain( `*${ MATCH }, *${ MATCH }::before{box-sizing:border-box;margin:0}` );
+		expect( out ).toContain( `${ SELF }{line-height:1.5}` );
+		expect( out ).toContain( `ul${ MATCH }, menu${ MATCH }{list-style:none}` );
+		expect( out ).toContain( `input:where([type="button"])${ MATCH }::file-selector-button{appearance:button}` );
+
+		// No bare element selector survives at the start of a rule.
+		expect( out ).not.toMatch( /(^|[{};])\s*(html|ul|menu|input)\s*[,{]/ );
+	} );
+
+	it( 'is a no-op on empty input', () => {
+		expect( scopeToAtomicWind( '' ) ).toBe( '' );
+	} );
+} );
+
+describe( 'prefixCss', () => {
+	it( 'prefixes selectors and collapses document-level ones onto the scope', () => {
+		expect( prefixCss( 'h1{color:red}html{tab-size:4}', ':where(.editor-styles-wrapper)' ) ).toBe(
+			':where(.editor-styles-wrapper) h1{color:red}:where(.editor-styles-wrapper){tab-size:4}'
+		);
+	} );
+
+	it( 'prefixes an already-scoped stylesheet without touching escaped utilities', () => {
+		const utility = '.hover\\:bg-\\[\\#C65D07\\]';
+
+		expect( prefixCss( `${ utility }{background:#C65D07}`, ':where(.editor-styles-wrapper)' ) ).toBe(
+			`:where(.editor-styles-wrapper) ${ utility }{background:#C65D07}`
+		);
+	} );
+
+	it( 'returns the stylesheet untouched without a scope selector', () => {
+		expect( prefixCss( 'h1{color:red}', '' ) ).toBe( 'h1{color:red}' );
+	} );
+} );

--- a/src/atomic-wind/tailwind/test/scope-css.test.js
+++ b/src/atomic-wind/tailwind/test/scope-css.test.js
@@ -153,9 +153,21 @@ describe( 'prefixCss', () => {
 		);
 	} );
 
-	it( 'prefixes a root-prefixed descendant instead of collapsing it', () => {
+	it( 'substitutes the scope for a leading document root, keeping the descendant', () => {
+		// The container is itself inside `body`, so prepending would produce
+		// `:where(.editor-styles-wrapper) body .utility` — unsatisfiable.
 		expect( prefixCss( 'body .utility{color:red}', ':where(.editor-styles-wrapper)' ) ).toBe(
-			':where(.editor-styles-wrapper) body .utility{color:red}'
+			':where(.editor-styles-wrapper) .utility{color:red}'
+		);
+
+		expect( prefixCss( 'html figure:where(x){margin:0}', ':where(.editor-styles-wrapper)' ) ).toBe(
+			':where(.editor-styles-wrapper) figure:where(x){margin:0}'
+		);
+	} );
+
+	it( 'keeps the combinator when substituting the scope', () => {
+		expect( prefixCss( 'body > .utility{color:red}', ':where(.editor-styles-wrapper)' ) ).toBe(
+			':where(.editor-styles-wrapper) > .utility{color:red}'
 		);
 	} );
 

--- a/src/blocks/test/e2e/blocks/atomic-wind-css-scope.spec.js
+++ b/src/blocks/test/e2e/blocks/atomic-wind-css-scope.spec.js
@@ -1,0 +1,89 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from '../fixtures';
+import { setAtomicWind } from '../helpers/design-library';
+import { publishAndViewPost } from '../helpers/editor';
+
+/**
+ * The generated Tailwind stylesheet carries preflight, whose rules target bare
+ * HTML elements, and a theme layer defining variables such as `--spacing`. It
+ * is injected into the document head, so both must only reach markup inside
+ * Atomic Wind blocks — theme markup elsewhere keeps its own element styling and
+ * its own variables.
+ */
+test.describe( 'Atomic Wind Tailwind CSS scope', () => {
+	test.beforeEach( async({ otterUtils, admin }) => {
+		await setAtomicWind( otterUtils, true );
+		await admin.createNewPost();
+	});
+
+	test.afterAll( async({ otterUtils }) => {
+		await setAtomicWind( otterUtils, false );
+	});
+
+	test( 'resets elements inside the block without touching theme markup', async({ editor, page }) => {
+		await editor.insertBlock({
+			name: 'core/list',
+			attributes: { className: 'theme-list' },
+			innerBlocks: [
+				{ name: 'core/list-item', attributes: { content: 'Theme item' } }
+			]
+		});
+
+		await editor.insertBlock({
+			name: 'atomic-wind/box',
+			attributes: { className: 'flex mt-4 p-8' },
+			innerBlocks: [
+				{
+					name: 'core/list',
+					attributes: { className: 'block-list' },
+					innerBlocks: [
+						{ name: 'core/list-item', attributes: { content: 'Block item' } }
+					]
+				}
+			]
+		});
+
+		await publishAndViewPost({ editor, page });
+
+		const box = page.locator( '.wp-block-atomic-wind-box' );
+
+		// The utility landing proves the stylesheet reached the page at all,
+		// so the assertions below cannot pass on a missing stylesheet.
+		await expect( box ).toHaveCSS( 'display', 'flex' );
+
+		// `mt-4`/`p-8` resolve through `var(--spacing)`, which is defined on the
+		// block wrapper rather than at `:root`. Zero values here would mean the
+		// variables no longer reach the utilities.
+		await expect( box ).toHaveCSS( 'margin-top', '16px' );
+		await expect( box ).toHaveCSS( 'padding', '32px' );
+
+		await expect( page.locator( 'ul.block-list' ) ).toHaveCSS( 'list-style-type', 'none' );
+		await expect( page.locator( 'ul.theme-list' ) ).toHaveCSS( 'list-style-type', 'disc' );
+	});
+
+	test( 'keeps Tailwind theme variables out of the document root', async({ editor, page }) => {
+		// `mt-4` is what pulls `--spacing` into the theme layer; without a
+		// variable-consuming utility the stylesheet defines none and the
+		// assertion below would hold either way.
+		await editor.insertBlock({
+			name: 'atomic-wind/box',
+			attributes: { className: 'flex mt-4' }
+		});
+
+		await publishAndViewPost({ editor, page });
+
+		await expect( page.locator( '.wp-block-atomic-wind-box' ) ).toHaveCSS( 'display', 'flex' );
+
+		const [ rootSpacing, blockSpacing ] = await page.evaluate( () => [
+			getComputedStyle( document.documentElement ).getPropertyValue( '--spacing' ).trim(),
+			getComputedStyle( document.querySelector( '.wp-block-atomic-wind-box' ) )
+				.getPropertyValue( '--spacing' )
+				.trim()
+		] );
+
+		expect( rootSpacing ).toBe( '' );
+		expect( blockSpacing ).toBe( '0.25rem' );
+	});
+});

--- a/src/blocks/test/e2e/playwright.config.js
+++ b/src/blocks/test/e2e/playwright.config.js
@@ -58,6 +58,7 @@ const SERIAL_SPECS = [
 
 	// Flips the site-wide atomic-wind blocks option.
 	'**/blocks/atomic-wind-list-view.spec.js',
+	'**/blocks/atomic-wind-css-scope.spec.js',
 
 	// Mutates the shared admin user's metabox order and editor preferences.
 	'**/blocks/woocommerce-builder.spec.js',

--- a/tests/test-atomic-wind-blocks.php
+++ b/tests/test-atomic-wind-blocks.php
@@ -1137,6 +1137,17 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Helper: set cached CSS for a post.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $css CSS string.
+	 */
+	private function set_cached_css( $post_id, $css ) {
+		update_post_meta( $post_id, '_atomic_wind_css', $css );
+		update_post_meta( $post_id, '_atomic_wind_css_version', Atomic_Wind_Blocks::ATOMIC_WIND_CSS_VERSION );
+	}
+
 	// -------------------------------------------------------
 	// Save-time CSS warm (hidden-iframe render)
 	// -------------------------------------------------------
@@ -1288,8 +1299,8 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 
 		$a = $this->make_atomic_wind_post( 'flex' );
 		$b = $this->make_atomic_wind_post( 'grid' );
-		update_post_meta( $a, '_atomic_wind_css', '.flex{display:flex}' );
-		update_post_meta( $b, '_atomic_wind_css', '.grid{display:grid}' );
+		$this->set_cached_css( $a, '.flex{display:flex}' );
+		$this->set_cached_css( $b, '.grid{display:grid}' );
 
 		global $post;
 		$post = get_post( $a );
@@ -1316,8 +1327,8 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 
 		$a = $this->make_atomic_wind_post( 'flex' );
 		$b = $this->make_atomic_wind_post( 'flex' );
-		update_post_meta( $a, '_atomic_wind_css', '.flex{display:flex}' );
-		update_post_meta( $b, '_atomic_wind_css', '.flex{display:flex}' );
+		$this->set_cached_css( $a, '.flex{display:flex}' );
+		$this->set_cached_css( $b, '.flex{display:flex}' );
 
 		global $post;
 		$post = get_post( $a );
@@ -1341,7 +1352,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->reset_style_globals();
 
 		$post_id = $this->make_atomic_wind_post( 'flex' );
-		update_post_meta( $post_id, '_atomic_wind_css', '.flex{display:flex}' );
+		$this->set_cached_css( $post_id, '.flex{display:flex}' );
 
 		$GLOBALS['wp_query']->posts = array( get_post( $post_id ) );
 
@@ -1358,7 +1369,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->instance->enqueue_base_css();
 
 		$late = $this->make_atomic_wind_post( 'flex' );
-		update_post_meta( $late, '_atomic_wind_css', '.late{color:blue}' );
+		$this->set_cached_css( $late, '.late{color:blue}' );
 
 		global $post;
 		$post = get_post( $late );
@@ -1384,7 +1395,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		update_option( 'themeisle_blocks_settings_atomic_wind_blocks', true );
 
 		$late = $this->make_atomic_wind_post( 'flex' );
-		update_post_meta( $late, '_atomic_wind_css', '.footer-callback{color:purple}' );
+		$this->set_cached_css( $late, '.footer-callback{color:purple}' );
 
 		global $post;
 		$post = get_post( $late );
@@ -1414,7 +1425,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->reset_in_query( false );
 
 		$late = $this->make_atomic_wind_post( 'flex' );
-		update_post_meta( $late, '_atomic_wind_css', '.late{color:blue}' );
+		$this->set_cached_css( $late, '.late{color:blue}' );
 
 		global $post;
 		$post = get_post( $late );
@@ -1435,7 +1446,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->reset_style_globals();
 
 		$singular = $this->make_atomic_wind_post( 'flex' );
-		update_post_meta( $singular, '_atomic_wind_css', '.flex{display:flex}' );
+		$this->set_cached_css( $singular, '.flex{display:flex}' );
 
 		$this->go_to( get_permalink( $singular ) );
 		$this->instance->enqueue_base_css();
@@ -1458,11 +1469,47 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->assertTrue( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
 	}
 
+	public function test_output_singular_css_regenerates_css_from_an_older_generator() {
+		$this->reset_style_globals();
+
+		$singular = $this->make_atomic_wind_post( 'flex' );
+		// Stylesheet cached before the resets were scoped to Atomic Wind blocks.
+		update_post_meta( $singular, '_atomic_wind_css', 'h1{font-size:inherit}' );
+
+		$this->go_to( get_permalink( $singular ) );
+		$this->instance->output_singular_css();
+
+		$this->assertSame( '', $this->inline_style_for( 'atomic-wind-tailwind' ) );
+		$this->assertTrue( wp_script_is( 'atomic-wind-tailwind-generator', 'enqueued' ) );
+	}
+
+	public function test_rest_save_style_stamps_the_generator_version() {
+		$request = new WP_REST_Request( 'POST', '/otter/v1/atomic-wind/style' );
+		$request->set_param( 'postId', $this->post_id );
+		$request->set_param( 'css', '.flex{display:flex}' );
+
+		$this->instance->rest_save_style( $request );
+
+		$this->assertSame(
+			Atomic_Wind_Blocks::ATOMIC_WIND_CSS_VERSION,
+			get_post_meta( $this->post_id, '_atomic_wind_css_version', true )
+		);
+	}
+
+	public function test_clear_cached_css_drops_the_version_stamp() {
+		$post_id = $this->make_atomic_wind_post( 'flex' );
+		$this->set_cached_css( $post_id, '.flex{display:flex}' );
+
+		$this->instance->clear_cached_css( $post_id );
+
+		$this->assertSame( '', get_post_meta( $post_id, '_atomic_wind_css_version', true ) );
+	}
+
 	public function test_output_singular_css_noop_on_non_singular_views() {
 		$this->reset_style_globals();
 
 		$listed = $this->make_atomic_wind_post( 'flex' );
-		update_post_meta( $listed, '_atomic_wind_css', '.flex{display:flex}' );
+		$this->set_cached_css( $listed, '.flex{display:flex}' );
 
 		$this->go_to( home_url( '/' ) );
 		$this->instance->output_singular_css();
@@ -1476,7 +1523,7 @@ class TestAtomicWindBlocks extends WP_UnitTestCase {
 		$this->reset_in_query( false );
 
 		$singular = $this->make_atomic_wind_post( 'flex' );
-		update_post_meta( $singular, '_atomic_wind_css', '.flex{display:flex}' );
+		$this->set_cached_css( $singular, '.flex{display:flex}' );
 
 		$this->go_to( get_permalink( $singular ) );
 		$this->instance->output_singular_css();


### PR DESCRIPTION
Closes https://github.com/Codeinwp/neve/issues/4585

### Summary
Rewrites selectors in generated Tailwind CSS, confining element resets to the Atomic Wind block subtree while keeping utility classes global. This prevents unwanted style overrides outside the intended scope. Updated both the frontend and editor-side CSS generators to apply the new `scopeToAtomicWind` function, ensuring all generated CSS is properly scoped before injection.

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

