### PR TITLE
Prevent reusable block dependency recursion cycles

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -507,10 +507,21 @@ class Registration {
 	 * Handler which checks the blocks used and enqueue the assets which needs.
 	 *
 	 * @since   2.0.0
-	 * @param   string|int|null $post Current post.
+	 * @param   string|int|null $post    Current post.
+	 * @param   array           $visited Reusable block IDs already traversed.
 	 * @access  public
 	 */
-	public function enqueue_dependencies( $post = null ) {
+	public function enqueue_dependencies( $post = null, $visited = array() ) {
+		if ( is_numeric( $post ) ) {
+			$post_id = (int) $post;
+
+			if ( isset( $visited[ $post_id ] ) ) {
+				return;
+			}
+
+			$visited[ $post_id ] = true;
+		}
+
 		$content = '';
 
 		if ( 'widgets' === $post ) {
@@ -570,7 +581,7 @@ class Registration {
 			);
 
 			foreach ( $blocks as $block ) {
-				$this->enqueue_dependencies( $block['attrs']['ref'] );
+				$this->enqueue_dependencies( $block['attrs']['ref'], $visited );
 			}
 		}
 

--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -507,8 +507,8 @@ class Registration {
 	 * Handler which checks the blocks used and enqueue the assets which needs.
 	 *
 	 * @since   2.0.0
-	 * @param   string|int|null $post    Current post.
-	 * @param   array           $visited Reusable block IDs already traversed.
+	 * @param   string|int|null  $post    Current post.
+	 * @param   array<int, bool> $visited Reusable block IDs already traversed.
 	 * @access  public
 	 */
 	public function enqueue_dependencies( $post = null, $visited = array() ) {

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -366,4 +366,32 @@ class Test_Registration extends WP_UnitTestCase {
 			$this->assertTrue( class_exists( $classname ), $classname . ' is registered as an AMP block but cannot be loaded.' );
 		}
 	}
+
+	/**
+	 * Circular reusable block references must not recurse indefinitely.
+	 */
+	public function test_enqueue_dependencies_stops_at_a_reusable_block_cycle() {
+		$first = $this->factory()->post->create(
+			array(
+				'post_type'   => 'wp_block',
+				'post_status' => 'publish',
+			)
+		);
+		$second = $this->factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:block {"ref":' . $first . '} /-->',
+			)
+		);
+
+		wp_update_post(
+			array(
+				'ID'           => $first,
+				'post_content' => '<!-- wp:block {"ref":' . $second . '} /-->',
+			)
+		);
+
+		$this->assertNull( ( new Registration() )->enqueue_dependencies( $first ) );
+	}
 }


### PR DESCRIPTION
## Summary

- track reusable block IDs already visited during dependency discovery
- stop recursion when two or more reusable blocks reference each other
- preserve normal nested reusable block traversal

## Testing

- focused PHPUnit reusable-block cycle regression
- PHPCS on the changed production and test files

Closes #3006