### PR TITLE
Added compatibility with WPML

### DIFF
--- a/plugins/otter-pro/wpml-config.xml
+++ b/plugins/otter-pro/wpml-config.xml
@@ -1,0 +1,39 @@
+<wpml-config>
+	<gutenberg-blocks>
+
+		<gutenberg-block type="themeisle-blocks/business-hours" translate="1">
+			<key name="title" />
+			<xpath>//div[contains(@class, "otter-business-hour__title")]/span</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/business-hours-item" translate="1">
+			<key name="label" />
+			<key name="time" />
+			<xpath>//div[contains(@class, "otter-business-hour-item__label")]/span</xpath>
+			<xpath>//div[contains(@class, "otter-business-hour-item__time")]/span</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/add-to-cart-button" translate="1">
+			<key name="label" />
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/review-comparison" translate="1">
+			<key name="buttonText" />
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/form-file" translate="1">
+			<key name="label" />
+			<key name="placeholder" />
+			<key name="helpText" />
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/form-hidden-field" translate="1">
+			<key name="label" />
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/form-stripe-field" translate="1">
+			<key name="label" />
+		</gutenberg-block>
+
+	</gutenberg-blocks>
+</wpml-config>

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -14,8 +14,12 @@
 		<gutenberg-block type="themeisle-blocks/flip" translate="1">
 			<key name="title" />
 			<key name="description" />
+			<key name="frontMedia">
+				<key name="alt" />
+			</key>
 			<xpath>//div[contains(@class, "o-flip-content")]/h3</xpath>
 			<xpath>//div[contains(@class, "o-flip-content")]/p</xpath>
+			<xpath>//div[contains(@class, "o-flip-content")]/img/@alt</xpath>
 		</gutenberg-block>
 
 		<gutenberg-block type="themeisle-blocks/circle-counter" translate="1">
@@ -31,7 +35,9 @@
 
 		<gutenberg-block type="themeisle-blocks/icon-list-item" translate="1">
 			<key name="content" />
+			<key name="iconAlt" />
 			<xpath>//p[contains(@class, "wp-block-themeisle-blocks-icon-list-item-content")]</xpath>
+			<xpath>//img/@alt</xpath>
 		</gutenberg-block>
 
 		<gutenberg-block type="themeisle-blocks/form" translate="1">
@@ -46,6 +52,7 @@
 			<key name="helpText" />
 			<xpath>//span[contains(@class, "otter-form-input-label__label")]</xpath>
 			<xpath>//input/@placeholder</xpath>
+			<xpath>//input[contains(@class, "otter-form-input")]/@value</xpath>
 			<xpath>//span[contains(@class, "o-form-help")]</xpath>
 		</gutenberg-block>
 
@@ -55,6 +62,7 @@
 			<key name="helpText" />
 			<xpath>//span[contains(@class, "otter-form-textarea-label__label")]</xpath>
 			<xpath>//textarea/@placeholder</xpath>
+			<xpath>//textarea[contains(@class, "otter-form-textarea-input")]</xpath>
 			<xpath>//span[contains(@class, "o-form-help")]</xpath>
 		</gutenberg-block>
 
@@ -77,6 +85,9 @@
 			<key name="links">
 				<key name="label" />
 			</key>
+			<key name="image">
+				<key name="alt" />
+			</key>
 		</gutenberg-block>
 
 		<gutenberg-block type="themeisle-blocks/stripe-checkout" translate="1">
@@ -88,6 +99,9 @@
 			<key name="label" />
 			<key name="placeholder" />
 			<key name="helpText" />
