### PR TITLE
fix: prevent animation crashes with older Otter versions

### DIFF
--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -178,7 +178,7 @@ class Blocks_Animation {
 			if (
 				! defined( 'OTTER_BLOCKS_VERSION' ) ||
 				! get_option( 'themeisle_blocks_settings_optimize_animations_css', true ) ||
-				! method_exists( Base_CSS::class, 'has_own_css_parser' ) ||
+				! method_exists( Base_CSS::class, 'has_own_css_parser' ) || // @phpstan-ignore function.alreadyNarrowedType (Older Otter can supply this class at runtime.)
 				! Base_CSS::has_own_css_parser()
 			) {
 				wp_enqueue_style( 'otter-animation' );

--- a/inc/class-blocks-animation.php
+++ b/inc/class-blocks-animation.php
@@ -172,11 +172,13 @@ class Blocks_Animation {
 		}
 
 		if ( ! self::$scripts_loaded['animation'] && strpos( $block_content, 'animated' ) ) {
+			// Older Otter versions lack the parser check; use the stock stylesheet.
 			// Foreign-parser pages (#2942) cache post-CSS with no animation rules,
 			// so deliver the stock stylesheet here rather than via the parser path.
 			if (
 				! defined( 'OTTER_BLOCKS_VERSION' ) ||
 				! get_option( 'themeisle_blocks_settings_optimize_animations_css', true ) ||
+				! method_exists( Base_CSS::class, 'has_own_css_parser' ) ||
 				! Base_CSS::has_own_css_parser()
 			) {
 				wp_enqueue_style( 'otter-animation' );

--- a/tests/php/animation-compatibility-sandbox.php
+++ b/tests/php/animation-compatibility-sandbox.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Isolated frontend asset-loading checks for Blocks Animation with older Otter.
+ *
+ * Run: php animation-compatibility-sandbox.php [legacy|owned|foreign|standalone|disabled]
+ *
+ * @package gutenberg-blocks
+ */
+
+// phpcs:ignoreFile -- WordPress stubs and incompatible class shapes need an isolated process.
+
+namespace ThemeIsle\GutenbergBlocks {
+	if ( 'legacy' === $argv[1] ) {
+		// Otter <= 3.2.2 has Base_CSS but no has_own_css_parser() method.
+		class Base_CSS {}
+	} else {
+		class Base_CSS {
+			public static function has_own_css_parser() {
+				if ( in_array( $GLOBALS['argv'][1], array( 'standalone', 'disabled' ), true ) ) {
+					throw new \RuntimeException( 'Parser check must be skipped.' );
+				}
+				return 'owned' === $GLOBALS['argv'][1];
+			}
+		}
+	}
+}
+
+namespace {
+	$root = dirname( __DIR__, 2 );
+	$temp = sys_get_temp_dir() . '/otter-animation-' . uniqid();
+	mkdir( $temp . '/build/animation', 0777, true );
+	file_put_contents( $temp . '/build/animation/frontend.asset.php', '<?php return array("version" => "test", "dependencies" => array());' );
+	register_shutdown_function( function () use ( $temp ) {
+		unlink( $temp . '/build/animation/frontend.asset.php' );
+		rmdir( $temp . '/build/animation' );
+		rmdir( $temp . '/build' );
+		rmdir( $temp );
+	} );
+	define( 'BLOCKS_ANIMATION_PATH', $temp );
+	define( 'BLOCKS_ANIMATION_URL', 'https://example.org/animation/' );
+	if ( 'standalone' !== $argv[1] ) {
+		define( 'OTTER_BLOCKS_VERSION', 'legacy' === $argv[1] ? '3.2.2' : '3.2.3' );
+	}
+	$styles = array();
+	$scripts = array();
+	function get_option( $name, $default = false ) { return 'disabled' !== $GLOBALS['argv'][1]; }
+	function wp_register_style() {}
+	function wp_enqueue_style( $handle ) { $GLOBALS['styles'][] = $handle; }
+	function wp_enqueue_script( $handle ) { $GLOBALS['scripts'][] = $handle; }
+	function wp_script_add_data() {}
+	function add_action() {}
+
+	require $root . '/inc/class-blocks-animation.php';
+	$animation = new \ThemeIsle\GutenbergBlocks\Blocks_Animation();
+	$content = '<p class="animated fadeIn">Example</p>';
+	$result = $animation->frontend_load( $content, array( 'blockName' => 'core/paragraph' ) );
+	$expected_styles = 'owned' === $argv[1] ? array() : array( 'otter-animation' );
+	if ( $content !== $result || $styles !== $expected_styles || array( 'otter-animation-frontend' ) !== $scripts ) {
+		throw new \RuntimeException( 'Animated content or asset loading is incorrect.' );
+	}
+	// A second animated block must not enqueue duplicate assets.
+	$animation->frontend_load( $content, array( 'blockName' => 'core/paragraph' ) );
+	if ( $styles !== $expected_styles || array( 'otter-animation-frontend' ) !== $scripts ) {
+		throw new \RuntimeException( 'Animation assets were enqueued twice.' );
+	}
+	echo "REQUEST COMPLETED WITHOUT FATAL\n";
+}

--- a/tests/test-animation-css.php
+++ b/tests/test-animation-css.php
@@ -18,6 +18,23 @@ use ThemeIsle\GutenbergBlocks\Base_CSS;
 class Test_Animation_CSS extends WP_UnitTestCase {
 
 	/**
+	 * Animation assets remain available with older Otter and parser fallbacks.
+	 */
+	public function test_frontend_assets_support_mixed_otter_versions() {
+		$sandbox = __DIR__ . '/php/animation-compatibility-sandbox.php';
+
+		foreach ( array( 'legacy', 'owned', 'foreign', 'standalone', 'disabled' ) as $scenario ) {
+			$command = escapeshellarg( PHP_BINARY ) . ' -d display_errors=1 ' . escapeshellarg( $sandbox ) . ' ' . escapeshellarg( $scenario ) . ' 2>&1';
+			$output  = array();
+			exec( $command, $output, $exit_code ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+			$output = implode( "\n", $output );
+
+			$this->assertSame( 0, $exit_code, $scenario . ': ' . $output );
+			$this->assertStringContainsString( 'REQUEST COMPLETED WITHOUT FATAL', $output );
+		}
+	}
+
+	/**
 	 * A single animated block, as parse_blocks() would shape it.
 	 *
 	 * @return array<int, array<string, mixed>>


### PR DESCRIPTION
Blocks Animation 3.2.3+ can crash when older Otter supplies a `Base_CSS` class without the parser-check method. This change loads the full animation stylesheet when that method is unavailable.

> [!NOTE]
> The bug was added in [f6a47092](https://github.com/Codeinwp/otter-blocks/commit/f6a47092eca8a8b3e83c98220b90c507341ebf1b) in version 3.2.3.

## What changed

- **Animation rendering** checks whether the parser-check method exists before calling it, preserving content and loading animation assets with older Otter.

- **Regression coverage** exercises older Otter, current and foreign parsers, standalone use, disabled optimization, and asset deduplication in isolated PHP processes.

Related issue: #3041. This PR targets `development`.
