### PR TITLE
Fix: Template Cloud panel never appears on a fresh install

### DIFF
--- a/inc/class-registration.php
+++ b/inc/class-registration.php
@@ -10,7 +10,6 @@ namespace ThemeIsle\GutenbergBlocks;
 use ThemeIsle\GutenbergBlocks\Main, ThemeIsle\GutenbergBlocks\Pro, ThemeIsle\GutenbergBlocks\Plugins\Stripe_API;
 use ThemeIsle\GutenbergBlocks\Plugins\Dashboard;
 use ThemeIsle\GutenbergBlocks\Plugins\LimitedOffers;
-use ThemeIsle\GutenbergBlocks\Plugins\Template_Cloud;
 use ThemeIsle\GutenbergBlocks\Server\AI_Client_Adaptor;
 
 /**
@@ -372,7 +371,9 @@ class Registration {
 				'aiClientSupported'       => function_exists( 'wp_ai_client_prompt' ),
 				'hasAIProvider'           => AI_Client_Adaptor::is_available(),
 				'connectorsUrl'           => esc_url( admin_url( 'options-connectors.php' ) ),
-				'hasPatternSources'       => Template_Cloud::has_used_pattern_sources(),
+				// Always expose the Template Cloud UI, otherwise a site that never had a source
+				// has no way to reach the "Add Source" entry point in the first place (#3048).
+				'hasPatternSources'       => true,
 				'proPatterns'             => boolval( get_option( 'themeisle_blocks_settings_patterns_library', true ) ) ? Patterns::get_upsell_patterns() : array(),
 		);
 

--- a/inc/plugins/class-dashboard.php
+++ b/inc/plugins/class-dashboard.php
@@ -9,7 +9,6 @@ namespace ThemeIsle\GutenbergBlocks\Plugins;
 
 use ThemeIsle\GutenbergBlocks\Pro;
 use ThemeIsle\GutenbergBlocks\Plugins\FSE_Onboarding;
-use ThemeIsle\GutenbergBlocks\Plugins\Template_Cloud;
 use ThemeIsle\GutenbergBlocks\Server\AI_Client_Adaptor;
 
 /**
@@ -510,7 +509,9 @@ class Dashboard {
 				)
 			),
 			'neveInstalled'          => defined( 'NEVE_VERSION' ),
-			'hasPatternSources'      => Template_Cloud::has_used_pattern_sources(),
+			// Always expose the Template Cloud UI, otherwise a site that never had a source
+			// has no way to reach the "Add Source" entry point in the first place (#3048).
+			'hasPatternSources'      => true,
 			'aiClientAvailable'      => AI_Client_Adaptor::is_available(),
 			'aiClientSupported'      => function_exists( 'wp_ai_client_prompt' ),
 			'connectorsUrl'          => esc_url( admin_url( 'options-connectors.php' ) ),

--- a/tests/test-dashboard.php
+++ b/tests/test-dashboard.php
@@ -103,6 +103,19 @@ class Test_Dashboard extends WP_UnitTestCase {
 	}
 
 	/**
+	 * hasPatternSources must be true even on a fresh install that has never saved
+	 * a Template Cloud source, otherwise the Integrations panel — and the only UI
+	 * that could ever create that option — stays hidden forever (#3048).
+	 */
+	public function test_get_dashboard_data_exposes_pattern_sources_on_fresh_install() {
+		delete_option( 'themeisle_template_cloud_sources' );
+
+		$data = $this->dashboard->get_dashboard_data();
+
+		$this->assertTrue( $data['hasPatternSources'], 'hasPatternSources should be true even when no source has ever been added' );
+	}
+
+	/**
 	 * Test get_dashboard_data exposes the AI client, connectors and YouTube playlist keys.
 	 */
 	public function test_get_dashboard_data_new_keys() {

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -92,6 +92,12 @@ class Test_Registration extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		delete_option( 'themeisle_blocks_settings_global_defaults' );
+		delete_option( 'themeisle_template_cloud_sources' );
+
+		foreach ( array( 'otter-blocks', 'otter-vendor', 'otter-patterns-library' ) as $handle ) {
+			wp_dequeue_script( $handle );
+			wp_deregister_script( $handle );
+		}
 
 		// Restore permissions before unlinking: a test that fails mid-way would
 		// otherwise leave an unreadable file behind and poison later runs.
@@ -105,6 +111,25 @@ class Test_Registration extends WP_UnitTestCase {
 		$this->temp_renderer_files = array();
 
 		parent::tear_down();
+	}
+
+	/**
+	 * The editor localization must expose Template Cloud regardless of whether the
+	 * themeisle_template_cloud_sources option has ever been saved, otherwise the
+	 * "Add Source" entry point in the Patterns Library — the only UI that could
+	 * ever create that option — stays hidden forever on a fresh install (#3048).
+	 */
+	public function test_enqueue_block_editor_assets_exposes_pattern_sources_on_fresh_install() {
+		delete_option( 'themeisle_template_cloud_sources' );
+
+		set_current_screen( 'post' );
+
+		( new Registration() )->enqueue_block_editor_assets();
+
+		$data = wp_scripts()->get_data( 'otter-blocks', 'data' );
+
+		$this->assertIsString( $data, 'The editor localization data should be set on the otter-blocks handle' );
+		$this->assertStringContainsString( '"hasPatternSources":true', $data, 'hasPatternSources should be exposed as true even when no source has ever been added' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Fixes #3048 — the Template Cloud panel (Otter → Integrations) and the "Add Source" entry point in the block editor's Patterns Library were both hidden on any site that had never had a source before, with no way to reach either UI to add the first one.
- Root cause: both were gated behind `hasPatternSources`, which called `Template_Cloud::has_used_pattern_sources()` — a check for whether the `themeisle_template_cloud_sources` option row already exists in the DB. A fresh install never has that row, so the flag was always `false`.
- Fix: always pass `hasPatternSources => true` from both localization points (`inc/plugins/class-dashboard.php`, `inc/class-registration.php`). Both consumers (`src/dashboard/components/pages/Integrations.js`, `src/blocks/plugins/patterns-library/library.js`) already render a proper empty state (`tc-sources-empty`) when there are no sources, so removing the gate is safe.
- Removed the now-unused `Template_Cloud` `use` imports from both files.

## Test plan
- [x] `php -l` on both changed files
- [ ] On a fresh WP install with no `themeisle_template_cloud_sources` option, confirm the Template Cloud panel now appears under Otter → Integrations with an empty state and a working "Add Source" button
- [ ] Confirm the Patterns Library "Add Source" entry point also appears in the block editor
- [ ] Confirm existing sites with sources already saved still show them correctly (no regression to the populated state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