+			<key name="options">
+				<key name="content" />
+			</key>
 			<key name="options" />
 		</gutenberg-block>
 

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,111 @@
+<wpml-config>
+	<gutenberg-blocks>
+		<gutenberg-block type="themeisle-blocks/accordion-item" translate="1">
+			<key name="title" />
+			<xpath>//summary/*[self::div or self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/tabs-item" translate="1">
+			<key name="title" />
+			<xpath>//div[contains(@class, "wp-block-themeisle-blocks-tabs-item__header")]</xpath>
+			<xpath>//div[@data-title]/@data-title</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/flip" translate="1">
+			<key name="title" />
+			<key name="description" />
+			<xpath>//div[contains(@class, "o-flip-content")]/h3</xpath>
+			<xpath>//div[contains(@class, "o-flip-content")]/p</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/circle-counter" translate="1">
+			<key name="title" />
+			<xpath>//span[contains(@class, "wp-block-themeisle-blocks-circle-counter-title__value")]</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/progress-bar" translate="1">
+			<key name="title" />
+			<xpath>//span[contains(@class, "wp-block-themeisle-blocks-progress-bar__outer__title")]</xpath>
+			<xpath>//div[contains(@class, "wp-block-themeisle-blocks-progress-bar__area__title")]/span</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/icon-list-item" translate="1">
+			<key name="content" />
+			<xpath>//p[contains(@class, "wp-block-themeisle-blocks-icon-list-item-content")]</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/form" translate="1">
+			<key name="submitLabel" />
+			<key name="submitMessage" />
+			<xpath>//button[contains(@class, "wp-block-button__link")]</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/form-input" translate="1">
+			<key name="label" />
+			<key name="placeholder" />
+			<key name="helpText" />
+			<xpath>//span[contains(@class, "otter-form-input-label__label")]</xpath>
+			<xpath>//input/@placeholder</xpath>
+			<xpath>//span[contains(@class, "o-form-help")]</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/form-textarea" translate="1">
+			<key name="label" />
+			<key name="placeholder" />
+			<key name="helpText" />
+			<xpath>//span[contains(@class, "otter-form-textarea-label__label")]</xpath>
+			<xpath>//textarea/@placeholder</xpath>
+			<xpath>//span[contains(@class, "o-form-help")]</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/lottie" translate="1">
+			<key name="ariaLabel" />
+			<xpath>//*[@aria-label]/@aria-label</xpath>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/review" translate="1">
+			<key name="title" />
+			<key name="description" />
+			<key name="prosLabel" />
+			<key name="consLabel" />
+			<key name="buttonsLabel" />
+			<key name="pros" />
+			<key name="cons" />
+			<key name="features">
+				<key name="title" />
+			</key>
+			<key name="links">
+				<key name="label" />
+			</key>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/stripe-checkout" translate="1">
+			<key name="successMessage" />
+			<key name="cancelMessage" />
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/form-multiple-choice" translate="1">
+			<key name="label" />
+			<key name="placeholder" />
+			<key name="helpText" />
+			<key name="options" />
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/google-map" translate="1">
+			<key name="location" />
+			<key name="markers">
+				<key name="title" />
+				<key name="description" />
+			</key>
+		</gutenberg-block>
+
+		<gutenberg-block type="themeisle-blocks/leaflet-map" translate="1">
+			<key name="location" />
+			<key name="markers">
+				<key name="title" />
+				<key name="description" />
+			</key>
+		</gutenberg-block>
+
+	</gutenberg-blocks>
+</wpml-config>

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -102,7 +102,6 @@
 			<key name="options">
 				<key name="content" />
 			</key>
-			<key name="options" />
 		</gutenberg-block>
 
 		<gutenberg-block type="themeisle-blocks/google-map" translate="1">


### PR DESCRIPTION
Closes https://github.com/Codeinwp/otter-blocks/issues/2968

### Summary
Added the `wpml-config.xml` file to make the blocks translatable with WPML. The file contains the necessary configuration for WPML to recognize the blocks and their translatable attributes.


### Test instructions
- Install and activate the WPML plugin.
- Add the Otter Accordion block to a page and add some content to it.
- Verify that the title and content of the Accordion block are translatable in the WPML translation editor.

### Checklist before the final review

- [ ] Included E2E or unit tests for the changes in this PR.
- [x] Visual elements are not affected by independent changes.
- [x] It is at least compatible with the [minimum WordPress version](https://wordpress.org/plugins/otter-blocks/).
- [x] It loads additional script in frontend only if it is required.
- [x] Does not impact the [Core Web Vitals](https://web.dev/vitals/).
- [x] In case of deprecation, old blocks are safely migrated.
- [x] It is usable in Widgets and FSE.
- [x] Copy/Paste is working if the attributes are modified.
- [x] PR is following [the best practices]()

## Why no test case
As the changes are to make the blocks compatible with WPML, they need to be tested with the WPML plugin installed and activated.