### PR TITLE
Wait for the pattern preview body before observing changes

### DIFF
--- a/src/atomic-wind/tailwind/generator.js
+++ b/src/atomic-wind/tailwind/generator.js
@@ -5,6 +5,7 @@ import preflightCSS from 'tailwindcss/preflight.css';
 import themeCSS from 'tailwindcss/theme.css';
 import utilitiesCSS from 'tailwindcss/utilities.css';
 import { prefixCss, scopeToAtomicWind } from './scope-css';
+import { observePreviewBody } from './preview-observer';
 
 const assets = {
 	index: indexCSS,
@@ -339,17 +340,10 @@ function bootstrapPreviewFrame() {
 		( window.requestAnimationFrame || window.setTimeout )( apply );
 	};
 
-	schedule();
-
 	// Parent injects markup after load; regenerate when it arrives. Body only,
 	// so our own <head> style writes can't retrigger this.
 	const observer = new MutationObserver( schedule );
-	observer.observe( document.body, {
-		attributes: true,
-		attributeFilter: [ 'class' ],
-		childList: true,
-		subtree: true,
-	} );
+	observePreviewBody( observer, schedule );
 }
 
 function start() {

--- a/src/atomic-wind/tailwind/preview-observer.js
+++ b/src/atomic-wind/tailwind/preview-observer.js
@@ -1,0 +1,18 @@
+export const observePreviewBody = ( observer, onAttach, doc = document, frameWindow = window ) => {
+	const attach = () => {
+		if ( ! doc.body ) {
+			( frameWindow.requestAnimationFrame || frameWindow.setTimeout )( attach );
+			return;
+		}
+
+		observer.observe( doc.body, {
+			attributes: true,
+			attributeFilter: [ 'class' ],
+			childList: true,
+			subtree: true,
+		} );
+		onAttach();
+	};
+
+	attach();
+};

--- a/src/atomic-wind/tailwind/test/preview-observer.test.js
+++ b/src/atomic-wind/tailwind/test/preview-observer.test.js
@@ -1,0 +1,29 @@
+import { observePreviewBody } from '../preview-observer';
+
+describe( 'observePreviewBody', () => {
+	it( 'waits for preview frames to create their body before observing it', () => {
+		const callbacks = [];
+		const observer = { observe: jest.fn() };
+		const onAttach = jest.fn();
+		const doc = { body: null };
+		const frameWindow = {
+			requestAnimationFrame: ( callback ) => callbacks.push( callback ),
+		};
+
+		observePreviewBody( observer, onAttach, doc, frameWindow );
+
+		expect( observer.observe ).not.toHaveBeenCalled();
+		expect( callbacks ).toHaveLength( 1 );
+
+		doc.body = {};
+		callbacks.shift()();
+
+		expect( observer.observe ).toHaveBeenCalledWith( doc.body, {
+			attributes: true,
+			attributeFilter: [ 'class' ],
+			childList: true,
+			subtree: true,
+		} );
+		expect( onAttach ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
## Summary

- defer the preview MutationObserver until its document body exists
- schedule the initial CSS generation only after the observer is attached
- cover the null-body transition with a focused unit test

## Testing

- npm run test:unit -- --runInBand src/atomic-wind/tailwind/test/preview-observer.test.js
- npm run prod:lite
- ESLint on the changed JavaScript files

Closes #3025