### PR TITLE
Clarify Neve Agency license eligibility for Otter Pro

### DIFF
--- a/src/dashboard/components/LicenseField.js
+++ b/src/dashboard/components/LicenseField.js
@@ -82,7 +82,7 @@ const LicenseField = () => {
 			<p>{ __( 'Enter your license from ThemeIsle purchase history in order to get plugin updates.', 'otter-blocks' ) }</p>
 
 			{ Boolean( window.otterObj.hasNevePro ) && (
-				<p>{ __( 'Neve Pro license can also be used to activate Otter Pro.', 'otter-blocks' ) }</p>
+				<p>{ __( 'A Neve Agency license can also be used to activate Otter Pro.', 'otter-blocks' ) }</p>
 			) }
 
 			<input


### PR DESCRIPTION
## Summary

- clarify that Otter Pro activation accepts a Neve Agency license
- avoid implying that every Neve Pro tier is eligible

## Testing

- ESLint on the changed component with no errors

Closes #2982