### PR TITLE
Enhanced license validation

### DIFF
--- a/plugins/otter-pro/inc/server/class-dashboard-server.php
+++ b/plugins/otter-pro/inc/server/class-dashboard-server.php
@@ -36,6 +36,13 @@ class Dashboard_Server {
 	public $version = 'v1';
 
 	/**
+	 * Neve price IDs that bundle Otter Pro.
+	 *
+	 * @var int[]
+	 */
+	const VALID_NEVE_PLANS = array( 5, 6, 9, 14, 17, 20, 23, 27, 28, 29 );
+
+	/**
 	 * Initialize the class
 	 */
 	public function init() {
@@ -141,11 +148,21 @@ class Dashboard_Server {
 		}
 
 		$response = apply_filters( 'themeisle_sdk_license_process_otter', $fields['key'], $fields['action'] );
+		$plan     = (int) apply_filters( 'product_otter_license_plan', 0 );
 
 		if ( is_wp_error( $response ) ) {
+			$message = $response->get_error_message();
+			if (
+				'activate' === $fields['action'] &&
+				'themeisle-license-invalid' === $response->get_error_code() &&
+				! in_array( $plan, self::VALID_NEVE_PLANS, true )
+			) {
+				$message = __( 'Entered license key does not include Otter Pro.', 'otter-pro' );
+			}
+
 			return new \WP_REST_Response(
 				array(
-					'message' => $response->get_error_message(),
+					'message' => $message,
 					'success' => false,
 				)
 			);

--- a/plugins/otter-pro/inc/server/class-dashboard-server.php
+++ b/plugins/otter-pro/inc/server/class-dashboard-server.php
@@ -43,6 +43,13 @@ class Dashboard_Server {
 	const VALID_NEVE_PLANS = array( 5, 6, 9, 14, 17, 20, 23, 27, 28, 29 );
 
 	/**
+	 * License statuses describing a key that does cover Otter Pro but cannot be used right now.
+	 *
+	 * @var string[]
+	 */
+	const NON_PLAN_LICENSE_STATUSES = array( 'expired', 'active_expired', 'revoked', 'site_inactive', 'no_activations_left', 'not_active' );
+
+	/**
 	 * Initialize the class
 	 */
 	public function init() {
@@ -155,7 +162,7 @@ class Dashboard_Server {
 			if (
 				'activate' === $fields['action'] &&
 				'themeisle-license-invalid' === $response->get_error_code() &&
-				! in_array( $plan, self::VALID_NEVE_PLANS, true )
+				$this->is_ineligible_plan( $plan )
 			) {
 				$message = __( 'Entered license key does not include Otter Pro.', 'otter-pro' );
 			}
@@ -179,6 +186,28 @@ class Dashboard_Server {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Whether the stored license data proves the key belongs to a plan without Otter Pro.
+	 *
+	 * @param int $plan Price ID reported for the stored license.
+	 * @return bool
+	 */
+	private function is_ineligible_plan( $plan ) {
+		$license_data = License::get_license_data();
+
+		if ( ! is_object( $license_data ) || ! isset( $license_data->price_id ) ) {
+			return false;
+		}
+
+		$status = isset( $license_data->license ) ? $license_data->license : '';
+
+		if ( in_array( $status, self::NON_PLAN_LICENSE_STATUSES, true ) ) {
+			return false;
+		}
+
+		return ! in_array( $plan, self::VALID_NEVE_PLANS, true );
 	}
 
 	/**

--- a/src/dashboard/components/LicenseField.js
+++ b/src/dashboard/components/LicenseField.js
@@ -65,7 +65,10 @@ const LicenseField = () => {
 					setLicenseKey( '' );
 				}
 
-				window.location.reload();
+				// Reloading on failure would discard the notice explaining why.
+				if ( res?.success ) {
+					window.location.reload();
+				}
 			}
 		).catch( err => {
 			setLoading( false );

--- a/src/dashboard/components/LicenseField.js
+++ b/src/dashboard/components/LicenseField.js
@@ -65,10 +65,7 @@ const LicenseField = () => {
 					setLicenseKey( '' );
 				}
 
-				// Reloading on failure would discard the notice explaining why.
-				if ( res?.success ) {
-					window.location.reload();
-				}
+				window.location.reload();
 			}
 		).catch( err => {
 			setLoading( false );

--- a/tests/test-dashboard-server-license.php
+++ b/tests/test-dashboard-server-license.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Class Dashboard_Server_License
+ *
+ * @package gutenberg-blocks
+ */
+
+use ThemeIsle\OtterPro\Plugins\License;
+use ThemeIsle\OtterPro\Server\Dashboard_Server;
+
+/**
+ * Tests for the license error messages returned by otter/v1/toggle_license.
+ */
+class Test_Dashboard_Server_License extends WP_UnitTestCase {
+
+	/**
+	 * The message the SDK returns for a license the store rejected.
+	 */
+	const SDK_INVALID_MESSAGE = 'ERROR: Invalid license provided.';
+
+	/**
+	 * The message the dashboard should show for a plan mismatch, before the
+	 * offending price ID is substituted in.
+	 */
+	const PLAN_MISMATCH_FORMAT = 'Entered license key does not include Otter Pro.';
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var Dashboard_Server
+	 */
+	private $server;
+
+	/**
+	 * Define the Otter Pro basefile the success path needs.
+	 *
+	 * The suite never boots otter-pro (development.php bails because WPINC is
+	 * not defined when Composer loads it), so the constant License reads for the
+	 * license option name is missing. Point it at the real plugin file.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		if ( ! defined( 'OTTER_PRO_BASEFILE' ) ) {
+			define( 'OTTER_PRO_BASEFILE', dirname( __DIR__ ) . '/plugins/otter-pro/otter-pro.php' );
+		}
+	}
+
+	/**
+	 * Set up test environment.
+	 *
+	 * The server is built directly instead of through instance(): init() would
+	 * register an otter_dashboard_data filter that reads OTTER_PRO_VERSION,
+	 * which is not defined in the test suite.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->server = new Dashboard_Server();
+	}
+
+	/**
+	 * Make the SDK license process return the given value.
+	 *
+	 * @param mixed $result Value the filter should return.
+	 */
+	private function mock_license_process( $result ) {
+		remove_all_filters( 'themeisle_sdk_license_process_otter' );
+		add_filter(
+			'themeisle_sdk_license_process_otter',
+			function () use ( $result ) {
+				return $result;
+			}
+		);
+	}
+
+	/**
+	 * Make the stored license plan resolve to the given price ID.
+	 *
+	 * @param int|string $plan Price ID.
+	 */
+	private function mock_license_plan( $plan ) {
+		remove_all_filters( 'product_otter_license_plan' );
+		add_filter(
+			'product_otter_license_plan',
+			function () use ( $plan ) {
+				return $plan;
+			}
+		);
+	}
+
+	/**
+	 * Run toggle_license and return the response payload.
+	 *
+	 * @param array $body JSON body.
+	 *
+	 * @return array
+	 */
+	private function toggle( $body ) {
+		$request = new WP_REST_Request( 'POST', '/otter/v1/toggle_license' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $body ) );
+
+		$response = $this->server->toggle_license( $request );
+
+		$this->assertInstanceOf( 'WP_REST_Response', $response );
+
+		return $response->get_data();
+	}
+
+	/**
+	 * Activate with the given key and return the response payload.
+	 *
+	 * @param string $key License key.
+	 *
+	 * @return array
+	 */
+	private function activate( $key = 'neve-personal-license-key' ) {
+		return $this->toggle(
+			array(
+				'action' => 'activate',
+				'key'    => $key,
+			)
+		);
+	}
+
+	/**
+	 * A key whose plan is outside the allow list does not include Otter Pro, so
+	 * the generic SDK error is replaced by the actual reason, naming the plan.
+	 *
+	 * 1 and 2 are Neve Personal; 0 is the plan filter's default, used when the
+	 * store's response carried no price ID.
+	 */
+	public function test_activation_with_an_unsupported_plan_reports_the_plan_mismatch() {
+		$this->mock_license_process( new WP_Error( 'themeisle-license-invalid', self::SDK_INVALID_MESSAGE ) );
+
+		foreach ( array( 0, 1, 2, 7, 12, 30 ) as $plan ) {
+			$this->assertNotContains( $plan, Dashboard_Server::VALID_NEVE_PLANS, "Plan {$plan} is a fixture for an unsupported plan" );
+
+			$this->mock_license_plan( $plan );
+
+			$data = $this->activate();
+
+			$this->assertFalse( $data['success'], "Activation should fail for plan {$plan}" );
+			$this->assertSame( self::PLAN_MISMATCH_FORMAT, $data['message'], "Plan {$plan} should report the plan mismatch, not the generic SDK error" );
+		}
+	}
+
+	/**
+	 * Plans that do bundle Otter Pro keep the SDK message: a rejected key on an
+	 * agency plan is not a plan problem.
+	 */
+	public function test_activation_with_a_supported_plan_keeps_the_sdk_message() {
+		$this->mock_license_process( new WP_Error( 'themeisle-license-invalid', self::SDK_INVALID_MESSAGE ) );
+
+		$this->assertNotEmpty( Dashboard_Server::VALID_NEVE_PLANS, 'The supported plan list should not be empty' );
+
+		foreach ( Dashboard_Server::VALID_NEVE_PLANS as $plan ) {
+			$this->mock_license_plan( $plan );
+
+			$data = $this->activate( 'some-agency-license-key' );
+
+			$this->assertFalse( $data['success'] );
+			$this->assertSame( self::SDK_INVALID_MESSAGE, $data['message'], "Plan {$plan} bundles Otter Pro, so the SDK message should be kept" );
+		}
+	}
+
+	/**
+	 * With no plan filter registered the default 0 is used, which is not in the
+	 * allow list.
+	 */
+	public function test_activation_without_a_plan_filter_reports_the_plan_mismatch() {
+		$this->mock_license_process( new WP_Error( 'themeisle-license-invalid', self::SDK_INVALID_MESSAGE ) );
+		remove_all_filters( 'product_otter_license_plan' );
+
+		$data = $this->activate( 'unknown-license-key' );
+
+		$this->assertFalse( $data['success'] );
+		$this->assertSame( self::PLAN_MISMATCH_FORMAT, $data['message'] );
+	}
+
+	/**
+	 * Only the store's "invalid license" rejection can be caused by a plan
+	 * mismatch. Every other failure is reported as the SDK worded it, even while
+	 * an unsupported plan is stored from an earlier key.
+	 */
+	public function test_only_the_invalid_license_error_is_rewritten() {
+		$this->mock_license_plan( 1 );
+
+		$codes = array(
+			'themeisle-license-500'            => 'ERROR: Failed to connect to the license service.',
+			'themeisle-license-404'            => 'ERROR: Failed to validate license. Please try again in one minute.',
+			'themeisle-license-invalid-format' => 'Invalid license.',
+			'themeisle-license-already-active' => 'License is already active.',
+		);
+
+		foreach ( $codes as $code => $message ) {
+			$this->mock_license_process( new WP_Error( $code, $message ) );
+
+			$data = $this->activate();
+
+			$this->assertFalse( $data['success'] );
+			$this->assertSame( $message, $data['message'], "Error {$code} is not a plan mismatch and should be reported as-is" );
+		}
+	}
+
+	/**
+	 * Otter's standalone plans are considered valid even if they are not in the Neve allow list.
+	 */
+	public function test_otter_standalone_plans_are_reported_as_a_valid_plan() {
+		$this->mock_license_process( true );
+
+		foreach ( array( 1, 2, 3, 4 ) as $plan ) {
+			$this->assertArrayHasKey( $plan, License::$plans_map, "Price ID {$plan} is a valid Otter plan" );
+
+			$this->mock_license_plan( $plan );
+
+			$data = $this->activate( 'an-otter-standalone-key' );
+
+			$this->assertSame( 'Activated.', $data['message'] );
+		}
+	}
+
+	/**
+	 * The rewrite is gated on the activate action, so deactivation failures are
+	 * never reported as a plan mismatch.
+	 */
+	public function test_deactivation_keeps_the_sdk_message() {
+		$this->mock_license_plan( 1 );
+
+		$errors = array(
+			'themeisle-license-already-deactivate' => 'License not active.',
+			'themeisle-license-invalid'            => self::SDK_INVALID_MESSAGE,
+		);
+
+		foreach ( $errors as $code => $message ) {
+			$this->mock_license_process( new WP_Error( $code, $message ) );
+
+			$data = $this->toggle( array( 'action' => 'deactivate' ) );
+
+			$this->assertFalse( $data['success'] );
+			$this->assertSame( $message, $data['message'], "Deactivation error {$code} should be reported as-is" );
+		}
+	}
+
+	/**
+	 * A successful toggle is unaffected by the stored plan: the rewrite is gated
+	 * on the SDK returning a WP_Error.
+	 */
+	public function test_successful_toggle_is_not_rewritten() {
+		$this->mock_license_process( true );
+		$this->mock_license_plan( 1 );
+
+		$data = $this->activate( 'a-valid-license-key' );
+
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'Activated.', $data['message'] );
+		$this->assertArrayHasKey( 'license', $data );
+	}
+
+	/**
+	 * A malformed payload is rejected before the SDK is called.
+	 */
+	public function test_invalid_action_payload_is_rejected() {
+		$this->mock_license_process( new WP_Error( 'themeisle-license-invalid', self::SDK_INVALID_MESSAGE ) );
+		$this->mock_license_plan( 1 );
+
+		foreach ( array( array(), array( 'action' => 'activate' ) ) as $body ) {
+			$data = $this->toggle( $body );
+
+			$this->assertFalse( $data['success'] );
+			$this->assertSame( 'Invalid Action. Please refresh the page and try again.', $data['message'] );
+		}
+	}
+}

--- a/tests/test-dashboard-server-license.php
+++ b/tests/test-dashboard-server-license.php
@@ -19,10 +19,14 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 	const SDK_INVALID_MESSAGE = 'ERROR: Invalid license provided.';
 
 	/**
-	 * The message the dashboard should show for a plan mismatch, before the
-	 * offending price ID is substituted in.
+	 * Option the SDK writes the store's answer to, derived from the plugin dir.
 	 */
-	const PLAN_MISMATCH_FORMAT = 'Entered license key does not include Otter Pro.';
+	const LICENSE_DATA_OPTION = 'otter_pro_license_data';
+
+	/**
+	 * The message the dashboard should show for a plan mismatch.
+	 */
+	const PLAN_MISMATCH_MESSAGE = 'Entered license key does not include Otter Pro.';
 
 	/**
 	 * Instance under test.
@@ -56,6 +60,7 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		$this->server = new Dashboard_Server();
+		delete_option( self::LICENSE_DATA_OPTION );
 	}
 
 	/**
@@ -86,6 +91,30 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 				return $plan;
 			}
 		);
+	}
+
+	/**
+	 * Mirror what the SDK stores after the store answers an activation.
+	 *
+	 * do_license_process() writes the response to the license data option before
+	 * it returns the WP_Error, and the plan filter reports price_id from that
+	 * same option, falling back to -1 when the response carried none.
+	 *
+	 * @param string   $status   License status returned by the store.
+	 * @param int|null $price_id Price ID returned by the store, null if absent.
+	 */
+	private function mock_store_response( $status, $price_id = null ) {
+		$data = array(
+			'license' => $status,
+			'key'     => 'a-license-key',
+		);
+
+		if ( null !== $price_id ) {
+			$data['price_id'] = $price_id;
+		}
+
+		update_option( self::LICENSE_DATA_OPTION, (object) $data );
+		$this->mock_license_plan( null === $price_id ? -1 : $price_id );
 	}
 
 	/**
@@ -124,24 +153,24 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A key whose plan is outside the allow list does not include Otter Pro, so
-	 * the generic SDK error is replaced by the actual reason, naming the plan.
+	 * A key the store answered for with a plan outside the allow list does not
+	 * include Otter Pro, so the generic SDK error is replaced by the reason.
 	 *
-	 * 1 and 2 are Neve Personal; 0 is the plan filter's default, used when the
-	 * store's response carried no price ID.
+	 * 1 and 2 are Neve Personal; 7, 12 and 30 are higher Neve tiers that still
+	 * exclude Otter Pro.
 	 */
 	public function test_activation_with_an_unsupported_plan_reports_the_plan_mismatch() {
 		$this->mock_license_process( new WP_Error( 'themeisle-license-invalid', self::SDK_INVALID_MESSAGE ) );
 
-		foreach ( array( 0, 1, 2, 7, 12, 30 ) as $plan ) {
+		foreach ( array( 1, 2, 7, 12, 30 ) as $plan ) {
 			$this->assertNotContains( $plan, Dashboard_Server::VALID_NEVE_PLANS, "Plan {$plan} is a fixture for an unsupported plan" );
 
-			$this->mock_license_plan( $plan );
+			$this->mock_store_response( 'invalid', $plan );
 
 			$data = $this->activate();
 
 			$this->assertFalse( $data['success'], "Activation should fail for plan {$plan}" );
-			$this->assertSame( self::PLAN_MISMATCH_FORMAT, $data['message'], "Plan {$plan} should report the plan mismatch, not the generic SDK error" );
+			$this->assertSame( self::PLAN_MISMATCH_MESSAGE, $data['message'], "Plan {$plan} should report the plan mismatch, not the generic SDK error" );
 		}
 	}
 
@@ -155,7 +184,7 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 		$this->assertNotEmpty( Dashboard_Server::VALID_NEVE_PLANS, 'The supported plan list should not be empty' );
 
 		foreach ( Dashboard_Server::VALID_NEVE_PLANS as $plan ) {
-			$this->mock_license_plan( $plan );
+			$this->mock_store_response( 'invalid', $plan );
 
 			$data = $this->activate( 'some-agency-license-key' );
 
@@ -165,26 +194,54 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 	}
 
 	/**
-	 * With no plan filter registered the default 0 is used, which is not in the
-	 * allow list.
+	 * A key that does cover Otter Pro but is expired, revoked or out of
+	 * activations is rejected with the same themeisle-license-invalid code. Its
+	 * plan is not the problem, so the SDK message must survive.
+	 *
+	 * Price ID 1 is deliberate: it is a standalone Otter plan per
+	 * License::$plans_map and is absent from VALID_NEVE_PLANS, so the plan check
+	 * alone would misreport every one of these as a plan mismatch.
 	 */
-	public function test_activation_without_a_plan_filter_reports_the_plan_mismatch() {
+	public function test_unusable_but_eligible_key_keeps_the_sdk_message() {
 		$this->mock_license_process( new WP_Error( 'themeisle-license-invalid', self::SDK_INVALID_MESSAGE ) );
-		remove_all_filters( 'product_otter_license_plan' );
 
-		$data = $this->activate( 'unknown-license-key' );
+		foreach ( Dashboard_Server::NON_PLAN_LICENSE_STATUSES as $status ) {
+			foreach ( array_keys( License::$plans_map ) as $plan ) {
+				$this->mock_store_response( $status, $plan );
 
-		$this->assertFalse( $data['success'] );
-		$this->assertSame( self::PLAN_MISMATCH_FORMAT, $data['message'] );
+				$data = $this->activate( 'an-otter-standalone-key' );
+
+				$this->assertFalse( $data['success'] );
+				$this->assertSame( self::SDK_INVALID_MESSAGE, $data['message'], "A {$status} key on Otter plan {$plan} is not a plan mismatch" );
+			}
+		}
 	}
 
 	/**
-	 * Only the store's "invalid license" rejection can be caused by a plan
-	 * mismatch. Every other failure is reported as the SDK worded it, even while
-	 * an unsupported plan is stored from an earlier key.
+	 * A key the store did not recognise comes back without a price ID, so the
+	 * plan filter reports -1. That is not evidence of anything and must not be
+	 * rewritten.
+	 */
+	public function test_unrecognised_key_without_a_price_id_keeps_the_sdk_message() {
+		$this->mock_license_process( new WP_Error( 'themeisle-license-invalid', self::SDK_INVALID_MESSAGE ) );
+
+		foreach ( array( 'invalid', 'missing', 'item_name_mismatch' ) as $status ) {
+			$this->mock_store_response( $status );
+
+			$data = $this->activate( 'a-made-up-key' );
+
+			$this->assertFalse( $data['success'] );
+			$this->assertSame( self::SDK_INVALID_MESSAGE, $data['message'], "A {$status} key with no price ID should keep the SDK message" );
+		}
+	}
+
+	/**
+	 * Only the store's rejection can be caused by a plan mismatch. Every other
+	 * failure is reported as the SDK worded it, even while an unsupported plan
+	 * is stored from an earlier key.
 	 */
 	public function test_only_the_invalid_license_error_is_rewritten() {
-		$this->mock_license_plan( 1 );
+		$this->mock_store_response( 'invalid', 1 );
 
 		$codes = array(
 			'themeisle-license-500'            => 'ERROR: Failed to connect to the license service.',
@@ -204,28 +261,11 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Otter's standalone plans are considered valid even if they are not in the Neve allow list.
-	 */
-	public function test_otter_standalone_plans_are_reported_as_a_valid_plan() {
-		$this->mock_license_process( true );
-
-		foreach ( array( 1, 2, 3, 4 ) as $plan ) {
-			$this->assertArrayHasKey( $plan, License::$plans_map, "Price ID {$plan} is a valid Otter plan" );
-
-			$this->mock_license_plan( $plan );
-
-			$data = $this->activate( 'an-otter-standalone-key' );
-
-			$this->assertSame( 'Activated.', $data['message'] );
-		}
-	}
-
-	/**
 	 * The rewrite is gated on the activate action, so deactivation failures are
 	 * never reported as a plan mismatch.
 	 */
 	public function test_deactivation_keeps_the_sdk_message() {
-		$this->mock_license_plan( 1 );
+		$this->mock_store_response( 'invalid', 1 );
 
 		$errors = array(
 			'themeisle-license-already-deactivate' => 'License not active.',
@@ -248,7 +288,7 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 	 */
 	public function test_successful_toggle_is_not_rewritten() {
 		$this->mock_license_process( true );
-		$this->mock_license_plan( 1 );
+		$this->mock_store_response( 'invalid', 1 );
 
 		$data = $this->activate( 'a-valid-license-key' );
 
@@ -262,7 +302,7 @@ class Test_Dashboard_Server_License extends WP_UnitTestCase {
 	 */
 	public function test_invalid_action_payload_is_rejected() {
 		$this->mock_license_process( new WP_Error( 'themeisle-license-invalid', self::SDK_INVALID_MESSAGE ) );
-		$this->mock_license_plan( 1 );
+		$this->mock_store_response( 'invalid', 1 );
 
 		foreach ( array( array(), array( 'action' => 'activate' ) ) as $body ) {
 			$data = $this->toggle( $body );


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2983

### Summary
Validated the invalid license key message when the provided license key is not in the Neve allowlist.

### Checklist before the final review

- [x] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

